### PR TITLE
redirect to login page if unauthorized 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Recent and upcoming changes to lightdash
 ## Unreleased
 ### Fixed
 - Fixed a bug where creating projects in the UI would fail for local/github/gitlab projects
+- We now redirect the user to the login page after cookie expires
 
 ## [0.8.0] - 2021-09-27
 ### Added

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -33,6 +33,13 @@ const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             refetchOnWindowFocus: false,
+            onError: async (result) => {
+                // @ts-ignore
+                const { error: { statusCode } = {} } = result;
+                if (statusCode === 401) {
+                    await queryClient.invalidateQueries('health');
+                }
+            },
         },
     },
 });

--- a/packages/frontend/src/components/ExploreSideBar.tsx
+++ b/packages/frontend/src/components/ExploreSideBar.tsx
@@ -217,14 +217,10 @@ export const ExplorePanel = ({ onBack }: ExplorePanelProps) => {
             </>
         );
     }
-    /* if (exploresResult.status === 'error') {
-        console.log('exploresResult sidebar')
+    if (exploresResult.status === 'error') {
         onBack();
-        const [title, ...lines] =
-            exploresResult.error.error.message.split('\n');
-        showError({ title, body: lines.join('\n') });
         return null;
-    } */
+    }
     if (exploresResult.status === 'loading') {
         return <SideBarLoadingState />;
     }

--- a/packages/frontend/src/components/ExploreSideBar.tsx
+++ b/packages/frontend/src/components/ExploreSideBar.tsx
@@ -217,13 +217,14 @@ export const ExplorePanel = ({ onBack }: ExplorePanelProps) => {
             </>
         );
     }
-    if (exploresResult.status === 'error') {
+    /* if (exploresResult.status === 'error') {
+        console.log('exploresResult sidebar')
         onBack();
         const [title, ...lines] =
             exploresResult.error.error.message.split('\n');
         showError({ title, body: lines.join('\n') });
         return null;
-    }
+    } */
     if (exploresResult.status === 'loading') {
         return <SideBarLoadingState />;
     }

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -30,7 +30,7 @@ export const useCompliedSql = () => {
             tableCalculations,
         },
     } = useExplorer();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     const metricQuery: MetricQuery = {
         dimensions: Array.from(dimensions),
         metrics: Array.from(metrics),
@@ -47,6 +47,6 @@ export const useCompliedSql = () => {
         queryKey,
         queryFn: () =>
             getCompiledQuery(projectUuid, tableId || '', metricQuery),
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useExplorer } from '../providers/ExplorerProvider';
+import useQueryError from './useQueryError';
 
 const getCompiledQuery = async (
     projectUuid: string,
@@ -29,6 +30,7 @@ export const useCompliedSql = () => {
             tableCalculations,
         },
     } = useExplorer();
+    const [, setErrorResponse] = useQueryError();
     const metricQuery: MetricQuery = {
         dimensions: Array.from(dimensions),
         metrics: Array.from(metrics),
@@ -45,5 +47,6 @@ export const useCompliedSql = () => {
         queryKey,
         queryFn: () =>
             getCompiledQuery(projectUuid, tableId || '', metricQuery),
+        onError: (result) => setErrorResponse(result.error),
     });
 };

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -16,7 +16,7 @@ const getExplore = async (projectUuid: string, exploreId: string) =>
 
 export const useExplore = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     const {
         state: { tableName: activeTableName },
     } = useExplorer();
@@ -25,7 +25,7 @@ export const useExplore = () => {
         queryKey,
         queryFn: () => getExplore(projectUuid, activeTableName || ''),
         enabled: activeTableName !== undefined,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
         retry: false,
     });
 };

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -18,9 +18,6 @@ export const useExplore = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [, setErrorResponse] = useQueryError();
     const {
-        errorLogs: { showError },
-    } = useApp();
-    const {
         state: { tableName: activeTableName },
     } = useExplorer();
     const queryKey = ['tables', activeTableName];

