### PR TITLE
fix: confine tooltips to charts

### DIFF
--- a/packages/frontend/src/components/SimpleChart.tsx
+++ b/packages/frontend/src/components/SimpleChart.tsx
@@ -129,6 +129,7 @@ export const SimpleChart: FC<SimpleChartProps> = ({
         tooltip: {
             show: true,
             trigger: 'item',
+            confine: true,
         },
     };
     return (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -70,6 +70,7 @@ const Dashboard = () => {
                 onSaveDashboard={() => mutate({ tiles: dashboardTiles })}
             />
             <ResponsiveGridLayout
+                useCSSTransforms={false}
                 draggableCancel=".non-draggable"
                 onDragStop={(layout) => updateTiles(layout)}
                 onResizeStop={(layout) => updateTiles(layout)}


### PR DESCRIPTION
Attempting to improve #781 

This does 80% of the job by forcing tooltips to stay inside the chart. However if the tooltip is much larger than the chart then it still overflows and hides behind others.

@ZeRego I couldn't find an option to increase the `z-index` in e-charts. Maybe there's something simpler I can do