### PR TITLE
fix: dont show option for local dbt for heroku and cloud deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Recent and upcoming changes to lightdash
 
 ## Unreleased
+### Fixed
+- Fixed a bug where we had the local dbt option when connecting a project in Cloud and Heroku deployments
 - show warning message for postgres or redshift users
 - filter dimensions and metrics by active fields in table calculation
 - exclude test files from build

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3,7 +3,7 @@ import Analytics, {
     Track as AnalyticsTrack,
 } from '@rudderstack/rudder-sdk-node';
 import { v4 as uuidv4 } from 'uuid';
-import { ProjectType, WarehouseTypes } from 'common';
+import { LightdashInstallType, ProjectType, WarehouseTypes } from 'common';
 import { VERSION } from '../version';
 
 type Identify = {
@@ -117,7 +117,9 @@ export class LightdashAnalytics extends Analytics {
             name: 'lightdash_server',
             version: VERSION,
             installId: process.env.LIGHTDASH_INSTALL_ID || uuidv4(),
-            installType: process.env.LIGHTDASH_INSTALL_TYPE || 'unknown',
+            installType:
+                process.env.LIGHTDASH_INSTALL_TYPE ||
+                LightdashInstallType.UNKNOWN,
         },
     };
 

--- a/packages/backend/src/health.mock.ts
+++ b/packages/backend/src/health.mock.ts
@@ -1,3 +1,5 @@
+import { LightdashMode } from 'common';
+
 export const Image = {
     creator: 12969647,
     id: 150371595,
@@ -51,4 +53,17 @@ export const ImagesResponse = {
     next: 'https://hub.docker.com/v2/repositories/lightdash/lightdash/tags?page=2',
     previous: null,
     results: [DevImage, OldImage, LatestImage, Image],
+};
+
+export const BaseResponse = {
+    healthy: true,
+    version: '0.1.0',
+    rudder: undefined,
+    mode: LightdashMode.DEFAULT,
+    isAuthenticated: false,
+    localDbtEnabled: true,
+    needsSetup: false,
+    needsProject: false,
+    defaultProject: undefined,
+    latest: { version: Image.name },
 };

--- a/packages/backend/src/health.ts
+++ b/packages/backend/src/health.ts
@@ -1,6 +1,9 @@
 import {
     DbtProjectConfig,
     HealthState,
+    LightdashInstallType,
+    LightdashMode,
+    ProjectType,
     sensitiveDbtCredentialsFieldNames,
 } from 'common';
 import fetch from 'node-fetch';
@@ -37,6 +40,10 @@ export const getHealthState = async (
 
     const needsProject = !(await projectService.hasProject());
 
+    const localDbtEnabled =
+        process.env.LIGHTDASH_INSTALL_TYPE !== LightdashInstallType.HEROKU &&
+        lightdashConfig.mode !== LightdashMode.CLOUD_BETA;
+
     const defaultProject =
         needsProject && lightdashConfig.projects[0]
             ? (Object.fromEntries(
@@ -55,7 +62,11 @@ export const getHealthState = async (
         version: VERSION,
         needsSetup: !(await hasUsers(database)),
         needsProject,
-        defaultProject,
+        localDbtEnabled,
+        defaultProject:
+            !localDbtEnabled && defaultProject?.type === ProjectType.DBT
+                ? undefined
+                : defaultProject,
         isAuthenticated,
         latest: { version: latestVersion },
         rudder: lightdashConfig.rudder,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -708,12 +708,20 @@ export enum LightdashMode {
     CLOUD_BETA = 'cloud_beta',
 }
 
+export enum LightdashInstallType {
+    DOCKER_IMAGE = 'docker_image',
+    BASH_INSTALL = 'bash_install',
+    HEROKU = 'heroku',
+    UNKNOWN = 'unknown',
+}
+
 export type HealthState = {
     healthy: boolean;
     mode: LightdashMode;
     version: string;
     needsSetup: boolean;
     needsProject: boolean;
+    localDbtEnabled: boolean;
     defaultProject?: DbtProjectConfig;
     isAuthenticated: boolean;
     latest: {

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -7,6 +7,7 @@ import DbtRemoteForm from './DbtForms/DbtRemoteForm';
 import DbtCloudForm from './DbtForms/DbtCloudForm';
 import GitlabForm from './DbtForms/GitlabForm';
 import SelectField from '../ReactHookForm/Select';
+import { useApp } from '../../providers/AppProvider';
 
 interface DbtSettingsFormProps {
     disabled: boolean;
@@ -14,6 +15,25 @@ interface DbtSettingsFormProps {
 }
 
 const DbtSettingsForm: FC<DbtSettingsFormProps> = ({ disabled, type }) => {
+    const { health } = useApp();
+
+    const options = useMemo(() => {
+        const enabledTypes = [
+            ProjectType.DBT_CLOUD_IDE,
+            ProjectType.GITHUB,
+            ProjectType.GITLAB,
+            ProjectType.DBT_REMOTE_SERVER,
+        ];
+        if (health.data?.localDbtEnabled) {
+            enabledTypes.push(ProjectType.DBT);
+        }
+
+        return enabledTypes.map((value) => ({
+            value,
+            label: ProjectTypeLabels[value],
+        }));
+    }, [health]);
+
     const form = useMemo(() => {
         switch (type) {
             case ProjectType.DBT:
@@ -40,12 +60,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({ disabled, type }) => {
             <SelectField
                 name="dbt.type"
                 label="Type"
-                options={Object.entries(ProjectTypeLabels).map(
-                    ([value, label]) => ({
-                        value,
-                        label,
-                    }),
-                )}
+                options={options}
                 rules={{
                     required: 'Required field',
                 }}


### PR DESCRIPTION
Changes:
- remove 'local dbt project' option when running Lightdash in Cloud or Heroku