### PR TITLE
docs: make a note of the memory docker requires to run the container

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -235,6 +235,8 @@ git clone https://github.com/lightdash/lightdash
 git submodule update --init --recursive
 
 # Create docker containers
+Note: before the next step make sure your docker has 4GB of memory ( Docker -> settings -> resources ) you should be able to manipulate the values here.
+
 cd docker
 docker compose -p lightdash-app -f docker-compose.dev.yml --env-file .env up --detach --remove-orphans 
 ```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Description:
This PR updates the contributing instructions with docker to mention the memory needed for Lightdash to run locally

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [x] Docs  
- [ ] CI/CD  
