### PR TITLE
build(#726): update dbt to 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Recent and upcoming changes to lightdash
 
 ## Unreleased
+### Changed
+- Lightdash requires dbt version 0.21.0 or higher
 
 ## [0.9.0] - 2021-10-26
 ### Added

--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install "dbt=>0.21.0,<0.22.0"
+RUN /usr/local/venv/bin/pip install "dbt>=0.21.0,<0.22.0"
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install dbt==0.21.0
+RUN /usr/local/venv/bin/pip install "dbt=>0.21.0,<0.22.0"
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install dbt==0.20.0
+RUN /usr/local/venv/bin/pip install dbt==0.21.0
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install "dbt=>0.21.0,<0.22.0"
+RUN /usr/local/venv/bin/pip install "dbt>=0.21.0,<0.22.0"
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install dbt==0.21.0
+RUN /usr/local/venv/bin/pip install "dbt=>0.21.0,<0.22.0"
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -10,7 +10,7 @@ FROM base AS dbt-builder
 
 # dbt
 RUN python -m venv /usr/local/venv
-RUN /usr/local/venv/bin/pip install dbt==0.20.0
+RUN /usr/local/venv/bin/pip install dbt==0.21.0
 
 # Install gcloud sdk
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/docs/docs/faqs/faqs.md
+++ b/docs/docs/faqs/faqs.md
@@ -107,4 +107,4 @@ the dbt process process is running correctly.
 ## I'm using an old version of dbt, is Lightdash supported?
 
 ---
-We only support dbt version `0.20.0`. Before using Lightdash, please check your project is compatible with the latest version.
+We only support dbt version `0.21.0`. Before using Lightdash, please check your project is compatible with the latest version.

--- a/docs/docs/get-started/setup-lightdash/connect-project.mdx
+++ b/docs/docs/get-started/setup-lightdash/connect-project.mdx
@@ -53,7 +53,7 @@ Once you've located your environments, follow these steps to get your environmen
 1. Click on the Environment that is `type: development`. This is the environment you use when developing in the dbt cloud IDE. 
 ![screenshot](../assets/dbt-cloud-env-select.png)
 2. Get your **Environment ID** from the URL after `/environments/`
-3. Check that your environment is using dbt `0.20.0` or above (you can change this in environment settings)
+3. Check that your environment is using dbt `0.21.0` or above (you can change this in environment settings)
 
 ![screenshot](../assets/dbt-cloud-env-details.png)
 

--- a/packages/backend/src/schema.json
+++ b/packages/backend/src/schema.json
@@ -92,16 +92,16 @@
             "properties": {
                 "dbt_schema_version": {
                     "type": "string",
-                    "default": "https://schemas.getdbt.com/dbt/manifest/v2.json"
+                    "default": "https://schemas.getdbt.com/dbt/manifest/v3.json"
                 },
                 "dbt_version": {
                     "type": "string",
-                    "default": "0.20.0rc1"
+                    "default": "0.21.0rc1"
                 },
                 "generated_at": {
                     "type": "string",
                     "format": "date-time",
-                    "default": "2021-06-07T14:49:01.099700Z"
+                    "default": "2021-09-24T13:29:14.317700Z"
                 },
                 "invocation_id": {
                     "oneOf": [
@@ -244,16 +244,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -350,7 +351,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -385,7 +390,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledAnalysisNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledAnalysisNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "FileHash": {
             "type": "object",
@@ -408,40 +413,6 @@
                 "enabled": {
                     "type": "boolean",
                     "default": true
-                },
-                "materialized": {
-                    "type": "string",
-                    "default": "view"
-                },
-                "persist_docs": {
-                    "type": "object",
-                    "default": {}
-                },
-                "post-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "pre-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "vars": {
-                    "type": "object",
-                    "default": {}
-                },
-                "quoting": {
-                    "type": "object",
-                    "default": {}
-                },
-                "column_types": {
-                    "type": "object",
-                    "default": {}
                 },
                 "alias": {
                     "oneOf": [
@@ -487,6 +458,40 @@
                     ],
                     "default": []
                 },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "view"
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
                 "full_refresh": {
                     "oneOf": [
                         {
@@ -496,10 +501,21 @@
                             "type": "null"
                         }
                     ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
                 }
             },
             "additionalProperties": true,
-            "description": "NodeConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, materialized: str = 'view', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, vars: Dict[str, Any] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, full_refresh: Union[bool, NoneType] = None)"
+            "description": "NodeConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'view', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Union[bool, NoneType] = None, on_schema_change: Union[str, NoneType] = 'ignore')"
         },
         "Hook": {
             "type": "object",
@@ -696,25 +712,19 @@
                     "$ref": "#/definitions/TestConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "test",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": "dbt_test__audit",
                         "database": null,
                         "tags": [],
-                        "full_refresh": null,
+                        "meta": {},
+                        "materialized": "test",
                         "severity": "ERROR",
                         "store_failures": null,
                         "where": null,
                         "limit": null,
                         "fail_calc": "count(*)",
                         "warn_if": "!= 0",
-                        "error_if": "!= 0",
-                        "post-hook": [],
-                        "pre-hook": []
+                        "error_if": "!= 0"
                     }
                 },
                 "tags": {
@@ -809,7 +819,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -844,7 +858,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledDataTestNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledDataTestNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "TestConfig": {
             "type": "object",
@@ -853,40 +867,6 @@
                 "enabled": {
                     "type": "boolean",
                     "default": true
-                },
-                "materialized": {
-                    "type": "string",
-                    "default": "test"
-                },
-                "persist_docs": {
-                    "type": "object",
-                    "default": {}
-                },
-                "post-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "pre-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "vars": {
-                    "type": "object",
-                    "default": {}
-                },
-                "quoting": {
-                    "type": "object",
-                    "default": {}
-                },
-                "column_types": {
-                    "type": "object",
-                    "default": {}
                 },
                 "alias": {
                     "oneOf": [
@@ -933,15 +913,13 @@
                     ],
                     "default": []
                 },
-                "full_refresh": {
-                    "oneOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "test"
                 },
                 "severity": {
                     "type": "string",
@@ -992,7 +970,7 @@
                 }
             },
             "additionalProperties": true,
-            "description": "TestConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, materialized: str = 'test', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, vars: Dict[str, Any] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = 'dbt_test__audit', database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, full_refresh: Union[bool, NoneType] = None, severity: dbt.contracts.graph.model_config.Severity = 'ERROR', store_failures: Union[bool, NoneType] = None, where: Union[str, NoneType] = None, limit: Union[int, NoneType] = None, fail_calc: str = 'count(*)', warn_if: str = '!= 0', error_if: str = '!= 0')"
+            "description": "TestConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = 'dbt_test__audit', database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'test', severity: dbt.contracts.graph.model_config.Severity = 'ERROR', store_failures: Union[bool, NoneType] = None, where: Union[str, NoneType] = None, limit: Union[int, NoneType] = None, fail_calc: str = 'count(*)', warn_if: str = '!= 0', error_if: str = '!= 0')"
         },
         "CompiledModelNode": {
             "type": "object",
@@ -1069,16 +1047,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -1176,7 +1155,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -1211,7 +1194,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledModelNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledModelNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "CompiledHookNode": {
             "type": "object",
@@ -1288,16 +1271,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -1394,7 +1378,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -1439,7 +1427,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledHookNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None, index: Union[int, NoneType] = None)"
+            "description": "CompiledHookNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None, index: Union[int, NoneType] = None)"
         },
         "CompiledRPCNode": {
             "type": "object",
@@ -1516,16 +1504,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -1622,7 +1611,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -1657,7 +1650,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledRPCNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledRPCNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "CompiledSchemaTestNode": {
             "type": "object",
@@ -1738,25 +1731,19 @@
                     "$ref": "#/definitions/TestConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "test",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": "dbt_test__audit",
                         "database": null,
                         "tags": [],
-                        "full_refresh": null,
+                        "meta": {},
+                        "materialized": "test",
                         "severity": "ERROR",
                         "store_failures": null,
                         "where": null,
                         "limit": null,
                         "fail_calc": "count(*)",
                         "warn_if": "!= 0",
-                        "error_if": "!= 0",
-                        "post-hook": [],
-                        "pre-hook": []
+                        "error_if": "!= 0"
                     }
                 },
                 "tags": {
@@ -1851,7 +1838,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -1896,7 +1887,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledSchemaTestNode(raw_sql: str, test_metadata: dbt.contracts.graph.parsed.TestMetadata, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None, column_name: Union[str, NoneType] = None)"
+            "description": "CompiledSchemaTestNode(raw_sql: str, test_metadata: dbt.contracts.graph.parsed.TestMetadata, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None, column_name: Union[str, NoneType] = None)"
         },
         "TestMetadata": {
             "type": "object",
@@ -1998,16 +1989,17 @@
                     "$ref": "#/definitions/SeedConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "seed",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "seed",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "quote_columns": null,
                         "post-hook": [],
                         "pre-hook": []
@@ -2105,7 +2097,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -2140,7 +2136,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledSeedNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledSeedNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "SeedConfig": {
             "type": "object",
@@ -2149,40 +2145,6 @@
                 "enabled": {
                     "type": "boolean",
                     "default": true
-                },
-                "materialized": {
-                    "type": "string",
-                    "default": "seed"
-                },
-                "persist_docs": {
-                    "type": "object",
-                    "default": {}
-                },
-                "post-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "pre-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "vars": {
-                    "type": "object",
-                    "default": {}
-                },
-                "quoting": {
-                    "type": "object",
-                    "default": {}
-                },
-                "column_types": {
-                    "type": "object",
-                    "default": {}
                 },
                 "alias": {
                     "oneOf": [
@@ -2228,6 +2190,40 @@
                     ],
                     "default": []
                 },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "seed"
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
                 "full_refresh": {
                     "oneOf": [
                         {
@@ -2237,6 +2233,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
                 },
                 "quote_columns": {
                     "oneOf": [
@@ -2250,7 +2257,7 @@
                 }
             },
             "additionalProperties": true,
-            "description": "SeedConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, materialized: str = 'seed', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, vars: Dict[str, Any] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, full_refresh: Union[bool, NoneType] = None, quote_columns: Union[bool, NoneType] = None)"
+            "description": "SeedConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'seed', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Union[bool, NoneType] = None, on_schema_change: Union[str, NoneType] = 'ignore', quote_columns: Union[bool, NoneType] = None)"
         },
         "CompiledSnapshotNode": {
             "type": "object",
@@ -2327,16 +2334,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -2433,7 +2441,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "compiled_sql": {
                     "oneOf": [
@@ -2468,7 +2480,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "CompiledSnapshotNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
+            "description": "CompiledSnapshotNode(raw_sql: str, compiled: bool, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_sql: Union[str, NoneType] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Union[str, NoneType] = None, _pre_injected_sql: Union[str, NoneType] = None)"
         },
         "ParsedAnalysisNode": {
             "type": "object",
@@ -2541,16 +2553,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -2647,11 +2660,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedAnalysisNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedAnalysisNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "ParsedDataTestNode": {
             "type": "object",
@@ -2724,25 +2741,19 @@
                     "$ref": "#/definitions/TestConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "test",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": "dbt_test__audit",
                         "database": null,
                         "tags": [],
-                        "full_refresh": null,
+                        "meta": {},
+                        "materialized": "test",
                         "severity": "ERROR",
                         "store_failures": null,
                         "where": null,
                         "limit": null,
                         "fail_calc": "count(*)",
                         "warn_if": "!= 0",
-                        "error_if": "!= 0",
-                        "post-hook": [],
-                        "pre-hook": []
+                        "error_if": "!= 0"
                     }
                 },
                 "tags": {
@@ -2837,11 +2848,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedDataTestNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedDataTestNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "ParsedHookNode": {
             "type": "object",
@@ -2914,16 +2929,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -3020,7 +3036,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "index": {
                     "oneOf": [
@@ -3034,7 +3054,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedHookNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, index: Union[int, NoneType] = None)"
+            "description": "ParsedHookNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, index: Union[int, NoneType] = None)"
         },
         "ParsedModelNode": {
             "type": "object",
@@ -3107,16 +3127,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -3213,11 +3234,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedModelNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedModelNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "ParsedRPCNode": {
             "type": "object",
@@ -3290,16 +3315,17 @@
                     "$ref": "#/definitions/NodeConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "post-hook": [],
                         "pre-hook": []
                     }
@@ -3396,11 +3422,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedRPCNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedRPCNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "ParsedSchemaTestNode": {
             "type": "object",
@@ -3477,25 +3507,19 @@
                     "$ref": "#/definitions/TestConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "test",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": "dbt_test__audit",
                         "database": null,
                         "tags": [],
-                        "full_refresh": null,
+                        "meta": {},
+                        "materialized": "test",
                         "severity": "ERROR",
                         "store_failures": null,
                         "where": null,
                         "limit": null,
                         "fail_calc": "count(*)",
                         "warn_if": "!= 0",
-                        "error_if": "!= 0",
-                        "post-hook": [],
-                        "pre-hook": []
+                        "error_if": "!= 0"
                     }
                 },
                 "tags": {
@@ -3590,7 +3614,11 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 },
                 "column_name": {
                     "oneOf": [
@@ -3604,7 +3632,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedSchemaTestNode(raw_sql: str, test_metadata: dbt.contracts.graph.parsed.TestMetadata, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, column_name: Union[str, NoneType] = None)"
+            "description": "ParsedSchemaTestNode(raw_sql: str, test_metadata: dbt.contracts.graph.parsed.TestMetadata, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>, column_name: Union[str, NoneType] = None)"
         },
         "ParsedSeedNode": {
             "type": "object",
@@ -3677,16 +3705,17 @@
                     "$ref": "#/definitions/SeedConfig",
                     "default": {
                         "enabled": true,
-                        "materialized": "seed",
-                        "persist_docs": {},
-                        "vars": {},
-                        "quoting": {},
-                        "column_types": {},
                         "alias": null,
                         "schema": null,
                         "database": null,
                         "tags": [],
+                        "meta": {},
+                        "materialized": "seed",
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
                         "full_refresh": null,
+                        "on_schema_change": "ignore",
                         "quote_columns": null,
                         "post-hook": [],
                         "pre-hook": []
@@ -3784,11 +3813,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedSeedNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedSeedNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "ParsedSnapshotNode": {
             "type": "object",
@@ -3953,11 +3986,15 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
                 }
             },
             "additionalProperties": false,
-            "description": "ParsedSnapshotNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SnapshotConfig, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>)"
+            "description": "ParsedSnapshotNode(raw_sql: str, database: Union[str, NoneType], schema: str, fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SnapshotConfig, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[Any]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Union[str, NoneType] = None, compiled_path: Union[str, NoneType] = None, build_path: Union[str, NoneType] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: int = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
         },
         "SnapshotConfig": {
             "type": "object",
@@ -3966,40 +4003,6 @@
                 "enabled": {
                     "type": "boolean",
                     "default": true
-                },
-                "materialized": {
-                    "type": "string",
-                    "default": "snapshot"
-                },
-                "persist_docs": {
-                    "type": "object",
-                    "default": {}
-                },
-                "post-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "pre-hook": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Hook"
-                    },
-                    "default": []
-                },
-                "vars": {
-                    "type": "object",
-                    "default": {}
-                },
-                "quoting": {
-                    "type": "object",
-                    "default": {}
-                },
-                "column_types": {
-                    "type": "object",
-                    "default": {}
                 },
                 "alias": {
                     "oneOf": [
@@ -4045,6 +4048,40 @@
                     ],
                     "default": []
                 },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "snapshot"
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
                 "full_refresh": {
                     "oneOf": [
                         {
@@ -4054,6 +4091,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
                 },
                 "strategy": {
                     "oneOf": [
@@ -4123,7 +4171,7 @@
                 }
             },
             "additionalProperties": true,
-            "description": "SnapshotConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, materialized: str = 'snapshot', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, vars: Dict[str, Any] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, full_refresh: Union[bool, NoneType] = None, strategy: Union[str, NoneType] = None, unique_key: Union[str, NoneType] = None, target_schema: Union[str, NoneType] = None, target_database: Union[str, NoneType] = None, updated_at: Union[str, NoneType] = None, check_cols: Union[str, List[str], NoneType] = None)"
+            "description": "SnapshotConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Union[str, NoneType] = None, schema: Union[str, NoneType] = None, database: Union[str, NoneType] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'snapshot', persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Union[bool, NoneType] = None, on_schema_change: Union[str, NoneType] = 'ignore', strategy: Union[str, NoneType] = None, unique_key: Union[str, NoneType] = None, target_schema: Union[str, NoneType] = None, target_database: Union[str, NoneType] = None, updated_at: Union[str, NoneType] = None, check_cols: Union[str, List[str], NoneType] = None)"
         },
         "ParsedSourceDefinition": {
             "type": "object",
@@ -4293,7 +4341,7 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
                 }
             },
             "additionalProperties": false,
@@ -4391,16 +4439,16 @@
             "properties": {
                 "dbt_schema_version": {
                     "type": "string",
-                    "default": "https://schemas.getdbt.com/dbt/sources/v1.json"
+                    "default": "https://schemas.getdbt.com/dbt/sources/v2.json"
                 },
                 "dbt_version": {
                     "type": "string",
-                    "default": "0.20.0rc1"
+                    "default": "0.21.0rc1"
                 },
                 "generated_at": {
                     "type": "string",
                     "format": "date-time",
-                    "default": "2021-06-07T14:49:01.095724Z"
+                    "default": "2021-09-24T13:29:14.312598Z"
                 },
                 "invocation_id": {
                     "oneOf": [
@@ -4421,7 +4469,7 @@
                 }
             },
             "additionalProperties": false,
-            "description": "FreshnessMetadata(dbt_schema_version: str = <factory>, dbt_version: str = '0.20.0rc1', generated_at: datetime.datetime = <factory>, invocation_id: Union[str, NoneType] = <factory>, env: Dict[str, str] = <factory>)"
+            "description": "FreshnessMetadata(dbt_schema_version: str = <factory>, dbt_version: str = '0.21.0rc1', generated_at: datetime.datetime = <factory>, invocation_id: Union[str, NoneType] = <factory>, env: Dict[str, str] = <factory>)"
         },
         "SourceFreshnessRuntimeError": {
             "type": "object",
@@ -4460,7 +4508,10 @@
                 "max_loaded_at_time_ago_in_s",
                 "status",
                 "criteria",
-                "adapter_response"
+                "adapter_response",
+                "timing",
+                "thread_id",
+                "execution_time"
             ],
             "properties": {
                 "unique_id": {
@@ -4486,10 +4537,22 @@
                 },
                 "adapter_response": {
                     "type": "object"
+                },
+                "timing": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimingInfo"
+                    }
+                },
+                "thread_id": {
+                    "type": "string"
+                },
+                "execution_time": {
+                    "type": "number"
                 }
             },
             "additionalProperties": false,
-            "description": "SourceFreshnessOutput(unique_id: str, max_loaded_at: datetime.datetime, snapshotted_at: datetime.datetime, max_loaded_at_time_ago_in_s: float, status: dbt.contracts.results.FreshnessStatus, criteria: dbt.contracts.graph.unparsed.FreshnessThreshold, adapter_response: Dict[str, Any])"
+            "description": "SourceFreshnessOutput(unique_id: str, max_loaded_at: datetime.datetime, snapshotted_at: datetime.datetime, max_loaded_at_time_ago_in_s: float, status: dbt.contracts.results.FreshnessStatus, criteria: dbt.contracts.graph.unparsed.FreshnessThreshold, adapter_response: Dict[str, Any], timing: List[dbt.contracts.results.TimingInfo], thread_id: str, execution_time: float)"
         },
         "Time": {
             "type": "object",
@@ -4505,6 +4568,39 @@
             },
             "additionalProperties": false,
             "description": "Time(count: int, period: dbt.contracts.graph.unparsed.TimePeriod)"
+        },
+        "TimingInfo": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "completed_at": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "TimingInfo(name: str, started_at: Union[datetime.datetime, NoneType] = None, completed_at: Union[datetime.datetime, NoneType] = None)"
         },
         "ExternalTable": {
             "type": "object",
@@ -4687,7 +4783,7 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
                 }
             },
             "additionalProperties": false,
@@ -4903,7 +4999,7 @@
                 },
                 "created_at": {
                     "type": "integer",
-                    "default": 1623077341
+                    "default": 1632490154
                 }
             },
             "additionalProperties": false,
@@ -4932,5 +5028,5 @@
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schemas.lightdash.com/dbt/dbtModel/v2.json"
+    "$id": "https://schemas.lightdash.com/dbt/dbtModel/v3.json"
 }


### PR DESCRIPTION
Closes #726

No major changes to `manifest.json`. `meta` can now be used in the `config` block of a dbt model but I've decided not to support that yet.

I've tested this with manifests from `0.20.0` and `0.21.0` without errors