### PR TITLE
chore: dont sync node_modules in docker compose

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -34,6 +34,7 @@ services:
       - EMAIL_SMTP_SENDER_EMAIL=${EMAIL_SMTP_SENDER_EMAIL}
     volumes:
       - "../:/usr/app"
+      - /usr/app/node_modules/ # clears the node_modules directory so it doesn't sync (v.slow on MacOS)
     ports:
       - "${PORT}:8080"
       - "3000:3000"


### PR DESCRIPTION
This is makes yarn commands substantially faster with docker for MacOs because syncing files is expensive

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)