### PR TITLE
Saved table calculations to db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Recent and upcoming changes to lightdash
 ### Added
 - Users can reorder the result table columns
 - Add dbt profile target option in lightdash project config
+- Add table calculations to your results table. Table calculations allow you to combine columns together 
+in your results. For example, adding together two metrics to make a third or compute a running total. Table calculations
+are written using raw sql. 
 
 ## [0.6.4] - 2021-08-23
 ### Added

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -9,6 +9,10 @@ import {
 import { UserTable, UserTableName } from '../database/entities/users';
 import { EmailTable, EmailTableName } from '../database/entities/emails';
 import { SessionTable, SessionTableName } from '../database/entities/sessions';
+import {
+    SavedQueryTableCalculationTable,
+    SavedQueryTableCalculationTableName,
+} from '../database/entities/savedQueries';
 
 declare module 'knex/types/tables' {
     interface Tables {
@@ -17,5 +21,6 @@ declare module 'knex/types/tables' {
         [UserTableName]: UserTable;
         [EmailTableName]: EmailTable;
         [SessionTableName]: SessionTable;
+        [SavedQueryTableCalculationTableName]: SavedQueryTableCalculationTable;
     }
 }

--- a/packages/backend/src/database/migrations/20210831103040_add_table_calculations_table.ts
+++ b/packages/backend/src/database/migrations/20210831103040_add_table_calculations_table.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex';
+
+const TABLE_CALCULATIONS_TABLE_NAME =
+    'saved_queries_version_table_calculations';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(TABLE_CALCULATIONS_TABLE_NAME))) {
+        await knex.schema.createTable(
+            TABLE_CALCULATIONS_TABLE_NAME,
+            (tableBuilder) => {
+                tableBuilder.specificType(
+                    'saved_queries_version_table_calculation_id',
+                    'integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY',
+                );
+                tableBuilder.text('name').notNullable();
+                tableBuilder.text('display_name').notNullable();
+                tableBuilder.integer('order').notNullable();
+                tableBuilder.text('calculation_raw_sql').notNullable();
+                tableBuilder
+                    .integer('saved_queries_version_id')
+                    .notNullable()
+                    .references('saved_queries_version_id')
+                    .inTable('saved_queries_versions')
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    knex.schema.dropTableIfExists(TABLE_CALCULATIONS_TABLE_NAME);
+}

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -46,6 +46,8 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             limit,
             filters,
             columnOrder,
+            tableCalculations,
+            selectedTableCalculations,
         },
         actions: { setRowLimit: setResultsRowLimit },
     } = useExplorer();
@@ -75,7 +77,9 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                   sorts,
                   filters,
                   limit,
-                  tableCalculations: [],
+                  tableCalculations: tableCalculations.filter((t) =>
+                      selectedTableCalculations.includes(t.name),
+                  ),
               },
               chartConfig: {
                   chartType: activeVizTab,

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -32,8 +32,9 @@ const SavedExplorer = () => {
                 sorts: data.metricQuery.sorts,
                 limit: data.metricQuery.limit,
                 columnOrder: data.tableConfig.columnOrder,
-                selectedTableCalculations: [],
-                tableCalculations: [],
+                selectedTableCalculations:
+                    data.metricQuery.tableCalculations.map((t) => t.name),
+                tableCalculations: data.metricQuery.tableCalculations,
             });
         }
     }, [data, setState]);


### PR DESCRIPTION
Closes #377
Closes #266 

Table calculations are now saved with a saved chart

Note that this will only save “selected” table calculations, any table calculations you have in the explorer but don’t include in the chart, will not be saved.

@ZeRego this makes me wonder if we should have the table dimensions as selectable