### PR TITLE
Add demo login details to run instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -259,10 +259,10 @@ docker exec -it lightdash-app_lightdash-dev_1 bash
 yarn dev # http://localhost:3000
 
 # Log in dev mode
-When navigating to `http://localhost:3000` you will be prompt to the login page, you can use our demo login details: 
+When navigating to http://localhost:3000 you will be prompt to the login page, you can use our demo login details: 
 
-**Username:** demo@lightdash.com
-**Password:** demo_password!
+Username: demo@lightdash.com
+Password: demo_password!
 
 # Or run in production mode
 # yarn build

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -258,6 +258,12 @@ docker exec -it lightdash-app_lightdash-dev_1 bash
 # Run Lightdash frontend and backend in dev mode
 yarn dev # http://localhost:3000
 
+# Log in dev mode
+When navigating to `http://localhost:3000` you will be prompt to the login page, you can use our demo login details: 
+
+**Username:** demo@lightdash.com
+**Password:** demo_password!
+
 # Or run in production mode
 # yarn build
 # yarn start # http://localhost:8080


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Description:
This PR adds the `demo login details` to the instructions to run Lightdash locally.

### Preview:
![Screenshot 2022-01-05 at 10 26 57](https://user-images.githubusercontent.com/31137824/148243321-469b8ce2-b603-4aaa-9fb6-ed2fe707d15c.png)

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [x] Common  
- [ ] E2E tests  
- [x] Docs  
- [ ] CI/CD  
