### PR TITLE
feat: support no-verify for postgres connections

### DIFF
--- a/packages/backend/src/services/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/backend/src/services/warehouseClients/RedshiftWarehouseClient.ts
@@ -13,6 +13,10 @@ const getSSLConfigFromMode = (mode: string): PoolConfig['ssl'] => {
     switch (mode) {
         case 'disable':
             return false;
+        case 'no-verify':
+            return {
+                rejectUnauthorized: false,
+            };
         case 'allow':
         case 'prefer':
         case 'require':

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -114,6 +114,7 @@ const PostgresForm: FC<{
                     documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#ssl-mode"
                     options={[
                         'disable',
+                        'no-verify',
                         'allow',
                         'prefer',
                         'require',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -108,6 +108,7 @@ const RedshiftForm: FC<{
                     documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#ssl-mode-1"
                     options={[
                         'disable',
+                        'no-verify',
                         'allow',
                         'prefer',
                         'require',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds support for setting SSL mode to `no-verify` via the UI for postgres connections. This is especially helpful for connecting to postgres databases on heroku
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
