### PR TITLE
feat: add filter from table cells and headers

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -447,6 +447,7 @@ export const getFilterTypeFromField = (field: FilterableField): FilterType => {
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     field: FilterableField,
     filterRule: T,
+    value?: any,
 ): T => {
     const filterType = getFilterTypeFromField(field);
     const filterRuleDefaults: Partial<FilterRule> = {};
@@ -458,7 +459,8 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
         switch (filterType) {
             case FilterType.DATE: {
                 if (filterRule.operator === FilterOperator.IN_THE_PAST) {
-                    filterRuleDefaults.values = [1];
+                    filterRuleDefaults.values =
+                        value !== undefined ? [value] : [1];
                     filterRuleDefaults.settings = {
                         unitOfTime: UnitOfTime.days,
                         completed: false,
@@ -469,7 +471,8 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                 break;
             }
             case FilterType.BOOLEAN: {
-                filterRuleDefaults.values = [false];
+                filterRuleDefaults.values =
+                    value !== undefined ? [value] : [false];
                 break;
             }
             default:
@@ -478,20 +481,27 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     }
     return {
         ...filterRule,
-        values: [],
+        values: value !== undefined ? [value] : [],
         settings: undefined,
         ...filterRuleDefaults,
     };
 };
 
-export const createFilterRuleFromField = (field: FilterableField): FilterRule =>
-    getFilterRuleWithDefaultValue(field, {
-        id: uuidv4(),
-        target: {
-            fieldId: fieldId(field),
+export const createFilterRuleFromField = (
+    field: FilterableField,
+    value?: any,
+): FilterRule =>
+    getFilterRuleWithDefaultValue(
+        field,
+        {
+            id: uuidv4(),
+            target: {
+                fieldId: fieldId(field),
+            },
+            operator: FilterOperator.EQUALS,
         },
-        operator: FilterOperator.EQUALS,
-    });
+        value,
+    );
 
 export const createDashboardFilterRuleFromField = (
     field: FilterableField,
@@ -524,15 +534,7 @@ export const addFilterRule = ({
             ...group,
             [getFilterGroupItemsPropertyName(group)]: [
                 ...getItemsFromFilterGroup(group),
-                //  createFilterRuleFromField(field),
-                {
-                    id: uuidv4(),
-                    target: {
-                        fieldId: fieldId(field),
-                    },
-                    operator: FilterOperator.EQUALS,
-                    ...(value !== undefined ? { values: [value] } : {}),
-                },
+                createFilterRuleFromField(field, value),
             ],
         },
     };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -507,7 +507,7 @@ export const createDashboardFilterRuleFromField = (
 
 type AddFilterRuleArgs = {
     filters: Filters;
-    field: Pick<Field, 'table' | 'name' | 'fieldType'>;
+    field: FilterableField;
     value?: any;
 };
 export const addFilterRule = ({
@@ -524,7 +524,7 @@ export const addFilterRule = ({
             ...group,
             [getFilterGroupItemsPropertyName(group)]: [
                 ...getItemsFromFilterGroup(group),
-                createFilterRuleFromField(field),
+                //  createFilterRuleFromField(field),
                 {
                     id: uuidv4(),
                     target: {

--- a/packages/e2e/cypress/integration/explore.spec.ts
+++ b/packages/e2e/cypress/integration/explore.spec.ts
@@ -16,7 +16,7 @@ describe('Explore', () => {
         cy.findByText('Orders').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
-        cy.get('th').findByText('First name').click();
-        cy.get('td', { timeout: 10000 }).first().should('have.text', 'Aaron');
+        cy.get('th b').first().should('have.text', 'First name').click();
+        cy.get('td', { timeout: 10000 }).eq(1).should('have.text', 'Aaron');
     });
 });

--- a/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
@@ -1,0 +1,31 @@
+import { Menu, MenuItem } from '@blueprintjs/core';
+import { ContextMenu2 } from '@blueprintjs/popover2';
+import React from 'react';
+import { Cell } from 'react-table';
+import { useFilters } from '../../hooks/useFilters';
+
+type CellContextMenuProps = {
+    cell: Cell;
+};
+export const CellContextMenu: React.FC<CellContextMenuProps> = ({
+    children,
+    cell,
+}) => {
+    const { addFilter } = useFilters();
+    return (
+        <ContextMenu2
+            content={
+                <Menu>
+                    <MenuItem
+                        label={`Filter on "${cell.value}"`}
+                        onClick={() => {
+                            addFilter(cell.column.field, cell.value);
+                        }}
+                    />
+                </Menu>
+            }
+        >
+            {children}
+        </ContextMenu2>
+    );
+};

--- a/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
@@ -19,7 +19,7 @@ export const CellContextMenu: React.FC<CellContextMenuProps> = ({
                     <MenuItem
                         label={`Filter on "${cell.value}"`}
                         onClick={() => {
-                            addFilter(cell.column.field, cell.value);
+                            addFilter(cell.column.field, cell.value, true);
                         }}
                     />
                 </Menu>

--- a/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/CellContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuItem } from '@blueprintjs/core';
 import { ContextMenu2 } from '@blueprintjs/popover2';
+import { isFilterableField } from 'common';
 import React from 'react';
 import { Cell } from 'react-table';
 import { useFilters } from '../../hooks/useFilters';
@@ -12,20 +13,24 @@ export const CellContextMenu: React.FC<CellContextMenuProps> = ({
     cell,
 }) => {
     const { addFilter } = useFilters();
-    return (
-        <ContextMenu2
-            content={
-                <Menu>
-                    <MenuItem
-                        label={`Filter on "${cell.value}"`}
-                        onClick={() => {
-                            addFilter(cell.column.field, cell.value, true);
-                        }}
-                    />
-                </Menu>
-            }
-        >
-            {children}
-        </ContextMenu2>
-    );
+    const field = cell.column?.field;
+    if (field && isFilterableField(field)) {
+        return (
+            <ContextMenu2
+                content={
+                    <Menu>
+                        <MenuItem
+                            text={`Filter by "${cell.value}"`}
+                            onClick={() => {
+                                addFilter(field, cell.value, true);
+                            }}
+                        />
+                    </Menu>
+                }
+            >
+                {children}
+            </ContextMenu2>
+        );
+    }
+    return <>{children}</>;
 };

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -1,0 +1,29 @@
+import { Menu, MenuItem } from '@blueprintjs/core';
+import { ContextMenu2 } from '@blueprintjs/popover2';
+import React from 'react';
+import { HeaderGroup } from 'react-table';
+import { useFilters } from '../../hooks/useFilters';
+
+type ColumnHeaderContextMenuProps = {
+    column: HeaderGroup | undefined;
+};
+export const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> =
+    ({ children, column }) => {
+        const { addFilter } = useFilters();
+        const menuContent =
+            column === undefined ? undefined : (
+                <Menu>
+                    <MenuItem
+                        label={`Filter ${column.field.name}`}
+                        onClick={() => {
+                            addFilter(column.field, undefined);
+                        }}
+                    />
+                </Menu>
+            );
+        return (
+            <ContextMenu2 disabled={column === undefined} content={menuContent}>
+                {children}
+            </ContextMenu2>
+        );
+    };

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -13,19 +13,21 @@ const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> = ({
     column,
 }) => {
     const { addFilter } = useFilters();
+    const cantFilter = !column || column.type === 'table_calculation';
+
     const menuContent = column && (
         <Menu>
             <MenuItem
                 label={`Filter ${column.field?.name}`}
                 onClick={(e) => {
                     e.stopPropagation();
-                    addFilter(column.field, undefined, false);
+                    addFilter(column?.field, undefined, false);
                 }}
             />
         </Menu>
     );
     return (
-        <ContextMenu2 disabled={!column} content={menuContent}>
+        <ContextMenu2 disabled={cantFilter} content={menuContent}>
             {children}
         </ContextMenu2>
     );

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -7,24 +7,29 @@ import { useFilters } from '../../hooks/useFilters';
 type ColumnHeaderContextMenuProps = {
     column: HeaderGroup | undefined;
 };
-export const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> =
-    ({ children, column }) => {
-        const { addFilter } = useFilters();
-        const menuContent =
-            column === undefined ? undefined : (
-                <Menu>
-                    <MenuItem
-                        label={`Filter ${column.field.name}`}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            addFilter(column.field, undefined, false);
-                        }}
-                    />
-                </Menu>
-            );
-        return (
-            <ContextMenu2 disabled={column === undefined} content={menuContent}>
-                {children}
-            </ContextMenu2>
+
+const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> = ({
+    children,
+    column,
+}) => {
+    const { addFilter } = useFilters();
+    const menuContent =
+        column === undefined ? undefined : (
+            <Menu>
+                <MenuItem
+                    label={`Filter ${column.field.name}`}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        addFilter(column.field, undefined, false);
+                    }}
+                />
+            </Menu>
         );
-    };
+    return (
+        <ContextMenu2 disabled={column === undefined} content={menuContent}>
+            {children}
+        </ContextMenu2>
+    );
+};
+
+export default ColumnHeaderContextMenu;

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -13,20 +13,19 @@ const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> = ({
     column,
 }) => {
     const { addFilter } = useFilters();
-    const menuContent =
-        column === undefined ? undefined : (
-            <Menu>
-                <MenuItem
-                    label={`Filter ${column.field.name}`}
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        addFilter(column.field, undefined, false);
-                    }}
-                />
-            </Menu>
-        );
+    const menuContent = column && (
+        <Menu>
+            <MenuItem
+                label={`Filter ${column.field.name}`}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    addFilter(column.field, undefined, false);
+                }}
+            />
+        </Menu>
+    );
     return (
-        <ContextMenu2 disabled={column === undefined} content={menuContent}>
+        <ContextMenu2 disabled={!column} content={menuContent}>
             {children}
         </ContextMenu2>
     );

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -16,7 +16,7 @@ const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> = ({
     const menuContent = column && (
         <Menu>
             <MenuItem
-                label={`Filter ${column.field.name}`}
+                label={`Filter ${column.field?.name}`}
                 onClick={(e) => {
                     e.stopPropagation();
                     addFilter(column.field, undefined, false);

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuItem } from '@blueprintjs/core';
 import { ContextMenu2 } from '@blueprintjs/popover2';
+import { isFilterableField } from 'common';
 import React from 'react';
 import { HeaderGroup } from 'react-table';
 import { useFilters } from '../../hooks/useFilters';
@@ -13,24 +14,27 @@ const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> = ({
     column,
 }) => {
     const { addFilter } = useFilters();
-    const cantFilter = !column || column.type === 'table_calculation';
-
-    const menuContent = column && (
-        <Menu>
-            <MenuItem
-                label={`Filter ${column.field?.name}`}
-                onClick={(e) => {
-                    e.stopPropagation();
-                    addFilter(column?.field, undefined, false);
-                }}
-            />
-        </Menu>
-    );
-    return (
-        <ContextMenu2 disabled={cantFilter} content={menuContent}>
-            {children}
-        </ContextMenu2>
-    );
+    const field = column?.field;
+    if (field && isFilterableField(field)) {
+        return (
+            <ContextMenu2
+                content={
+                    <Menu>
+                        <MenuItem
+                            text={`Filter by ${field.label}`}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                addFilter(field, undefined, false);
+                            }}
+                        />
+                    </Menu>
+                }
+            >
+                {children}
+            </ContextMenu2>
+        );
+    }
+    return <>{children}</>;
 };
 
 export default ColumnHeaderContextMenu;

--- a/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/ResultsTable/ColumnHeaderContextMenu.tsx
@@ -15,8 +15,9 @@ export const ColumnHeaderContextMenu: React.FC<ColumnHeaderContextMenuProps> =
                 <Menu>
                     <MenuItem
                         label={`Filter ${column.field.name}`}
-                        onClick={() => {
-                            addFilter(column.field, undefined);
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            addFilter(column.field, undefined, false);
                         }}
                     />
                 </Menu>

--- a/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
@@ -1,5 +1,13 @@
-import { Button, Colors, HTMLTable, Icon, Tag } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
+import {
+    Button,
+    Colors,
+    HTMLTable,
+    Icon,
+    Menu,
+    MenuItem,
+    Tag,
+} from '@blueprintjs/core';
+import { ContextMenu2, Tooltip2 } from '@blueprintjs/popover2';
 import { DimensionType, hexToRGB } from 'common';
 import React, { FC, ReactNode, useEffect } from 'react';
 import {
@@ -18,6 +26,7 @@ import {
     usePagination,
     useTable as useReactTable,
 } from 'react-table';
+import { useFilters } from '../../hooks/useFilters';
 import { TrackSection } from '../../providers/TrackingProvider';
 import { SectionName } from '../../types/Events';
 import TableCalculationHeaderButton from '../TableCalculationHeaderButton';
@@ -169,6 +178,7 @@ export const ResultsTable: FC<Props> = ({
     emptyState,
     tableAction,
 }) => {
+    const { addFilter } = useFilters();
     const currentColOrder = React.useRef<Array<string>>([]);
     const {
         getTableProps,
@@ -378,7 +388,27 @@ export const ResultsTable: FC<Props> = ({
                                                             ),
                                                         ])}
                                                     >
-                                                        {cell.render('Cell')}
+                                                        <ContextMenu2
+                                                            content={
+                                                                <Menu>
+                                                                    <MenuItem
+                                                                        label={`Filter on "${cell.value}"`}
+                                                                        onClick={() => {
+                                                                            addFilter(
+                                                                                cell
+                                                                                    .column
+                                                                                    .field,
+                                                                                cell.value,
+                                                                            );
+                                                                        }}
+                                                                    />
+                                                                </Menu>
+                                                            }
+                                                        >
+                                                            {cell.render(
+                                                                'Cell',
+                                                            )}
+                                                        </ContextMenu2>
                                                     </td>
                                                 ))}
                                             </tr>

--- a/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
@@ -18,7 +18,6 @@ import {
     usePagination,
     useTable as useReactTable,
 } from 'react-table';
-import { useFilters } from '../../hooks/useFilters';
 import { TrackSection } from '../../providers/TrackingProvider';
 import { SectionName } from '../../types/Events';
 import TableCalculationHeaderButton from '../TableCalculationHeaderButton';
@@ -174,7 +173,6 @@ export const ResultsTable: FC<Props> = ({
     emptyState,
     tableAction,
 }) => {
-    const { addFilter } = useFilters();
     const currentColOrder = React.useRef<Array<string>>([]);
     const {
         getTableProps,

--- a/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
@@ -1,13 +1,5 @@
-import {
-    Button,
-    Colors,
-    HTMLTable,
-    Icon,
-    Menu,
-    MenuItem,
-    Tag,
-} from '@blueprintjs/core';
-import { ContextMenu2, Tooltip2 } from '@blueprintjs/popover2';
+import { Button, Colors, HTMLTable, Icon, Tag } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { DimensionType, hexToRGB } from 'common';
 import React, { FC, ReactNode, useEffect } from 'react';
 import {
@@ -43,6 +35,8 @@ import {
     TableInnerContainer,
     TableOuterContainer,
 } from './ResultsTable.styles';
+import { CellContextMenu } from './CellContextMenu';
+import { ColumnHeaderContextMenu } from './ColumnHeaderContextMenu';
 import { EmptyState, IdleState, LoadingState } from './States';
 
 const getSortIndicator = (
@@ -134,7 +128,9 @@ const Item: FC<ItemProps> = ({
             ...getItemStyle(snapshot, draggableProps.style),
         }}
     >
-        {column?.render('Header')}
+        <ColumnHeaderContextMenu column={column}>
+            {column?.render('Header')}
+        </ColumnHeaderContextMenu>
         {column?.isSorted &&
             getSortIndicator(
                 column.type,
@@ -388,27 +384,13 @@ export const ResultsTable: FC<Props> = ({
                                                             ),
                                                         ])}
                                                     >
-                                                        <ContextMenu2
-                                                            content={
-                                                                <Menu>
-                                                                    <MenuItem
-                                                                        label={`Filter on "${cell.value}"`}
-                                                                        onClick={() => {
-                                                                            addFilter(
-                                                                                cell
-                                                                                    .column
-                                                                                    .field,
-                                                                                cell.value,
-                                                                            );
-                                                                        }}
-                                                                    />
-                                                                </Menu>
-                                                            }
+                                                        <CellContextMenu
+                                                            cell={cell}
                                                         >
                                                             {cell.render(
                                                                 'Cell',
                                                             )}
-                                                        </ContextMenu2>
+                                                        </CellContextMenu>
                                                     </td>
                                                 ))}
                                             </tr>

--- a/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
+++ b/packages/frontend/src/components/ResultsTable/ResultsTable.tsx
@@ -36,7 +36,7 @@ import {
     TableOuterContainer,
 } from './ResultsTable.styles';
 import { CellContextMenu } from './CellContextMenu';
-import { ColumnHeaderContextMenu } from './ColumnHeaderContextMenu';
+import ColumnHeaderContextMenu from './ColumnHeaderContextMenu';
 import { EmptyState, IdleState, LoadingState } from './States';
 
 const getSortIndicator = (

--- a/packages/frontend/src/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModal.tsx
@@ -271,3 +271,5 @@ export const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> =
             </Dialog>
         );
     };
+
+export default TableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModal.tsx
@@ -171,29 +171,30 @@ interface CreateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> =
-    ({ isOpen, onClose }) => {
-        const {
-            actions: { addTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
-        const onCreate = (value: TableCalculation) => {
-            addTableCalculation(value);
-            track({
-                name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-
-        return (
-            <TableCalculationModal
-                isOpen={isOpen}
-                isDisabled={false}
-                onSave={onCreate}
-                onClose={onClose}
-            />
-        );
+export const CreateTableCalculationModal: FC<
+    CreateTableCalculationModalProps
+> = ({ isOpen, onClose }) => {
+    const {
+        actions: { addTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
+    const onCreate = (value: TableCalculation) => {
+        addTableCalculation(value);
+        track({
+            name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
     };
+
+    return (
+        <TableCalculationModal
+            isOpen={isOpen}
+            isDisabled={false}
+            onSave={onCreate}
+            onClose={onClose}
+        />
+    );
+};
 
 interface UpdateTableCalculationModalProps {
     isOpen: boolean;
@@ -201,30 +202,31 @@ interface UpdateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> =
-    ({ isOpen, tableCalculation, onClose }) => {
-        const {
-            actions: { updateTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
-        const onUpdate = (value: TableCalculation) => {
-            updateTableCalculation(tableCalculation.name, value);
-            track({
-                name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-
-        return (
-            <TableCalculationModal
-                isOpen={isOpen}
-                isDisabled={false}
-                tableCalculation={tableCalculation}
-                onSave={onUpdate}
-                onClose={onClose}
-            />
-        );
+export const UpdateTableCalculationModal: FC<
+    UpdateTableCalculationModalProps
+> = ({ isOpen, tableCalculation, onClose }) => {
+    const {
+        actions: { updateTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
+    const onUpdate = (value: TableCalculation) => {
+        updateTableCalculation(tableCalculation.name, value);
+        track({
+            name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
     };
+
+    return (
+        <TableCalculationModal
+            isOpen={isOpen}
+            isDisabled={false}
+            tableCalculation={tableCalculation}
+            onSave={onUpdate}
+            onClose={onClose}
+        />
+    );
+};
 
 interface DeleteTableCalculationModalProps {
     isOpen: boolean;
@@ -232,44 +234,43 @@ interface DeleteTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> =
-    ({ isOpen, tableCalculation, onClose }) => {
-        const {
-            actions: { deleteTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
+export const DeleteTableCalculationModal: FC<
+    DeleteTableCalculationModalProps
+> = ({ isOpen, tableCalculation, onClose }) => {
+    const {
+        actions: { deleteTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
 
-        const onConfirm = () => {
-            deleteTableCalculation(tableCalculation.name);
-            track({
-                name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-        return (
-            <Dialog
-                isOpen={isOpen}
-                icon="cog"
-                onClose={onClose}
-                title="Settings"
-                lazy
-                canOutsideClickClose={false}
-            >
-                <div className={Classes.DIALOG_BODY}>
-                    <p>
-                        Are you sure you want to delete this table calculation ?
-                    </p>
-                </div>
-                <div className={Classes.DIALOG_FOOTER}>
-                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <Button onClick={onClose}>Cancel</Button>
-                        <Button intent="danger" onClick={onConfirm}>
-                            Delete
-                        </Button>
-                    </div>
-                </div>
-            </Dialog>
-        );
+    const onConfirm = () => {
+        deleteTableCalculation(tableCalculation.name);
+        track({
+            name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
     };
+    return (
+        <Dialog
+            isOpen={isOpen}
+            icon="cog"
+            onClose={onClose}
+            title="Settings"
+            lazy
+            canOutsideClickClose={false}
+        >
+            <div className={Classes.DIALOG_BODY}>
+                <p>Are you sure you want to delete this table calculation ?</p>
+            </div>
+            <div className={Classes.DIALOG_FOOTER}>
+                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                    <Button onClick={onClose}>Cancel</Button>
+                    <Button intent="danger" onClick={onConfirm}>
+                        Delete
+                    </Button>
+                </div>
+            </div>
+        </Dialog>
+    );
+};
 
 export default TableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModal.tsx
@@ -171,30 +171,29 @@ interface CreateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const CreateTableCalculationModal: FC<
-    CreateTableCalculationModalProps
-> = ({ isOpen, onClose }) => {
-    const {
-        actions: { addTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
-    const onCreate = (value: TableCalculation) => {
-        addTableCalculation(value);
-        track({
-            name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
+export const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> =
+    ({ isOpen, onClose }) => {
+        const {
+            actions: { addTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
+        const onCreate = (value: TableCalculation) => {
+            addTableCalculation(value);
+            track({
+                name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
 
-    return (
-        <TableCalculationModal
-            isOpen={isOpen}
-            isDisabled={false}
-            onSave={onCreate}
-            onClose={onClose}
-        />
-    );
-};
+        return (
+            <TableCalculationModal
+                isOpen={isOpen}
+                isDisabled={false}
+                onSave={onCreate}
+                onClose={onClose}
+            />
+        );
+    };
 
 interface UpdateTableCalculationModalProps {
     isOpen: boolean;
@@ -202,31 +201,30 @@ interface UpdateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const UpdateTableCalculationModal: FC<
-    UpdateTableCalculationModalProps
-> = ({ isOpen, tableCalculation, onClose }) => {
-    const {
-        actions: { updateTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
-    const onUpdate = (value: TableCalculation) => {
-        updateTableCalculation(tableCalculation.name, value);
-        track({
-            name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
+export const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> =
+    ({ isOpen, tableCalculation, onClose }) => {
+        const {
+            actions: { updateTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
+        const onUpdate = (value: TableCalculation) => {
+            updateTableCalculation(tableCalculation.name, value);
+            track({
+                name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
 
-    return (
-        <TableCalculationModal
-            isOpen={isOpen}
-            isDisabled={false}
-            tableCalculation={tableCalculation}
-            onSave={onUpdate}
-            onClose={onClose}
-        />
-    );
-};
+        return (
+            <TableCalculationModal
+                isOpen={isOpen}
+                isDisabled={false}
+                tableCalculation={tableCalculation}
+                onSave={onUpdate}
+                onClose={onClose}
+            />
+        );
+    };
 
 interface DeleteTableCalculationModalProps {
     isOpen: boolean;
@@ -234,41 +232,42 @@ interface DeleteTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const DeleteTableCalculationModal: FC<
-    DeleteTableCalculationModalProps
-> = ({ isOpen, tableCalculation, onClose }) => {
-    const {
-        actions: { deleteTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
+export const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> =
+    ({ isOpen, tableCalculation, onClose }) => {
+        const {
+            actions: { deleteTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
 
-    const onConfirm = () => {
-        deleteTableCalculation(tableCalculation.name);
-        track({
-            name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
-    return (
-        <Dialog
-            isOpen={isOpen}
-            icon="cog"
-            onClose={onClose}
-            title="Settings"
-            lazy
-            canOutsideClickClose={false}
-        >
-            <div className={Classes.DIALOG_BODY}>
-                <p>Are you sure you want to delete this table calculation ?</p>
-            </div>
-            <div className={Classes.DIALOG_FOOTER}>
-                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                    <Button onClick={onClose}>Cancel</Button>
-                    <Button intent="danger" onClick={onConfirm}>
-                        Delete
-                    </Button>
+        const onConfirm = () => {
+            deleteTableCalculation(tableCalculation.name);
+            track({
+                name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
+        return (
+            <Dialog
+                isOpen={isOpen}
+                icon="cog"
+                onClose={onClose}
+                title="Settings"
+                lazy
+                canOutsideClickClose={false}
+            >
+                <div className={Classes.DIALOG_BODY}>
+                    <p>
+                        Are you sure you want to delete this table calculation ?
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    );
-};
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Button onClick={onClose}>Cancel</Button>
+                        <Button intent="danger" onClick={onConfirm}>
+                            Delete
+                        </Button>
+                    </div>
+                </div>
+            </Dialog>
+        );
+    };

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -150,7 +150,7 @@ const NodeItemButtons: FC<{
                 text="Add filter"
                 onClick={(e) => {
                     e.stopPropagation();
-                    addFilter(node);
+                    addFilter(node, undefined);
                 }}
             />,
         );

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -80,7 +80,7 @@ const FiltersForm: FC<Props> = ({
                               }
                             : undefined,
                 },
-                false,
+                true,
             );
         },
         [fields, filters, setFilters],

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -50,7 +50,7 @@ const FiltersForm: FC<Props> = ({
 
     const addFieldRule = useCallback(
         (field: FilterableField) => {
-            setFilters(addFilterRule({ filters, field }), true);
+            setFilters(addFilterRule({ filters, field }), false);
             toggleFieldInput(false);
         },
         [filters, setFilters, toggleFieldInput],
@@ -80,7 +80,7 @@ const FiltersForm: FC<Props> = ({
                               }
                             : undefined,
                 },
-                true,
+                false,
             );
         },
         [fields, filters, setFilters],

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -21,7 +21,7 @@ type Props = {
     dimensions: FilterableDimension[];
     metrics: Metric[];
     filters: Filters;
-    setFilters: (value: Filters) => void;
+    setFilters: (value: Filters, syncState: boolean) => void;
 };
 
 const FiltersForm: FC<Props> = ({
@@ -50,7 +50,7 @@ const FiltersForm: FC<Props> = ({
 
     const addFieldRule = useCallback(
         (field: FilterableField) => {
-            setFilters(addFilterRule({ filters, field }));
+            setFilters(addFilterRule({ filters, field }), true);
             toggleFieldInput(false);
         },
         [filters, setFilters, toggleFieldInput],
@@ -60,25 +60,28 @@ const FiltersForm: FC<Props> = ({
         (filterRules: FilterRule[]) => {
             const result = getFilterRulesByFieldType(fields, filterRules);
 
-            setFilters({
-                ...filters,
-                dimensions:
-                    result.dimensions.length > 0
-                        ? {
-                              id: uuidv4(),
-                              ...filters.dimensions,
-                              and: result.dimensions,
-                          }
-                        : undefined,
-                metrics:
-                    result.metrics.length > 0
-                        ? {
-                              id: uuidv4(),
-                              ...filters.metrics,
-                              and: result.metrics,
-                          }
-                        : undefined,
-            });
+            setFilters(
+                {
+                    ...filters,
+                    dimensions:
+                        result.dimensions.length > 0
+                            ? {
+                                  id: uuidv4(),
+                                  ...filters.dimensions,
+                                  and: result.dimensions,
+                              }
+                            : undefined,
+                    metrics:
+                        result.metrics.length > 0
+                            ? {
+                                  id: uuidv4(),
+                                  ...filters.metrics,
+                                  and: result.metrics,
+                              }
+                            : undefined,
+                },
+                true,
+            );
         },
         [fields, filters, setFilters],
     );
@@ -113,16 +116,22 @@ const FiltersForm: FC<Props> = ({
                                         filterGroup={filters.dimensions}
                                         fields={dimensions}
                                         onChange={(value) =>
-                                            setFilters({
-                                                ...filters,
-                                                dimensions: value,
-                                            })
+                                            setFilters(
+                                                {
+                                                    ...filters,
+                                                    dimensions: value,
+                                                },
+                                                false,
+                                            )
                                         }
                                         onDelete={() =>
-                                            setFilters({
-                                                ...filters,
-                                                dimensions: undefined,
-                                            })
+                                            setFilters(
+                                                {
+                                                    ...filters,
+                                                    dimensions: undefined,
+                                                },
+                                                true,
+                                            )
                                         }
                                     />
                                 )}
@@ -149,16 +158,22 @@ const FiltersForm: FC<Props> = ({
                                     filterGroup={filters.metrics}
                                     fields={metrics}
                                     onChange={(value) =>
-                                        setFilters({
-                                            ...filters,
-                                            metrics: value,
-                                        })
+                                        setFilters(
+                                            {
+                                                ...filters,
+                                                metrics: value,
+                                            },
+                                            false,
+                                        )
                                     }
                                     onDelete={() =>
-                                        setFilters({
-                                            ...filters,
-                                            metrics: undefined,
-                                        })
+                                        setFilters(
+                                            {
+                                                ...filters,
+                                                metrics: undefined,
+                                            },
+                                            true,
+                                        )
                                     }
                                 />
                             )}

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -50,7 +50,7 @@ const FiltersForm: FC<Props> = ({
 
     const addFieldRule = useCallback(
         (field: FilterableField) => {
-            setFilters(addFilterRule(filters, field));
+            setFilters(addFilterRule({ filters, field }));
             toggleFieldInput(false);
         },
         [filters, setFilters, toggleFieldInput],

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -80,6 +80,7 @@ export const useColumns = (): Column<{ [col: string]: any }>[] => {
                                 sortFields,
                                 toggleSortField,
                             ),
+                            field,
                         },
                     ];
                 }

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -28,7 +28,8 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any) => setFilters(addFilterRule({ filters, field, value })),
+        (field: FilterableField, value: any, syncState?: boolean) =>
+            setFilters(addFilterRule({ filters, field, value }), !!syncState),
         [filters, setFilters],
     );
 

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -28,7 +28,7 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField) => setFilters(addFilterRule(filters, field)),
+        (field: FilterableField, value: any) => setFilters(addFilterRule({ filters, field, value })),
         [filters, setFilters],
     );
 

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -100,7 +100,10 @@ interface ExplorerContext {
         toggleSortField: (fieldId: FieldId) => void;
         setSortFields: (sortFields: SortField[]) => void;
         setRowLimit: (limit: number) => void;
-        setFilters: (filters: MetricQuery['filters']) => void;
+        setFilters: (
+            filters: MetricQuery['filters'],
+            syncPristineState: boolean,
+        ) => void;
         setColumnOrder: (order: string[]) => void;
         addTableCalculation: (tableCalculation: TableCalculation) => void;
         updateTableCalculation: (
@@ -482,12 +485,24 @@ export const ExplorerProvider: FC = ({ children }) => {
         });
     }, []);
 
-    const setFilters = useCallback((filters: MetricQuery['filters']) => {
-        dispatch({
-            type: ActionType.SET_FILTERS,
-            payload: filters,
-        });
-    }, []);
+    const setFilters = useCallback(
+        (filters: MetricQuery['filters'], syncPristineState: boolean) => {
+            dispatch({
+                type: ActionType.SET_FILTERS,
+                payload: filters,
+            });
+            if (syncPristineState) {
+                pristineDispatch({
+                    type: ActionType.SET_STATE,
+                    payload: {
+                        ...reducerState,
+                        filters,
+                    },
+                });
+            }
+        },
+        [reducerState],
+    );
 
     const setColumnOrder = useCallback((order: string[]) => {
         dispatch({

--- a/packages/frontend/src/types/react-table-config.d.ts
+++ b/packages/frontend/src/types/react-table-config.d.ts
@@ -108,6 +108,7 @@ declare module 'react-table' {
             UseGroupByColumnProps<D>,
             UseResizeColumnsColumnProps<D> {
         // UseSortByColumnProps<D> {
+        field: Field;
         type: 'dimension' | 'metric' | 'table_calculation';
         dimensionType: DimensionType;
         description: string;

--- a/packages/frontend/src/types/react-table-config.d.ts
+++ b/packages/frontend/src/types/react-table-config.d.ts
@@ -1,4 +1,4 @@
-import { DimensionType, TableCalculation } from 'common';
+import { DimensionType, Field, TableCalculation } from 'common';
 import {
     UseColumnOrderInstanceProps,
     UseColumnOrderState,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #86 

### Description:
Right-click a table cell and you can filter to values including that value. Right-click a column header and create an empty filter for that column.

**Todo**
- Get data to refresh after filter added via cell
- Get data to not refresh after filter added via column header
- Improve right-click target for column headers (only on text currently)
- Show filter indicator in column headers?
- Show icon suggesting right-click on cell/column header hover? Similar to the sidebar

### Preview:
https://www.loom.com/share/9851baae02ad469ba43071d0691ddac1

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
