### PR TITLE
fix: make it easier to find the project settings page

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -14,7 +14,7 @@ import {
 import { Popover2 } from '@blueprintjs/popover2';
 import { DBChartTypes, SavedQuery } from 'common';
 import EChartsReact from 'echarts-for-react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import FiltersForm from '../filters';
 import { ExplorerResults } from './ExplorerResults';
 import { SimpleChart } from './SimpleChart';
@@ -38,6 +38,7 @@ interface Props {
 }
 
 export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
     const chartRef = useRef<EChartsReact>(null);
     const location = useLocation<{ fromExplorer?: boolean } | undefined>();
@@ -135,6 +136,11 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     <Popover2
                         content={
                             <Menu>
+                                <MenuItem
+                                    icon="cog"
+                                    text="Project settings"
+                                    href={`/projects/${projectUuid}/settings`}
+                                />
                                 {savedQueryUuid && (
                                     <MenuItem
                                         icon="saved"

--- a/packages/frontend/src/components/UserSettingsModal/ProjectManagementPanel.tsx
+++ b/packages/frontend/src/components/UserSettingsModal/ProjectManagementPanel.tsx
@@ -1,55 +1,47 @@
 import React, { FC } from 'react';
 import { OrganizationProject } from 'common';
-import { Card, Classes, Button, ButtonGroup } from '@blueprintjs/core';
-import { useHistory } from 'react-router-dom';
+import { Card, Classes, ButtonGroup, AnchorButton } from '@blueprintjs/core';
 import { useProjects } from '../../hooks/useProjects';
 
 const ProjectListItem: FC<{ project: OrganizationProject }> = ({
     project: { projectUuid, name },
-}) => {
-    const history = useHistory();
-    return (
-        <Card
-            elevation={0}
+}) => (
+    <Card
+        elevation={0}
+        style={{
+            display: 'flex',
+            flexDirection: 'column',
+            marginBottom: '20px',
+        }}
+    >
+        <div
             style={{
                 display: 'flex',
-                flexDirection: 'column',
-                marginBottom: '20px',
+                alignItems: 'center',
             }}
         >
-            <div
+            <p
                 style={{
-                    display: 'flex',
-                    alignItems: 'center',
+                    margin: 0,
+                    marginRight: '10px',
+                    flex: 1,
+                    fontWeight: 'bold',
                 }}
+                className={Classes.TEXT_OVERFLOW_ELLIPSIS}
             >
-                <p
-                    style={{
-                        margin: 0,
-                        marginRight: '10px',
-                        flex: 1,
-                        fontWeight: 'bold',
-                    }}
-                    className={Classes.TEXT_OVERFLOW_ELLIPSIS}
-                >
-                    {name}
-                </p>
-                <ButtonGroup>
-                    <Button
-                        icon="edit"
-                        outlined
-                        text="Edit"
-                        onClick={() => {
-                            history.push({
-                                pathname: `/projects/${projectUuid}/settings`,
-                            });
-                        }}
-                    />
-                </ButtonGroup>
-            </div>
-        </Card>
-    );
-};
+                {name}
+            </p>
+            <ButtonGroup>
+                <AnchorButton
+                    icon="cog"
+                    outlined
+                    text="Settings"
+                    href={`/projects/${projectUuid}/settings`}
+                />
+            </ButtonGroup>
+        </div>
+    </Card>
+);
 
 const ProjectManagementPanel: FC = () => {
     const { data } = useProjects();


### PR DESCRIPTION
Closes: #543 

Changes: 
- access project page from explore 
- rename button from 'Edit' to 'Settings' and changed icon

Preview:
![Screenshot 2021-11-09 at 14 41 13](https://user-images.githubusercontent.com/9117144/140945247-b19e8261-3745-40f8-990a-1cd75f2b963e.png)
![Screenshot 2021-11-09 at 14 41 26](https://user-images.githubusercontent.com/9117144/140945256-87c6390a-76ba-4601-b1c3-423b45e59097.png)


