### PR TITLE
fix: dont install dbt deps on query run

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -31,6 +31,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     async destroy(): Promise<void> {}
 
     public async test(): Promise<void> {
+        await this.dbtClient.installDeps();
         await this.runQuery("SELECT 'test connection'");
     }
 
@@ -86,11 +87,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     }
 
     public async runQuery(sql: string): Promise<Record<string, any>[]> {
-        // TODO: remove temporary fix while query runner depends on dbt
-        // Installs dependencies on every query
-        if (this.queryRunner instanceof DbtRpcClientBase) {
-            await this.queryRunner.installDeps();
-        }
+        // Possible error if query is ran before dependencies are installed
         return this.queryRunner.runQuery(sql);
     }
 


### PR DESCRIPTION
This undoes a change in #622 - we install dependencies on every runQuery

This was a conservative move because it makes it possible to a run a query before dbt has been setup properly (with `dbt deps`). 

This PR reverts that. So it's possible to run a query before `dbt deps` is run. However, this is extremely difficult to do with the UI, since the first thing happens is the project is compiled.

Note that running `test()` **will** run `dbt deps` before executing the test query
—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)