### PR TITLE
fix(#487): support multiple metrics with a grouped dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Recent and upcoming changes to lightdash
 
 ### Fixed
 - Fixed a bug where chart config would reset after running a query
+- Fixed a bug in the chart where we could only select 1 metric when we were grouping by dimension
 
 ## [0.8.1] - 2021-09-29
 ### Added

--- a/packages/frontend/src/components/ChartConfigPanel.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel.tsx
@@ -7,7 +7,6 @@ import {
     Colors,
     Divider,
     Icon,
-    Intent,
     Switch,
 } from '@blueprintjs/core';
 
@@ -48,12 +47,6 @@ const Content: React.FC<ContentProps> = ({ chartConfig }) => (
                     label={displayName}
                     alignIndicator={Alignment.RIGHT}
                     onChange={() => chartConfig.toggleYMetric(name)}
-                    disabled={
-                        chartConfig.seriesLayout.yMetrics?.find(
-                            (m) => m === name,
-                        ) === undefined &&
-                        chartConfig.seriesLayout.groupDimension !== undefined
-                    }
                 />
             </div>
         ))}
@@ -77,13 +70,7 @@ const Content: React.FC<ContentProps> = ({ chartConfig }) => (
                     }
                     label={friendlyName(metric)}
                     alignIndicator={Alignment.RIGHT}
-                    onChange={(e) => chartConfig.toggleYMetric(metric)}
-                    disabled={
-                        chartConfig.seriesLayout.yMetrics?.find(
-                            (m) => m === metric,
-                        ) === undefined &&
-                        chartConfig.seriesLayout.groupDimension !== undefined
-                    }
+                    onChange={() => chartConfig.toggleYMetric(metric)}
                 />
             </div>
         ))}
@@ -127,11 +114,7 @@ const Content: React.FC<ContentProps> = ({ chartConfig }) => (
                                     : dimension,
                             )
                         }
-                        disabled={
-                            (chartConfig.seriesLayout.yMetrics &&
-                                chartConfig.seriesLayout.yMetrics.length > 1) ||
-                            chartConfig.dimensionOptions.length <= 1
-                        }
+                        disabled={chartConfig.dimensionOptions.length <= 1}
                     >
                         Group
                     </Button>

--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -12,10 +12,10 @@ const flipXFromChartType = (chartType: DBChartTypes) => {
             return false;
         case DBChartTypes.BAR:
             return true;
-        default:
-            // eslint-disable-next-line
+        default: {
             const nope: never = chartType;
             return undefined;
+        }
     }
 };
 const echartType = (chartType: DBChartTypes) => {
@@ -28,10 +28,10 @@ const echartType = (chartType: DBChartTypes) => {
             return 'bar';
         case DBChartTypes.SCATTER:
             return 'scatter';
-        default:
-            // eslint-disable-next-line
+        default: {
             const nope: never = chartType;
             return undefined;
+        }
     }
 };
 
@@ -59,6 +59,7 @@ export const SimpleChart: FC<SimpleChartProps> = ({
     const xlabel = friendlyName(chartConfig.seriesLayout.xDimension);
     const ylabel =
         chartConfig.seriesLayout.groupDimension &&
+        chartConfig.seriesLayout.yMetrics.length === 1 &&
         friendlyName(chartConfig.seriesLayout.yMetrics[0]);
     const xType = 'category';
     const yType = 'value';
@@ -85,9 +86,9 @@ export const SimpleChart: FC<SimpleChartProps> = ({
             2,
     };
 
-    const series = chartConfig.series
-        .map(() => ({ type: echartType(chartType) }))
-        .slice(0, 10); // not more than 10 lines
+    const series = chartConfig.series.map(() => ({
+        type: echartType(chartType),
+    }));
     const options = {
         xAxis,
         yAxis,


### PR DESCRIPTION
Closes: #487 

When we have multiple metrics + grouped dimension the labels are formatted like `[group_dimension_value] metric name`

Preview:
![Screenshot 2021-10-04 at 17 44 38](https://user-images.githubusercontent.com/9117144/135890964-838d87e5-b5cd-4e8a-b983-aa7cecac7c85.png)

FYI: I opened a separate bug for the legend overlap #541