### PR TITLE
fix(filters): set default filter values

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -5,6 +5,7 @@ import {
     FilterRule,
     FilterType,
     getFieldLabel,
+    getFilterTypeFromField,
 } from 'common';
 import React, { FC, useMemo } from 'react';
 import {
@@ -15,7 +16,6 @@ import {
 import {
     filterOperatorLabel,
     FilterTypeConfig,
-    getFilterTypeFromField,
 } from '../../common/Filters/configs';
 import { FilterValues, TagContainer } from './ActiveFilters.styles';
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,18 +1,15 @@
 import { HTMLSelect, Intent } from '@blueprintjs/core';
 import {
+    createDashboardFilterRuleFromField,
     DashboardFilterRule,
-    fieldId,
     FilterableField,
-    FilterOperator,
     FilterRule,
     FilterType,
+    getFilterRuleWithDefaultValue,
+    getFilterTypeFromField,
 } from 'common';
 import React, { FC, useMemo, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
-import {
-    FilterTypeConfig,
-    getFilterTypeFromField,
-} from '../../common/Filters/configs';
+import { FilterTypeConfig } from '../../common/Filters/configs';
 import {
     ApplyFilterButton,
     BackButton,
@@ -36,15 +33,7 @@ const FilterConfiguration: FC<Props> = ({
 }) => {
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
-            filterRule || {
-                id: uuidv4(),
-                target: {
-                    fieldId: fieldId(field),
-                    tableName: field.table,
-                },
-                operator: FilterOperator.EQUALS,
-                values: [],
-            },
+            filterRule || createDashboardFilterRuleFromField(field),
         );
 
     const filterType = field
@@ -65,11 +54,13 @@ const FilterConfiguration: FC<Props> = ({
                 <HTMLSelect
                     fill
                     onChange={(e) =>
-                        setInternalFilterRule((prevState) => ({
-                            ...prevState,
-                            operator: e.currentTarget
-                                .value as FilterRule['operator'],
-                        }))
+                        setInternalFilterRule((prevState) =>
+                            getFilterRuleWithDefaultValue(field, {
+                                ...prevState,
+                                operator: e.currentTarget
+                                    .value as FilterRule['operator'],
+                            }),
+                        )
                     }
                     options={filterConfig.operatorOptions}
                     value={internalFilterRule.operator}

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -1,10 +1,10 @@
 import { Colors, Icon, MenuItem } from '@blueprintjs/core';
 import { ItemRenderer, Suggest } from '@blueprintjs/select';
-import { Field, fieldId as getFieldId, isDimension } from 'common';
+import { fieldId as getFieldId, FilterableField, isDimension } from 'common';
 import React, { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
-const FieldSuggest = Suggest.ofType<Field>();
+const FieldSuggest = Suggest.ofType<FilterableField>();
 
 const AutocompleteMaxHeight = createGlobalStyle`
     .autocomplete-max-height {
@@ -13,7 +13,10 @@ const AutocompleteMaxHeight = createGlobalStyle`
     }
 `;
 
-const renderItem: ItemRenderer<Field> = (field, { modifiers, handleClick }) => {
+const renderItem: ItemRenderer<FilterableField> = (
+    field,
+    { modifiers, handleClick },
+) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
@@ -40,9 +43,9 @@ const renderItem: ItemRenderer<Field> = (field, { modifiers, handleClick }) => {
 
 type Props = {
     autoFocus?: boolean;
-    activeField?: Field;
-    fields: Field[];
-    onChange: (value: Field) => void;
+    activeField?: FilterableField;
+    fields: FilterableField[];
+    onChange: (value: FilterableField) => void;
     onClosed?: () => void;
 };
 
@@ -75,7 +78,7 @@ const FieldAutoComplete: FC<Props> = ({
             itemsEqual={(value, other) =>
                 getFieldId(value) === getFieldId(other)
             }
-            inputValueRenderer={(field: Field) =>
+            inputValueRenderer={(field: FilterableField) =>
                 `${field.tableLabel} ${field.label}`
             }
             popoverProps={{
@@ -89,7 +92,7 @@ const FieldAutoComplete: FC<Props> = ({
             onItemSelect={onChange}
             itemPredicate={(
                 query: string,
-                field: Field,
+                field: FilterableField,
                 index?: undefined | number,
                 exactMatch?: undefined | false | true,
             ) => {

--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -1,10 +1,9 @@
 import { Button, HTMLSelect } from '@blueprintjs/core';
 import {
-    fieldId,
+    createFilterRuleFromField,
     FilterableField,
     FilterGroup,
     FilterGroupOperator,
-    FilterOperator,
     FilterRule,
     getFilterGroupItemsPropertyName,
     getItemsFromFilterGroup,
@@ -12,7 +11,6 @@ import {
     isFilterRule,
 } from 'common';
 import React, { FC, useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import {
     FilterGroupHeader,
     FilterGroupItemsWrapper,
@@ -76,13 +74,7 @@ const FilterGroupForm: FC<Props> = ({
                 ...filterGroup,
                 [getFilterGroupItemsPropertyName(filterGroup)]: [
                     ...items,
-                    {
-                        id: uuidv4(),
-                        target: {
-                            fieldId: fieldId(fields[0]),
-                        },
-                        operator: FilterOperator.EQUALS,
-                    },
+                    createFilterRuleFromField(fields[0]),
                 ],
             });
         }

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -1,14 +1,16 @@
 import { Button, Colors, HTMLSelect } from '@blueprintjs/core';
 import {
+    createFilterRuleFromField,
     Field,
     fieldId as getFieldId,
     FilterableField,
-    FilterOperator,
     FilterRule,
     FilterType,
+    getFilterRuleWithDefaultValue,
+    getFilterTypeFromField,
 } from 'common';
 import React, { FC, useCallback, useMemo } from 'react';
-import { FilterTypeConfig, getFilterTypeFromField } from './configs';
+import { FilterTypeConfig } from './configs';
 import FieldAutoComplete from './FieldAutoComplete';
 
 type Props = {
@@ -50,15 +52,7 @@ const FilterRuleForm: FC<Props> = ({
                         },
                     });
                 } else {
-                    onChange({
-                        ...filterRule,
-                        target: {
-                            fieldId,
-                        },
-                        operator: FilterOperator.EQUALS,
-                        settings: undefined,
-                        values: undefined,
-                    });
+                    onChange(createFilterRuleFromField(selectedField));
                 }
             }
         },
@@ -87,11 +81,13 @@ const FilterRuleForm: FC<Props> = ({
                         fill={false}
                         style={{ width: 150 }}
                         onChange={(e) =>
-                            onChange({
-                                ...filterRule,
-                                operator: e.currentTarget
-                                    .value as FilterRule['operator'],
-                            })
+                            onChange(
+                                getFilterRuleWithDefaultValue(activeField, {
+                                    ...filterRule,
+                                    operator: e.currentTarget
+                                        .value as FilterRule['operator'],
+                                }),
+                            )
                         }
                         options={filterConfig.operatorOptions}
                         value={filterRule.operator}

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -1,10 +1,4 @@
-import {
-    DimensionType,
-    FilterableField,
-    FilterOperator,
-    FilterType,
-    MetricType,
-} from 'common';
+import { FilterOperator, FilterType } from 'common';
 import { FC } from 'react';
 import BooleanFilterInputs from './FilterInputs/BooleanFilterInputs';
 import DateFilterInputs from './FilterInputs/DateFilterInputs';
@@ -50,35 +44,6 @@ const timeFilterOptions: Array<{
     { value: FilterOperator.GREATER_THAN, label: 'is after' },
     { value: FilterOperator.GREATER_THAN_OR_EQUAL, label: 'is on or after' },
 ];
-
-export const getFilterTypeFromField = (field: FilterableField): FilterType => {
-    const fieldType = field.type;
-    switch (field.type) {
-        case DimensionType.STRING:
-        case MetricType.STRING:
-            return FilterType.STRING;
-        case DimensionType.NUMBER:
-        case MetricType.NUMBER:
-        case MetricType.AVERAGE:
-        case MetricType.COUNT:
-        case MetricType.COUNT_DISTINCT:
-        case MetricType.SUM:
-        case MetricType.MIN:
-        case MetricType.MAX:
-            return FilterType.NUMBER;
-        case DimensionType.TIMESTAMP:
-        case DimensionType.DATE:
-        case MetricType.DATE:
-            return FilterType.DATE;
-        case DimensionType.BOOLEAN:
-        case MetricType.BOOLEAN:
-            return FilterType.BOOLEAN;
-        default: {
-            const never: never = field;
-            throw Error(`No filter type found for field type: ${fieldType}`);
-        }
-    }
-};
 
 export const FilterTypeConfig: Record<
     FilterType,

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -2,8 +2,8 @@ import { Button, Colors, Divider, Tag } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import {
     addFilterRule,
-    Field,
     FilterableDimension,
+    FilterableField,
     FilterRule,
     Filters,
     getFilterRulesByFieldType,
@@ -49,7 +49,7 @@ const FiltersForm: FC<Props> = ({
         filterRulesPerFieldType.metrics.length >= 1;
 
     const addFieldRule = useCallback(
-        (field: Field) => {
+        (field: FilterableField) => {
             setFilters(addFilterRule(filters, field));
             toggleFieldInput(false);
         },

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -1,4 +1,10 @@
-import { addFilterRule, Field, fieldId, getTotalFilterRules } from 'common';
+import {
+    addFilterRule,
+    Field,
+    fieldId,
+    FilterableField,
+    getTotalFilterRules,
+} from 'common';
 import { useCallback, useMemo } from 'react';
 import { useExplorer } from '../providers/ExplorerProvider';
 
@@ -22,7 +28,7 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: Field) => setFilters(addFilterRule(filters, field)),
+        (field: FilterableField) => setFilters(addFilterRule(filters, field)),
         [filters, setFilters],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
When we added a filter to the dashboard or changed the operator, without changing the value it would create a filter sql with an empty value. the UI would show a default value but it wasn't being applied.

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
