### PR TITLE
chore(#601): serve api docs

### DIFF
--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -30,7 +30,7 @@ COPY --from=dbt-builder /usr/local/gcloud /usr/local/gcloud
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Setup common config
-COPY lightdash.yml /usr/app/lightdash.yml
+COPY lightdash-pr.yml /usr/app/lightdash.yml
 ENV LIGHTDASH_CONFIG_FILE /usr/app/lightdash.yml
 
 

--- a/lightdash-pr.yml
+++ b/lightdash-pr.yml
@@ -1,0 +1,7 @@
+version: '1.0'
+mode: pr
+projects:
+  - name: default
+    type: 'dbt'
+    profiles_dir: /usr/app/profiles
+    project_dir: /usr/app/dbt

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -60,6 +60,7 @@
         "passport-local": "^1.0.0",
         "pg": "^8.6.0",
         "pg-connection-string": "^2.5.0",
+        "redoc-express": "^1.0.0",
         "tempy": "^1.0.1",
         "uuid": "^8.3.2"
     },

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,7 +5,8 @@ import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import expressSession from 'express-session';
 import cookieParser from 'cookie-parser';
-import { SessionUser } from 'common';
+import { LightdashMode, SessionUser } from 'common';
+import reDoc from 'redoc-express';
 import connectSessionKnex from 'connect-session-knex';
 import bodyParser from 'body-parser';
 import * as OpenApiValidator from 'express-openapi-validator';
@@ -87,6 +88,23 @@ app.use(
 );
 // api router
 app.use('/api/v1', apiV1Router);
+
+// Api docs
+if (
+    lightdashConfig.mode === LightdashMode.PR ||
+    process.env.NODE_ENV !== 'production'
+) {
+    app.get('/api/docs/openapi.json', (req, res) => {
+        res.send(apiSpec);
+    });
+    app.get(
+        '/api/docs',
+        reDoc({
+            title: 'Lightdash API Docs',
+            specUrl: '/api/docs/openapi.json',
+        }),
+    );
+}
 
 // frontend
 app.use(express.static(path.join(__dirname, '../../frontend/build')));

--- a/yarn.lock
+++ b/yarn.lock
@@ -13142,6 +13142,11 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
+redoc-express@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redoc-express/-/redoc-express-1.0.0.tgz#2b4f684293adc83f5af3461b583f7f9350bd0e0f"
+  integrity sha512-N/0/WrA6U2rJc9hzLy2Jh2CHrQttIcW02jE4xGCiKkU40uTlpFTcEfu9bpsJlTcpffPXVNhhaIbTwz8kxz+M5A==
+
 redux@^4.0.0, redux@^4.0.4:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"


### PR DESCRIPTION
Closes: #601 

We now have an easy way to check the api docs when running in development mode and in the PR envs.

Docs url path: `/api/docs` 

Preview:

https://lightdash-pr-603.onrender.com/api/docs

<a href="https://www.loom.com/share/cf65de40e082497690894dec25db5e42">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/cf65de40e082497690894dec25db5e42-with-play.gif">
  </a>
