### PR TITLE
fix(dashboards): filter button is disabled when there are no tiles in the dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -10,15 +10,12 @@ import {
 } from './DashboardFilter.styles';
 import FilterSearch from './FilterSearch';
 
-interface Props {
-    hasCharts: boolean;
-}
-
-const DashboardFilter: FC<Props> = ({ hasCharts }) => {
+const DashboardFilter: FC = () => {
     const [isOpen, setIsOpen] = useState(false);
     const { dashboard, dashboardFilters } = useDashboardContext();
     const { isLoading, data: filterableFields } =
         useAvailableDashboardFilterTargets(dashboard);
+    const hasTiles = dashboard.tiles.length >= 1;
 
     return (
         <DashboardFilterWrapper>
@@ -35,12 +32,12 @@ const DashboardFilter: FC<Props> = ({ hasCharts }) => {
                 onInteraction={setIsOpen}
                 position="bottom-right"
                 lazy={false}
-                disabled={isLoading || !hasCharts}
+                disabled={!hasTiles || isLoading}
             >
                 <FilterTrigger
                     minimal
                     icon="filter-list"
-                    disabled={isLoading || !hasCharts}
+                    disabled={!hasTiles || isLoading}
                 >
                     Add filter
                 </FilterTrigger>

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -10,7 +10,11 @@ import {
 } from './DashboardFilter.styles';
 import FilterSearch from './FilterSearch';
 
-const DashboardFilter: FC = () => {
+interface Props {
+    hasCharts: boolean;
+}
+
+const DashboardFilter: FC<Props> = ({ hasCharts }) => {
     const [isOpen, setIsOpen] = useState(false);
     const { dashboard, dashboardFilters } = useDashboardContext();
     const { isLoading, data: filterableFields } =
@@ -31,9 +35,13 @@ const DashboardFilter: FC = () => {
                 onInteraction={setIsOpen}
                 position="bottom-right"
                 lazy={false}
-                disabled={isLoading}
+                disabled={isLoading || !hasCharts}
             >
-                <FilterTrigger minimal icon="filter-list" disabled={isLoading}>
+                <FilterTrigger
+                    minimal
+                    icon="filter-list"
+                    disabled={isLoading || !hasCharts}
+                >
                     Add filter
                 </FilterTrigger>
             </TriggerWrapper>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -166,7 +166,7 @@ const Dashboard = () => {
                 onCancel={onCancel}
             />
             <Page isContentFullWidth>
-                <DashboardFilter />
+                <DashboardFilter hasCharts={!(dashboardTiles.length <= 0)} />
                 <ResponsiveGridLayout
                     useCSSTransforms={false}
                     draggableCancel=".non-draggable"

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -166,7 +166,7 @@ const Dashboard = () => {
                 onCancel={onCancel}
             />
             <Page isContentFullWidth>
-                <DashboardFilter hasCharts={!(dashboardTiles.length <= 0)} />
+                <DashboardFilter />
                 <ResponsiveGridLayout
                     useCSSTransforms={false}
                     draggableCancel=".non-draggable"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1334 

### Description:
This PR disables the filter button when there are no tiles in the dashboard

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
