### PR TITLE
fix: delete tiles with types markdown or loom during rollback

### DIFF
--- a/packages/backend/src/database/migrations/20211118105119_add_markdown_and_loom_dashboard_tiles.ts
+++ b/packages/backend/src/database/migrations/20211118105119_add_markdown_and_loom_dashboard_tiles.ts
@@ -62,6 +62,9 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex(TABLE_NAMES.dashboardTiles)
+        .delete()
+        .whereIn('type', ['loom', 'markdown']);
     await knex(TABLE_NAMES.dashboardTileTypes)
         .delete()
         .whereIn('dashboard_tile_type', ['loom', 'markdown']);


### PR DESCRIPTION
Closes: #879