### PR TITLE
feat: set lightdash mode from envvar

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -9,6 +9,7 @@ import {
     DbtGithubProjectConfig,
     DbtGitlabProjectConfig,
     ProjectType,
+    isLightdashMode,
 } from 'common';
 import lightdashV1JsonSchema from '../jsonSchemas/lightdashConfig/v1.json';
 import { ParseError } from '../errors';
@@ -137,8 +138,19 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             {},
         );
     }
+    const lightdashMode = process.env.LIGHTDASH_MODE;
+    if (lightdashMode !== undefined && !isLightdashMode(lightdashMode)) {
+        throw new ParseError(
+            `Lightdash mode set by environment variable LIGHTDASH_MODE=${lightdashMode} is invalid. Must be one of ${Object.values(
+                LightdashMode,
+            )}`,
+            {},
+        );
+    }
+
     return {
         ...config,
+        mode: lightdashMode || config.mode,
         projects: mergedProjects,
         rudder: {
             writeKey:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -727,6 +727,8 @@ export enum LightdashMode {
     PR = 'pr',
     CLOUD_BETA = 'cloud_beta',
 }
+export const isLightdashMode = (x: string): x is LightdashMode =>
+    Object.values<string>(LightdashMode).includes(x);
 
 export enum LightdashInstallType {
     DOCKER_IMAGE = 'docker_image',


### PR DESCRIPTION
The LightdashMode can now be set using an environment variable. This will override the value provided in the `lightdash.yml` to be consistent with other variables in `lightdash.yml`

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)