### PR TITLE
feat(#585): dashboard open api + database migration

### DIFF
--- a/packages/backend/src/database/migrations/20211007175643_add_dashboards_table.ts
+++ b/packages/backend/src/database/migrations/20211007175643_add_dashboards_table.ts
@@ -1,0 +1,121 @@
+import { Knex } from 'knex';
+
+const dashboardsTableName = 'dashboards';
+const dashboardVersionsTableName = 'dashboard_versions';
+const dashboardTilesTableName = 'dashboard_tiles';
+const dashboardTileTypesTableName = 'dashboard_tile_types';
+const dashboardTileChartTableName = 'dashboard_tile_charts';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(dashboardsTableName))) {
+        await knex.schema.createTable(dashboardsTableName, (tableBuilder) => {
+            tableBuilder.specificType(
+                'dashboard_id',
+                'INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY',
+            );
+            tableBuilder
+                .integer('space_id')
+                .references('space_id')
+                .inTable('spaces')
+                .notNullable()
+                .onDelete('CASCADE');
+            tableBuilder.text('name').notNullable();
+            tableBuilder.text('description').notNullable();
+            tableBuilder
+                .timestamp('created_at', { useTz: false })
+                .notNullable();
+            tableBuilder
+                .uuid('dashboard_uuid')
+                .notNullable()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+        });
+    }
+    if (!(await knex.schema.hasTable(dashboardVersionsTableName))) {
+        await knex.schema.createTable(
+            dashboardVersionsTableName,
+            (tableBuilder) => {
+                tableBuilder.specificType(
+                    'dashboard_version_id',
+                    'INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY',
+                );
+                tableBuilder
+                    .integer('dashboard_id')
+                    .notNullable()
+                    .references('dashboard_id')
+                    .inTable(dashboardsTableName)
+                    .onDelete('CASCADE');
+                tableBuilder
+                    .timestamp('created_at', { useTz: false })
+                    .notNullable();
+            },
+        );
+    }
+    if (!(await knex.schema.hasTable(dashboardTileTypesTableName))) {
+        await knex.schema.createTable(
+            dashboardTileTypesTableName,
+            (tableBuilder) => {
+                tableBuilder.text('dashboard_tile_type').primary();
+            },
+        );
+        await knex(dashboardTileTypesTableName).insert([
+            { dashboard_tile_type: 'saved_chart' },
+        ]);
+    }
+    if (!(await knex.schema.hasTable(dashboardTilesTableName))) {
+        await knex.schema.createTable(
+            dashboardTilesTableName,
+            (tableBuilder) => {
+                tableBuilder
+                    .integer('dashboard_version_id')
+                    .notNullable()
+                    .references('dashboard_version_id')
+                    .inTable('dashboard_versions')
+                    .onDelete('CASCADE');
+                tableBuilder.specificType(
+                    'rank',
+                    'INTEGER NOT NULL CHECK(rank > 0)',
+                );
+                tableBuilder.primary(['dashboard_version_id', 'rank']);
+                tableBuilder
+                    .text('type')
+                    .notNullable()
+                    .references('dashboard_tile_type')
+                    .inTable(dashboardTileTypesTableName)
+                    .onDelete('RESTRICT');
+                tableBuilder.float('x_offset').notNullable();
+                tableBuilder.float('y_offset').notNullable();
+                tableBuilder.float('height').notNullable();
+                tableBuilder.float('width').notNullable();
+            },
+        );
+    }
+    if (!(await knex.schema.hasTable(dashboardTileChartTableName))) {
+        await knex.schema.createTable(
+            dashboardTileChartTableName,
+            (tableBuilder) => {
+                tableBuilder.integer('dashboard_version_id').notNullable();
+                tableBuilder.integer('rank').notNullable();
+                tableBuilder.primary(['dashboard_version_id', 'rank']);
+                tableBuilder
+                    .foreign(['dashboard_version_id', 'rank'])
+                    .references(['dashboard_version_id', 'rank'])
+                    .inTable(dashboardTilesTableName)
+                    .onDelete('CASCADE');
+                tableBuilder
+                    .integer('saved_chart_id')
+                    .nullable()
+                    .references('saved_query_id')
+                    .inTable('saved_queries')
+                    .onDelete('SET NULL');
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(dashboardTileChartTableName);
+    await knex.schema.dropTableIfExists(dashboardTilesTableName);
+    await knex.schema.dropTableIfExists(dashboardTileTypesTableName);
+    await knex.schema.dropTableIfExists(dashboardVersionsTableName);
+    await knex.schema.dropTableIfExists(dashboardsTableName);
+}

--- a/packages/common/src/openapi/openapi.json
+++ b/packages/common/src/openapi/openapi.json
@@ -45,6 +45,15 @@
         },
         "/invite-links/{inviteLinkId}": {
             "$ref": "./paths/inviteLink.json"
+        },
+        "/projects/{projectId}/dashboards": {
+            "$ref": "./paths/projectDashboards.json"
+        },
+        "/dashboards/{dashboardId}": {
+            "$ref": "./paths/dashboards.json"
+        },
+        "/dashboards/{dashboardId}/versions": {
+            "$ref": "./paths/dashboardVersions.json"
         }
     },
     "security": [{ "cookieAuth": [] }],

