### PR TITLE
fix: trigger helm chart update upon release

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -39,3 +39,14 @@ jobs:
         run: "git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/alpha"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger helm chart update on release
+        if: |
+          steps.semantic.outputs.new_release_published == 'true' &&
+          steps.semantic.outputs.new_release_channel == null
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.LIGHTDASH_BOT_PAT }}" \
+            -d '{"ref": "main", "inputs": {"lightdash-version": "${{ steps.semantic.outputs.new_release_version }}"}}' \
+            https://api.github.com/repos/lightdash/helm-charts/action/workflows/increment-lightdash-app-version.yml/dispatches


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Description:
After release, trigger a helm chart update. 

There are prerequisites for adding this trigger:
- [ ]  https://github.com/lightdash/helm-charts/pull/9
- [ ] The creation of a [machine account](https://docs.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements)
- [ ] A [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for the machine account populated in a secret named `LIGHTDASH_BOT_PAT`.

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [X] CI/CD  
