### PR TITLE
fix: pin docker image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs14 AS base
+FROM nikolaik/python-nodejs:python3.8-nodejs14@sha256:f7d84950cac6a56e99e99747aad93ad77f949475ac1a5e9782669b8f5bedd2b6 AS base
 
 WORKDIR /usr/app
 

--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs14 AS base
+FROM nikolaik/python-nodejs:python3.8-nodejs14@sha256:f7d84950cac6a56e99e99747aad93ad77f949475ac1a5e9782669b8f5bedd2b6 AS base
 
 WORKDIR /usr/app
 

--- a/packages/backend/src/database/migrations/20210831103040_add_table_calculations_table.ts
+++ b/packages/backend/src/database/migrations/20210831103040_add_table_calculations_table.ts
@@ -28,5 +28,5 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-    knex.schema.dropTableIfExists(TABLE_CALCULATIONS_TABLE_NAME);
+    await knex.schema.dropTableIfExists(TABLE_CALCULATIONS_TABLE_NAME);
 }


### PR DESCRIPTION
Seems like there is a bug in the python+nodejs docker image

https://github.com/nikolaik/docker-python-nodejs/issues/31

Until then we need to pin the docker image to the last version that worked. 
