### PR TITLE
fix: use time-series layout for time-like dimensions in charts

### DIFF
--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -1,6 +1,6 @@
 import EChartsReact from 'echarts-for-react';
-import React, { RefObject, FC } from 'react';
-import { friendlyName, DBChartTypes } from 'common';
+import React, { FC, RefObject } from 'react';
+import { DBChartTypes, DimensionType, friendlyName } from 'common';
 import { NonIdealState, Spinner } from '@blueprintjs/core';
 import { ChartConfig } from '../hooks/useChartConfig';
 
@@ -50,6 +50,18 @@ const LoadingChart = () => (
     </div>
 );
 
+const axisTypeFromDimensionType = (
+    dimensionType: DimensionType | undefined,
+) => {
+    switch (dimensionType) {
+        case DimensionType.DATE:
+        case DimensionType.TIMESTAMP:
+            return 'time';
+        default:
+            return 'category';
+    }
+};
+
 type SimpleChartProps = {
     isLoading: boolean;
     chartRef: RefObject<EChartsReact>;
@@ -69,7 +81,7 @@ export const SimpleChart: FC<SimpleChartProps> = ({
         chartConfig.seriesLayout.groupDimension &&
         chartConfig.seriesLayout.yMetrics.length === 1 &&
         friendlyName(chartConfig.seriesLayout.yMetrics[0]);
-    const xType = 'category';
+    const xType = axisTypeFromDimensionType(chartConfig.xDimensionType);
     const yType = 'value';
 
     const flipX = flipXFromChartType(chartType);

--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -93,7 +93,7 @@ export const SimpleChart: FC<SimpleChartProps> = ({
         nameTextStyle: { fontWeight: 'bold' },
     };
     const yAxis = {
-        type: flipX ? xType : yType,
+        type: flipX ? 'category' : yType,
         name: flipX ? xlabel : ylabel,
         nameTextStyle: { fontWeight: 'bold' },
     };

--- a/packages/frontend/src/hooks/useChartConfig.tsx
+++ b/packages/frontend/src/hooks/useChartConfig.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import {
     ApiQueryResults,
     CompiledDimension,
+    DimensionType,
     fieldId as getFieldId,
     friendlyName,
     getDimensions,
@@ -59,6 +60,7 @@ type ChartConfigBase = {
     tableCalculationOptions: TableCalculation[];
     eChartDimensions: { name: string; displayName: string }[];
     series: string[];
+    xDimensionType: DimensionType | undefined;
 };
 export type ChartConfig = ChartConfigBase &
     (
@@ -333,6 +335,9 @@ export const useChartConfig = (
                     : row,
             );
         }
+        const xDimensionType = dimensions.find(
+            (dimension) => getFieldId(dimension) === seriesLayout.xDimension,
+        )?.type;
         return {
             setXDimension,
             setGroupDimension,
@@ -344,6 +349,7 @@ export const useChartConfig = (
             tableCalculationOptions,
             dimensionOptions,
             series,
+            xDimensionType,
         };
     }
     return {
@@ -357,5 +363,6 @@ export const useChartConfig = (
         tableCalculationOptions,
         dimensionOptions,
         series: [],
+        xDimensionType: undefined,
     };
 };


### PR DESCRIPTION
This PR sets the xAxis on a chart to an [echarts 'time' type](https://echarts.apache.org/en/option.html#xAxis.type).

**Before**
* Points are equally spaced even though timestamps have very irregular spacing
* Labels are ISO timestamp strings
* Chart is in wrong order with most recent on the left (because of the sort direction)

<img width="1111" alt="Screenshot 2021-11-01 at 20 55 50" src="https://user-images.githubusercontent.com/11660098/139741413-2e5427ad-6310-4d13-84f3-d1bfbf9f4e48.png">

**After**
* Points are correctly spaced in time
* Labels are human friendly
* Chart is always in increasing time order from left to right

<img width="1122" alt="Screenshot 2021-11-01 at 20 56 15" src="https://user-images.githubusercontent.com/11660098/139741553-a145d156-4edd-4790-ada3-400afc32ee5b.png">


**Considerations** 

* For bar style (where the axes are flipped) - it didn't render with `time` types, so it defaults to categorical as before.
* The chart uses linear interpolation. e.g. in the second image above, there is a huge gap between the peak value of 50 and the next value of 2 (row above 50). This is rendered as a long slope. This is a good start I think but could be improved if we could infer a reasonable date grid automatically.