### PR TITLE
fix(#665): parse bigquery types to js

### DIFF
--- a/packages/backend/src/services/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/backend/src/services/warehouseClients/BigqueryWarehouseClient.ts
@@ -1,7 +1,66 @@
 import { CreateBigqueryCredentials } from 'common';
-import { BigQuery } from '@google-cloud/bigquery';
+import {
+    BigQuery,
+    BigQueryDate,
+    BigQueryDatetime,
+    BigQueryTime,
+    BigQueryTimestamp,
+} from '@google-cloud/bigquery';
 import { WarehouseConnectionError, WarehouseQueryError } from '../../errors';
 import { QueryRunner } from '../../types';
+
+const parseDateCell = (cell: BigQueryDate) => new Date(cell.value);
+const parseTimestampCell = (cell: BigQueryTimestamp) => new Date(cell.value);
+const parseDateTimeCell = (cell: BigQueryDatetime) => new Date(cell.value);
+const parseTimeCell = (cell: BigQueryTime) => new Date(cell.value);
+const parseDefault = (cell: any) => cell;
+
+const getParser = (type: string | undefined) => {
+    switch (type) {
+        case 'DATE':
+            return parseDateCell;
+        case 'DATETIME':
+            return parseDateTimeCell;
+        case 'TIMESTAMP':
+            return parseTimestampCell;
+        case 'TIME':
+            return parseTimeCell;
+        default:
+            return parseDefault;
+    }
+};
+
+type SchemaFields = {
+    name: string;
+    type: string;
+};
+type RawSchemaFields = Partial<SchemaFields>;
+
+const isSchemaFields = (
+    rawSchemaFields: RawSchemaFields[],
+): rawSchemaFields is SchemaFields[] =>
+    rawSchemaFields.every((field) => field.type && field.name);
+
+const parseRows = (
+    rows: Record<string, any>[],
+    schemaFields: RawSchemaFields[],
+) => {
+    // TODO: assumes columns cannot have the same name
+    if (!isSchemaFields(schemaFields)) {
+        throw new Error('Could not parse response from bigquery');
+    }
+    const parsers: Record<string, (cell: any) => any> = Object.fromEntries(
+        schemaFields.map((field) => [field.name, getParser(field.type)]),
+    );
+    return rows.map((row) =>
+        Object.fromEntries(
+            Object.entries(row).map(([name, value]) => [
+                name,
+                parsers[name](value),
+            ]),
+        ),
+    );
+};
 
 export default class BigqueryWarehouseClient implements QueryRunner {
     client: BigQuery;
@@ -31,8 +90,16 @@ export default class BigqueryWarehouseClient implements QueryRunner {
                 priority: this.credentials.priority,
                 jobTimeoutMs: this.credentials.timeoutSeconds * 1000,
             });
-            const [rows] = await job.getQueryResults(job);
-            return rows;
+            // auto paginate - hides full response
+            const [rows] = await job.getQueryResults({ autoPaginate: true });
+
+            // manual paginate - gives access to full api
+            const [firstPage, nextQuery, apiResponse] =
+                await job.getQueryResults({ autoPaginate: false });
+            if (apiResponse?.schema?.fields === undefined) {
+                throw new Error('Not a valid response from bigquery');
+            }
+            return parseRows(rows, apiResponse.schema.fields);
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         }


### PR DESCRIPTION
Closes #665

* Fetch the first page of results a secondtime but with a manual callback that returns the full api response containing the schema
* Use the schema to parse all data return from bigquery.

Doesn't support `RECORD`, `ARRAY` or `REPEATED`

Alternative solution to #671 

---

These are temporary solutions. We need to either:
1. Request changes to the node client: https://github.com/googleapis/nodejs-bigquery to include type information on rows
2. Use our own manual callback in `.getQueryClientResults` which will need to handle pagination (this is done for us) but will also give access to the entire api response, including schema information.