### PR TITLE
chore: instrument dbt cli calls

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -60,7 +60,7 @@ Sentry.init({
 app.use(
     Sentry.Handlers.requestHandler({
         user: ['userUuid', 'organizationUuid', 'organizationName'],
-    }),
+    }) as express.RequestHandler,
 );
 app.use(Sentry.Handlers.tracingHandler());
 app.use(express.json());


### PR DESCRIPTION
These only show in traces when an GET request triggers a recompile. When hitting the "refresh" button, the work happens async and traces don't render.