### PR TITLE
build: remove gcloud oauth mode for bigquery

### DIFF
--- a/docker-compose.oauth.yml
+++ b/docker-compose.oauth.yml
@@ -1,5 +1,0 @@
-version: "3.9"
-services:
-  lightdash:
-    volumes:
-      - "${GCLOUD_CONFIG_DIR}:/root/.config/gcloud"

--- a/docker-compose.service-account.yml
+++ b/docker-compose.service-account.yml
@@ -1,5 +1,0 @@
-version: "3.9"
-services:
-  lightdash:
-    volumes:
-      - "${KEY_FILE_PATH}:${KEY_FILE_PATH}"

--- a/dockerfile
+++ b/dockerfile
@@ -12,11 +12,6 @@ FROM base AS dbt-builder
 RUN python -m venv /usr/local/venv
 RUN /usr/local/venv/bin/pip install "dbt>=0.21.0,<0.22.0"
 
-# Install gcloud sdk
-RUN apt-get update && apt-get install -y --no-install-recommends curl
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-341.0.0-linux-x86_64.tar.gz > /tmp/gcloud-sdk.tar.gz
-RUN mkdir /usr/local/gcloud && tar -C /usr/local/gcloud -xvf /tmp/gcloud-sdk.tar.gz
-
 
 # -------------------------------
 # Stage 2: base with dependencies
@@ -26,8 +21,6 @@ FROM base as base-dependencies
 # Copy in dependencies
 COPY --from=dbt-builder /usr/local/venv /usr/local/venv
 ENV PATH $PATH:/usr/local/venv/bin
-COPY --from=dbt-builder /usr/local/gcloud /usr/local/gcloud
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Setup common config
 COPY lightdash.yml /usr/app/lightdash.yml

--- a/dockerfile-demo
+++ b/dockerfile-demo
@@ -12,11 +12,6 @@ FROM base AS dbt-builder
 RUN python -m venv /usr/local/venv
 RUN /usr/local/venv/bin/pip install "dbt>=0.21.0,<0.22.0"
 
-# Install gcloud sdk
-RUN apt-get update && apt-get install -y --no-install-recommends curl
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-341.0.0-linux-x86_64.tar.gz > /tmp/gcloud-sdk.tar.gz
-RUN mkdir /usr/local/gcloud && tar -C /usr/local/gcloud -xvf /tmp/gcloud-sdk.tar.gz
-
 
 # -------------------------------
 # Stage 2: base with dependencies
@@ -26,8 +21,6 @@ FROM base as base-dependencies
 # Copy in dependencies
 COPY --from=dbt-builder /usr/local/venv /usr/local/venv
 ENV PATH $PATH:/usr/local/venv/bin
-COPY --from=dbt-builder /usr/local/gcloud /usr/local/gcloud
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Setup common config
 COPY lightdash-pr.yml /usr/app/lightdash.yml

--- a/docs/docs/faqs/faqs.md
+++ b/docs/docs/faqs/faqs.md
@@ -96,13 +96,7 @@ Finding the problem:
 ## Lightdash timedout trying to connect to dbt. Is dbt running correctly?
 
 ---
-This means that Lightdash had to wait too long for dbt to respond. This could be because:
-
-* You're a bigquery user and use `method: oauth` in your `profiles.yml` file. Check that the Lightdash server can access 
-credentials at `~/.config/gcloud`
-* You're running dbt in a separate process using the flag `LIGHTDASH_SPAWN_DBT=false`. In this case please check whether
-the dbt process process is running correctly.
-* If neither apply please [open an issue](https://github.com/lightdash/lightdash/issues/new/choose)
+This means that Lightdash had to wait too long for dbt to respond. Please [open an issue](https://github.com/lightdash/lightdash/issues/new/choose)
 
 ## I'm using an old version of dbt, is Lightdash supported?
 

--- a/packages/backend/src/dbt/dbtRpcClientBase.ts
+++ b/packages/backend/src/dbt/dbtRpcClientBase.ts
@@ -240,16 +240,6 @@ export class DbtRpcClientBase implements DbtClient {
         const result = await this._post('poll', {
             request_token: requestToken,
         });
-        if (
-            result?.logs?.some(
-                (log: any) => log.message === 'Please log into GCP to continue',
-            )
-        ) {
-            throw new DbtError(
-                `Lightdash cannot connect to dbt because of missing GCP credentials. This error happened because your profiles.yml contains a bigquery profile with method: oauth`,
-                {},
-            );
-        }
         return result;
     }
 


### PR DESCRIPTION
Since we only accept credentials through the UI with a service account, we no longer need to support oauth.

Improvements:
* slimmer docker image
* no more scanning dbt logs

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)