### PR TITLE
feat: self hosted gitlab

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -85,6 +85,7 @@ const dbtGitlabProjectConfigKeys: ConfigKeys<DbtGitlabProjectConfig> = {
     repository: true,
     branch: true,
     project_sub_path: true,
+    host_domain: true,
 };
 
 const mergeProjectWithEnvironment = <T extends DbtProjectConfig>(

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -2,6 +2,8 @@ import { CreateWarehouseCredentials } from 'common';
 import { WarehouseClient } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
+const DEFAULT_GITLAB_HOST_DOMAIN = 'gitlab.com';
+
 type DbtGitlabProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
     gitlabPersonalAccessToken: string;
@@ -9,6 +11,7 @@ type DbtGitlabProjectAdapterArgs = {
     gitlabBranch: string;
     projectDirectorySubPath: string;
     warehouseCredentials: CreateWarehouseCredentials;
+    hostDomain?: string;
 };
 
 export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
@@ -19,8 +22,11 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         gitlabRepository,
         projectDirectorySubPath,
         warehouseCredentials,
+        hostDomain,
     }: DbtGitlabProjectAdapterArgs) {
-        const remoteRepositoryUrl = `https://:${gitlabPersonalAccessToken}@gitlab.com/${gitlabRepository}.git`;
+        const remoteRepositoryUrl = `https://:${gitlabPersonalAccessToken}@${
+            hostDomain || DEFAULT_GITLAB_HOST_DOMAIN
+        }/${gitlabRepository}.git`;
         super({
             warehouseClient,
             gitBranch: gitlabBranch,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -48,6 +48,7 @@ export const projectAdapterFromConfig = async (
                 gitlabRepository: config.repository,
                 gitlabBranch: config.branch,
                 projectDirectorySubPath: config.project_sub_path,
+                hostDomain: config.host_domain,
                 warehouseCredentials,
             });
         default:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1123,6 +1123,7 @@ export interface DbtGitlabProjectConfig extends DbtProjectConfigBase {
     repository: string;
     branch: string;
     project_sub_path: string;
+    host_domain?: string;
 }
 
 export type DbtProjectConfig =

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GitlabForm.tsx
@@ -44,6 +44,13 @@ const GitlabForm: FC<{ disabled: boolean }> = ({ disabled }) => (
             disabled={disabled}
             defaultValue="/"
         />
+        <Input
+            name="dbt.host_domain"
+            label="Host domain (for self-hosted instances)"
+            documentationUrl="https://docs.lightdash.com"
+            disabled={disabled}
+            defaultValue="gitlab.com"
+        />
     </>
 );
 


### PR DESCRIPTION
Allows users to specify a domain host for gitlab. This is useful if user's are self-hosting a gitlab instance on their own domain.