### PR TITLE
run dbt process in production docker image

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 DBT_PROJECT_DIR=./dbt
-DBT_PROFILE_DIR=~/.dbt
+DBT_PROFILES_DIR=~/.dbt
 GCLOUD_CONFIG_DIR=~/.config/gcloud

--- a/docker-compose.gcloud.yml
+++ b/docker-compose.gcloud.yml
@@ -1,8 +1,5 @@
 version: "3.9"
 services:
-  dbt:
-    build:
-      context: ./docker
-      dockerfile: dockerfile-dbt-server
+  lightdash:
     volumes:
       - "${GCLOUD_CONFIG_DIR}:/root/.config/gcloud"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,14 @@
 version: "3.9"
 services:
-  dbt:
-    image: "fishtownanalytics/dbt:0.19.1"
-    volumes:
-      - "${DBT_PROFILE_DIR}:/usr/app/profile"
-      - "${DBT_PROJECT_DIR}:/usr/app"
-    command: ["rpc", "--profiles-dir", "profile", "--host", "0.0.0.0", "--port", "8580"]
-
   lightdash:
     build:
       context: .
-    depends_on: 
-      - dbt
     environment:
-      - LIGHTDASH_DBT_HOST=dbt
-      - LIGHTDASH_DBT_PORT=8580
-      - LIGHTDASH_SPAWN_DBT=false
+      - LIGHTDASH_SPAWN_DBT=true
+      - DBT_PROJECT_DIR=/usr/app/dbt
+      - DBT_PROFILES_DIR=/usr/app/profiles
+    volumes:
+      - "${DBT_PROFILES_DIR}:/usr/app/profiles"
+      - "${DBT_PROJECT_DIR}:/usr/app/dbt"
     ports:
       - 8080:8080

--- a/docker/dockerfile-dbt-server
+++ b/docker/dockerfile-dbt-server
@@ -1,6 +1,0 @@
-FROM fishtownanalytics/dbt:0.19.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends curl
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-341.0.0-linux-x86_64.tar.gz > /tmp/gcloud-sdk.tar.gz
-RUN mkdir /usr/local/gcloud && tar -C /usr/local/gcloud -xvf /tmp/gcloud-sdk.tar.gz
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
           routeBasePath: '/',
           // Please change this to your repo.
           editUrl:
-            'https://github.com/lightdash/lightdash/edit/master/docs/',
+            'https://github.com/lightdash/lightdash/edit/main/docs/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -20,17 +20,20 @@ app.use(morgan('dev'))
 const spawnDbt = process.env.LIGHTDASH_SPAWN_DBT === undefined ? true : process.env.LIGHTDASH_SPAWN_DBT === 'true'
 const dbtHost = process.env.LIGHTDASH_DBT_HOST || '0.0.0.0'
 const dbtPort = process.env.LIGHTDASH_DBT_PORT || '8580'
+const dbtProfilesDir = process.env.DBT_PROFILES_DIR || '~/.dbt'
 
-if (spawnDbt && !process.env.DBT_PROJECT_PATH) {
-    throw Error('Must specify DBT_PROJECT_PATH')
+if (spawnDbt && !process.env.DBT_PROJECT_DIR) {
+    throw Error('Must specify DBT_PROJECT_DIR')
 }
 
 let dbtChildProcess: undefined | ChildProcess = undefined
-const runDbt = () => execa('dbt', ['rpc', '--host', dbtHost, '--port', dbtPort], {cwd: process.env.DBT_PROJECT_DIR})
+const runDbt = () => execa('dbt', ['rpc', '--host', dbtHost, '--port', dbtPort, '--profiles-dir', dbtProfilesDir], {cwd: process.env.DBT_PROJECT_DIR})
 const respawnDbt = (childProcess: ChildProcess) => {
     dbtChildProcess = childProcess
     if (childProcess.stdout)
         childProcess.stdout.pipe(process.stdout)
+    if (childProcess.stderr)
+        childProcess.stderr.pipe(process.stderr)
     childProcess.on('exit', () => {
         respawnDbt(runDbt())
     })


### PR DESCRIPTION
Running dbt in a separate docker container makes it very difficult to force dbt to recompile (needs SIGHUP).

Allow dbt to run as child process in production image.