### PR TITLE
missing keys in results table

### DIFF
--- a/packages/frontend/src/components/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable.tsx
@@ -260,7 +260,7 @@ export const ResultsTable = () => {
                             style={{ flex: 1 }}
                         >
                             {headerGroups.map((headerGroup) => (
-                                <colgroup key={headerGroup.id}>
+                                <colgroup key={`headerGroup_${headerGroup.id}`}>
                                     {headerGroup.headers.map((column) => (
                                         <col
                                             {...column.getHeaderProps([
@@ -273,6 +273,7 @@ export const ResultsTable = () => {
                             <thead>
                                 {headerGroups.map((headerGroup) => (
                                     <DragDropContext
+                                        key={`DragDropContext_${headerGroup.id}`}
                                         onDragStart={() => {
                                             currentColOrder.current =
                                                 allColumns.map(


### PR DESCRIPTION
Not a life threatening issue, but getting a lot stuff in the console because of those missing keys in `ResultsTable`

```
index.js:1 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ResultsTable`. See https://reactjs.org/link/warning-keys for more information.
    at DragDropContext (http://localhost:3000/static/js/vendors~main.chunk.js:250755:19)
    at ResultsTable (http://localhost:3000/static/js/main.chunk.js:10501:91)
    at div
    at div
```