### PR TITLE
Add State tracking and replace queryResult prop drill with hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Recent and upcoming changes to lightdash
 ### Fixed
 - Fixed bug with wrong quote strings for dbt's athena adapter
 - Fixed bug where optional project configs set via env where not recognised
+- Add local state to track and update query parameters changes without affecting the current query data
+- Url Parameters are now updated only when the query is run
 
 ## [0.6.5] - 2021-09-03
 ### Added

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -22,7 +22,6 @@ import { RenderedSql } from './RenderedSql';
 import { RefreshServerButton } from './RefreshServerButton';
 import { RefreshButton } from './RefreshButton';
 import { ChartConfigPanel } from './ChartConfigPanel';
-import { useQueryResults } from '../hooks/useQueryResults';
 import { useChartConfig } from '../hooks/useChartConfig';
 import { ChartDownloadMenu } from './ChartDownload';
 import { useExplorer } from '../providers/ExplorerProvider';
@@ -53,7 +52,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         },
         actions: { setRowLimit: setResultsRowLimit },
     } = useExplorer();
-    const queryResults = useQueryResults();
     const chartConfig = useChartConfig(savedQueryUuid);
     const { data } = useSavedQuery({ id: savedQueryUuid });
     const update = useAddVersionMutation();
@@ -107,17 +105,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             setActiveVizTab(data.chartConfig.chartType);
         }
     }, [data]);
-
-    useEffect(() => {
-        if (
-            queryResults.isIdle &&
-            savedQueryUuid &&
-            tableName &&
-            !location.state?.fromExplorer
-        ) {
-            queryResults.refetch();
-        }
-    }, [savedQueryUuid, queryResults, tableName, location]);
 
     const isChartEmpty: boolean = !chartConfig.plotData;
     return (

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -53,10 +53,8 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         },
         actions: { setRowLimit: setResultsRowLimit },
     } = useExplorer();
-    // queryResults are used here for prop-drill because the keepPreviousData: true option doesn't persist when
-    // child components unmount: https://github.com/tannerlinsley/react-query/issues/2363
     const queryResults = useQueryResults();
-    const chartConfig = useChartConfig(savedQueryUuid, queryResults);
+    const chartConfig = useChartConfig(savedQueryUuid);
     const { data } = useSavedQuery({ id: savedQueryUuid });
     const update = useAddVersionMutation();
 
@@ -132,7 +130,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                         justifyContent: 'flex-end',
                     }}
                 >
-                    <RefreshButton queryResults={queryResults} />
+                    <RefreshButton />
                     <RefreshServerButton />
                     <Popover2
                         content={
@@ -321,7 +319,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     )}
                 </div>
                 <Collapse isOpen={resultsIsOpen}>
-                    <ResultsTable queryResults={queryResults} />
+                    <ResultsTable />
                 </Collapse>
             </Card>
             <div style={{ paddingTop: '10px' }} />

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -5,14 +5,16 @@ import { ApiError, ApiQueryResults } from 'common';
 import { useExplorer } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
+import { useQueryResults } from '../hooks/useQueryResults';
 
 type RefreshButtonProps = {
     queryResults: UseQueryResult<ApiQueryResults, ApiError>;
 };
