### PR TITLE
feat: set environment tag for sentry sdk

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -34,6 +34,10 @@ const app = express();
 Sentry.init({
     release: VERSION,
     dsn: process.env.SENTRY_DSN,
+    environment:
+        process.env.NODE_ENV === 'development'
+            ? 'development'
+            : lightdashConfig.mode,
     integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Express({


### PR DESCRIPTION
Sets the environment to `development` when in dev. Otherwise sets it to `lightdashMode` to capture different production environments.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)