### PR TITLE
Ui fix input fields overlapping at  filterblock if used more than one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Recent and upcoming changes to lightdash
 
 ### Fixed
  - UI bug where the search box in the sidebar was cutoff
+ - UI bug input fields overlapping at filterblock if used more than one
 
 ## [0.2.7] - 2021-06-28
 ### Added

--- a/packages/frontend/src/filters/FiltersForm.tsx
+++ b/packages/frontend/src/filters/FiltersForm.tsx
@@ -37,7 +37,7 @@ export const FiltersForm = () => {
             }}>
                 {activeFilters.map( (filterGroup, idx) => (
                     <React.Fragment key={idx}>
-                        <div style={{paddingLeft: '15px', width: '100%', paddingBottom: '20px'}}>
+                        <div style={{paddingLeft: '15px', width: '100%', paddingBottom: '20px', display: 'flex', flexDirection: 'column', gap: '5px'}}>
                             <FilterGroupForm filterGroup={filterGroup} key={idx} onDelete={() => onDeleteFilterGroup(idx)} onChange={filterGroup => onChangeFilterGroup(idx, filterGroup)}/>
                         </div>
                     </React.Fragment>


### PR DESCRIPTION
Ui fix input fields overlapping at  filterblock if used more than one

### Now 
![Inputerror](https://user-images.githubusercontent.com/24385409/123903359-31dabe00-d98c-11eb-8869-38ed5b273250.JPG)

----------

### After fix

![InputerrorFix](https://user-images.githubusercontent.com/24385409/123903375-369f7200-d98c-11eb-9acd-07d9efb56093.JPG)