### PR TITLE
feat: add cmd+enter hotkey to RefreshButton

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import { useHotkeys } from '@blueprintjs/core';
+import React, { useMemo } from 'react';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
 import { useServerStatus } from '../hooks/useServerStatus';
@@ -16,17 +17,34 @@ export const RefreshButton = () => {
     const { isFetching, remove } = useQueryResults();
     const { track } = useTracking();
     const defaultSort = useDefaultSortField();
+    const onClick = async () => {
+        remove();
+        syncState(sorts.length === 0 ? defaultSort : undefined);
+        track({
+            name: EventName.RUN_QUERY_BUTTON_CLICKED,
+        });
+    };
+    const hotkeys = useMemo(
+        () => [
+            {
+                combo: 'cmd+enter',
+                group: 'Explorer',
+                label: 'Run query',
+                allowInInput: true,
+                onKeyDown: onClick,
+                global: true,
+                preventDefault: true,
+                stopPropagation: true,
+            },
+        ],
+        [onClick],
+    );
+    useHotkeys(hotkeys);
     return (
         <BigButton
             intent="primary"
             style={{ width: 150, marginRight: '10px' }}
-            onClick={async () => {
-                remove();
-                syncState(sorts.length === 0 ? defaultSort : undefined);
-                track({
-                    name: EventName.RUN_QUERY_BUTTON_CLICKED,
-                });
-            }}
+            onClick={onClick}
             disabled={!isValidQuery}
             loading={isFetching || status.data === 'loading'}
         >

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,5 +1,5 @@
 import { useHotkeys } from '@blueprintjs/core';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
 import { useServerStatus } from '../hooks/useServerStatus';
@@ -17,28 +17,32 @@ export const RefreshButton = () => {
     const { isFetching, remove } = useQueryResults();
     const { track } = useTracking();
     const defaultSort = useDefaultSortField();
-    const onClick = async () => {
+    const onClick = useCallback(async () => {
         remove();
         syncState(sorts.length === 0 ? defaultSort : undefined);
         track({
             name: EventName.RUN_QUERY_BUTTON_CLICKED,
         });
-    };
-    const hotkeys = useMemo(
-        () => [
+    }, [defaultSort, remove, sorts, syncState, track]);
+    const hotkeys = useMemo(() => {
+        const runQueryHotkey = {
+            combo: 'ctrl+enter',
+            group: 'Explorer',
+            label: 'Run query',
+            allowInInput: true,
+            onKeyDown: onClick,
+            global: true,
+            preventDefault: true,
+            stopPropagation: true,
+        };
+        return [
+            runQueryHotkey,
             {
+                ...runQueryHotkey,
                 combo: 'cmd+enter',
-                group: 'Explorer',
-                label: 'Run query',
-                allowInInput: true,
-                onKeyDown: onClick,
-                global: true,
-                preventDefault: true,
-                stopPropagation: true,
             },
-        ],
-        [onClick],
-    );
+        ];
+    }, [onClick]);
     useHotkeys(hotkeys);
     return (
         <BigButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1392 <!-- reference the related issue e.g. #150 -->

### Description:

Whenever the "Run query" (`RefreshButton.tsx`) is visible, the user can use `cmd+enter` to execute the query in place of pressing the button.

This is also true whenever there is a modal open, even if the "Run query" button is in the background. This won't be a problem since the "Run query" button only exists on the explorer and the settings modal over the explorer is planned to be moved.
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
