### PR TITLE
Fix : Broken padding on sidebar #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Recent and upcoming changes to lightdash
  - improve table tree to show join details
 
 ### Fixed
- - bug where we could group the only dimension available making the chart inaccessible
+ - bug where we could group the only dimension available making the chart inaccessible  
+ - only show scroll bar in sidebar when content is scrollable
 
 ## [0.2.6] - 2021-06-23
 ### Fixed

--- a/packages/frontend/src/components/ExploreSideBar.tsx
+++ b/packages/frontend/src/components/ExploreSideBar.tsx
@@ -68,7 +68,7 @@ const BasePanel = () => {
             </div>
             <Menu style={{
                 flex: '1',
-                overflow: 'scroll'
+                overflow: 'auto'
             }}>
                 {(exploresResult.data || []).map((explore, idx) => (
                     <React.Fragment key={idx}>


### PR DESCRIPTION
Now the scrollbar will not show only when the table-content overflows,

![overflowFix](https://user-images.githubusercontent.com/24385409/123266394-9a9fe180-d519-11eb-845b-8265f53cb88a.JPG)
