### PR TITLE
docs(#529): add help buttons in project form

### DIFF
--- a/packages/frontend/src/components/DocumentationHelpButton.css
+++ b/packages/frontend/src/components/DocumentationHelpButton.css
@@ -1,0 +1,4 @@
+label.bp3-label .bp3-popover2-target.documentation-help-button {
+    margin: 0;
+    display: inline-block;
+}

--- a/packages/frontend/src/components/DocumentationHelpButton.tsx
+++ b/packages/frontend/src/components/DocumentationHelpButton.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react';
+import { AnchorButton, Colors, Icon } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
+import './DocumentationHelpButton.css';
+
+type Props = {
+    url: string;
+};
+
+const DocumentationHelpButton: FC<Props> = ({ url }) => (
+    <Tooltip2
+        content="Open documentation"
+        className="documentation-help-button"
+    >
+        <a
+            role="button"
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: Colors.GRAY3 }}
+        >
+            <Icon icon="help" intent="none" iconSize={15} />
+        </a>
+    </Tooltip2>
+);
+
+export default DocumentationHelpButton;

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -7,6 +7,7 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <PasswordInput
             name="dbt.api_key"
             label="API key"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#how-to-get-your-api-key"
             rules={{
                 required: 'Required field',
             }}
@@ -16,14 +17,7 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.account_id"
             label="Account ID"
-            rules={{
-                required: 'Required field',
-            }}
-            disabled={disabled}
-        />
-        <Input
-            name="dbt.environment_id"
-            label="Environment ID"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#how-to-get-your-account-id-and-project-id-from-your-dbt-cloud-project"
             rules={{
                 required: 'Required field',
             }}
@@ -32,6 +26,16 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.project_id"
             label="Project ID"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#how-to-get-your-account-id-and-project-id-from-your-dbt-cloud-project"
+            rules={{
+                required: 'Required field',
+            }}
+            disabled={disabled}
+        />
+        <Input
+            name="dbt.environment_id"
+            label="Environment ID"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#how-to-get-your-environment-id"
             rules={{
                 required: 'Required field',
             }}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtLocalForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtLocalForm.tsx
@@ -19,6 +19,7 @@ const DbtLocalForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.project_dir"
             label="Project directory"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#local-dbt-project"
             rules={{
                 required: 'Required field',
             }}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtRemoteForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtRemoteForm.tsx
@@ -1,12 +1,26 @@
 import React, { FC } from 'react';
