### PR TITLE
fix: prevent unnecessary renders in dashboard page

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -67,7 +67,10 @@ const Dashboard = () => {
     const layouts = useMemo(
         () => ({
             lg: dashboardTiles.map<Layout>((tile) => ({
-                ...tile,
+                x: tile.x,
+                y: tile.y,
+                w: tile.w,
+                h: tile.h,
                 i: tile.uuid,
                 isDraggable: isEditMode,
                 isResizable: isEditMode,


### PR DESCRIPTION
Closes: #874 Closes: #873 

@owlas I wasn't able to reproduce these bugs locally but from my investigation they seem to relate to unnecessary re-renders in the dashboard page.