### PR TITLE
fix: align y axis label

### DIFF
--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -95,7 +95,8 @@ export const SimpleChart: FC<SimpleChartProps> = ({
     const yAxis = {
         type: flipX ? 'category' : yType,
         name: flipX ? xlabel : ylabel,
-        nameTextStyle: { fontWeight: 'bold' },
+        nameTextStyle: { fontWeight: 'bold', align: 'left' },
+        nameLocation: 'end',
     };
 
     const legend = {


### PR DESCRIPTION
Closes #797 

## Before

<img width="753" alt="Screenshot 2021-11-16 at 15 07 37" src="https://user-images.githubusercontent.com/11660098/142010901-500cab36-8c78-4796-b39d-31277c6b0a98.png">

## After

<img width="748" alt="Screenshot 2021-11-16 at 15 07 16" src="https://user-images.githubusercontent.com/11660098/142010943-84504ea0-8354-462e-b0d5-5e0480e7fbb3.png">