+import { Callout } from '@blueprintjs/core';
 import Input from '../../ReactHookForm/Input';
 import NumericInput from '../../ReactHookForm/NumericInput';
 
 const DbtRemoteForm: FC<{ disabled: boolean }> = ({ disabled }) => (
     <>
+        <Callout intent="warning" style={{ marginBottom: 20 }}>
+            dbt is planning to deprecate the rpc server soon so we suggest using
+            a different way to connect your dbt project. Read docs{' '}
+            <a
+                href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#dbt-remote-server"
+                target="_blank"
+                rel="noreferrer"
+            >
+                here
+            </a>{' '}
+            to know more.
+        </Callout>
         <Input
             name="dbt.rpc_server_host"
             label="RPC server host"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#rpc-server-host"
             rules={{
                 required: 'Required field',
             }}
@@ -15,6 +29,7 @@ const DbtRemoteForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <NumericInput
             name="dbt.rpc_server_port"
             label="RPC server port"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#rpc-server-port"
             rules={{
                 required: 'Required field',
             }}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -7,6 +7,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <PasswordInput
             name="dbt.personal_access_token"
             label="Personal access token"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#personal-access-token"
             rules={{
                 required: 'Required field',
             }}
@@ -16,6 +17,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.repository"
             label="Repository"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#repository"
             rules={{
                 required: 'Required field',
             }}
@@ -24,6 +26,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.branch"
             label="Branch"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#branch"
             rules={{
                 required: 'Required field',
             }}
@@ -32,6 +35,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.project_sub_path"
             label="Project directory path"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#project-directory-path"
             rules={{
                 required: 'Required field',
             }}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
@@ -7,6 +7,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <PasswordInput
             name="dbt.personal_access_token"
             label="Personal access token"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#personal-access-token-1"
             rules={{
                 required: 'Required field',
             }}
@@ -16,6 +17,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.repository"
             label="Repository"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#repository-1"
             rules={{
                 required: 'Required field',
             }}
@@ -24,6 +26,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.branch"
             label="Branch"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#branch-1"
             rules={{
                 required: 'Required field',
             }}
@@ -32,6 +35,7 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => (
         <Input
             name="dbt.project_sub_path"
             label="Project directory path"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#project-directory-path-1"
             rules={{
                 required: 'Required field',
             }}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -16,6 +16,7 @@ const BigQueryForm: FC<{
             <Input
                 name="warehouse.project"
                 label="Project"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#project"
                 rules={{
                     required: 'Required field',
                 }}
@@ -24,6 +25,7 @@ const BigQueryForm: FC<{
             <Input
                 name="warehouse.dataset"
                 label="Data set"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#data-set"
                 rules={{
                     required: 'Required field',
                 }}
@@ -32,6 +34,7 @@ const BigQueryForm: FC<{
             <Input
                 name="warehouse.location"
                 label="Location"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#location"
                 rules={{
                     required: 'Required field',
                 }}
@@ -40,6 +43,7 @@ const BigQueryForm: FC<{
             <FileInput
                 name="warehouse.keyfileContents"
                 label="Key File"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#key-file"
                 rules={{
                     required: 'Required field',
                 }}
@@ -50,6 +54,7 @@ const BigQueryForm: FC<{
                 <NumericInput
                     name="warehouse.threads"
                     label="Threads"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#threads"
                     rules={{
                         required: 'Required field',
                     }}
@@ -59,6 +64,7 @@ const BigQueryForm: FC<{
                 <NumericInput
                     name="warehouse.timeoutSeconds"
                     label="Timeout in seconds"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#timeout-in-seconds"
                     rules={{
                         required: 'Required field',
                     }}
@@ -68,6 +74,7 @@ const BigQueryForm: FC<{
                 <SelectField
                     name="warehouse.priority"
                     label="Priority"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#timeout-in-seconds"
                     options={[
                         {
                             value: 'interactive',
@@ -87,6 +94,7 @@ const BigQueryForm: FC<{
                 <NumericInput
                     name="warehouse.retries"
                     label="Retries"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#retries"
                     rules={{
                         required: 'Required field',
                     }}
@@ -95,6 +103,7 @@ const BigQueryForm: FC<{
                 <NumericInput
                     name="warehouse.maximumBytesBilled"
                     label="Maximum bytes billed"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#maximum-bytes-billed"
                     rules={{
                         required: 'Required field',
                     }}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -15,6 +15,7 @@ const PostgresForm: FC<{
             <Input
                 name="warehouse.host"
                 label="Host"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#host"
                 rules={{
                     required: 'Required field',
                 }}
@@ -23,6 +24,7 @@ const PostgresForm: FC<{
             <Input
                 name="warehouse.user"
                 label="User"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#user"
                 rules={{
                     required: 'Required field',
                 }}
@@ -31,6 +33,7 @@ const PostgresForm: FC<{
             <PasswordInput
                 name="warehouse.password"
                 label="Password"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#password"
                 rules={{
                     required: 'Required field',
                 }}
@@ -39,6 +42,7 @@ const PostgresForm: FC<{
             <Input
                 name="warehouse.dbname"
                 label="DB name"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#db-name"
                 rules={{
                     required: 'Required field',
                 }}
@@ -47,6 +51,7 @@ const PostgresForm: FC<{
             <Input
                 name="warehouse.schema"
                 label="Schema"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema"
                 rules={{
                     required: 'Required field',
                 }}
@@ -56,6 +61,7 @@ const PostgresForm: FC<{
                 <NumericInput
                     name="warehouse.port"
                     label="Port"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#port"
                     rules={{
                         required: 'Required field',
                     }}
@@ -65,6 +71,7 @@ const PostgresForm: FC<{
                 <NumericInput
                     name="warehouse.threads"
                     label="Threads"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#threads-1"
                     rules={{
                         required: 'Required field',
                     }}
@@ -74,6 +81,7 @@ const PostgresForm: FC<{
                 <NumericInput
                     name="warehouse.keepalivesIdle"
                     label="Keep alive idle (seconds)"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#keep-alive-idle-seconds"
                     rules={{
                         required: 'Required field',
                     }}
@@ -83,11 +91,13 @@ const PostgresForm: FC<{
                 <Input
                     name="warehouse.searchPath"
                     label="Search path"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#search-path"
                     disabled={disabled}
                 />
                 <Input
                     name="warehouse.sslmode"
                     label="SSL mode"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#ssl-mode"
                     disabled={disabled}
                 />
                 <Input name="warehouse.role" label="Role" disabled={disabled} />

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -15,6 +15,7 @@ const RedshiftForm: FC<{
             <Input
                 name="warehouse.host"
                 label="Host"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#host-1"
                 rules={{
                     required: 'Required field',
                 }}
@@ -23,6 +24,7 @@ const RedshiftForm: FC<{
             <Input
                 name="warehouse.user"
                 label="User"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#user-1"
                 rules={{
                     required: 'Required field',
                 }}
@@ -31,6 +33,7 @@ const RedshiftForm: FC<{
             <PasswordInput
                 name="warehouse.password"
                 label="Password"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#password-1"
                 rules={{
                     required: 'Required field',
                 }}
@@ -39,6 +42,7 @@ const RedshiftForm: FC<{
             <Input
                 name="warehouse.dbname"
                 label="DB name"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#db-name-1"
                 rules={{
                     required: 'Required field',
                 }}
@@ -47,6 +51,7 @@ const RedshiftForm: FC<{
             <Input
                 name="warehouse.schema"
                 label="Schema"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-1"
                 rules={{
                     required: 'Required field',
                 }}
@@ -56,6 +61,7 @@ const RedshiftForm: FC<{
                 <NumericInput
                     name="warehouse.port"
                     label="Port"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#port-1"
                     rules={{
                         required: 'Required field',
                     }}
@@ -65,6 +71,7 @@ const RedshiftForm: FC<{
                 <NumericInput
                     name="warehouse.threads"
                     label="Threads"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#threads-2"
                     rules={{
                         required: 'Required field',
                     }}
@@ -74,6 +81,7 @@ const RedshiftForm: FC<{
                 <NumericInput
                     name="warehouse.keepalivesIdle"
                     label="Keep alive idle (seconds)"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#keep-alive-idle-seconds-1"
                     rules={{
                         required: 'Required field',
                     }}
@@ -83,6 +91,7 @@ const RedshiftForm: FC<{
                 <Input
                     name="warehouse.sslmode"
                     label="SSL mode"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#ssl-mode-1"
                     disabled={disabled}
                 />
             </FormSection>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -16,6 +16,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.accout"
                 label="Account"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#account"
                 rules={{
                     required: 'Required field',
                 }}
@@ -24,6 +25,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.user"
                 label="User"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#user-2"
                 rules={{
                     required: 'Required field',
                 }}
@@ -32,6 +34,7 @@ const SnowflakeForm: FC<{
             <PasswordInput
                 name="warehouse.password"
                 label="Password"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#password-2"
                 rules={{
                     required: 'Required field',
                 }}
@@ -40,6 +43,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.role"
                 label="Role"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#role"
                 rules={{
                     required: 'Required field',
                 }}
@@ -48,6 +52,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.database"
                 label="Database"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#database"
                 rules={{
                     required: 'Required field',
                 }}
@@ -56,6 +61,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.warehouse"
                 label="Warehouse"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse"
                 rules={{
                     required: 'Required field',
                 }}
@@ -64,6 +70,7 @@ const SnowflakeForm: FC<{
             <Input
                 name="warehouse.schema"
                 label="Schema"
+                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-2"
                 rules={{
                     required: 'Required field',
                 }}
@@ -73,6 +80,7 @@ const SnowflakeForm: FC<{
                 <NumericInput
                     name="warehouse.threads"
                     label="Threads"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#threads-3"
                     rules={{
                         required: 'Required field',
                     }}
@@ -82,6 +90,7 @@ const SnowflakeForm: FC<{
                 <SelectField
                     name="warehouse.clientSessionKeepAlive"
                     label="Keep client session alive"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#keep-client-session-alive"
                     options={[
                         {
                             value: 1,
@@ -101,6 +110,7 @@ const SnowflakeForm: FC<{
                 <Input
                     name="warehouse.queryTag"
                     label="Query tag"
+                    documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#query-tag"
                     disabled={disabled}
                 />
             </FormSection>

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -23,6 +23,7 @@ import {
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import { useApp } from '../../providers/AppProvider';
+import DocumentationHelpButton from '../DocumentationHelpButton';
 
 type ProjectConnectionForm = {
     dbt: DbtProjectConfig;
@@ -52,7 +53,12 @@ const ProjectForm: FC<Props> = ({ disabled, defaultType, methods }) => {
                 }}
                 elevation={1}
             >
-                <H5 style={{ flex: 1 }}>dbt connection</H5>
+                <div style={{ flex: 1 }}>
+                    <H5 style={{ display: 'inline', marginRight: 5 }}>
+                        dbt connection
+                    </H5>
+                    <DocumentationHelpButton url="https://docs.lightdash.com/get-started/setup-lightdash/connect-project" />
+                </div>
                 <div style={{ flex: 1 }}>
                     <DbtSettingsForm disabled={disabled} type={type} />
                 </div>
@@ -65,7 +71,12 @@ const ProjectForm: FC<Props> = ({ disabled, defaultType, methods }) => {
                 }}
                 elevation={1}
             >
-                <H5 style={{ flex: 1 }}>Warehouse connection</H5>
+                <div style={{ flex: 1 }}>
+                    <H5 style={{ display: 'inline', marginRight: 5 }}>
+                        Warehouse connection
+                    </H5>
+                    <DocumentationHelpButton url="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse-connection" />
+                </div>
                 <div style={{ flex: 1 }}>
                     {type &&
                     [

--- a/packages/frontend/src/components/ReactHookForm/InputWrapper.css
+++ b/packages/frontend/src/components/ReactHookForm/InputWrapper.css
@@ -1,0 +1,11 @@
+.bp3-form-group.input-wrapper label.bp3-label {
+    display: inline-flex;
+    gap: 3px;
+}
+
+.bp3-form-group.input-wrapper .bp3-text-muted {
+    flex: 1;
+    display: inline-flex;
+    gap: 3px;
+    padding-right: 7px;
+}

--- a/packages/frontend/src/components/ReactHookForm/InputWrapper.tsx
+++ b/packages/frontend/src/components/ReactHookForm/InputWrapper.tsx
@@ -3,6 +3,8 @@ import { Controller, get, useFormContext } from 'react-hook-form';
 import { FormGroup } from '@blueprintjs/core';
 import { ErrorMessage } from '@hookform/error-message';
 import { ArgumentsOf } from 'common';
+import DocumentationHelpButton from '../DocumentationHelpButton';
+import './InputWrapper.css';
 
 interface InputProps {
     id: string;
@@ -16,6 +18,7 @@ export interface InputWrapperProps {
     disabled?: boolean;
     placeholder?: string;
     defaultValue?: any;
+    documentationUrl?: string;
     rules?: React.ComponentProps<typeof Controller>['rules'];
     render: (
         inputProps: InputProps,
@@ -28,6 +31,7 @@ export interface InputWrapperProps {
 const InputWrapper: FC<InputWrapperProps> = ({
     name,
     defaultValue,
+    documentationUrl,
     label,
     rules,
     render,
@@ -38,11 +42,21 @@ const InputWrapper: FC<InputWrapperProps> = ({
         formState: { errors },
     } = useFormContext();
     const id = `${name}-input`;
+    const requiredLabel = rules?.required ? '(required)' : '(optional)';
+
     return (
         <FormGroup
+            className="input-wrapper"
             label={label}
             labelFor={id}
-            labelInfo={rules?.required ? '(required)' : '(optional)'}
+            labelInfo={
+                <>
+                    <span style={{ flex: 1 }}>{requiredLabel}</span>
+                    {documentationUrl && (
+                        <DocumentationHelpButton url={documentationUrl} />
+                    )}
+                </>
+            }
             intent={get(errors, name) ? 'danger' : 'none'}
             helperText={<ErrorMessage errors={errors} name={name} as="p" />}
         >


### PR DESCRIPTION
Closes: #529 

Changes:
- create reusable Documentation Help Button 
- update InputWrapper so we can have a help button on the field label
- add doc urls on all project settings fields

Preview:
![Screenshot 2021-10-08 at 11 25 07](https://user-images.githubusercontent.com/9117144/136540915-48608576-0fc6-43c1-a30a-23b605b759b7.png)

