### PR TITLE
Ordering is lost with table calculations

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -70,10 +70,10 @@ FROM \`db\`.\`schema\`.\`table1\` AS table1
 
 
 GROUP BY 1
-ORDER BY table1_metric1 DESC
-LIMIT 10
 )
 SELECT
   *,
   table1_dim1 + table1_metric1 AS \`calc3\`
-FROM metrics`;
+FROM metrics
+ORDER BY table1_metric1 DESC
+LIMIT 10`;

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -271,19 +271,16 @@ export const buildQuery = ({
 
     const sqlLimit = `LIMIT ${limit}`;
 
-    const metricQuerySql = [
-        sqlSelect,
-        sqlFrom,
-        sqlJoins,
-        sqlWhere,
-        sqlGroupBy,
-        sqlOrderBy,
-        sqlLimit,
-    ].join('\n');
-
     if (compiledMetricQuery.compiledTableCalculations.length > 0) {
+        const cteSql = [
+            sqlSelect,
+            sqlFrom,
+            sqlJoins,
+            sqlWhere,
+            sqlGroupBy,
+        ].join('\n');
         const cteName = 'metrics';
-        const cte = `WITH ${cteName} AS (\n${metricQuerySql}\n)`;
+        const cte = `WITH ${cteName} AS (\n${cteSql}\n)`;
         const tableCalculationSelects =
             compiledMetricQuery.compiledTableCalculations.map(
                 (tableCalculation) => {
@@ -295,7 +292,17 @@ export const buildQuery = ({
             ',\n  ',
         )}`;
         const finalFrom = `FROM ${cteName}`;
-        return [cte, finalSelect, finalFrom].join('\n');
+        return [cte, finalSelect, finalFrom, sqlOrderBy, sqlLimit].join('\n');
     }
+
+    const metricQuerySql = [
+        sqlSelect,
+        sqlFrom,
+        sqlJoins,
+        sqlWhere,
+        sqlGroupBy,
+        sqlOrderBy,
+        sqlLimit,
+    ].join('\n');
     return metricQuerySql;
 };


### PR DESCRIPTION
Closes #396

* Moves `LIMIT` clause out of CTE for table calculations
* Moves `ORDER BY ` clause out of CTE for table calculations