### PR TITLE
fix(dashboards): hide+disable dashboard filters when in edit mode

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -154,7 +154,7 @@ const Dashboard = () => {
         return <Spinner />;
     }
     return (
-        <DashboardProvider dashboard={dashboard}>
+        <DashboardProvider dashboard={dashboard} isEditMode={isEditMode}>
             <DashboardHeader
                 dashboardName={dashboard.name}
                 isEditMode={isEditMode}
@@ -166,7 +166,7 @@ const Dashboard = () => {
                 onCancel={onCancel}
             />
             <Page isContentFullWidth>
-                <DashboardFilter />
+                {!isEditMode && <DashboardFilter />}
                 <ResponsiveGridLayout
                     useCSSTransforms={false}
                     draggableCancel=".non-draggable"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1356

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Hide filters section
- Don't apply filters to charts
- Reset filters when going back to view mode

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->
<a href="https://www.loom.com/share/d318a1f4b0ee4fdc8c59b4684b6ba5cc">
    <p>Lightdash - 15 February 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d318a1f4b0ee4fdc8c59b4684b6ba5cc-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
