### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs/get-started/setup-lightdash/add-metrics.mdx
+++ b/docs/docs/get-started/setup-lightdash/add-metrics.mdx
@@ -27,7 +27,8 @@ splitting the metric by "status of order". In Lightdash you'd get the following 
 
 ![two metrics on a bar chart](./assets/metric-on-bar-chart.png)
 
-To learn more about why we use dimensions and metrics in Lightdash, [read the Lightdash approach to BI](../../best-practice/lightdashWay.md)
+To learn more about why we use dimensions and metrics in Lightdash, [read the Lightdash approach to BI](../..
+/best-practice/lightdash-way.md)
 
 ## Add a metric:
 


### PR DESCRIPTION
There was a broken link in the documentation that was blocking deployment to docs.lightdash.com

Discovered by @drernie on #803

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)