### PR TITLE
use get-manifest method rather than compile in dbt rpc

### DIFF
--- a/packages/backend/src/dbt/dbtRpcClientBase.ts
+++ b/packages/backend/src/dbt/dbtRpcClientBase.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import fetch from 'node-fetch';
 import {
-    DbtRpcCompileResults,
     DbtRpcDocsGenerateResults,
-    isDbtRpcCompileResults,
+    DbtRpcGetManifestResults,
     isDbtRpcDocsGenerateResults,
+    isDbtRpcManifestResults,
     isDbtRpcRunSqlResults,
 } from 'common';
 import { DbtError, NetworkError, RetryableNetworkError } from '../errors';
@@ -285,11 +285,11 @@ export class DbtRpcClientBase {
         return true;
     }
 
-    public async getDbtManifest(): Promise<DbtRpcCompileResults> {
+    public async getDbtManifest(): Promise<DbtRpcGetManifestResults> {
         await this._waitForServerReady();
-        const requestToken = await this._submitJob('compile', {});
+        const requestToken = await this._submitJob('get-manifest', {});
         const jobResults = await this._waitForJobComplete(requestToken);
-        if (isDbtRpcCompileResults(jobResults)) {
+        if (isDbtRpcManifestResults(jobResults)) {
             return jobResults;
         }
         throw new NetworkError(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -714,6 +714,36 @@ export const isDbtRpcDocsGenerateResults = (
             'columns' in node,
     );
 
+export interface DbtManifest {
+    nodes: Record<string, DbtNode>;
+    metadata: DbtManifestMetadata;
+}
+
+export interface DbtManifestMetadata {
+    dbt_schema_version: string;
+    generated_at: string;
+    adapter_type: string;
+}
+const isDbtManifestMetadata = (x: any): x is DbtManifestMetadata =>
+    typeof x === 'object' &&
+    x !== null &&
+    'dbt_schema_version' in x &&
+    'generated_at' in x &&
+    'adapter_type' in x;
+
+export interface DbtRpcGetManifestResults {
+    manifest: DbtManifest;
+}
+export const isDbtRpcManifestResults = (
+    results: Record<string, any>,
+): results is DbtRpcGetManifestResults =>
+    'manifest' in results &&
+    typeof results.manifest === 'object' &&
+    results.manifest !== null &&
+    'nodes' in results.manifest &&
+    'metadata' in results.manifest &&
+    isDbtManifestMetadata(results.manifest.metadata);
+
 export interface DbtRpcCompileResults {
     results: { node: DbtNode }[];
 }


### PR DESCRIPTION
Thanks to @jtcohen6 on https://github.com/dbt-labs/dbt/issues/3702 we're actually able to get the entire `manifest.json` from the dbt rpc server.

