### PR TITLE
style(dashboard): alignment and space between tags

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
@@ -17,6 +17,7 @@ export const TagsWrapper = styled.div`
     flex-direction: row;
     flex-wrap: wrap;
     gap: 0.5em;
+    padding-top: 0.2em;
 `;
 
 export const FilterValues = styled.span`

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 export const TagContainer = styled(Tag)`
     width: fit-content;
-    margin-right: 0.714em;
     padding: 0 0.5em;
     background: #5c7080 !important;
     border-radius: 0.214em;
@@ -17,7 +16,7 @@ export const TagsWrapper = styled.div`
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    margin-right: 0.714em;
+    gap: 0.5em;
 `;
 
 export const FilterValues = styled.span`

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 export const TriggerWrapper = styled(Popover2)`
     width: fit-content;
-    margin-bottom: 0.5em;
+    align-self: center;
 `;
 
 export const FilterTrigger = styled(AnchorButton)`
@@ -32,6 +32,8 @@ export const FilterTrigger = styled(AnchorButton)`
 `;
 
 export const DashboardFilterWrapper = styled.div`
-    display: flex;
-    align-items: baseline;
+    display: grid;
+    align-items: center;
+    grid-template-columns: 7.3em auto;
+    margin-bottom: 0.5em;
 `;

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 export const TriggerWrapper = styled(Popover2)`
     width: fit-content;
-    align-self: center;
+    align-self: baseline;
 `;
 
 export const FilterTrigger = styled(AnchorButton)`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1335 

### Description:
This PR aligns and adds space to the active filter tags in the dashboard

### Preview:
<img width="1376" alt="Screenshot 2022-02-10 at 08 54 40" src="https://user-images.githubusercontent.com/31137824/153422216-42980422-7c33-4fb9-bfd4-7b13655ea9d3.png">
<img width="1428" alt="Screenshot 2022-02-10 at 08 54 29" src="https://user-images.githubusercontent.com/31137824/153422224-26ce44aa-33c1-462c-8f43-6e5aacbdc432.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
