### PR TITLE
Explorer provider improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Recent and upcoming changes to lightdash
 - Users can reorder the result table columns
 - Add dbt profile target option in lightdash project config
 
+### Fixed
+- Fixed error drawer from opening on each query change
+
 ## [0.6.4] - 2021-08-23
 ### Added
 - Users can create and revoke invite links

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -1,6 +1,5 @@
 import { ApiError, ApiQueryResults, MetricQuery } from 'common';
 import { useQuery } from 'react-query';
-import { useEffect } from 'react';
 import { lightdashApi } from '../api';
 import { useExplorer } from '../providers/ExplorerProvider';
 import { useApp } from '../providers/AppProvider';
@@ -39,20 +38,15 @@ export const useQueryResults = () => {
         ),
     };
     const queryKey = ['queryResults', tableId, metricQuery];
-    const query = useQuery<ApiQueryResults, ApiError>({
+    return useQuery<ApiQueryResults, ApiError>({
         queryKey,
         queryFn: () => getQueryResults(tableId || '', metricQuery),
         enabled: false, // don't run automatically
         keepPreviousData: true, // changing the query won't update results until fetch
         retry: false,
-    });
-
-    useEffect(() => {
-        if (query.error) {
-            const [first, ...rest] = query.error.error.message.split('\n');
+        onError: (error) => {
+            const [first, ...rest] = error.error.message.split('\n');
             showError({ title: first, body: rest.join('\n') });
-        }
-    }, [query.error, showError]);
-
-    return query;
+        },
+    });
 };


### PR DESCRIPTION
Closes: #384

Each commit represents an improvement: 
- only show error when runs the query
- ~remove prop drilling and improve state management by having the results query in the main explorer provider~
- ~update explorer url params on query run~

@silentninja since you were working on the same problem in #388, would you like to review these changes? Is easier to review by checking each commit.

Update: 
Updated PR to only fix the error drawer

