### PR TITLE
fix: use prod as default dbt target

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -3,7 +3,7 @@ import * as yaml from 'js-yaml';
 import { DRIVER_PATH } from '../services/warehouseClients/DatabricksWarehouseClient';
 
 export const LIGHTDASH_PROFILE_NAME = 'lightdash_profile';
-export const LIGHTDASH_TARGET_NAME = 'lightdash_target';
+export const LIGHTDASH_TARGET_NAME = 'prod';
 
 const envVar = (v: string) => `LIGHTDASH_DBT_PROFILE_VAR_${v.toUpperCase()}`;
 const envVarReference = (v: string) => `{{ env_var('${envVar(v)}') }}`;


### PR DESCRIPTION
Many dbt projects customise the destinations of materialized tables depending on the value of the `target` name in `profiles.yml` 

Since we generate a `profiles.yml` under-the-hood, the name we choose for the `target` will influence the destinations of dbt models, meaning we could look for tables in the wrong places in the warehouse if we don’t set `target` correctly. 

Currently we use `lightdash_target` but many dbt projects use [`generate_schema_name_for_env`](https://docs.getdbt.com/docs/guides/debugging-schema-names#4-put-the-two-together) that rely on the target name being `prod`

I suggest we use `prod` by default and I’ve opened #801 to make more permanent change.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)