--- a/packages/common/src/openapi/paths/dashboardVersions.json
+++ b/packages/common/src/openapi/paths/dashboardVersions.json
@@ -1,0 +1,56 @@
+{
+    "post": {
+        "summary": "Create new dashboard version",
+        "tags": ["dashboard"],
+        "operationId": "createDashboardVersion",
+        "parameters": [
+            {
+                "in": "path",
+                "name": "dashboardId",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "required": true
+            }
+        ],
+        "requestBody": {
+            "description": "New dashboard version specification",
+            "required": true,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "../schemas/CreateDashboard.json"
+                    }
+                }
+            }
+        },
+        "responses": {
+            "201": {
+                "description": "Successfully created dashboard version",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "../schemas/Success.json"
+                                },
+                                {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "../schemas/Dashboard.json"
+                                        }
+                                    },
+                                    "required": ["results"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "default": {
+                "$ref": "../responses/ErrorResponse.json"
+            }
+        }
+    }
+}

--- a/packages/common/src/openapi/paths/dashboards.json
+++ b/packages/common/src/openapi/paths/dashboards.json
@@ -1,0 +1,45 @@
+{
+    "get": {
+        "summary": "Get details for a single dashboard by dashboard_id",
+        "tags": ["dashboard"],
+        "operationId": "getDashboard",
+        "parameters": [
+            {
+                "in": "path",
+                "name": "dashboardId",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "required": true
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "Details for a single dashboard",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "../schemas/Success.json"
+                                },
+                                {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "../schemas/Dashboard.json"
+                                        }
+                                    },
+                                    "required": ["results"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "default": {
+                "$ref": "../responses/ErrorResponse.json"
+            }
+        }
+    }
+}

--- a/packages/common/src/openapi/paths/projectDashboards.json
+++ b/packages/common/src/openapi/paths/projectDashboards.json
@@ -1,0 +1,102 @@
+{
+    "post": {
+        "summary": "Create new dashboard on project",
+        "tags": ["dashboard"],
+        "operationId": "createDashboard",
+        "parameters": [
+            {
+                "in": "path",
+                "name": "projectId",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "required": true
+            }
+        ],
+        "requestBody": {
+            "description": "New dashboard specification",
+            "required": true,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "../schemas/CreateDashboard.json"
+                    }
+                }
+            }
+        },
+        "responses": {
+            "201": {
+                "description": "Successfully created dashboard",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "../schemas/Success.json"
+                                },
+                                {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "../schemas/Dashboard.json"
+                                        }
+                                    },
+                                    "required": ["results"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "default": {
+                "$ref": "../responses/ErrorResponse.json"
+            }
+        }
+    },
+    "get": {
+        "summary": "List all dashboards in a project",
+        "tags": ["dashboard"],
+        "operationId": "getDashboards",
+        "parameters": [
+            {
+                "in": "path",
+                "name": "projectId",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "required": true
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "List of all dashboards in project",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "../schemas/Success.json"
+                                },
+                                {
+                                    "properties": {
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "../schemas/DashboardListItem.json"
+                                            }
+                                        }
+                                    },
+                                    "required": ["results"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "default": {
+                "$ref": "../responses/ErrorResponse.json"
+            }
+        }
+    }
+}

--- a/packages/common/src/openapi/schemas/CreateDashboard.json
+++ b/packages/common/src/openapi/schemas/CreateDashboard.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "tiles": {
+            "type": "array",
+            "items": {
+                "$ref": "./DashboardTile.json"
+            }
+        }
+    },
+    "required": ["tiles", "name", "description"]
+}

--- a/packages/common/src/openapi/schemas/Dashboard.json
+++ b/packages/common/src/openapi/schemas/Dashboard.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "properties": {
+        "dashboardUuid": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "tiles": {
+            "type": "array",
+            "items": {
+                "$ref": "./DashboardTile.json"
+            }
+        }
+    },
+    "required": ["dashboardUuid", "tiles", "name", "description", "updatedAt"]
+}

--- a/packages/common/src/openapi/schemas/DashboardListItem.json
+++ b/packages/common/src/openapi/schemas/DashboardListItem.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "properties": {
+        "dashboardUuid": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "required": ["dashboardUuid", "name", "description", "updatedAt"]
+}

