### PR TITLE
style: bignumber charts have smaller tiles by default

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
+import { DashboardTileTypes } from './types/dashboard';
 import {
     DashboardFilterRule,
     DateFilterRule,
@@ -12,12 +13,15 @@ import {
     UnitOfTime,
 } from './types/filter';
 import { OrganizationMemberProfile } from './types/organizationMemberProfile';
+import { DBChartTypes } from './types/savedCharts';
 import { LightdashUser } from './types/user';
 
 export * from './authorization/organizationMemberAbility';
+export * from './types/dashboard';
 export * from './types/filter';
 export * from './types/organization';
 export * from './types/organizationMemberProfile';
+export * from './types/savedCharts';
 export * from './types/user';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
@@ -1114,15 +1118,6 @@ export enum DBFieldTypes {
     METRIC = 'metric',
 }
 
-export enum DBChartTypes {
-    COLUMN = 'column',
-    BAR = 'bar',
-    LINE = 'line',
-    SCATTER = 'scatter',
-    TABLE = 'table',
-    BIG_NUMBER = 'big_number',
-}
-
 export enum WarehouseTypes {
     BIGQUERY = 'bigquery',
     POSTGRES = 'postgres',
@@ -1330,12 +1325,6 @@ export type CreateProject = Omit<Project, 'projectUuid'> & {
 export type UpdateProject = Omit<Project, 'projectUuid'> & {
     warehouseConnection: CreateWarehouseCredentials;
 };
-
-export enum DashboardTileTypes {
-    SAVED_CHART = 'saved_chart',
-    MARKDOWN = 'markdown',
-    LOOM = 'loom',
-}
 
 type CreateDashboardTileBase = {
     uuid?: string;

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,0 +1,28 @@
+import { DBChartTypes } from './savedCharts';
+
+export enum DashboardTileTypes {
+    SAVED_CHART = 'saved_chart',
+    MARKDOWN = 'markdown',
+    LOOM = 'loom',
+}
+
+export const getDefaultChartTileSize = (
+    chartType: DBChartTypes | undefined,
+) => {
+    switch (chartType) {
+        case DBChartTypes.BIG_NUMBER:
+            return {
+                h: 2,
+                w: 3,
+                x: 0,
+                y: 0,
+            };
+        default:
+            return {
+                h: 3,
+                w: 5,
+                x: 0,
+                y: 0,
+            };
+    }
+};

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -6,6 +6,13 @@ export enum DashboardTileTypes {
     LOOM = 'loom',
 }
 
+export const defaultTileSize = {
+    h: 3,
+    w: 5,
+    x: 0,
+    y: 0,
+};
+
 export const getDefaultChartTileSize = (
     chartType: DBChartTypes | undefined,
 ) => {
@@ -18,11 +25,6 @@ export const getDefaultChartTileSize = (
                 y: 0,
             };
         default:
-            return {
-                h: 3,
-                w: 5,
-                x: 0,
-                y: 0,
-            };
+            return defaultTileSize;
     }
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/prefer-default-export
+export enum DBChartTypes {
+    COLUMN = 'column',
+    BAR = 'bar',
+    LINE = 'line',
+    SCATTER = 'scatter',
+    TABLE = 'table',
+    BIG_NUMBER = 'big_number',
+}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileModal.tsx
@@ -1,4 +1,4 @@
-import { Dashboard, DashboardTileTypes } from 'common';
+import { Dashboard, DashboardTileTypes, getDefaultChartTileSize } from 'common';
 import React, { FC, useState } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import ActionModal, { ActionTypeModal } from '../../common/modal/ActionModal';
@@ -88,10 +88,7 @@ export const AddTileModal: FC<AddProps> = ({ onClose, onAddTile, type }) => {
             uuid: uuid4(),
             properties: properties as any,
             type,
-            h: 3,
-            w: 5,
-            x: 0,
-            y: 0,
+            ...getDefaultChartTileSize(undefined), // requires a fetch to know chart type
         });
     };
 

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileModal.tsx
@@ -1,4 +1,4 @@
-import { Dashboard, DashboardTileTypes, getDefaultChartTileSize } from 'common';
+import { Dashboard, DashboardTileTypes, defaultTileSize } from 'common';
 import React, { FC, useState } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import ActionModal, { ActionTypeModal } from '../../common/modal/ActionModal';
@@ -88,7 +88,7 @@ export const AddTileModal: FC<AddProps> = ({ onClose, onAddTile, type }) => {
             uuid: uuid4(),
             properties: properties as any,
             type,
-            ...getDefaultChartTileSize(undefined), // requires a fetch to know chart type
+            ...defaultTileSize,
         });
     };
 

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -17,6 +17,7 @@ import {
     DashboardTileTypes,
     DBChartTypes,
     filterableDimensionsOnly,
+    getDefaultChartTileSize,
     getDimensions,
     getMetrics,
 } from 'common';
