### PR TITLE
Add non-aggregate metric types and support metric references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Recent and upcoming changes to lightdash
  - Add footer with Lightdash version
  - Add Lightdash about dialog
  - Warn user when there is a new version available
+ - Add non-aggregate metric types and support metric references in sql
 
 ### Fixed
  - UI bug where the search box in the sidebar was cutoff

--- a/docs/docs/references/metrics.md
+++ b/docs/docs/references/metrics.md
@@ -28,14 +28,18 @@ models:
 
 ## Metric types:
 
-|       Type      | Description                                               |
-|:---------------:| --------------------------------------------------------- |
-| average         | Generates an average (mean) of values within a column     |
-| count           | Counts the total number of values in the dimension        |
-| count_distinct  | Counts the total unique number of values in the dimension |
-| max             | Generates the maximum value within a column               |
-| min             | Generates the minimum value within a column               |
-| sum             | Generates a sum of values within a column                 |
+|       Type      | Category  | Description                                                 |
+|:---------------:| --------- | ----------------------------------------------------------- |
+| average         | Aggregate | Generates an average (mean) of values within a column       |
+| count           | Aggregate | Counts the total number of values in the dimension          |
+| count_distinct  | Aggregate | Counts the total unique number of values in the dimension   |
+| max             | Aggregate | Generates the maximum value within a column                 |
+| min             | Aggregate | Generates the minimum value within a column                 |
+| sum             | Aggregate | Generates a sum of values within a column                   |
+| string          | Non-aggregate | For measures that contain letters or special characters |
+| number          | Non-aggregate | For measures that contain numbers                       |
+| date            | Non-aggregate | For measures that contain dates                         |
+| boolean         | Non-aggregate | For fields that will show if something is true or false |
 
 ## Adding your own metric descriptions
 
@@ -48,7 +52,7 @@ metrics:
     description: "Total number of user IDs. NOTE: this is NOT counting unique user IDs"
 ```
 
-## Using custom SQL in metrics
+## Using custom SQL in aggregate metrics
 
 You can include custom SQL in your metric definition to build more advanced metrics using the sql parameter.
 Inside the sql parameter, you can reference any other dimension from the given model and any joined models. You **can’t reference other metrics.**
@@ -64,4 +68,23 @@ metrics:
   num_unique_paid_user_ids:
     type: count_distinct
     sql: "IF(${subscriptions.is_active}, ${user_id}, NULL)"
+```
+
+## Using custom SQL in non-aggregate metrics
+
+In non-aggregate metrics, you can reference any other metric from the given model and any joined models. You **can’t reference other dimensions.**
+
+You can reference metrics from the same model like this: `sql: "${metric_in_this_model}"`
+Or from joined models like this: `sql: "${other_model.metric_in_other_model}"`
+
+```
+metrics:
+  num_unique_users:
+      type: count_distinct
+  num_unique_7d_web_active_users:
+    type: count_distinct
+    sql: "IF(${is_7d_web_active}, ${user_id}, NULL)"
+  num_unique_non_7d_web_active_users:
+    type: sum
+    sql: "${num_unique_users} - ${num_unique_7d_web_active_users}" # both are metrics coming from the base model
 ```

--- a/packages/backend/src/exploreCompiler.mock.ts
+++ b/packages/backend/src/exploreCompiler.mock.ts
@@ -430,3 +430,74 @@ export const exploreReferenceInJoinCompiled: Explore = {
         }
     }
 }
