### PR TITLE
Fix adapter for local credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Recent and upcoming changes to lightdash
 
 ## Unreleased
+### Fixed
+- Fixed a bug where creating projects in the UI would fail for local/github/gitlab projects
 
 ## [0.8.0] - 2021-09-27
 ### Added

--- a/packages/backend/src/config/parseConfig.mock.ts
+++ b/packages/backend/src/config/parseConfig.mock.ts
@@ -23,22 +23,6 @@ export const LOCAL_PROJECT = {
     name: 'project',
     profiles_dir: 'hello',
     project_dir: 'yo',
-    rpc_server_port: 8580,
-};
-
-export const LOCAL_PROJECT_NO_PORT = {
-    ...LOCAL_PROJECT,
-    rpc_server_port: undefined,
-};
-
-export const LOCAL_PROJECT_PORT_AS_STRING = {
-    ...LOCAL_PROJECT,
-    rpc_server_port: '8580',
-};
-
-export const LOCAL_PROJECT_NON_INT_PORT = {
-    ...LOCAL_PROJECT,
-    rpc_server_port: 1.1,
 };
 
 export const LOCAL_PROJECT_UNDEFINED_PROJECT_DIR = {
@@ -50,7 +34,6 @@ export const LOCAL_PROJECT_MISSING_PROFILES_DIR = {
     type: 'dbt',
     name: 'project',
     project_dir: 'hello',
-    rpc_server_port: 8580,
 };
 
 export const REMOTE_PROJECT = {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -68,10 +68,11 @@ test('Should throw ParseError for invalid port', () => {
     ).toThrowError(ParseError);
 });
 
-test('Should throw ParseError for missing profiles dir', () => {
-    expect(() =>
-        parseConfig(wrapProject(LOCAL_PROJECT_MISSING_PROFILES_DIR)),
-    ).toThrowError(ParseError);
+test('Should parse local project with missing profiles dir', () => {
+    const expected = wrapProject(LOCAL_PROJECT_MISSING_PROFILES_DIR);
+    expect(
+        parseConfig(wrapProject(LOCAL_PROJECT_MISSING_PROFILES_DIR)).projects,
+    ).toEqual(expected.projects);
 });
 
 test('Should throw ParseError for undefined project dir', () => {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -3,9 +3,6 @@ import {
     LOCAL_PROJECT,
     LOCAL_PROJECT_MISSING_PROFILES_DIR,
     LOCAL_PROJECT_UNDEFINED_PROJECT_DIR,
-    LOCAL_PROJECT_NO_PORT,
-    LOCAL_PROJECT_NON_INT_PORT,
-    LOCAL_PROJECT_PORT_AS_STRING,
     NO_PROJECTS,
     REMOTE_PROJECT,
     REMOTE_PROJECT_INVALID_HOST,
@@ -47,25 +44,6 @@ test('Should throw ParseError for unrecognised project', () => {
 test('Should parse valid local project config', () => {
     const expected = wrapProject(LOCAL_PROJECT);
     expect(parseConfig(expected).projects).toEqual(expected.projects);
-});
-
-test('Should parse local project without port', () => {
-    const expected = wrapProject(LOCAL_PROJECT);
-    expect(parseConfig(wrapProject(LOCAL_PROJECT_NO_PORT)).projects).toEqual(
-        expected.projects,
-    );
-});
-
-test('Should throw ParseError for local project with string port', () => {
-    expect(() =>
-        parseConfig(wrapProject(LOCAL_PROJECT_PORT_AS_STRING)),
-    ).toThrowError(ParseError);
-});
-
-test('Should throw ParseError for invalid port', () => {
-    expect(() =>
-        parseConfig(wrapProject(LOCAL_PROJECT_NON_INT_PORT)),
-    ).toThrowError(ParseError);
 });
 
 test('Should parse local project with missing profiles dir', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -47,7 +47,6 @@ const dbtLocalProjectConfigKeys: ConfigKeys<DbtLocalProjectConfig> = {
     name: true,
     profiles_dir: false,
     project_dir: true,
-    rpc_server_port: true,
     target: false,
 };
 const dbtRemoteProjectConfigKeys: ConfigKeys<DbtRemoteProjectConfig> = {
@@ -71,9 +70,6 @@ const dbtGithubProjectConfigKeys: ConfigKeys<DbtGithubProjectConfig> = {
     repository: true,
     branch: true,
     project_sub_path: true,
-    profiles_sub_path: true,
-    rpc_server_port: true,
-    target: false,
 };
 const dbtGitlabProjectConfigKeys: ConfigKeys<DbtGitlabProjectConfig> = {
     type: true,
@@ -82,9 +78,6 @@ const dbtGitlabProjectConfigKeys: ConfigKeys<DbtGitlabProjectConfig> = {
     repository: true,
     branch: true,
     project_sub_path: true,
-    profiles_sub_path: true,
-    rpc_server_port: true,
-    target: false,
 };
 
 const mergeProjectWithEnvironment = <T extends DbtProjectConfig>(

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -45,7 +45,7 @@ type ConfigKeys<T extends DbtProjectConfig> = {
 const dbtLocalProjectConfigKeys: ConfigKeys<DbtLocalProjectConfig> = {
     type: true,
     name: true,
-    profiles_dir: true,
+    profiles_dir: false,
     project_dir: true,
     rpc_server_port: true,
     target: false,

--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -2,6 +2,7 @@ import { CreateWarehouseCredentials } from 'common';
 import * as yaml from 'js-yaml';
 
 export const LIGHTDASH_PROFILE_NAME = 'lightdash_profile';
+export const LIGHTDASH_TARGET_NAME = 'lightdash_target';
 
 const envVar = (v: string) => `LIGHTDASH_DBT_PROFILE_VAR_${v.toUpperCase()}`;
 const envVarReference = (v: string) => `{{ env_var('${envVar(v)}') }}`;
@@ -103,9 +104,9 @@ const credentialsTarget = (
 };
 export const profileFromCredentials = (
     credentials: CreateWarehouseCredentials,
-    customTargetName: string | undefined,
+    customTargetName: string | undefined = undefined,
 ) => {
-    const targetName = customTargetName || 'lightdash_target';
+    const targetName = customTargetName || LIGHTDASH_TARGET_NAME;
     const { target, environment } = credentialsTarget(credentials);
     const profile = yaml.dump({
         config: {

--- a/packages/backend/src/jsonSchemas/lightdashConfig/v1.json
+++ b/packages/backend/src/jsonSchemas/lightdashConfig/v1.json
@@ -54,21 +54,6 @@
                                 "description": "Path inside repository containing dbt_project.yml file.",
                                 "type": "string",
                                 "default": "/"
-                            },
-                            "profiles_sub_path": {
-                                "description": "Path inside repository containing profiles.yml file.",
-                                "type": "string",
-                                "default": "/"
-                            },
-                            "rpc_server_port": {
-                                "description": "Port for the internal dbt server running on localhost",
-                                "type": "integer",
-                                "minimum": 1,
-                                "default": 8580
-                            },
-                            "target": {
-                                "description": "dbt profile target name",
-                                "type": "string"
                             }
                         }
                     },
@@ -100,21 +85,6 @@
                                 "description": "Path inside repository containing dbt_project.yml file.",
                                 "type": "string",
                                 "default": "/"
-                            },
-                            "profiles_sub_path": {
-                                "description": "Path inside repository containing profiles.yml file.",
-                                "type": "string",
-                                "default": "/"
-                            },
-                            "rpc_server_port": {
-                                "description": "Port for the internal dbt server running on localhost",
-                                "type": "integer",
-                                "minimum": 1,
-                                "default": 8580
-                            },
-                            "target": {
-                                "description": "dbt profile target name",
-                                "type": "string"
                             }
                         }
                     },
@@ -136,12 +106,6 @@
                             "profiles_dir": {
                                 "description": "File path to your dbt profiles directory containing a profiles.yml file",
                                 "type": "string"
-                            },
-                            "rpc_server_port": {
-                                "description": "Port for the internal dbt server running on localhost",
-                                "type": "integer",
-                                "minimum": 1,
-                                "default": 8580
                             },
                             "target": {
                                 "description": "dbt profile target name",

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -15,12 +15,17 @@ import { ProjectAdapter } from '../types';
 const ajv = new Ajv();
 addFormats(ajv);
 
-export abstract class DbtBaseProjectAdapter implements ProjectAdapter {
-    abstract rpcClient: DbtRpcClientBase;
+export class DbtBaseProjectAdapter implements ProjectAdapter {
+    rpcClient: DbtRpcClientBase;
 
     catalog: DbtRpcDocsGenerateResults | undefined;
 
+    constructor(rpcClient: DbtRpcClientBase) {
+        this.rpcClient = rpcClient;
+    }
+
     public async test(): Promise<void> {
+        await this.rpcClient.installDeps();
         await this.runQuery("SELECT 'test connection'");
     }
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -24,6 +24,9 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         this.rpcClient = rpcClient;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-empty-function,class-methods-use-this
+    async destroy(): Promise<void> {}
+
     public async test(): Promise<void> {
         await this.rpcClient.installDeps();
         await this.runQuery("SELECT 'test connection'");

--- a/packages/backend/src/projectAdapters/dbtCloudIdeProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtCloudIdeProjectAdapter.ts
@@ -2,22 +2,27 @@ import { Explore, ExploreError } from 'common';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtCloudV2RpcClient } from '../dbt/dbtCloudV2RpcClient';
 
-export class DbtCloudIdeProjectAdapter extends DbtBaseProjectAdapter {
-    rpcClient: DbtCloudV2RpcClient;
+type DbtCloudideProjectAdapterArgs = {
+    accountId: string | number;
+    environmentId: string | number;
+    projectId: string | number;
+    apiKey: string;
+};
 
-    constructor(
-        accountId: string | number,
-        environmentId: string | number,
-        projectId: string | number,
-        apiKey: string,
-    ) {
-        super();
-        this.rpcClient = new DbtCloudV2RpcClient(
+export class DbtCloudIdeProjectAdapter extends DbtBaseProjectAdapter {
+    constructor({
+        accountId,
+        environmentId,
+        projectId,
+        apiKey,
+    }: DbtCloudideProjectAdapterArgs) {
+        const rpcClient = new DbtCloudV2RpcClient(
             accountId,
             environmentId,
             projectId,
             apiKey,
         );
+        super(rpcClient);
     }
 
     public async compileAllExplores(): Promise<(Explore | ExploreError)[]> {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -45,6 +45,11 @@ export class DbtGitProjectAdapter extends DbtLocalCredentialsProjectAdapter {
         this.branch = gitBranch;
     }
 
+    async destroy(): Promise<void> {
+        await this._cleanLocal();
+        await super.destroy();
+    }
+
     private async _cleanLocal() {
         try {
             const contents = await fspromises.readdir(this.localRepositoryDir);

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -52,15 +52,10 @@ export class DbtGitProjectAdapter extends DbtLocalCredentialsProjectAdapter {
 
     private async _cleanLocal() {
         try {
-            const contents = await fspromises.readdir(this.localRepositoryDir);
-            await Promise.all(
-                contents.map(async (filename) => {
-                    await fspromises.rm(
-                        path.join(this.localRepositoryDir, filename),
-                        { recursive: true, force: true },
-                    );
-                }),
-            );
+            await fspromises.rm(this.localRepositoryDir, {
+                recursive: true,
+                force: true,
+            });
         } catch (e) {
             throw new UnexpectedServerError(
                 `Unexpected error while processing git repository: ${e}`,

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -1,23 +1,31 @@
+import { CreateWarehouseCredentials } from 'common';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
+type DbtGithubProjectAdapterArgs = {
+    githubPersonalAccessToken: string;
+    githubRepository: string;
+    githubBranch: string;
+    projectDirectorySubPath: string;
+    port: number;
+    warehouseCredentials: CreateWarehouseCredentials;
+};
+
 export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
-    constructor(
-        githubPersonalAccessToken: string,
-        githubRepository: string,
-        githubBranch: string,
-        projectDirectorySubPath: string,
-        profilesDirectorySubPath: string,
-        port: number,
-        target: string | undefined,
-    ) {
+    constructor({
+        githubBranch,
+        githubPersonalAccessToken,
+        githubRepository,
+        projectDirectorySubPath,
+        port,
+        warehouseCredentials,
+    }: DbtGithubProjectAdapterArgs) {
         const remoteRepositoryUrl = `https://${githubPersonalAccessToken}@github.com/${githubRepository}.git`;
-        super(
+        super({
             remoteRepositoryUrl,
-            githubBranch,
-            projectDirectorySubPath,
-            profilesDirectorySubPath,
             port,
-            target,
-        );
+            projectDirectorySubPath,
+            warehouseCredentials,
+            gitBranch: githubBranch,
+        });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -1,23 +1,31 @@
+import { CreateWarehouseCredentials } from 'common';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
+type DbtGitlabProjectAdapterArgs = {
+    gitlabPersonalAccessToken: string;
+    gitlabRepository: string;
+    gitlabBranch: string;
+    projectDirectorySubPath: string;
+    port: number;
+    warehouseCredentials: CreateWarehouseCredentials;
+};
+
 export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
-    constructor(
-        gitlabPersonalAccessToken: string,
-        gitlabRepository: string,
-        gitlabBranch: string,
-        projectDirectorySubPath: string,
-        profilesDirectorySubPath: string,
-        port: number,
-        target: string | undefined,
-    ) {
+    constructor({
+        gitlabBranch,
+        gitlabPersonalAccessToken,
+        gitlabRepository,
+        projectDirectorySubPath,
+        port,
+        warehouseCredentials,
+    }: DbtGitlabProjectAdapterArgs) {
         const remoteRepositoryUrl = `https://:${gitlabPersonalAccessToken}@gitlab.com/${gitlabRepository}.git`;
-        super(
+        super({
+            gitBranch: gitlabBranch,
             remoteRepositoryUrl,
-            gitlabBranch,
             projectDirectorySubPath,
-            profilesDirectorySubPath,
             port,
-            target,
-        );
+            warehouseCredentials,
+        });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -1,5 +1,6 @@
 import { CreateWarehouseCredentials } from 'common';
 import tempy from 'tempy';
+import * as fspromises from 'fs/promises';
 import * as path from 'path';
 import { writeFileSync } from 'fs';
 import {
@@ -16,6 +17,8 @@ type DbtLocalCredentialsProjectAdapterArgs = {
 };
 
 export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
+    profilesDir: string;
+
     constructor({
         projectDir,
         warehouseCredentials,
@@ -34,5 +37,11 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             port,
             environment,
         });
+        this.profilesDir = profilesDir;
+    }
+
+    async destroy() {
+        await fspromises.rm(this.profilesDir, { recursive: true, force: true });
+        await super.destroy();
     }
 }

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -1,0 +1,38 @@
+import { CreateWarehouseCredentials } from 'common';
+import tempy from 'tempy';
+import * as path from 'path';
+import { writeFileSync } from 'fs';
+import {
+    LIGHTDASH_PROFILE_NAME,
+    LIGHTDASH_TARGET_NAME,
+    profileFromCredentials,
+} from '../dbt/profiles';
+import { DbtLocalProjectAdapter } from './dbtLocalProjectAdapter';
+
+type DbtLocalCredentialsProjectAdapterArgs = {
+    projectDir: string;
+    warehouseCredentials: CreateWarehouseCredentials;
+    port: number;
+};
+
+export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
+    constructor({
+        projectDir,
+        warehouseCredentials,
+        port,
+    }: DbtLocalCredentialsProjectAdapterArgs) {
+        const profilesDir = tempy.directory();
+        const profilesFilename = path.join(profilesDir, 'profiles.yml');
+        const { profile, environment } =
+            profileFromCredentials(warehouseCredentials);
+        writeFileSync(profilesFilename, profile);
+        super({
+            target: LIGHTDASH_TARGET_NAME,
+            profileName: LIGHTDASH_PROFILE_NAME,
+            profilesDir,
+            projectDir,
+            port,
+            environment,
+        });
+    }
+}

--- a/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
@@ -37,6 +37,11 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
         this.dbtChildProcess = childProcess;
     }
 
+    async destroy(): Promise<void> {
+        await this.dbtChildProcess.kill();
+        await super.destroy();
+    }
+
     private _handleError(e: Error): Error {
         if (e instanceof NetworkError) {
             // extend error with latest dbt error messages

--- a/packages/backend/src/projectAdapters/dbtRemoteProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtRemoteProjectAdapter.ts
@@ -2,14 +2,22 @@ import { Explore, ExploreError } from 'common';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtRpcClient } from '../dbt/dbtRpcClient';
 
-export class DbtRemoteProjectAdapter extends DbtBaseProjectAdapter {
-    rpcClient: DbtRpcClient;
+type DbtRemoteProjectAdapterArgs = {
+    host: string;
+    port: number;
+    protocol?: string;
+};
 
-    constructor(host: string, port: number, protocol: string = 'http') {
-        super();
-        this.rpcClient = new DbtRpcClient(
+export class DbtRemoteProjectAdapter extends DbtBaseProjectAdapter {
+    constructor({
+        host,
+        port,
+        protocol = 'http',
+    }: DbtRemoteProjectAdapterArgs) {
+        const rpcClient = new DbtRpcClient(
             `${protocol}://${host}:${port}/jsonrpc`,
         );
+        super(rpcClient);
     }
 
     async compileAllExplores(): Promise<(Explore | ExploreError)[]> {

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -24,14 +24,14 @@ export const projectAdapterFromConfig = async (
                 return new DbtLocalCredentialsProjectAdapter({
                     projectDir: config.project_dir,
                     warehouseCredentials,
-                    port: await getPort({ port: config.rpc_server_port }),
+                    port: await getPort(),
                 });
             }
             if (config.profiles_dir !== undefined) {
                 return new DbtLocalProjectAdapter({
                     projectDir: config.project_dir,
                     profilesDir: config.profiles_dir,
-                    port: await getPort({ port: config.rpc_server_port }),
+                    port: await getPort(),
                     target: config.target,
                 });
             }
@@ -62,7 +62,7 @@ export const projectAdapterFromConfig = async (
                 githubBranch: config.branch,
                 projectDirectorySubPath: config.project_sub_path,
                 warehouseCredentials,
-                port: await getPort({ port: config.rpc_server_port }),
+                port: await getPort(),
             });
         case ProjectType.GITLAB:
             if (warehouseCredentials === undefined) {
@@ -76,7 +76,7 @@ export const projectAdapterFromConfig = async (
                 gitlabBranch: config.branch,
                 projectDirectorySubPath: config.project_sub_path,
                 warehouseCredentials,
-                port: await getPort({ port: config.rpc_server_port }),
+                port: await getPort(),
             });
         default:
             const never: never = config;

--- a/packages/backend/src/services/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService.ts
@@ -115,18 +115,14 @@ export class ProjectService {
         try {
             await adapter.test();
         } finally {
-            if (adapter instanceof DbtLocalProjectAdapter) {
-                await adapter.dbtChildProcess.kill();
-            }
+            await adapter.destroy();
         }
     }
 
     private async restartAdapter(projectUuid: string): Promise<ProjectAdapter> {
         const runningAdapter = this.projectAdapters[projectUuid];
         if (runningAdapter !== undefined) {
-            if (runningAdapter instanceof DbtLocalProjectAdapter) {
-                await runningAdapter.dbtChildProcess.kill();
-            }
+            await runningAdapter.destroy();
         }
         const project = await this.projectModel.getWithSensitiveFields(
             projectUuid,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -4,4 +4,5 @@ export interface ProjectAdapter {
     compileAllExplores(): Promise<(Explore | ExploreError)[]>;
     runQuery(sql: string): Promise<Record<string, any>[]>;
     test(): Promise<void>;
+    destroy(): Promise<void>;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1005,7 +1005,7 @@ export interface DbtProjectConfigBase {
 
 export interface DbtLocalProjectConfig extends DbtProjectConfigBase {
     type: ProjectType.DBT;
-    profiles_dir: string;
+    profiles_dir?: string;
     project_dir: string;
     rpc_server_port: number;
     target?: string;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1007,13 +1007,11 @@ export interface DbtLocalProjectConfig extends DbtProjectConfigBase {
     type: ProjectType.DBT;
     profiles_dir?: string;
     project_dir: string;
-    rpc_server_port: number;
     target?: string;
 }
 
 export interface DbtRemoteProjectConfig extends DbtProjectConfigBase {
     type: ProjectType.DBT_REMOTE_SERVER;
-    name: string;
     rpc_server_host: string;
     rpc_server_port: number;
 }
@@ -1032,9 +1030,6 @@ export interface DbtGithubProjectConfig extends DbtProjectConfigBase {
     repository: string;
     branch: string;
     project_sub_path: string;
-    profiles_sub_path: string;
-    rpc_server_port: number;
-    target?: string;
 }
 
 export interface DbtGitlabProjectConfig extends DbtProjectConfigBase {
@@ -1043,9 +1038,6 @@ export interface DbtGitlabProjectConfig extends DbtProjectConfigBase {
     repository: string;
     branch: string;
     project_sub_path: string;
-    profiles_sub_path: string;
-    rpc_server_port: number;
-    target?: string;
 }
 
 export type DbtProjectConfig =

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -5,7 +5,7 @@ import PasswordInput from '../../ReactHookForm/PasswordInput';
 const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => (
     <>
         <PasswordInput
-            name="dbt.apiKey"
+            name="dbt.api_key"
             label="API key"
             rules={{
                 required: 'Required field',


### PR DESCRIPTION
* Fix bug where project adapter attempted to start before credentials were available
* Added new adapter type dedicated to handling dbt projects with custom credentials
* Added destroy method to clean up adapter resources
* Fix field name typo in dbt cloud form
* Remove unused project config fields (`port, target,profiles_dir` on git adapters and `port` on local adapters)