### PR TITLE
fix(#414): disable metric toggle and dimension group button when they are t…

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel.tsx
@@ -71,6 +71,7 @@ export const ChartConfigOptions: React.FC<ContentProps> = ({ chartConfig }) => (
                     label={friendlyName(metric)}
                     alignIndicator={Alignment.RIGHT}
                     onChange={() => chartConfig.toggleYMetric(metric)}
+                    disabled={chartConfig.metricOptions.length <= 1}
                 />
             </div>
         ))}
@@ -97,6 +98,7 @@ export const ChartConfigOptions: React.FC<ContentProps> = ({ chartConfig }) => (
                             dimension === chartConfig.seriesLayout.xDimension
                         }
                         onClick={() => chartConfig.setXDimension(dimension)}
+                        disabled={chartConfig.dimensionOptions.length <= 1}
                     >
                         X-axis
                     </Button>


### PR DESCRIPTION
…he only possible values

Closes: #414 

We now disable the metric toggle and the dimension 'X-axis' button. 

Preview:
![Screenshot 2021-11-09 at 13 54 16](https://user-images.githubusercontent.com/9117144/140937648-9912ca49-32e3-4175-b82a-7307bf4fbfe0.png)

