### PR TITLE
fix(#133): sync state on run query button click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Recent and upcoming changes to lightdash
 
 ### Fixed
 - Fixed request that shows the sql query
+- Fixed a bug where the chart wouldn't clear when leaving the explore page
 
 ## [0.7.1] - 2021-09-24
 ### Fixed

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,28 +1,24 @@
 import { Button } from '@blueprintjs/core';
 import React from 'react';
-import { UseQueryResult } from 'react-query';
-import { ApiError, ApiQueryResults } from 'common';
 import { useExplorer } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
 import { useQueryResults } from '../hooks/useQueryResults';
 
-type RefreshButtonProps = {
-    queryResults: UseQueryResult<ApiQueryResults, ApiError>;
-};
 export const RefreshButton = () => {
     const {
         state: { isValidQuery },
+        actions: { syncState },
     } = useExplorer();
-    const queryResults = useQueryResults(false);
-    const { refetch, isFetching } = queryResults;
+    const { isFetching, remove } = useQueryResults();
     const { track } = useTracking();
     return (
         <Button
             intent="primary"
             style={{ height: '40px', width: 150, marginRight: '10px' }}
-            onClick={() => {
-                refetch();
+            onClick={async () => {
+                remove();
+                syncState();
                 track({
                     name: EventName.RUN_QUERY_BUTTON_CLICKED,
                 });

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -16,10 +16,10 @@ export const getQueryResults = async (
         body: JSON.stringify(query),
     });
 
-export const useQueryResults = (pristine = true) => {
+export const useQueryResults = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const {
-        [pristine ? 'pristineState' : 'state']: {
+        pristineState: {
             tableName: tableId,
             dimensions,
             metrics,
@@ -29,7 +29,6 @@ export const useQueryResults = (pristine = true) => {
             tableCalculations,
             selectedTableCalculations,
         },
-        actions: { syncState },
     } = useExplorer();
     const {
         errorLogs: { showError },
@@ -48,13 +47,9 @@ export const useQueryResults = (pristine = true) => {
     return useQuery<ApiQueryResults, ApiError>({
         queryKey,
         queryFn: () => getQueryResults(projectUuid, tableId || '', metricQuery),
-        enabled: false, // don't run automatically
-        keepPreviousData: true, // changing the query won't update results until fetch
+        enabled: !!tableId,
         retry: false,
-        onSettled: (data) => {
-            // Update the pristine state once the query request is completed.
-            syncState();
-        },
+        refetchOnMount: false,
         onError: (error) => {
             const [first, ...rest] = error.error.message.split('\n');
             showError({ title: first, body: rest.join('\n') });

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -10,30 +10,17 @@ import { useQueryResults } from '../hooks/useQueryResults';
 
 const SavedExplorer = () => {
     const history = useHistory();
-    const location = useLocation<{ fromExplorer?: boolean } | undefined>();
     const pathParams = useParams<{ savedQueryUuid: string }>();
     const {
-        state: { tableName },
         actions: { setState, reset },
     } = useExplorer();
     const { data } = useSavedQuery({ id: pathParams.savedQueryUuid });
-    const queryResults = useQueryResults();
     const onBack = () => {
         reset();
         history.push({
             pathname: `/saved`,
         });
     };
-    useEffect(() => {
-        if (
-            queryResults.isIdle &&
-            pathParams.savedQueryUuid &&
-            tableName &&
-            !location.state?.fromExplorer
-        ) {
-            queryResults.refetch();
-        }
-    }, [pathParams.savedQueryUuid, queryResults, tableName, location]);
 
     useEffect(() => {
         if (data) {


### PR DESCRIPTION
Closes: #133 

Now that we have a pristine state we can use useQuery without workarounds. 

The 'run query' button syncs the pristine state and the useQueryResults hook handles the rest.
