### PR TITLE
fix(#752): encode echarts dimensions explicitly

### DIFF
--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -106,8 +106,15 @@ export const SimpleChart: FC<SimpleChartProps> = ({
             2,
     };
 
-    const series = chartConfig.series.map(() => ({
+    const series = chartConfig.series.map((seriesDimension) => ({
         type: echartType(chartType),
+        connectNulls: true,
+        encode: {
+            x: flipX ? seriesDimension : chartConfig.seriesLayout.xDimension,
+            y: flipX ? chartConfig.seriesLayout.xDimension : seriesDimension,
+            tooltip: [chartConfig.seriesLayout.xDimension, seriesDimension],
+            seriesName: seriesDimension,
+        },
     }));
     const options = {
         xAxis,


### PR DESCRIPTION
Closes #752

When showing multiple series, echarts was showing some strange behaviour for time-series plots.

This seemed to be fixed by providing explicit encoding from the data to each series.

This change also adds:
* More reliable series labels
* Better tooltips


—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)