### PR TITLE
fix: numbers are no longer removed from column name #1346

### DIFF
--- a/packages/backend/src/exploreCompiler.test.ts
+++ b/packages/backend/src/exploreCompiler.test.ts
@@ -84,4 +84,10 @@ describe('Default field labels render for', () => {
     test('snake case names', () => {
         expect(friendlyName('my_field_id')).toEqual('My field id');
     });
+    test('names with numbers at the start', () => {
+        expect(friendlyName('1_field_id')).toEqual('1 field id');
+    });
+    test('names with numbers in the middle', () => {
+        expect(friendlyName('my_1field_id')).toEqual('My 1field id');
+    });
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -565,8 +565,7 @@ const capitalize = (word: string): string =>
 export const friendlyName = (text: string): string => {
     const normalisedText =
         text === text.toUpperCase() ? text.toLowerCase() : text; // force all uppercase to all lowercase
-    const [first, ...rest] =
-        normalisedText.match(/[0-9]*[A-Za-z][a-z]*/g) || [];
+    const [first, ...rest] = normalisedText.match(/[0-9]*[A-Za-z]*/g) || [];
     return [
         capitalize(first.toLowerCase()),
         ...rest.map((word) => word.toLowerCase()),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -565,7 +565,8 @@ const capitalize = (word: string): string =>
 export const friendlyName = (text: string): string => {
     const normalisedText =
         text === text.toUpperCase() ? text.toLowerCase() : text; // force all uppercase to all lowercase
-    const [first, ...rest] = normalisedText.match(/[0-9]*[A-Za-z]*/g) || [];
+    const [first, ...rest] =
+        normalisedText.match(/[0-9]*[A-Za-z][a-z]*|[0-9]+/g) || [];
     return [
         capitalize(first.toLowerCase()),
         ...rest.map((word) => word.toLowerCase()),


### PR DESCRIPTION
Closes: #1346

Fixed regex in friendlyName to allow for purely numeric words in a field name whether at the start or otherwise

- [ ] Backend  
- [ ] Common