### PR TITLE
clarifies project path instructions

### DIFF
--- a/docs/docs/get-started/setup-lightdash/connect-project.mdx
+++ b/docs/docs/get-started/setup-lightdash/connect-project.mdx
@@ -92,7 +92,7 @@ By default, we've set this to `main` but you can change it to whatever you'd lik
 This is the folder where your `dbt_project.yml` file is found in the GitHub repository you entered above.
 
 - Put `/` if your `dbt_project.yml` file is in the main folder of your repo (e.g. lightdash/lightdash-analytics/dbt_project.yml)
-- Include the path to the sub-folder where your dbt project is if your dbt project is in a sub-folder in your repo. For example, if my project was in lightdash/lightdash/analytics/dbt/dbt_project.yml, I'd write `/dbt` in this field.
+- Include the path to the sub-folder where your dbt project is if your dbt project is in a sub-folder in your repo. For example, if my project was in lightdash/lightdash-analytics/dbt/dbt_project.yml, I'd write `/dbt` in this field.
 
 ----
 


### PR DESCRIPTION
Going through the instructions with someone, they misread them because the full path was highlighted (so they tried to write the full path). 

Updated the docs to make it clear that you should be using directory values, not full-path values.