### PR TITLE
Fix group the only dimension 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Recent and upcoming changes to lightdash
 
 ## Unreleased
+- bug where we could group the only dimension available making the chart inaccessible  
 
 ## [0.2.6] - 2021-06-23
 ### Fixed

--- a/packages/frontend/src/components/ChartConfigPanel.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel.tsx
@@ -46,7 +46,7 @@ const Content: React.FC<ContentProps> = ({ chartConfig }) => {
                             outlined={true}
                             active={dimension === chartConfig.seriesLayout.groupDimension}
                             onClick={() => chartConfig.setGroupDimension(dimension === chartConfig.seriesLayout.groupDimension ? undefined : dimension)}
-                            disabled={chartConfig.seriesLayout.yMetrics && chartConfig.seriesLayout.yMetrics.length > 1}
+                            disabled={chartConfig.seriesLayout.yMetrics && chartConfig.seriesLayout.yMetrics.length > 1 || chartConfig.dimensionOptions.length <= 1}
                         >Group</Button>
                     </ButtonGroup>
                 </div>


### PR DESCRIPTION
Close: #117 

Bug where we could group the only dimension available making the chart inaccessible  

Fix: 
- disable group button if there is only 1 dimension available