--- a/packages/common/src/openapi/schemas/DashboardTile.json
+++ b/packages/common/src/openapi/schemas/DashboardTile.json
@@ -1,0 +1,29 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": ["saved_chart"]
+        },
+        "properties": {
+            "oneOf": [
+                {
+                    "$ref": "./TilePropertiesChart.json"
+                }
+            ]
+        },
+        "x": {
+            "type": "number"
+        },
+        "y": {
+            "type": "number"
+        },
+        "h": {
+            "type": "number"
+        },
+        "w": {
+            "type": "number"
+        }
+    },
+    "required": ["properties", "type", "x", "y", "h", "w"]
+}

--- a/packages/common/src/openapi/schemas/TilePropertiesChart.json
+++ b/packages/common/src/openapi/schemas/TilePropertiesChart.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "savedChartUuid": {
+            "type": "string",
+            "format": "uuid"
+        }
+    }
+}

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -239,6 +239,209 @@
                     }
                 }
             }
+        },
+        "/projects/{projectId}/dashboards": {
+            "post": {
+                "summary": "Create new dashboard on project",
+                "tags": ["dashboard"],
+                "operationId": "createDashboard",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectId",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "requestBody": {
+                    "description": "New dashboard specification",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateDashboard"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successfully created dashboard",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "properties": {
+                                                "results": {
+                                                    "$ref": "#/components/schemas/Dashboard"
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            },
+            "get": {
+                "summary": "List all dashboards in a project",
+                "tags": ["dashboard"],
+                "operationId": "getDashboards",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectId",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of all dashboards in project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "properties": {
+                                                "results": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/DashboardListItem"
+                                                    }
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/dashboards/{dashboardId}": {
+            "get": {
+                "summary": "Get details for a single dashboard by dashboard_id",
+                "tags": ["dashboard"],
+                "operationId": "getDashboard",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dashboardId",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details for a single dashboard",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "properties": {
+                                                "results": {
+                                                    "$ref": "#/components/schemas/Dashboard"
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/dashboards/{dashboardId}/versions": {
+            "post": {
+                "summary": "Create new dashboard version",
+                "tags": ["dashboard"],
+                "operationId": "createDashboardVersion",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dashboardId",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "requestBody": {
+                    "description": "New dashboard version specification",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateDashboard"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successfully created dashboard version",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "properties": {
+                                                "results": {
+                                                    "$ref": "#/components/schemas/Dashboard"
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
         }
     },
     "security": [
@@ -399,6 +602,119 @@
                     }
                 },
                 "required": ["expiresAt", "inviteCode"]
+            },
+            "DashboardListItem": {
+                "type": "object",
+                "properties": {
+                    "dashboardUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "dashboardUuid",
+                    "name",
+                    "description",
+                    "updatedAt"
+                ]
+            },
+            "TilePropertiesChart": {
+                "type": "object",
+                "properties": {
+                    "savedChartUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            },
+            "DashboardTile": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["saved_chart"]
+                    },
+                    "properties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/TilePropertiesChart"
+                            }
+                        ]
+                    },
+                    "x": {
+                        "type": "number"
+                    },
+                    "y": {
+                        "type": "number"
+                    },
+                    "h": {
+                        "type": "number"
+                    },
+                    "w": {
+                        "type": "number"
+                    }
+                },
+                "required": ["properties", "type", "x", "y", "h", "w"]
+            },
+            "CreateDashboard": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "tiles": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DashboardTile"
+                        }
+                    }
+                },
+                "required": ["tiles", "name", "description"]
+            },
+            "Dashboard": {
+                "type": "object",
+                "properties": {
+                    "dashboardUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "tiles": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DashboardTile"
+                        }
+                    }
+                },
+                "required": [
+                    "dashboardUuid",
+                    "tiles",
+                    "name",
+                    "description",
+                    "updatedAt"
+                ]
             }
         },
         "responses": {


### PR DESCRIPTION
Closes: #585 

- [x] Database schema
- [x] API design


## Schema design

- Dashboards exist in a single project space
- Dashboards have many versions
- A dashboard version is composed of many tiles
- A dashboard version tile might be a saved chart tile type
- A saved chart tile might have a null reference to a saved chart that doesn’t exist anymore
- No restriction on which space saved charts come from. We could enforce this at the DB level but probably better at the service level

<img width="1525" alt="Screenshot 2021-10-08 at 09 51 52" src="https://user-images.githubusercontent.com/11660098/136527667-28d87c40-5f18-436b-8d16-ad2cabab76ca.png">

Changes not in image: 
- dashboard table now as a `created_at` and a `description` column

## API design
<img width="276" alt="Screenshot 2021-10-08 at 11 04 17" src="https://user-images.githubusercontent.com/11660098/136538010-76e23db6-c602-4da3-a6a0-d625c109d365.png">

## ReDoc:
http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/lightdash/lightdash/add-dashboards-api/packages/common/src/openapibundle.json#tag/dashboard