@@ -530,7 +531,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     ModalContent={SavedQueryForm}
                 />
             )}
-            {savedQueryUuid && (
+            {data && (
                 <CreateSavedDashboardModal
                     isOpen={isAddToNewDashboardModalOpen}
                     tiles={[
@@ -538,12 +539,11 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                             uuid: uuid4(),
                             type: DashboardTileTypes.SAVED_CHART,
                             properties: {
-                                savedChartUuid: savedQueryUuid,
+                                savedChartUuid: data.uuid,
                             },
-                            h: 3,
-                            w: 5,
-                            x: 0,
-                            y: 0,
+                            ...getDefaultChartTileSize(
+                                data.chartConfig.chartType,
+                            ),
                         },
                     ]}
                     showRedirectButton
@@ -551,9 +551,9 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     ModalContent={DashboardForm}
                 />
             )}
-            {savedQueryUuid && isAddToDashboardModalOpen && (
+            {data && isAddToDashboardModalOpen && (
                 <AddTilesToDashboardModal
-                    savedChartUuid={savedQueryUuid}
+                    savedChart={data}
                     onClose={() => setIsAddToDashboardModalOpen(false)}
                 />
             )}

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -1,4 +1,8 @@
-import { DashboardTileTypes } from 'common';
+import {
+    DashboardTileTypes,
+    getDefaultChartTileSize,
+    SavedQuery,
+} from 'common';
 import React, { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
@@ -50,11 +54,11 @@ const useUpdateMutation = (id?: string) => {
 };
 
 interface Props {
-    savedChartUuid: string;
+    savedChart: SavedQuery;
     onClose?: () => void;
 }
 
-const AddTilesToDashboardModal: FC<Props> = ({ savedChartUuid, onClose }) => {
+const AddTilesToDashboardModal: FC<Props> = ({ savedChart, onClose }) => {
     const [selectedDashboardUuid, setSelectedDashboardUuid] =
         useState<string>();
     const { data } = useDashboardQuery(selectedDashboardUuid);
@@ -82,17 +86,16 @@ const AddTilesToDashboardModal: FC<Props> = ({ savedChartUuid, onClose }) => {
                         uuid: uuid4(),
                         type: DashboardTileTypes.SAVED_CHART,
                         properties: {
-                            savedChartUuid,
+                            savedChartUuid: savedChart.uuid,
                         },
-                        h: 3,
-                        w: 5,
-                        x: 0,
-                        y: 0,
+                        ...getDefaultChartTileSize(
+                            savedChart.chartConfig.chartType,
+                        ),
                     },
                 ],
             });
         }
-    }, [data, mutate, isIdle, savedChartUuid]);
+    }, [data, mutate, isIdle, savedChart]);
 
     useEffect(() => {
         if (isSuccess) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1327 

### Description:

Default uses smaller tiles for big number charts.

**Todo**

 - Get it working for "add tile" button on edit dashboard view

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