--- a/packages/frontend/src/hooks/useExplores.tsx
+++ b/packages/frontend/src/hooks/useExplores.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
+import useQueryError from './useQueryError';
 
 const getExplores = async (projectUuid: string) =>
     lightdashApi<ApiExploresResults>({
@@ -14,22 +15,15 @@ const getExplores = async (projectUuid: string) =>
 
 export const useExplores = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [, setErrorResponse] = useQueryError();
     const {
         errorLogs: { showError },
     } = useApp();
     const queryKey = 'tables';
-    const query = useQuery<ApiExploresResults, ApiError>({
+    return useQuery<ApiExploresResults, ApiError>({
         queryKey,
         queryFn: () => getExplores(projectUuid),
+        onError: (result) => setErrorResponse(result.error),
         retry: false,
     });
-
-    useEffect(() => {
-        if (query.error) {
-            const [first, ...rest] = query.error.error.message.split('\n');
-            showError({ title: first, body: rest.join('\n') });
-        }
-    }, [query.error, showError]);
-
-    return query;
 };

--- a/packages/frontend/src/hooks/useExplores.tsx
+++ b/packages/frontend/src/hooks/useExplores.tsx
@@ -15,7 +15,7 @@ const getExplores = async (projectUuid: string) =>
 
 export const useExplores = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     const {
         errorLogs: { showError },
     } = useApp();
@@ -23,7 +23,7 @@ export const useExplores = () => {
     return useQuery<ApiExploresResults, ApiError>({
         queryKey,
         queryFn: () => getExplores(projectUuid),
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
         retry: false,
     });
 };

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -19,11 +19,11 @@ const deleteUserQuery = async (id: string) =>
     });
 
 export const useOrganizationUsers = () => {
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     return useQuery<OrganizationUser[], ApiError>({
         queryKey: ['organization_users'],
         queryFn: getOrganizationUsersQuery,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };
 

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -2,6 +2,7 @@ import { ApiError, OrganizationUser } from 'common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
+import useQueryError from './useQueryError';
 
 const getOrganizationUsersQuery = async () =>
     lightdashApi<OrganizationUser[]>({
@@ -17,11 +18,14 @@ const deleteUserQuery = async (id: string) =>
         body: undefined,
     });
 
-export const useOrganizationUsers = () =>
-    useQuery<OrganizationUser[], ApiError>({
+export const useOrganizationUsers = () => {
+    const [, setErrorResponse] = useQueryError();
+    return useQuery<OrganizationUser[], ApiError>({
         queryKey: ['organization_users'],
         queryFn: getOrganizationUsersQuery,
+        onError: (result) => setErrorResponse(result.error),
     });
+};
 
 export const useDeleteUserMutation = () => {
     const queryClient = useQueryClient();

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -2,6 +2,7 @@ import { ApiError, CreateProject, Project, UpdateProject } from 'common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
+import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
     lightdashApi<Project>({
@@ -24,13 +25,16 @@ const getProject = async (id: string) =>
         body: undefined,
     });
 
-export const useProject = (id: string) =>
-    useQuery<Project, ApiError>({
+export const useProject = (id: string) => {
+    const [, setErrorResponse] = useQueryError();
+    return useQuery<Project, ApiError>({
         queryKey: ['project', id],
         queryFn: () => getProject(id || ''),
         enabled: id !== undefined,
         retry: false,
+        onError: (result) => setErrorResponse(result.error),
     });
+};
 
 export const useUpdateMutation = (id: string) => {
     const queryClient = useQueryClient();

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -26,13 +26,13 @@ const getProject = async (id: string) =>
     });
 
 export const useProject = (id: string) => {
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     return useQuery<Project, ApiError>({
         queryKey: ['project', id],
         queryFn: () => getProject(id || ''),
         enabled: id !== undefined,
         retry: false,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };
 

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -11,10 +11,10 @@ const getProjectsQuery = async () =>
     });
 
 export const useProjects = () => {
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     return useQuery<OrganizationProject[], ApiError>({
         queryKey: ['projects'],
         queryFn: getProjectsQuery,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -1,6 +1,7 @@
 import { ApiError, OrganizationProject } from 'common';
 import { useQuery } from 'react-query';
 import { lightdashApi } from '../api';
+import useQueryError from './useQueryError';
 
 const getProjectsQuery = async () =>
     lightdashApi<OrganizationProject[]>({
@@ -9,8 +10,11 @@ const getProjectsQuery = async () =>
         body: undefined,
     });
 
-export const useProjects = () =>
-    useQuery<OrganizationProject[], ApiError>({
+export const useProjects = () => {
+    const [, setErrorResponse] = useQueryError();
+    return useQuery<OrganizationProject[], ApiError>({
         queryKey: ['projects'],
         queryFn: getProjectsQuery,
+        onError: (result) => setErrorResponse(result.error),
     });
+};

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useQueryClient } from 'react-query';
+import { useApp } from '../providers/AppProvider';
+
+const useQueryError = () => {
+    const queryClient = useQueryClient();
+    const [errorResponse, setErrorResponse] = useState<any>(null);
+    const {
+        errorLogs: { showError },
+    } = useApp();
+    useEffect(() => {
+        (async function doIfError() {
+            if (errorResponse) {
+                // @ts-ignore
+                const { statusCode } = errorResponse;
+                if (statusCode === 401) {
+                    await queryClient.invalidateQueries('health');
+                } else {
+                    const { message } = errorResponse;
+                    const [first, ...rest] = message.split('\n');
+                    showError({ title: first, body: rest.join('\n') });
+                }
+            }
+        })();
+    }, [errorResponse]);
+    return [errorResponse, setErrorResponse];
+};
+
+export default useQueryError;

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useApp } from '../providers/AppProvider';
 
-const useQueryError = () => {
+type UseQueryError = {
+    showToastError: () => void;
+};
+
+const useQueryError = (props?: UseQueryError) => {
+    const { showToastError } = props || {};
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<any>(null);
     const {
@@ -15,7 +20,10 @@ const useQueryError = () => {
                 const { statusCode } = errorResponse;
                 if (statusCode === 401) {
                     await queryClient.invalidateQueries('health');
+                } else if (showToastError) {
+                    showToastError();
                 } else {
+                    // drawer
                     const { message } = errorResponse;
                     const [first, ...rest] = message.split('\n');
                     showError({ title: first, body: rest.join('\n') });

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -2,12 +2,7 @@ import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useApp } from '../providers/AppProvider';
 
-type UseQueryError = {
-    showToastError: () => void;
-};
-
-const useQueryError = (props?: UseQueryError) => {
-    const { showToastError } = props || {};
+const useQueryError = () => {
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<any>(null);
     const {
@@ -20,8 +15,6 @@ const useQueryError = (props?: UseQueryError) => {
                 const { statusCode } = errorResponse;
                 if (statusCode === 401) {
                     await queryClient.invalidateQueries('health');
-                } else if (showToastError) {
-                    showToastError();
                 } else {
                     // drawer
                     const { message } = errorResponse;

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useExplorer } from '../providers/ExplorerProvider';
 import { useApp } from '../providers/AppProvider';
+import useQueryError from './useQueryError';
 
 export const getQueryResults = async (
     projectUuid: string,
@@ -18,6 +19,7 @@ export const getQueryResults = async (
 
 export const useQueryResults = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [, setErrorResponse] = useQueryError();
     const {
         pristineState: {
             tableName: tableId,
@@ -50,9 +52,6 @@ export const useQueryResults = () => {
         enabled: !!tableId,
         retry: false,
         refetchOnMount: false,
-        onError: (error) => {
-            const [first, ...rest] = error.error.message.split('\n');
-            showError({ title: first, body: rest.join('\n') });
-        },
+        onError: (result) => setErrorResponse(result.error),
     });
 };

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -19,7 +19,7 @@ export const getQueryResults = async (
 
 export const useQueryResults = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     const {
         pristineState: {
             tableName: tableId,
@@ -52,6 +52,6 @@ export const useQueryResults = () => {
         enabled: !!tableId,
         retry: false,
         refetchOnMount: false,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };

--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -20,7 +20,7 @@ export const useRefreshServer = () => {
         errorLogs: { showError },
     } = useApp();
     const queryClient = useQueryClient();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     return useMutation<void, ApiError>({
         mutationKey: 'refresh',
         mutationFn: () => refresh(projectUuid),
@@ -30,6 +30,6 @@ export const useRefreshServer = () => {
             queryClient.invalidateQueries('tables');
             queryClient.setQueryData('status', 'loading');
         },
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
     });
 };

--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
+import useQueryError from './useQueryError';
 
 const refresh = async (projectUuid: string) => {
     await lightdashApi<ApiRefreshResults>({
@@ -19,7 +20,8 @@ export const useRefreshServer = () => {
         errorLogs: { showError },
     } = useApp();
     const queryClient = useQueryClient();
-    const refreshMutation = useMutation<void, ApiError>({
+    const [, setErrorResponse] = useQueryError();
+    return useMutation<void, ApiError>({
         mutationKey: 'refresh',
         mutationFn: () => refresh(projectUuid),
         onSettled: () => {
@@ -28,15 +30,6 @@ export const useRefreshServer = () => {
             queryClient.invalidateQueries('tables');
             queryClient.setQueryData('status', 'loading');
         },
+        onError: (result) => setErrorResponse(result.error),
     });
-
-    useEffect(() => {
-        if (refreshMutation.error) {
-            const [first, ...rest] =
-                refreshMutation.error.error.message.split('\n');
-            showError({ title: first, body: rest.join('\n') });
-        }
-    }, [refreshMutation.error, showError]);
-
-    return refreshMutation;
 };

--- a/packages/frontend/src/hooks/useServerStatus.tsx
+++ b/packages/frontend/src/hooks/useServerStatus.tsx
@@ -14,7 +14,7 @@ const getStatus = async (projectUuid: string) =>
 
 export const useServerStatus = (refetchInterval = 5000) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const [, setErrorResponse] = useQueryError();
+    const setErrorResponse = useQueryError();
     const queryKey = 'status';
     const {
         errorLogs: { showError },
@@ -23,7 +23,7 @@ export const useServerStatus = (refetchInterval = 5000) => {
         queryKey,
         queryFn: () => getStatus(projectUuid),
         refetchInterval,
-        onError: (result) => setErrorResponse(result.error),
+        onError: (result) => setErrorResponse(result),
         refetchIntervalInBackground: false,
     });
 };


### PR DESCRIPTION
## Context (Bugs #470  #482)
When query response returns 401, the user must be redirected to login page

## Tasks done
I've seen some redundant code in the hooks that fetch data and deal with issues.
So I created a common hook that deal with 401 and other errors:

```
const useQueryError = () => {
    const queryClient = useQueryClient();
    const [errorResponse, setErrorResponse] = useState<any>(null);
    const {
        errorLogs: { showError },
    } = useApp();
    useEffect(() => {
        (async function doIfError() {
            if (errorResponse) {
                // @ts-ignore
                const { statusCode } = errorResponse;
                if (statusCode === 401) {
                    await queryClient.invalidateQueries('health');
                } else {
                    const { message } = errorResponse;
                    const [first, ...rest] = message.split('\n');
                    showError({ title: first, body: rest.join('\n') });
                }
            }
        })();
    }, [errorResponse]);
    return [errorResponse, setErrorResponse];
};
```

Then for each `useQuery` I import the previous hook and set the response in the `onError` callback as shown below

```
 const [, setErrorResponse] = useQueryError();

 return useQuery<ApiStatusResults, ApiError>({
       ...,
        onError: (result) => setErrorResponse(result.error),
    });
```

There was also an issue with the popup showing up for a split second before the redirection actually occurs.
That was because of a piece of code in `ExploreSideBar.tsx` that i've commented out

```
if (exploresResult.status === 'error') {
        console.log('exploresResult sidebar')
        onBack();
        const [title, ...lines] =
            exploresResult.error.error.message.split('\n');
        showError({ title, body: lines.join('\n') });
        return null;
    }
```

The above code is no longer needed as the redirection is done by the new hook `useQueryError`

