### PR TITLE
Add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,55 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# If a PR or issue is untoched for 60 days, it becomes stale
+daysUntilStale: 60
+
+# Don't automatically close issues ever
+daysUntilClose: false
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Mark issues with a stale label
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Is this issue still relevant? There have been no updates for 60 days, please close the issue or keep the conversation going! 
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
I'm adding stale bot here to help us catch issues that have been reported for 60 days but have seen no activity

The aim here **is not** to automatically close issues but to encourage action such as:
* Reviewing whether the issue is still relevant
* Retro on why the issue has not progressed
* Reframe the issue
* Or possibly close the issue

The bot simply adds a stale label and doesn't close issues.