### PR TITLE
feat(#922): add filters from sidebar

### DIFF
--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -166,7 +166,11 @@ const NodeItemButtons: FC<{
                 width: '56px',
             }}
         >
-            {isFiltered && <Icon icon="filter" />}
+            {isFiltered ? (
+                <Icon icon="filter" />
+            ) : (
+                <div style={{ width: '16px' }} />
+            )}
             {menuItems && isHovered ? (
                 <Popover2
                     content={<Menu>{menuItems}</Menu>}

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -163,6 +163,7 @@ const NodeItemButtons: FC<{
                 gap: '10px',
                 alignItems: 'center',
                 height: '30px',
+                width: '56px',
             }}
         >
             {isFiltered && <Icon icon="filter" />}

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -163,7 +163,7 @@ const NodeItemButtons: FC<{
                 gap: '10px',
                 alignItems: 'center',
                 height: '30px',
-                width: '56px',
+                width: '60px',
             }}
         >
             {isFiltered ? (
@@ -195,7 +195,7 @@ const NodeItemButtons: FC<{
                     )}
                 />
             ) : (
-                <div style={{ width: '30px' }} />
+                <div style={{ width: '34px' }} />
             )}
         </div>
     );

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -152,7 +152,10 @@ const NodeItemButtons: FC<{
                 key="filter"
                 icon="filter"
                 text="Add filter"
-                onClick={onFilter}
+                onClick={(e) => {
+                    onFilter();
+                    e.stopPropagation();
+                }}
             />,
         );
     }

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -122,7 +122,6 @@ const NodeItemButtons: FC<{
     onOpenSourceDialog: (source: Source) => void;
     isHovered: boolean;
 }> = ({ node, onOpenSourceDialog, isHovered }) => {
-    const [isOpen, setIsOpen] = useState<boolean>();
     const { isFilteredField, addDefaultFilterForDimension } = useFilters();
     const isFiltered = isFilteredField(node);
     const onFilter =
@@ -143,7 +142,6 @@ const NodeItemButtons: FC<{
                     }
                     e.stopPropagation();
                     onOpenSourceDialog(node.source);
-                    setIsOpen(false);
                 }}
             />,
         );
@@ -170,23 +168,27 @@ const NodeItemButtons: FC<{
             {isFiltered && <Icon icon="filter" />}
             {menuItems && isHovered ? (
                 <Popover2
-                    isOpen={isOpen === undefined ? false : isOpen}
-                    onInteraction={setIsOpen}
                     content={<Menu>{menuItems}</Menu>}
+                    autoFocus={false}
                     position={PopoverPosition.BOTTOM_LEFT}
+                    minimal
                     lazy
-                >
-                    <Tooltip2 content="View options">
-                        <Button
-                            minimal
-                            icon="more"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                setIsOpen(true);
-                            }}
-                        />
-                    </Tooltip2>
-                </Popover2>
+                    interactionKind="click"
+                    renderTarget={({ isOpen, ref, ...targetProps }) => (
+                        <Tooltip2 content="View options">
+                            <Button
+                                {...targetProps}
+                                elementRef={ref === null ? undefined : ref}
+                                icon="more"
+                                minimal
+                                onClick={(e) => {
+                                    (targetProps as any).onClick(e);
+                                    e.stopPropagation();
+                                }}
+                            />
+                        </Tooltip2>
+                    )}
+                />
             ) : (
                 <div style={{ width: '30px' }} />
             )}

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -1,0 +1,100 @@
+import {
+    Dimension,
+    DimensionType,
+    Field,
+    FilterGroup,
+    FilterGroupOperator,
+} from 'common';
+import { defaultValuesForNewStringFilter } from '../filters/string-filter/StringFilterForm';
+import { useExplorer } from '../providers/ExplorerProvider';
+
+export const useFilters = () => {
+    const {
+        state: { filters: activeFilters },
+        actions: { setFilters },
+    } = useExplorer();
+
+    const addFilterGroup = (filterGroup: FilterGroup) =>
+        setFilters([filterGroup, ...activeFilters]);
+
+    const createFilterGroup = ({
+        filters,
+        dimension,
+    }: {
+        filters: any[];
+        dimension: Dimension;
+    }): FilterGroup => ({
+        type: dimension.type,
+        tableName: dimension.table,
+        fieldName: dimension.name,
+        operator: FilterGroupOperator.and,
+        filters,
+    });
+
+    const isFilteredField = (field: Field) =>
+        activeFilters.some(
+            (filter) =>
+                filter.tableName === field.table &&
+                filter.fieldName === field.name,
+        );
+
+    const addDefaultFilterForDimension = (dimension: Dimension) => {
+        if (isFilteredField(dimension)) {
+            return;
+        }
+        switch (dimension.type) {
+            case DimensionType.STRING:
+                addFilterGroup(
+                    createFilterGroup({
+                        dimension,
+                        filters: [defaultValuesForNewStringFilter.equals],
+                    }),
+                );
+                break;
+            case DimensionType.NUMBER:
+                addFilterGroup(
+                    createFilterGroup({
+                        dimension,
+                        filters: [defaultValuesForNewStringFilter.equals],
+                    }),
+                );
+                break;
+            case DimensionType.DATE:
+                addFilterGroup(
+                    createFilterGroup({
+                        dimension,
+                        filters: [defaultValuesForNewStringFilter.equals],
+                    }),
+                );
+                break;
+            case DimensionType.TIMESTAMP:
+                addFilterGroup(
+                    createFilterGroup({
+                        dimension,
+                        filters: [defaultValuesForNewStringFilter.equals],
+                    }),
+                );
+                break;
+            case DimensionType.BOOLEAN:
+                addFilterGroup(
+                    createFilterGroup({
+                        dimension,
+                        filters: [defaultValuesForNewStringFilter.equals],
+                    }),
+                );
+                break;
+            default: {
+                const nope: never = dimension.type;
+                throw Error(
+                    `No default filter group implemented for filter group with type ${dimension.type}`,
+                );
+            }
+        }
+    };
+
+    return {
+        isFilteredField,
+        addFilterGroup,
+        addDefaultFilterForDimension,
+    };
+};

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -15,7 +15,7 @@ export const useFilters = () => {
     } = useExplorer();
 
     const addFilterGroup = (filterGroup: FilterGroup) =>
-        setFilters([filterGroup, ...activeFilters]);
+        setFilters([...activeFilters, filterGroup]);
 
     const createFilterGroup = ({
         filters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #922 

### Description:

@ZeRego @nathaliabj - I need some help

1. How can I prevent the dimension from being toggled when hitting the filter button? i.e. when I click the filter button it toggles the dimension state
2. Anyone have a better idea for showing active/not-active state for the filter icon? When active, it can't be clicked again. And it must render both when the dimension is active and not. See screenshot below for the four cases:

In order from top to bottom:
* dimension selected, filter active
* dimension not selected, filter active
* dimension selected, filter not active
* dimension not selected, filter not active
<img width="375" alt="Screenshot 2022-01-28 at 14 56 42" src="https://user-images.githubusercontent.com/11660098/151568966-710d0e25-22ed-4a66-8361-bc963715484a.png">


### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
