### PR TITLE
feat(filters): add week, month and year pickers [skip ci]

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -231,11 +231,18 @@ export enum DimensionType {
     BOOLEAN = 'boolean',
 }
 
+export enum TimeInterval {
+    DAY = 'DAY',
+    WEEK = 'WEEK',
+    MONTH = 'MONTH',
+    YEAR = 'YEAR',
+}
+
 export interface Dimension extends Field {
     fieldType: FieldType.DIMENSION;
     type: DimensionType;
     group?: string;
-    timeInterval?: string;
+    timeInterval?: TimeInterval | string;
 }
 
 export interface CompiledDimension extends Dimension {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -12,8 +12,11 @@ import {
     TimeInterval,
     UnitOfTime,
 } from 'common';
+import moment from 'moment';
 import React, { FC } from 'react';
+import MonthAndYearInput from '../../MonthAndYearInput';
 import WeekPicker from '../../WeekPicker';
+import YearInput from '../../YearInput';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 import UnitOfTimeAutoComplete from './UnitOfTimeAutoComplete';
 
@@ -27,31 +30,58 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
         case FilterOperator.GREATER_THAN_OR_EQUAL:
         case FilterOperator.LESS_THAN:
         case FilterOperator.LESS_THAN_OR_EQUAL:
-            if (
-                isDimension(field) &&
-                field.timeInterval &&
-                field.timeInterval.toUpperCase() === TimeInterval.WEEK
-            ) {
-                return (
-                    <>
-                        <span style={{ whiteSpace: 'nowrap' }}>
-                            week commencing
-                        </span>
-                        <WeekPicker
-                            value={
-                                filterRule.values?.[0]
-                                    ? new Date(filterRule.values?.[0])
-                                    : new Date()
-                            }
-                            onChange={(value: Date) => {
-                                onChange({
-                                    ...filterRule,
-                                    values: [value],
-                                });
-                            }}
-                        />
-                    </>
-                );
+            if (isDimension(field) && field.timeInterval) {
+                switch (field.timeInterval.toUpperCase()) {
+                    case TimeInterval.WEEK:
+                        return (
+                            <>
+                                <span style={{ whiteSpace: 'nowrap' }}>
+                                    week commencing
+                                </span>
+                                <WeekPicker
+                                    value={
+                                        filterRule.values?.[0]
+                                            ? new Date(filterRule.values?.[0])
+                                            : new Date()
+                                    }
+                                    onChange={(value: Date) => {
+                                        onChange({
+                                            ...filterRule,
+                                            values: [value],
+                                        });
+                                    }}
+                                />
+                            </>
+                        );
+                    case TimeInterval.MONTH:
+                        return (
+                            <MonthAndYearInput
+                                value={filterRule.values?.[0] || new Date()}
+                                onChange={(value: Date) => {
+                                    onChange({
+                                        ...filterRule,
+                                        values: [
+                                            moment(value).startOf('month'),
+                                        ],
+                                    });
+                                }}
+                            />
+                        );
+                    case TimeInterval.YEAR:
+                        return (
+                            <YearInput
+                                value={filterRule.values?.[0] || new Date()}
+                                onChange={(value: Date) => {
+                                    onChange({
+                                        ...filterRule,
+                                        values: [moment(value).startOf('year')],
+                                    });
+                                }}
+                            />
+                        );
+                    default:
+                        break;
+                }
             }
             return (
                 <DateInput
@@ -82,7 +112,7 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                 <>
                     <NumericInput
                         fill
-                        value={filterRule.values?.[0] || 1}
+                        value={parseInt(filterRule.values?.[0], 10) || 1}
                         onValueChange={(value) =>
                             onChange({
                                 ...filterRule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -33,19 +33,24 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                 field.timeInterval.toUpperCase() === TimeInterval.WEEK
             ) {
                 return (
-                    <WeekPicker
-                        value={
-                            filterRule.values?.[0]
-                                ? new Date(filterRule.values?.[0])
-                                : new Date()
-                        }
-                        onChange={(value: Date) => {
-                            onChange({
-                                ...filterRule,
-                                values: [value],
-                            });
-                        }}
-                    />
+                    <>
+                        <span style={{ whiteSpace: 'nowrap' }}>
+                            week commencing
+                        </span>
+                        <WeekPicker
+                            value={
+                                filterRule.values?.[0]
+                                    ? new Date(filterRule.values?.[0])
+                                    : new Date()
+                            }
+                            onChange={(value: Date) => {
+                                onChange({
+                                    ...filterRule,
+                                    values: [value],
+                                });
+                            }}
+                        />
+                    </>
                 );
             }
             return (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -6,11 +6,14 @@ import {
     FilterOperator,
     formatDate,
     formatTimestamp,
+    isDimension,
     parseDate,
     parseTimestamp,
+    TimeInterval,
     UnitOfTime,
 } from 'common';
 import React, { FC } from 'react';
+import WeekPicker from '../../WeekPicker';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 import UnitOfTimeAutoComplete from './UnitOfTimeAutoComplete';
 
@@ -24,6 +27,27 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
         case FilterOperator.GREATER_THAN_OR_EQUAL:
         case FilterOperator.LESS_THAN:
         case FilterOperator.LESS_THAN_OR_EQUAL:
+            if (
+                isDimension(field) &&
+                field.timeInterval &&
+                field.timeInterval.toUpperCase() === TimeInterval.WEEK
+            ) {
+                return (
+                    <WeekPicker
+                        value={
+                            filterRule.values?.[0]
+                                ? new Date(filterRule.values?.[0])
+                                : new Date()
+                        }
+                        onChange={(value: Date) => {
+                            onChange({
+                                ...filterRule,
+                                values: [value],
+                            });
+                        }}
+                    />
+                );
+            }
             return (
                 <DateInput
                     fill

--- a/packages/frontend/src/components/common/MonthAndYearInput.tsx
+++ b/packages/frontend/src/components/common/MonthAndYearInput.tsx
@@ -1,0 +1,28 @@
+import { HTMLSelect } from '@blueprintjs/core';
+import moment from 'moment';
+import React, { FC } from 'react';
+import YearInput from './YearInput';
+
+type Props = {
+    value: Date;
+    onChange: (value: Date) => void;
+};
+
+const months = moment.months();
+
+const MonthAndYearInput: FC<Props> = ({ value, onChange }) => (
+    <>
+        <HTMLSelect
+            fill={false}
+            style={{ width: 150 }}
+            onChange={(e) =>
+                onChange(moment(value).month(e.currentTarget.value).toDate())
+            }
+            options={months.map((label, index) => ({ value: index, label }))}
+            value={moment(value).month()}
+        />
+        <YearInput value={value} onChange={onChange} />
+    </>
+);
+
+export default MonthAndYearInput;

--- a/packages/frontend/src/components/common/WeekPicker.tsx
+++ b/packages/frontend/src/components/common/WeekPicker.tsx
@@ -1,0 +1,121 @@
+import { Colors } from '@blueprintjs/core';
+import { DateInput } from '@blueprintjs/datetime';
+import { formatDate, hexToRGB, parseDate } from 'common';
+import moment from 'moment';
+import React, { FC, useState } from 'react';
+import { createGlobalStyle } from 'styled-components';
+
+const SelectedWeekStyles = createGlobalStyle`
+  .WeekPicker .DayPicker-Month {
+    border-collapse: separate;
+  }
+
+  .WeekPicker .DayPicker-WeekNumber {
+    outline: none;
+  }
+
+  .WeekPicker .DayPicker-Day {
+    outline: none;
+    border: 1px solid transparent;
+  }
+
+  .WeekPicker .DayPicker-Day--hoverRange {
+    border-radius: 0 !important;
+    background-color: ${hexToRGB(Colors.BLUE3, 0.3)} !important;
+  }
+
+  .WeekPicker .DayPicker-Day--selectedRange {
+    border-radius: 0 !important;
+    background-color: ${hexToRGB(Colors.BLUE3, 0.5)} !important;
+    border-top-color: ${Colors.BLUE3};
+    border-bottom-color: ${Colors.BLUE3};
+    color: ${Colors.WHITE};
+    &:hover {
+      color: ${Colors.WHITE};
+    }
+  }
+
+  .WeekPicker .DayPicker-Day--selectedRangeStart {
+    background-color: ${Colors.BLUE3} !important;
+    border-left: 1px solid ${Colors.BLUE3};
+    border-radius: 3px 0 0 3px!important;
+  }
+
+  .WeekPicker .DayPicker-Day--selectedRangeEnd {
+    background-color: ${Colors.BLUE3} !important;
+    border-right: 1px solid ${Colors.BLUE3};
+    border-radius: 0 3px 3px 0 !important;
+  }
+`;
+
+function getWeekDays(weekStart: Date): Date[] {
+    const days = [weekStart];
+    for (let i = 1; i < 7; i += 1) {
+        days.push(moment(weekStart).add(i, 'days').toDate());
+    }
+    return days;
+}
+
+type WeekRange = { from: Date; to: Date };
+
+function getWeekRange(date: Date): WeekRange {
+    return {
+        from: moment(date).startOf('week').toDate(),
+        to: moment(date).endOf('week').toDate(),
+    };
+}
+
+type Props = {
+    value: Date;
+    onChange: (value: Date) => void;
+};
+
+const WeekPicker: FC<Props> = ({ value, onChange }) => {
+    const [hoverRange, setHoverRange] = useState<WeekRange>();
+    const selectedDays = getWeekDays(getWeekRange(value).from);
+    const daysAreSelected = selectedDays.length > 0;
+    const modifiers = {
+        hoverRange,
+        selectedRange: daysAreSelected && {
+            from: selectedDays[0],
+            to: selectedDays[6],
+        },
+        hoverRangeStart: hoverRange && hoverRange.from,
+        hoverRangeEnd: hoverRange && hoverRange.to,
+        selectedRangeStart: daysAreSelected && selectedDays[0],
+        selectedRangeEnd: daysAreSelected && selectedDays[6],
+    };
+    const onDayMouseEnter = (date: Date) => {
+        setHoverRange(getWeekRange(date));
+    };
+    const onDayMouseLeave = () => {
+        setHoverRange(undefined);
+    };
+    return (
+        <>
+            <SelectedWeekStyles />
+            <DateInput
+                fill
+                value={value}
+                formatDate={formatDate}
+                parseDate={parseDate}
+                defaultValue={getWeekRange(new Date()).from}
+                onChange={(pickedDate: Date | null) => {
+                    onChange(getWeekRange(pickedDate || value).from);
+                }}
+                dayPickerProps={{
+                    selectedDays,
+                    showOutsideDays: true,
+                    modifiers: modifiers as any,
+                    onDayMouseEnter,
+                    onDayMouseLeave,
+                }}
+                popoverProps={{
+                    popoverClassName: 'WeekPicker',
+                }}
+            />
+        </>
+    );
+};
+
+export default WeekPicker;

--- a/packages/frontend/src/components/common/YearInput.tsx
+++ b/packages/frontend/src/components/common/YearInput.tsx
@@ -1,0 +1,35 @@
+import { NumericInput } from '@blueprintjs/core';
+import moment from 'moment';
+import React, { FC } from 'react';
+
+type Props = {
+    value: Date;
+    onChange: (value: Date) => void;
+};
+
+const YearInput: FC<Props> = ({ value, onChange }) => (
+    <NumericInput
+        fill
+        max={9999}
+        min={1000}
+        minLength={4}
+        maxLength={4}
+        defaultValue={moment(value).year()}
+        onValueChange={(year) => {
+            if (year > 1000 && year < 9999) {
+                onChange(moment(value).year(year).toDate());
+            }
+        }}
+        onBlur={(e) => {
+            let year = parseInt(e.currentTarget.value, 10);
+            if (year < 1000) {
+                year = 1000;
+            } else if (year > 9999) {
+                year = 9999;
+            }
+            onChange(moment(value).year(year).toDate());
+        }}
+    />
+);
+
+export default YearInput;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
For dimensions that have the time interval 'week' it should display a week picker

### Preview:
<a href="https://www.loom.com/share/9b7e9dda4a624737b5968e885666b409">
    <p>Lightdash - week picker - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9b7e9dda4a624737b5968e885666b409-with-play.gif">
  </a>

<a href="https://www.loom.com/share/5b74cd099a6a4abb96aeffa7121543bc">
    <p>Lightdash - Month and Year pickers</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/5b74cd099a6a4abb96aeffa7121543bc-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
