### PR TITLE
chore: send opted-in with identify

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -18,6 +18,7 @@ type Identify = {
         first_name?: string;
         last_name?: string;
         is_tracking_anonymized: boolean;
+        is_marketing_opted_in?: boolean;
     };
 };
 type BaseTrack = Omit<AnalyticsTrack, 'context'>;

--- a/packages/backend/src/analytics/client.ts
+++ b/packages/backend/src/analytics/client.ts
@@ -14,7 +14,9 @@ export const analytics: LightdashAnalytics = new LightdashAnalytics(
     },
 );
 
-export const identifyUser = (user: LightdashUser): void => {
+export const identifyUser = (
+    user: LightdashUser & { isMarketingOptedIn?: boolean },
+): void => {
     if (lightdashConfig.mode === LightdashMode.DEMO) {
         return;
     }
@@ -27,6 +29,7 @@ export const identifyUser = (user: LightdashUser): void => {
                   first_name: user.firstName,
                   last_name: user.lastName,
                   is_tracking_anonymized: user.isTrackingAnonymized,
+                  is_marketing_opted_in: user.isMarketingOptedIn,
               },
     });
     if (user.organizationUuid) {

--- a/packages/backend/src/models/User.ts
+++ b/packages/backend/src/models/User.ts
@@ -46,9 +46,13 @@ export const UserModel = {
         if (await hasUsers(database)) {
             throw new ForbiddenError('User already registered');
         }
+        const [createUser] = data;
         const user = await createInitialUser(...data);
         const lightdashUser = mapDbUserDetailsToLightdashUser(user);
-        identifyUser(lightdashUser);
+        identifyUser({
+            ...lightdashUser,
+            isMarketingOptedIn: createUser.isMarketingOptedIn,
+        });
         analytics.track({
             event: 'user.created',
             organizationId: lightdashUser.organizationUuid,


### PR DESCRIPTION
@ZeRego since we don't add opted-in to the database, we only capture this on register. 

This means the `identify` command just has an additional argument. It's not as clean as adding it to the db (which would also enable us to later opt-out).