### PR TITLE
fix: remove sorts when field is toggled in explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Recent and upcoming changes to lightdash
 ### Fixed
 - Fixed boolean value formatter to show yes/no values correctly.
 - Fixed chart dimensions formatting issues, should format date and boolean correctly now
+- Fixed sort behaviour where removing a field would not remove it from the list of sort fields
 
 ## [0.6.3] - 2021-08-10
 ### Fixed

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -112,12 +112,14 @@ function reducer(
             return {
                 ...state,
                 dimensions: toggleArrayValue(state.dimensions, action.payload),
+                sorts: state.sorts.filter((s) => s.fieldId !== action.payload),
             };
         }
         case ActionType.TOGGLE_METRIC: {
             return {
                 ...state,
                 metrics: toggleArrayValue(state.metrics, action.payload),
+                sorts: state.sorts.filter((s) => s.fieldId !== action.payload),
             };
         }
         case ActionType.TOGGLE_SORT_FIELD: {


### PR DESCRIPTION

![piece](https://user-images.githubusercontent.com/11660098/130459389-9a7f38fd-96e6-4d20-a9f1-f8c8b51bd40c.gif)
Closes #321