+
+export const exploreWithMetricNumber: UncompiledExplore = {
+    name: '',
+    baseTable: 'a',
+    joinedTables: [],
+    tables: {
+        a: {
+            name: 'a',
+            sqlTable: 'test.table',
+            dimensions: {
+                dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'dim1',
+                    table: 'a',
+                    sql: '${TABLE}.dim1',
+                    source: sourceMock
+                }
+            },
+            metrics: {
+                m1: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'm1',
+                    table: 'a',
+                    sql: '${dim1}',
+                    source: sourceMock
+                },
+                m2: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.NUMBER,
+                    name: 'm2',
+                    table: 'a',
+                    sql: '2 + ${m1}',
+                    source: sourceMock
+                }
+            },
+            lineageGraph: {},
+            source: sourceMock
+        }
+    },
+}
+
+export const exploreWithMetricNumberCompiled: Explore = {
+    ...exploreWithMetricNumber,
+    joinedTables: [],
+    tables: {
+        a: {
+            name: 'a',
+            sqlTable: 'test.table',
+            dimensions: {
+                dim1: {
+                    ...exploreWithMetricNumber.tables['a'].dimensions['dim1'],
+                    compiledSql: 'a.dim1',
+                },
+            },
+            metrics: {
+                m1: {
+                    ...exploreWithMetricNumber.tables['a'].metrics['m1'],
+                    compiledSql: 'SUM((a.dim1))',
+                },
+                m2: {
+                    ...exploreWithMetricNumber.tables['a'].metrics['m2'],
+                    compiledSql: '2 + (SUM((a.dim1)))',
+                }
+            },
+            lineageGraph: {},
+            source: sourceMock
+        }
+    },
+}

--- a/packages/backend/src/exploreCompiler.test.ts
+++ b/packages/backend/src/exploreCompiler.test.ts
@@ -11,7 +11,9 @@ import {
     exploreReferenceInJoin,
     exploreReferenceInJoinCompiled,
     exploreTableSelfReference,
-    exploreTableSelfReferenceCompiled
+    exploreTableSelfReferenceCompiled,
+    exploreWithMetricNumber,
+    exploreWithMetricNumberCompiled
 } from "./exploreCompiler.mock";
 import {compileExplore} from "./exploreCompiler";
 import {CompileError} from "./errors";
@@ -47,4 +49,8 @@ test('Should compile table with nested references in dimensions and metrics', ()
 
 test('Should compile with a reference to a dimension in a joined table', () => {
     expect(compileExplore(exploreReferenceInJoin)).toStrictEqual(exploreReferenceInJoinCompiled)
+})
+
+test('Should compile with a reference to a metric in a non-aggregate metric', () => {
+    expect(compileExplore(exploreWithMetricNumber)).toStrictEqual(exploreWithMetricNumberCompiled)
 })

--- a/packages/backend/src/schema.json
+++ b/packages/backend/src/schema.json
@@ -39,7 +39,11 @@
             "count_distinct",
             "sum",
             "min",
-            "max"
+            "max",
+            "number",
+            "string",
+            "date",
+            "boolean"
           ]
         },
         "description": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -82,6 +82,10 @@ export interface Field {
     source: Source;
 }
 
+export const isField = (field: any): field is Field => {
+    return field?.fieldType;
+}
+
 export enum DimensionType {
     STRING = 'string',
     NUMBER = 'number',
@@ -122,6 +126,16 @@ export enum MetricType {
     SUM = 'sum',
     MIN = 'min',
     MAX = 'max',
+    NUMBER = 'number',
+    STRING = ' string',
+    DATE = ' date',
+    BOOLEAN = ' boolean',
+}
+
+const NonAggregateMetricTypes = [MetricType.STRING, MetricType.NUMBER, MetricType.DATE, MetricType.BOOLEAN];
+
+export const isNonAggregateMetric = (field: Field): boolean => {
+    return isMetric(field) && NonAggregateMetricTypes.includes(field.type);
 }
 
 export interface Metric extends Field {
@@ -131,6 +145,10 @@ export interface Metric extends Field {
 
 export interface CompiledMetric extends Metric {
     compiledSql: string;
+}
+
+export const isMetric = (field: Field): field is Metric => {
+    return field.fieldType === FieldType.METRIC;
 }
 
 // Object used to query an explore. Queries only happen within a single explore


### PR DESCRIPTION
Closes: #58 

Preview:
![Screenshot 2021-06-30 at 20 08 11](https://user-images.githubusercontent.com/9117144/124106460-21921400-da5c-11eb-91ee-62a8733ac5dc.png)

Preview YAML:
```
        meta:
          metrics:
            my_total_customers:
              type: count_distinct
            my_total_customers_plus:
              type: number
              sql: 2 + ${my_total_customers}
```
