### PR TITLE
ci: add semantic release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,40 @@
+name: Release on Merge
+on:
+  push:
+    branches:
+      - main
+      - alpha
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    concurrency: ${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          semantic_version: 19
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+            @semantic-release/github@8
+            @amanda-mitchell/semantic-release-npm-multiple@2.17.0
+      - name: Reset alpha branch upon release
+        if: |
+          steps.semantic.outputs.new_release_published == 'true' &&
+          steps.semantic.outputs.new_release_channel == 'undefined'
+        run: "git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/alpha"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,61 @@
+module.exports = {
+  'branches': ['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}],
+  'plugins': [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/changelog',
+      {
+        'changelogFile': 'CHANGELOG.md',
+      }
+    ],
+    [
+      '@amanda-mitchell/semantic-release-npm-multiple',
+      {
+        'registries': {
+          'main':{
+            'npmPublish': false,
+            'pkgRoot': '.'
+          },
+          'common': {
+            'npmPublish': false,
+            'pkgRoot': 'packages/common'
+          },
+          'backend': {
+            'npmPublish': false,
+            'pkgRoot': 'packages/backend'
+          },
+          'frontend': {
+            'npmPublish': false,
+            'pkgRoot': 'packages/frontend'
+          },
+          'e2e': {
+            'npmPublish': false,
+            'pkgRoot': 'packages/e2e'
+          }
+        }
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        'assets': [
+          'CHANGELOG.md',
+          'package.json',
+          'packages/common/package.json',
+          'packages/backend/package.json',
+          'packages/frontend/package.json',
+          'packages/e2e/package.json'
+        ],
+        'message': 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      }
+    ],
+    [
+      '@semantic-release/github',
+      {},
+    ],
+  ],
+  'tagFormat': '${version}',
+};
+
+


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1286

### Description:
Merge to `main` to publish a release. 
Requires using[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in order to categorize the appropriate release type:
```
fix: a commit of the type fix patches a bug in your codebase (this correlates with [PATCH](http://semver.org/#summary) in Semantic Versioning).
feat: a commit of the type feat introduces a new feature to the codebase (this correlates with [MINOR](http://semver.org/#summary) in Semantic Versioning).
BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with [MAJOR](http://semver.org/#summary) in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
```

Publishing a release will:
- update the package.jsons
- write out the commits (categorized by features, fixes, and breaking changes) into the CHANGELOG.md
- publish to github
- post release updates to PRs and issues

**NOTE: Merging this PR may produce a release depending on what is in main between the last release and HEAD.** 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [x] CI/CD  
