### PR TITLE
fix(filters): add min value to input instead of 'or' operator

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -75,9 +75,9 @@ const renderNumberFilterSql = (
         case FilterOperator.NOT_NULL:
             return `(${dimensionSql}) IS NOT NULL`;
         case FilterOperator.GREATER_THAN:
-            return `(${dimensionSql}) > ${filter.values?.[0]}`;
+            return `(${dimensionSql}) > (${filter.values?.[0] || 0})`;
         case FilterOperator.LESS_THAN:
-            return `(${dimensionSql}) < ${filter.values?.[0]}`;
+            return `(${dimensionSql}) < (${filter.values?.[0] || 0})`;
         default:
             throw Error(
                 `No function implemented to render sql for filter type ${filterType} on dimension of number type`,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -109,12 +109,13 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                 />
             );
         case FilterOperator.IN_THE_PAST:
+            const parsedValue = parseInt(filterRule.values?.[0], 10);
             return (
                 <MultipleInputsWrapper>
                     <NumericInput
                         fill
-                        value={parseInt(filterRule.values?.[0], 10)}
-                        min={1}
+                        value={isNaN(parsedValue) ? undefined : parsedValue}
+                        min={0}
                         onValueChange={(value) =>
                             onChange({
                                 ...filterRule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -113,7 +113,8 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                 <MultipleInputsWrapper>
                     <NumericInput
                         fill
-                        value={parseInt(filterRule.values?.[0], 10) || 1}
+                        value={parseInt(filterRule.values?.[0], 10)}
+                        min={1}
                         onValueChange={(value) =>
                             onChange({
                                 ...filterRule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -89,10 +89,12 @@ const DefaultFilterInputs: FC<FilterInputsProps> = ({
         case FilterOperator.LESS_THAN:
         case FilterOperator.LESS_THAN_OR_EQUAL:
         case FilterOperator.IN_THE_PAST:
+            const parsedValue = parseInt(filterRule.values?.[0], 10);
             return (
                 <NumericInput
                     fill
-                    value={filterRule.values?.[0]}
+                    value={isNaN(parsedValue) ? undefined : parsedValue}
+                    min={0}
                     onValueChange={(value) =>
                         onChange({
                             ...filterRule,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
closes: #1452, closes: #1466

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
In: https://github.com/lightdash/lightdash/blob/5e742cb32c761a805c32c491bd188f5b6834997e/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx#L111-L123
whenever the field is empty, it defaults to 1, so even if you hit backspace, you can only add the number to 1 as explained in #1452 
By adding a minimum value of 1, it allows you to enter any numeric value and not get default to 1.
### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/fa859128d8ae49918b4f1356386b65ea">
    <p>Lightdash - fix-numeric-input - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/fa859128d8ae49918b4f1356386b65ea-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
