### PR TITLE
fix(#571): add axis tooltip for categorical plots

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -152,7 +152,7 @@ const SimpleChart: FC<SimpleChartProps> = ({
         encode: {
             x: flipX ? seriesDimension : chartConfig.seriesLayout.xDimension,
             y: flipX ? chartConfig.seriesLayout.xDimension : seriesDimension,
-            tooltip: [chartConfig.seriesLayout.xDimension, seriesDimension],
+            tooltip: [seriesDimension],
             seriesName: seriesDimension,
         },
     }));
@@ -164,7 +164,7 @@ const SimpleChart: FC<SimpleChartProps> = ({
         ? {
               ...commonTooltip,
               trigger: 'axis',
-              axisPointer: { label: { show: true } },
+              axisPointer: { type: 'shadow', label: { show: true } },
           }
         : { ...commonTooltip, trigger: 'item' };
     const options = {

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -122,12 +122,14 @@ const SimpleChart: FC<SimpleChartProps> = ({
     const yType = 'value';
 
     const flipX = flipXFromChartType(chartType);
+    const xAxisType = flipX ? yType : xType;
     const xAxis = {
-        type: flipX ? yType : xType,
+        type: xAxisType,
         name: flipX ? ylabel : xlabel,
         nameLocation: 'center',
         nameGap: 30,
         nameTextStyle: { fontWeight: 'bold' },
+        axisLabel: xAxisType === 'category' ? { interval: 0, rotate: 35 } : {},
     };
     const yAxis = {
         type: flipX ? 'category' : yType,

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -129,7 +129,7 @@ const SimpleChart: FC<SimpleChartProps> = ({
         nameLocation: 'center',
         nameGap: 30,
         nameTextStyle: { fontWeight: 'bold' },
-        axisLabel: xAxisType === 'category' ? { interval: 0, rotate: 35 } : {},
+        // axisLabel: xAxisType === 'category' ? { interval: 0, rotate: 35 } : {},
     };
     const yAxis = {
         type: flipX ? 'category' : yType,
@@ -156,6 +156,17 @@ const SimpleChart: FC<SimpleChartProps> = ({
             seriesName: seriesDimension,
         },
     }));
+    const commonTooltip = {
+        show: true,
+        confine: true,
+    };
+    const tooltip = [DBChartTypes.COLUMN, DBChartTypes.BAR].includes(chartType)
+        ? {
+              ...commonTooltip,
+              trigger: 'axis',
+              axisPointer: { label: { show: true } },
+          }
+        : { ...commonTooltip, trigger: 'item' };
     const options = {
         xAxis,
         yAxis,
@@ -166,11 +177,7 @@ const SimpleChart: FC<SimpleChartProps> = ({
             source: chartConfig.plotData,
             dimensions: chartConfig.eChartDimensions,
         },
-        tooltip: {
-            show: true,
-            trigger: 'item',
-            confine: true,
-        },
+        tooltip,
     };
 
     return (

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -152,7 +152,9 @@ const SimpleChart: FC<SimpleChartProps> = ({
         encode: {
             x: flipX ? seriesDimension : chartConfig.seriesLayout.xDimension,
             y: flipX ? chartConfig.seriesLayout.xDimension : seriesDimension,
-            tooltip: [seriesDimension],
+            tooltip: [DBChartTypes.COLUMN, DBChartTypes.BAR].includes(chartType)
+                ? [seriesDimension]
+                : [chartConfig.seriesLayout.xDimension, seriesDimension],
             seriesName: seriesDimension,
         },
     }));


### PR DESCRIPTION
Closes #571 

For **categorical x-axes only** rotate labels and force them to render for every value on the chart.

## Before (categorical)

<img width="771" alt="Screenshot 2021-11-16 at 15 30 05" src="https://user-images.githubusercontent.com/11660098/142015522-5ecf18e9-d56b-44f4-86f9-e03314702a44.png">


## After (categorical)

<img width="769" alt="Screenshot 2021-11-16 at 15 29 55" src="https://user-images.githubusercontent.com/11660098/142015490-d3a54d72-e64b-4b74-bc8d-4de3f98719ce.png">

## Unchanged (time-based)

<img width="760" alt="Screenshot 2021-11-16 at 15 30 28" src="https://user-images.githubusercontent.com/11660098/142015570-4f926c02-a27b-4937-b7dc-7397ea391c67.png">


