### PR TITLE
fix: make latest saved charts full width

### DIFF
--- a/packages/frontend/src/components/Home/LatestSavedCharts.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts.tsx
@@ -44,6 +44,7 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         minimal
                         href={`/projects/${projectUuid}/saved/${uuid}`}
                         style={{
+                            width: '100%',
                             justifyContent: 'left',
                             color: Colors.DARK_GRAY1,
                             fontWeight: 600,
@@ -58,6 +59,7 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     minimal
                     href={`/projects/${projectUuid}/tables`}
                     style={{
+                        width: '100%',
                         justifyContent: 'left',
                         fontWeight: 500,
                         marginBottom: 10,


### PR DESCRIPTION
### Closes: 
#970

### Description:
n/a
### Preview:
<img width="827" alt="Screenshot 2021-12-09 at 09 52 55" src="https://user-images.githubusercontent.com/9117144/145374013-b84650fa-aec3-4430-a54c-a810d3259d66.png">


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
