### PR TITLE
Fix rudderstack traits bug

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -126,7 +126,7 @@ export class LightdashAnalytics extends Analytics {
     identify(payload: Identify) {
         super.identify({
             ...payload,
-            context: LightdashAnalytics.lightdashContext,
+            context: { ...LightdashAnalytics.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
         });
     }
 
@@ -134,14 +134,14 @@ export class LightdashAnalytics extends Analytics {
         super.track({
             ...payload,
             event: `${LightdashAnalytics.lightdashContext.app.name}.${payload.event}`,
-            context: LightdashAnalytics.lightdashContext,
+            context: { ...LightdashAnalytics.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
         });
     }
 
     group(payload: Group) {
         super.group({
             ...payload,
-            context: LightdashAnalytics.lightdashContext,
+            context: { ...LightdashAnalytics.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
         });
     }
 }


### PR DESCRIPTION
Rudderstack assigns to the payloads passed into the sdk, we use spread to preserve our static context.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)