### PR TITLE
Fix codespace startup

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -28,6 +28,8 @@ services:
     ports:
       - "${PORT}:8080"
       - "3000:3000"
+    command: ""
+    entrypoint: ["/bin/sh", "-c", "sleep infinity"]
 
   db-dev:
     image: postgres


### PR DESCRIPTION
When using a Docker-compose config, the main codespace container needs to remain running indefinitely. Since the Dockerfile has an entrypoint script which ends up exiting, the devcontainer config for the codespace needs to override the entrypoint and command to provide a simple script which runs forever. This allows the main codespace container to stay running and connectable.

I verified that running a codespace on this branch remains available.

Note that Codespaces does not yet support the `workspaceFolder` property in devcontainer.json, but the codespace itself does launch with this configuration. The source code is mounted to `/workspaces/lightdash`.