### PR TITLE
fix(redshift): amend ra3 node default value

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -123,7 +123,7 @@ const RedshiftForm: FC<{
                     name="warehouse.ra3Node"
                     label="Use RA3 node"
                     documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#ra3-node"
-                    defaultValue="true"
+                    defaultValue
                     disabled={disabled}
                 />
             </FormSection>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Fixes error when connecting to a redshift warehouse. 

Error:
```
 Credentials in profile “lightdash_profile”, target “prod” invalid: ‘true’ is not valid under any of the given schemas
```

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
