### PR TITLE
fix(#1223,#1127): get columns from all snowflake databases and schemas

### DIFF
--- a/packages/backend/src/services/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/backend/src/services/warehouseClients/SnowflakeWarehouseClient.ts
@@ -155,7 +155,8 @@ export default class SnowflakeWarehouseClient implements WarehouseClient {
             columns: string[];
         }[],
     ) {
-        const sqlText = 'SHOW COLUMNS';
+        // needs to be custom database + schema + table.
+        const sqlText = 'SHOW COLUMNS IN ACCOUNT';
         const rows = await this.runQuery(sqlText);
         return rows.reduce<WarehouseCatalog>((acc, row) => {
             const match = config.find(

--- a/packages/backend/src/services/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/backend/src/services/warehouseClients/SnowflakeWarehouseClient.ts
@@ -155,7 +155,6 @@ export default class SnowflakeWarehouseClient implements WarehouseClient {
             columns: string[];
         }[],
     ) {
-        // needs to be custom database + schema + table.
         const sqlText = 'SHOW COLUMNS IN ACCOUNT';
         const rows = await this.runQuery(sqlText);
         return rows.reduce<WarehouseCatalog>((acc, row) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1123
Closes: #1127 <!-- reference the related issue e.g. #150 -->

### Description:
The snowflake client is passed a default database (the value provided by the user in the warehouse settings page). This means that `SHOW COLUMNS` defaults to showing columns only in that default database. 

To get columns across all databases we need to run `SHOW COLUMNS IN ACCOUNT` which gets all columns across all databases. [Snowflake docs on `SHOW COLUMNS`](https://docs.snowflake.com/en/sql-reference/sql/show-columns.html)
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
