### PR TITLE
ci: fix docker compose yml version 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.8"
 services:
   lightdash:
     image: lightdash/lightdash:latest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.8"
 services:
   lightdash-dev:
     build:

--- a/examples/full-jaffle-shop-demo/docker-compose.yml
+++ b/examples/full-jaffle-shop-demo/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.8"
 services:
   lightdash:
     build:


### PR DESCRIPTION
First Line of Code is wrong

version: "3.9"  #does not exist, docker compose correct latest version at the time of this writing is 
version: "3.8"

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [x] CI/CD  
