### PR TITLE
fix(charts): disable chart configuration for table visualization

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -414,16 +414,18 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                             </Tooltip2>
                             <ChartConfigPanel
                                 chartConfig={chartConfig}
-                                disabled={isChartEmpty || isBigNumber}
+                                disabled={
+                                    isChartEmpty ||
+                                    isBigNumber ||
+                                    activeVizTab === DBChartTypes.TABLE
+                                }
                             />
-                            {chartConfig.plotData && !isBigNumber && (
-                                <ChartDownloadMenu
-                                    chartRef={chartRef}
-                                    disabled={isChartEmpty}
-                                    chartType={activeVizTab}
-                                    chartData={chartConfig.plotData}
-                                />
-                            )}
+                            <ChartDownloadMenu
+                                chartRef={chartRef}
+                                disabled={isChartEmpty || isBigNumber}
+                                chartType={activeVizTab}
+                                chartData={chartConfig.plotData || []}
+                            />
                             <ButtonGroup>
                                 <Button
                                     text="Save chart"

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -43,7 +43,7 @@ const LightdashVisualization: FC<Props> = ({
                     />
                 );
             case DBChartTypes.TABLE:
-                return <SimpleTable data={chartConfig.plotData} />;
+                return <SimpleTable data={resultsData} />;
             case DBChartTypes.COLUMN:
             case DBChartTypes.LINE:
             case DBChartTypes.SCATTER:

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,5 @@
 import { Colors, HTMLTable, NonIdealState } from '@blueprintjs/core';
-import { friendlyName } from 'common';
+import { ApiQueryResults, friendlyName } from 'common';
 import React, { FC } from 'react';
 import { mapDataToTable, modifiedItem } from '../../utils/tableData';
 import {
@@ -9,10 +9,10 @@ import {
 } from './SimpleTable.styles';
 
 interface Props {
-    data: Record<string, any>[] | undefined;
+    data: ApiQueryResults | undefined;
 }
 const SimpleTable: FC<Props> = ({ data }) => {
-    const tableItems = data ? data.slice(0, 25) : [];
+    const tableItems = data ? data.rows.slice(0, 25) : [];
     const { headers, rows } = mapDataToTable(tableItems);
     const validData = rows && headers;
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Data in table visualisation can no longer be grouped/pivoted.

### Preview:

![Screenshot 2022-02-23 at 17 42 40](https://user-images.githubusercontent.com/9117144/155376262-ca22800f-df2e-4a61-b298-bdec4fa5178a.png)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