-export const RefreshButton = ({ queryResults }: RefreshButtonProps) => {
+export const RefreshButton = () => {
     const {
         state: { isValidQuery },
     } = useExplorer();
+    const queryResults = useQueryResults(false);
     const { refetch, isFetching } = queryResults;
     const { track } = useTracking();
     return (

--- a/packages/frontend/src/components/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable.tsx
@@ -34,6 +34,7 @@ import { Section } from '../providers/TrackingProvider';
 import { SectionName } from '../types/Events';
 import TableCalculationHeaderButton from './TableCalculationHeaderButton';
 import AddColumnButton from './AddColumnButton';
+import { useQueryResults } from '../hooks/useQueryResults';
 
 const hexToRGB = (hex: string, alpha: number) => {
     // eslint-disable-next-line radix
@@ -57,17 +58,12 @@ const EmptyStateNoColumns = () => (
     </div>
 );
 
-type EmptyStateNoTableDataProps = {
-    queryResults: UseQueryResult<ApiQueryResults, ApiError>;
-};
-const EmptyStateNoTableData = ({
-    queryResults,
-}: EmptyStateNoTableDataProps) => (
+const EmptyStateNoTableData = () => (
     <Section name={SectionName.EMPTY_RESULTS_TABLE}>
         <div style={{ padding: '50px 0' }}>
             <NonIdealState
                 description="Click run query to see your results"
-                action={<RefreshButton queryResults={queryResults} />}
+                action={<RefreshButton />}
             />
         </div>
     </Section>
@@ -187,11 +183,9 @@ const Item: FC<ItemProps> = ({
     </div>
 );
 
-type ResultsTableProps = {
-    queryResults: UseQueryResult<ApiQueryResults, ApiError>;
-};
-export const ResultsTable = ({ queryResults }: ResultsTableProps) => {
+export const ResultsTable = () => {
     const dataColumns = useColumns();
+    const queryResults = useQueryResults();
     const {
         state: { tableName: activeTableName, columnOrder: explorerColumnOrder },
         actions: { setColumnOrder: setExplorerColumnOrder },
@@ -427,9 +421,7 @@ export const ResultsTable = ({ queryResults }: ResultsTableProps) => {
                             />
                         </>
                     )}
-                    {queryResults.isIdle && (
-                        <EmptyStateNoTableData queryResults={queryResults} />
-                    )}
+                    {queryResults.isIdle && <EmptyStateNoTableData />}
                     {queryResults.status === 'success' &&
                         queryResults.data.rows.length === 0 && (
                             <EmptyStateNoRows />

--- a/packages/frontend/src/hooks/useChartConfig.tsx
+++ b/packages/frontend/src/hooks/useChartConfig.tsx
@@ -12,6 +12,7 @@ import { UseQueryResult } from 'react-query';
 import { useSavedQuery } from './useSavedQuery';
 import { useTable } from './useTable';
 import { getDimensionFormatter } from './useColumns';
+import { useQueryResults } from './useQueryResults';
 
 const getDimensionFormatterByKey = (
     dimensions: CompiledDimension[],
@@ -116,9 +117,9 @@ const isValidSeriesLayout = (
 
 export const useChartConfig = (
     savedQueryUuid: string | undefined,
-    queryResults: UseQueryResult<ApiQueryResults, ApiError>,
 ): ChartConfig => {
     const { data } = useSavedQuery({ id: savedQueryUuid });
+    const queryResults = useQueryResults();
     const [seriesLayout, setSeriesLayout] = useState<SeriesLayout>(
         defaultLayout(queryResults),
     );

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -10,7 +10,7 @@ export const useExplorerRoute = () => {
     const history = useHistory();
     const pathParams = useParams<{ tableId: string | undefined }>();
     const {
-        state,
+        pristineState,
         actions: { setState, reset },
     } = useExplorer();
 
@@ -66,56 +66,59 @@ export const useExplorerRoute = () => {
         }
     });
 
-    // Update url params based on state
+    // Update url params based on pristine state
     useEffect(() => {
-        if (state.tableName) {
+        if (pristineState.tableName) {
             const newParams = new URLSearchParams();
-            if (state.dimensions.length === 0) {
+            if (pristineState.dimensions.length === 0) {
                 newParams.delete('dimensions');
             } else {
-                newParams.set('dimensions', state.dimensions.join(','));
+                newParams.set('dimensions', pristineState.dimensions.join(','));
             }
-            if (state.metrics.length === 0) {
+            if (pristineState.metrics.length === 0) {
                 newParams.delete('metrics');
             } else {
-                newParams.set('metrics', state.metrics.join(','));
+                newParams.set('metrics', pristineState.metrics.join(','));
             }
-            if (state.sorts.length === 0) {
+            if (pristineState.sorts.length === 0) {
                 newParams.delete('sort');
             } else {
-                newParams.set('sort', JSON.stringify(state.sorts));
+                newParams.set('sort', JSON.stringify(pristineState.sorts));
             }
-            if (state.filters.length === 0) {
+            if (pristineState.filters.length === 0) {
                 newParams.delete('filters');
             } else {
-                newParams.set('filters', JSON.stringify(state.filters));
+                newParams.set('filters', JSON.stringify(pristineState.filters));
             }
-            newParams.set('limit', `${state.limit}`);
-            if (state.columnOrder.length === 0) {
+            newParams.set('limit', `${pristineState.limit}`);
+            if (pristineState.columnOrder.length === 0) {
                 newParams.delete('column_order');
             } else {
-                newParams.set('column_order', state.columnOrder.join(','));
+                newParams.set(
+                    'column_order',
+                    pristineState.columnOrder.join(','),
+                );
             }
-            if (state.selectedTableCalculations.length === 0) {
+            if (pristineState.selectedTableCalculations.length === 0) {
                 newParams.delete('selected_table_calculations');
             } else {
                 newParams.set(
                     'selected_table_calculations',
-                    state.selectedTableCalculations.join(','),
+                    pristineState.selectedTableCalculations.join(','),
                 );
             }
-            if (state.tableCalculations.length === 0) {
+            if (pristineState.tableCalculations.length === 0) {
                 newParams.delete('table_calculations');
             } else {
                 newParams.set(
                     'table_calculations',
-                    JSON.stringify(state.tableCalculations),
+                    JSON.stringify(pristineState.tableCalculations),
                 );
             }
             history.replace({
-                pathname: `/tables/${state.tableName}`,
+                pathname: `/tables/${pristineState.tableName}`,
                 search: newParams.toString(),
             });
         }
-    }, [state, history]);
+    }, [pristineState, history]);
 };

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -11,9 +11,9 @@ export const getQueryResults = async (tableId: string, query: MetricQuery) =>
         body: JSON.stringify(query),
     });
 
-export const useQueryResults = () => {
+export const useQueryResults = (pristine = true) => {
     const {
-        state: {
+        [pristine ? 'pristineState' : 'state']: {
             tableName: tableId,
             dimensions,
             metrics,
@@ -23,6 +23,7 @@ export const useQueryResults = () => {
             tableCalculations,
             selectedTableCalculations,
         },
+        actions: { syncState },
     } = useExplorer();
     const {
         errorLogs: { showError },
@@ -44,6 +45,10 @@ export const useQueryResults = () => {
         enabled: false, // don't run automatically
         keepPreviousData: true, // changing the query won't update results until fetch
         retry: false,
+        onSettled: (data) => {
+            // Update the pristine state once the query request is completed.
+            syncState();
+        },
         onError: (error) => {
             const [first, ...rest] = error.error.message.split('\n');
             showError({ title: first, body: rest.join('\n') });

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,26 +1,39 @@
 import React, { useEffect } from 'react';
 import { Card } from '@blueprintjs/core';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { ExplorePanel } from '../components/ExploreSideBar';
 import { Explorer } from '../components/Explorer';
 import { useExplorer } from '../providers/ExplorerProvider';
 import AboutFooter from '../components/AboutFooter';
 import { useSavedQuery } from '../hooks/useSavedQuery';
+import { useQueryResults } from '../hooks/useQueryResults';
 
 const SavedExplorer = () => {
     const history = useHistory();
+    const location = useLocation<{ fromExplorer?: boolean } | undefined>();
     const pathParams = useParams<{ savedQueryUuid: string }>();
     const {
+        state: { tableName },
         actions: { setState, reset },
     } = useExplorer();
     const { data } = useSavedQuery({ id: pathParams.savedQueryUuid });
-
+    const queryResults = useQueryResults();
     const onBack = () => {
         reset();
         history.push({
             pathname: `/saved`,
         });
     };
+    useEffect(() => {
+        if (
+            queryResults.isIdle &&
+            pathParams.savedQueryUuid &&
+            tableName &&
+            !location.state?.fromExplorer
+        ) {
+            queryResults.refetch();
+        }
+    }, [pathParams.savedQueryUuid, queryResults, tableName, location]);
 
     useEffect(() => {
         if (data) {

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -375,11 +375,15 @@ export const ExplorerProvider: FC = ({ children }) => {
         const fields = new Set([
             ...pristineReducerState.dimensions,
             ...pristineReducerState.metrics,
+            ...pristineReducerState.selectedTableCalculations,
         ]);
         return [fields, fields.size > 0];
     }, [pristineReducerState]);
     const reset = useCallback(() => {
         dispatch({
+            type: ActionType.RESET,
+        });
+        pristineDispatch({
             type: ActionType.RESET,
         });
     }, []);


### PR DESCRIPTION
This PR adds local state tracking for the Explore data. This should provide a clear separation of concern between actions/data that are displaying the current query(displaying charts) vs the ones dealing with the next query(filters). 

This should help clear up few bugs and makes way for new possibilities. As a bonus writing an integration test should be easier since the queryResults prop has been removed.

Fixes #77

https://www.loom.com/share/a356c6d446e941b7a6bb30d5b3909c98