### PR TITLE
Feat/allow flexible chart types

### DIFF
--- a/packages/common/src/openapi/openapi.json
+++ b/packages/common/src/openapi/openapi.json
@@ -63,6 +63,46 @@
         },
         "/dashboards/{dashboardUuid}": {
             "$ref": "./paths/dashboards.json"
+        },
+        "/saved/{savedChartUuid}": {
+            "get": {
+                "summary": "Get a saved chart",
+                "tags": ["saved"],
+                "operationId": "getSavedChart",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "savedChartUuid",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details for a saved chart",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        { "$ref": "./schemas/Success.json" },
+                                        {
+                                            "properties": {
+                                                "results": {
+                                                    "$ref": "./schemas/SavedChart.json"
+                                                }
+                                            },
+                                            "required": true
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "security": [{ "cookieAuth": [] }],

--- a/packages/common/src/openapi/schemas/ChartConfig.json
+++ b/packages/common/src/openapi/schemas/ChartConfig.json
@@ -3,23 +3,65 @@
     "properties": {
         "chartType": {
             "type": "string",
-            "enum": ["column", "bar", "line", "scatter"]
+            "enum": [
+                "series",
+                "echarts_raw",
+                "table",
+                "big_number",
+                "funnel",
+                "vega_raw"
+            ]
         },
-        "seriesLayout": {
-            "type": "object",
-            "properties": {
-                "xDimension": {
-                    "type": "string"
+        "config": {
+            "oneOf": [
+                {
+                    // Series type (multiple lines / scatter / bars / ...)
+                    // It's a Lightdash specific config that generates echart configurations
+                    "type": "object",
+                    "properties": {
+                        "axes": {}, // multiple axes, change labels, ticks, intervals, etc.
+                        "series": {} // could be lines, bars, different colours etc.
+                    }
                 },
-                "yMetrics": {
-                    "type": "array",
-                    "items": "string"
+                {
+                    // Table type (for showing raw tables as visualisations)
+                    "type": "object",
+                    "properties": {
+                        "hiddenColumns": {}, // perhaps some simple viz config
+                        "maxRows": {}
+                    }
                 },
-                "groupDimension": {
-                    "type": "string"
+                {
+                    // Big number (for showing.... a big number)
+                    "type": "object",
+                    "properties": {
+                        "suffix": {} // user requested custom suffix
+                    }
+                },
+                {
+                    // Funnel
+                    // Another Lightdash chart that just generates an echart config for you
+                    "type": "object",
+                    "properties": {
+                        "events": {} // a list of events?
+                    }
+                },
+                {
+                    // echarts raw for power users - they just provide their own echarts config
+                    "type": "object",
+                    "properties": {
+                        // everything from echarts
+                    }
+                },
+                {
+                    // vega raw - who knows maybe we can even support multiple charting languages
+                    "type": "object",
+                    "properties": {
+                        // everything from vega-lite
+                    }
                 }
-            }
+            ]
         }
     },
-    "required": ["seriesLayout", "chartType"]
+    "required": ["config", "chartType"]
 }

--- a/packages/common/src/openapi/schemas/ChartConfig.json
+++ b/packages/common/src/openapi/schemas/ChartConfig.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "properties": {
+        "chartType": {
+            "type": "string",
+            "enum": ["column", "bar", "line", "scatter"]
+        },
+        "seriesLayout": {
+            "type": "object",
+            "properties": {
+                "xDimension": {
+                    "type": "string"
+                },
+                "yMetrics": {
+                    "type": "array",
+                    "items": "string"
+                },
+                "groupDimension": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "required": ["seriesLayout", "chartType"]
+}

--- a/packages/common/src/openapi/schemas/SavedChart.json
+++ b/packages/common/src/openapi/schemas/SavedChart.json
@@ -1,0 +1,35 @@
+{
+    "properties": {
+        "uuid": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string"
+        },
+        "tableName": {
+            "type": "string"
+        },
+        "metricQuery": {
+            "type": "object"
+        },
+        "chartConfig": {
+            "type": "object"
+        },
+        "tableConfig": {
+            "type": "object",
+            "properties": {
+                "columnOrder": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": ["columnOrder"]
+        },
+        "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

We should make the way we store chart configuration more flexible. When I say configuration, imagine the chart settings panel in the UI that the user will interact with for certain chart types.

Here I propose that:
1. Line / bar / scatter plots and combinations of those will have the same chart configuration panel. So we'll store these as a single chart type called a `series` chart. We can still have nice presets in the UI for creating a simple bar or line chart with a single metric. Essentially all existing charts are `series` charts.
2. We add different types for things like `table` or `big-number` or `funnel` or `gauge`, which will have very different configurations and map dimensions/metrics very different to `series` charts.
3. We allow users to provide raw eChart configurations if they're a power user. This would only provide a code editor in the UI not a form.

**Questions**

* @TuringLovesDeathMetal I think this pretty much covers all the different requested chart types. Do you think there is some specific configuration I'm missing?
* @ZeRego are you happy for us to store the config for each chart type as a simple json blob (unindexed) in Postgres? I believe we only need to read and write - nothing more complex.
* @PriPatel does this make sense that we'd have different "configuration panels" for very different chart types? And does it make sense that a single configuration panel would be used to create simple->complex combinations of lines/bars/scatters
* @nathaliabj I think your current work on big numbers and tables can keep going without these changes and we'll update those plots soon (especially if we decide to add configuration such as `suffix` on `big-number` types.

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
