### PR TITLE
Add derived columns to metric queries

### DIFF
--- a/packages/backend/src/database/entities/savedQueries.ts
+++ b/packages/backend/src/database/entities/savedQueries.ts
@@ -168,6 +168,7 @@ export const getSavedQueryByUuid = async (
                 descending: sort.descending,
             })),
             limit: savedQuery.row_limit,
+            tableCalculations: [],
         },
         chartConfig: {
             chartType: savedQuery.chart_type,

--- a/packages/backend/src/database/seeds/development/saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/saved_queries.ts
@@ -21,6 +21,7 @@ export async function seed(knex: Knex): Promise<void> {
                 },
             ],
             limit: 10,
+            tableCalculations: [],
         },
         chartConfig: {
             chartType: DBChartTypes.COLUMN,

--- a/packages/backend/src/exploreCompiler.ts
+++ b/packages/backend/src/exploreCompiler.ts
@@ -13,7 +13,7 @@ import {
 } from 'common';
 import { CompileError } from './errors';
 
-const lightdashVariablePattern = /\$\{([a-zA-Z0-9_.]+)\}/g;
+export const lightdashVariablePattern = /\$\{([a-zA-Z0-9_.]+)\}/g;
 
 const getParsedReference = (
     ref: string,

--- a/packages/backend/src/lightdash.ts
+++ b/packages/backend/src/lightdash.ts
@@ -3,6 +3,7 @@ import { NotExistsError } from './errors';
 import { buildQuery } from './queryBuilder';
 import { projectAdapterFromConfig } from './projectAdapters/projectAdapter';
 import { lightdashConfig } from './config/lightdashConfig';
+import { compileMetricQuery } from './queryCompiler';
 
 // Setup dbt adapter
 const projectConfig = lightdashConfig.projects[0];
@@ -49,7 +50,8 @@ export const getTable = async (tableId: string): Promise<Explore> => {
 
 export const runQuery = async (tableId: string, metricQuery: MetricQuery) => {
     const explore = await getTable(tableId);
-    const sql = await buildQuery({ explore, metricQuery });
+    const compiledMetricQuery = compileMetricQuery(metricQuery);
+    const sql = buildQuery({ explore, compiledMetricQuery });
     const rows = await adapter.runQuery(sql);
     return {
         metricQuery,

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -1,0 +1,74 @@
+import {
+    CompiledMetricQuery,
+    DimensionType,
+    Explore,
+    FieldType,
+    MetricType,
+} from 'common';
+
+export const EXPLORE: Explore = {
+    name: 'table1',
+    baseTable: 'table1',
+    joinedTables: [],
+    tables: {
+        table1: {
+            name: 'table1',
+            sqlTable: '`db`.`schema`.`table1`',
+            dimensions: {
+                dim1: {
+                    type: DimensionType.NUMBER,
+                    name: 'dim1',
+                    table: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.dim1',
+                    compiledSql: 'table1.dim1',
+                },
+            },
+            metrics: {
+                metric1: {
+                    type: MetricType.MAX,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    name: 'metric1',
+                    sql: '${TABLE}.number_column',
+                    compiledSql: 'MAX(table1.number_column)',
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+export const METRIC_QUERY: CompiledMetricQuery = {
+    dimensions: ['table1_dim1'],
+    metrics: ['table1_metric1'],
+    filters: [],
+    sorts: [{ fieldId: 'table1_metric1', descending: true }],
+    limit: 10,
+    tableCalculations: [
+        { name: 'calc3', sql: '${table1.dim1} + ${table1.metric1}' },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'calc3',
+            sql: '${table1.dim1} + ${table1.metric1}',
+            compiledSql: 'table1_dim1 + table1_metric1',
+        },
+    ],
+};
+
+export const METRIC_QUERY_SQL = `WITH metrics AS (
+SELECT
+  table1.dim1 AS \`table1_dim1\`,
+  MAX(table1.number_column) AS \`table1_metric1\`
+FROM \`db\`.\`schema\`.\`table1\` AS table1
+
+
+GROUP BY 1
+ORDER BY table1_metric1 DESC
+LIMIT 10
+)
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS \`calc3\`
+FROM metrics`;

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -1,0 +1,11 @@
+import { buildQuery } from './queryBuilder';
+import { EXPLORE, METRIC_QUERY, METRIC_QUERY_SQL } from './queryBuilder.mock';
+
+test('Should build simple metric query', () => {
+    expect(
+        buildQuery({
+            explore: EXPLORE,
+            compiledMetricQuery: METRIC_QUERY,
+        }),
+    ).toStrictEqual(METRIC_QUERY_SQL);
+});

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -1,4 +1,5 @@
 import {
+    CompiledMetricQuery,
     DateAndTimestampFilter,
     Explore,
     fieldId,
@@ -215,10 +216,13 @@ const getQuoteChar = (quotedExample: string): string => {
 
 export type BuildQueryProps = {
     explore: Explore;
-    metricQuery: MetricQuery;
+    compiledMetricQuery: CompiledMetricQuery;
 };
-export const buildQuery = ({ explore, metricQuery }: BuildQueryProps) => {
-    const { dimensions, metrics, filters, sorts, limit } = metricQuery;
+export const buildQuery = ({
+    explore,
+    compiledMetricQuery,
+}: BuildQueryProps) => {
+    const { dimensions, metrics, filters, sorts, limit } = compiledMetricQuery;
     const baseTable = explore.tables[explore.baseTable].sqlTable;
     const sqlFrom = `FROM ${baseTable} AS ${explore.baseTable}`;
     const q = getQuoteChar(baseTable); // quote char
@@ -267,7 +271,7 @@ export const buildQuery = ({ explore, metricQuery }: BuildQueryProps) => {
 
     const sqlLimit = `LIMIT ${limit}`;
 
-    const sql = [
+    const metricQuerySql = [
         sqlSelect,
         sqlFrom,
         sqlJoins,
@@ -276,5 +280,22 @@ export const buildQuery = ({ explore, metricQuery }: BuildQueryProps) => {
         sqlOrderBy,
         sqlLimit,
     ].join('\n');
-    return sql;
+
+    if (compiledMetricQuery.compiledTableCalculations.length > 0) {
+        const cteName = 'metrics';
+        const cte = `WITH ${cteName} AS (\n${metricQuerySql}\n)`;
+        const tableCalculationSelects =
+            compiledMetricQuery.compiledTableCalculations.map(
+                (tableCalculation) => {
+                    const alias = tableCalculation.name;
+                    return `${tableCalculation.compiledSql} AS ${q}${alias}${q}`;
+                },
+            );
+        const finalSelect = `SELECT\n  *,\n  ${tableCalculationSelects.join(
+            ',\n  ',
+        )}`;
+        const finalFrom = `FROM ${cteName}`;
+        return [cte, finalSelect, finalFrom].join('\n');
+    }
+    return metricQuerySql;
 };

--- a/packages/backend/src/queryCompiler.mock.ts
+++ b/packages/backend/src/queryCompiler.mock.ts
@@ -1,0 +1,55 @@
+import { CompiledMetricQuery, MetricQuery } from 'common';
+
+export const METRIC_QUERY_NO_CALCS: MetricQuery = {
+    dimensions: ['table1_dim_1', 'table_2_dim_2'],
+    metrics: ['table_3_metric_1', 'table55_metric__23_1'],
+    filters: [],
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+export const METRIC_QUERY_VALID_REFERENCES: MetricQuery = {
+    ...METRIC_QUERY_NO_CALCS,
+    tableCalculations: [
+        { name: 'calc1', sql: 'no references ${nope ' },
+        { name: 'calc2', sql: 'dim reference ${table1.dim_1}' },
+        { name: 'calc3', sql: 'metric reference ${table_3.metric_1}' },
+    ],
+};
+
+export const METRIC_QUERY_VALID_REFERENCES_COMPILED: CompiledMetricQuery = {
+    ...METRIC_QUERY_VALID_REFERENCES,
+    compiledTableCalculations: [
+        {
+            name: 'calc1',
+            sql: 'no references ${nope ',
+            compiledSql: 'no references ${nope ',
+        },
+        {
+            name: 'calc2',
+            sql: 'dim reference ${table1.dim_1}',
+            compiledSql: 'dim reference table1_dim_1',
+        },
+        {
+            name: 'calc3',
+            sql: 'metric reference ${table_3.metric_1}',
+            compiledSql: 'metric reference table_3_metric_1',
+        },
+    ],
+};
+
+export const METRIC_QUERY_MISSING_REFERENCE: MetricQuery = {
+    ...METRIC_QUERY_NO_CALCS,
+    tableCalculations: [{ name: 'calc1', sql: '${notexists.nah}' }],
+};
+
+export const METRIC_QUERY_INVALID_REFERENCE_FORMAT: MetricQuery = {
+    ...METRIC_QUERY_NO_CALCS,
+    tableCalculations: [{ name: 'calc1', sql: '${nodot}' }],
+};
+
+export const METRIC_QUERY_DUPLICATE_NAME: MetricQuery = {
+    ...METRIC_QUERY_NO_CALCS,
+    tableCalculations: [{ name: 'table_3_metric_1', sql: '${table1.dim_1}' }],
+};

--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1,0 +1,43 @@
+import { CompiledMetricQuery } from 'common';
+import { compileMetricQuery } from './queryCompiler';
+import {
+    METRIC_QUERY_DUPLICATE_NAME,
+    METRIC_QUERY_INVALID_REFERENCE_FORMAT,
+    METRIC_QUERY_MISSING_REFERENCE,
+    METRIC_QUERY_NO_CALCS,
+    METRIC_QUERY_VALID_REFERENCES,
+    METRIC_QUERY_VALID_REFERENCES_COMPILED,
+} from './queryCompiler.mock';
+import { CompileError } from './errors';
+
+test('Should compile without table calculations', () => {
+    const expected: CompiledMetricQuery = {
+        ...METRIC_QUERY_NO_CALCS,
+        compiledTableCalculations: [],
+    };
+    expect(compileMetricQuery(METRIC_QUERY_NO_CALCS)).toStrictEqual(expected);
+});
+
+test('Should compile table calculations', () => {
+    expect(compileMetricQuery(METRIC_QUERY_VALID_REFERENCES)).toStrictEqual(
+        METRIC_QUERY_VALID_REFERENCES_COMPILED,
+    );
+});
+
+test('Should throw error when table calculation contains missing reference', () => {
+    expect(() =>
+        compileMetricQuery(METRIC_QUERY_MISSING_REFERENCE),
+    ).toThrowError(CompileError);
+});
+
+test('Should throw error when table calculation has invalid reference format', () => {
+    expect(() =>
+        compileMetricQuery(METRIC_QUERY_INVALID_REFERENCE_FORMAT),
+    ).toThrowError(CompileError);
+});
+
+test('Should throw error when table calculation has duplicate name', () => {
+    expect(() => compileMetricQuery(METRIC_QUERY_DUPLICATE_NAME)).toThrowError(
+        CompileError,
+    );
+});

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -1,0 +1,69 @@
+import {
+    CompiledMetricQuery,
+    CompiledTableCalculation,
+    FieldId,
+    MetricQuery,
+    TableCalculation,
+} from 'common';
+import { CompileError } from './errors';
+import { lightdashVariablePattern } from './exploreCompiler';
+
+const resolveQueryFieldReference = (ref: string): FieldId => {
+    const parts = ref.split('.');
+    if (parts.length !== 2) {
+        throw new CompileError(
+            `Table calculation contains an invalid reference: ${ref}. References must be of the format "table.field"`,
+            {},
+        );
+    }
+    const [tableName, fieldName] = parts;
+    const fieldId = `${tableName}_${fieldName}`;
+
+    return fieldId;
+};
+
+const compileTableCalculation = (
+    tableCalculation: TableCalculation,
+    validFieldIds: string[],
+): CompiledTableCalculation => {
+    if (validFieldIds.includes(tableCalculation.name)) {
+        throw new CompileError(
+            `Table calculation has a name that already exists in the query: ${tableCalculation.name}`,
+            {},
+        );
+    }
+    const compiledSql = tableCalculation.sql.replace(
+        lightdashVariablePattern,
+        (_, p1) => {
+            const fieldId = resolveQueryFieldReference(p1);
+            if (validFieldIds.includes(fieldId)) {
+                return fieldId;
+            }
+            throw new CompileError(
+                `Table calculation contains a reference ${p1} to a field that isn't included in the query.`,
+                {},
+            );
+        },
+    );
+    return {
+        ...tableCalculation,
+        compiledSql,
+    };
+};
+
+// TODO: independent of quote char behaviour - should depend on database target
+export const compileMetricQuery = (
+    metricQuery: MetricQuery,
+): CompiledMetricQuery => {
+    const compiledTableCalculations = metricQuery.tableCalculations.map(
+        (tableCalculation) =>
+            compileTableCalculation(tableCalculation, [
+                ...metricQuery.dimensions,
+                ...metricQuery.metrics,
+            ]),
+    );
+    return {
+        ...metricQuery,
+        compiledTableCalculations,
+    };
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -185,6 +185,15 @@ export interface CompiledMetric extends Metric {
     compiledSql: string;
 }
 
+export type TableCalculation = {
+    name: string;
+    sql: string;
+};
+
+export type CompiledTableCalculation = TableCalculation & {
+    compiledSql: string;
+};
+
 // Object used to query an explore. Queries only happen within a single explore
 export type MetricQuery = {
     dimensions: FieldId[]; // Dimensions to group by in the explore
@@ -192,6 +201,11 @@ export type MetricQuery = {
     filters: FilterGroup[]; // Filters applied to the table to query (logical AND)
     sorts: SortField[]; // Sorts for the data
     limit: number; // Max number of rows to return from query
+    tableCalculations: TableCalculation[]; // calculations to append to results
+};
+
+export type CompiledMetricQuery = MetricQuery & {
+    compiledTableCalculations: CompiledTableCalculation[];
 };
 
 // Sort by

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -75,6 +75,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                   sorts,
                   filters,
                   limit,
+                  tableCalculations: [],
               },
               chartConfig: {
                   chartType: activeVizTab,

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -26,12 +26,13 @@ export const useCompliedSql = () => {
     const {
         errorLogs: { showError },
     } = useApp();
-    const metricQuery = {
+    const metricQuery: MetricQuery = {
         dimensions: Array.from(dimensions),
         metrics: Array.from(metrics),
         sorts,
         filters,
         limit: limit || 500,
+        tableCalculations: [],
     };
     const queryKey = ['compiledQuery', tableId, metricQuery];
     const query = useQuery<ApiCompiledQueryResults, ApiError>({

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -26,12 +26,13 @@ export const useQueryResults = () => {
     const {
         errorLogs: { showError },
     } = useApp();
-    const metricQuery = {
+    const metricQuery: MetricQuery = {
         dimensions: Array.from(dimensions),
         metrics: Array.from(metrics),
         sorts,
         filters,
         limit: limit || 500,
+        tableCalculations: [],
     };
     const queryKey = ['queryResults', tableId, metricQuery];
     const query = useQuery<ApiQueryResults, ApiError>({


### PR DESCRIPTION
Closes #375

   - add compile step to metric queries
 - compile table calculations in metric queries
 - do not save table calculations
 - compile table calculations on /compileSql endpoint
 - compile table calculations on /runQuery endpoint
 - update frontend to always assume no table calculations

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)