### PR TITLE
Fix(#1278): lower case field names

### DIFF
--- a/packages/backend/src/exploreCompiler.test.ts
+++ b/packages/backend/src/exploreCompiler.test.ts
@@ -1,3 +1,4 @@
+import { friendlyName } from 'common';
 import { CompileError } from './errors';
 import { compileExplore } from './exploreCompiler';
 import {
@@ -70,4 +71,17 @@ test('Should compile with a reference to a metric in a non-aggregate metric', ()
     expect(compileExplore(exploreWithMetricNumber)).toStrictEqual(
         exploreWithMetricNumberCompiled,
     );
+});
+
+describe('Default field labels render for', () => {
+    test('uppercase field names', () => {
+        expect(friendlyName('MYFIELDID')).toEqual('Myfieldid');
+        expect(friendlyName('MY_FIELD_ID')).toEqual('My field id');
+    });
+    test('camel case names', () => {
+        expect(friendlyName('myFieldId')).toEqual('My field id');
+    });
+    test('snake case names', () => {
+        expect(friendlyName('my_field_id')).toEqual('My field id');
+    });
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -385,10 +385,14 @@ const capitalize = (word: string): string =>
     word ? `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}` : '';
 
 export const friendlyName = (text: string): string => {
-    const [first, ...rest] = text.match(/[0-9]*[A-Za-z][a-z]*/g) || [];
-    return [capitalize(first), ...rest.map((word) => word.toLowerCase())].join(
-        ' ',
-    );
+    const normalisedText =
+        text === text.toUpperCase() ? text.toLowerCase() : text; // force all uppercase to all lowercase
+    const [first, ...rest] =
+        normalisedText.match(/[0-9]*[A-Za-z][a-z]*/g) || [];
+    return [
+        capitalize(first.toLowerCase()),
+        ...rest.map((word) => word.toLowerCase()),
+    ].join(' ');
 };
 
 export const snakeCaseName = (text: string): string =>

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -382,11 +382,13 @@ export const filterableDimensionsOnly = (
 ): FilterableDimension[] => dimensions.filter(isFilterableDimension);
 
 const capitalize = (word: string): string =>
-    word ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : '';
+    word ? `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}` : '';
 
 export const friendlyName = (text: string): string => {
     const [first, ...rest] = text.match(/[0-9]*[A-Za-z][a-z]*/g) || [];
-    return [capitalize(first), ...rest].join(' ');
+    return [capitalize(first), ...rest.map((word) => word.toLowerCase())].join(
+        ' ',
+    );
 };
 
 export const snakeCaseName = (text: string): string =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1278 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Better handling for all uppercase column names, common on snowflake. 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

```js
    test('uppercase field names', () => {
        expect(friendlyName('MYFIELDID')).toEqual('Myfieldid');
        expect(friendlyName('MY_FIELD_ID')).toEqual('My field id');
    });
    test('camel case names', () => {
        expect(friendlyName('myFieldId')).toEqual('My field id');
    });
    test('snake case names', () => {
        expect(friendlyName('my_field_id')).toEqual('My field id');
    });
```

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
