### PR TITLE
fix: pre compile project before running e2e tests

### DIFF
--- a/packages/e2e/cypress/integration/explore.spec.ts
+++ b/packages/e2e/cypress/integration/explore.spec.ts
@@ -2,6 +2,8 @@ describe('Explore', () => {
     before(() => {
         // @ts-ignore
         cy.login();
+        // @ts-ignore
+        cy.preCompileProject();
     });
 
     beforeEach(() => {

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -29,6 +29,7 @@ import { USER_SEED } from 'common';
 declare namespace Cypress {
     interface Chainable<AUTWindow> {
         login(): Chainable<AUTWindow>;
+        preCompileProject(): Chainable<AUTWindow>;
     }
 }
 
@@ -40,5 +41,28 @@ Cypress.Commands.add('login', () => {
             email: USER_SEED.email,
             password: USER_SEED.password,
         },
+    });
+});
+Cypress.Commands.add('preCompileProject', () => {
+    cy.request({
+        url: 'api/v1/login',
+        method: 'POST',
+        body: {
+            email: USER_SEED.email,
+            password: USER_SEED.password,
+        },
+    });
+    cy.request({
+        url: 'api/v1/org/projects',
+        method: 'GET',
+    }).then(({ body }) => {
+        const project = body.results[0];
+        cy.log(
+            `Pre-compiling project ${project.name} (${project.projectUuid})`,
+        );
+        cy.request({
+            url: `api/v1/projects/${project.projectUuid}/explores`,
+            method: 'GET',
+        });
     });
 });


### PR DESCRIPTION
Make sure we pre compile the project before running the tests to avoid timeouts in the test.