### PR TITLE
Add quotes to aliases in order by clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Recent and upcoming changes to lightdash
 
 ## Unreleased
 ### Fixed
+- Fixed a bug with missing quotes in order by clause (fixed errors with snowflake)
 - Fixed bug with wrong quote strings for dbt's athena adapter
 - Fixed bug where optional project configs set via env where not recognised
 - Add local state to track and update query parameters changes without affecting the current query data

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -76,5 +76,5 @@ SELECT
   *,
   table1_dim1 + table1_metric1 AS "calc3"
 FROM metrics
-ORDER BY table1_metric1 DESC
+ORDER BY "table1_metric1" DESC
 LIMIT 10`;

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -11,7 +11,6 @@ import {
     formatTimestamp,
     getDimensions,
     getMetrics,
-    MetricQuery,
     NumberFilter,
     StringFilter,
 } from 'common';
@@ -262,7 +261,7 @@ export const buildQuery = ({
             : '';
 
     const fieldOrders = sorts.map(
-        (sort) => `${sort.fieldId}${sort.descending ? ' DESC' : ''}`,
+        (sort) => `${q}${sort.fieldId}${q}${sort.descending ? ' DESC' : ''}`,
     );
     const sqlOrderBy =
         fieldOrders.length > 0 ? `ORDER BY ${fieldOrders.join(', ')}` : '';


### PR DESCRIPTION
Fixes error in snowfalke, which assumes all identifiers are uppercase if not quoted

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)