### PR TITLE
feat(charts): allow all field types to be applied to both axis and pivoting

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -64,17 +64,9 @@ const ChartConfigTabs: FC = () => {
         (item) => !yFields.includes(isField(item) ? fieldId(item) : item.name),
     );
 
-    const groupDimensionsInMetricQuery = explore
-        ? getDimensions(explore).filter(
-              (field) =>
-                  resultsData?.metricQuery.dimensions.includes(
-                      fieldId(field),
-                  ) && fieldId(field) !== xField,
-          )
-        : [];
-
-    const activeGroupDimension = groupDimensionsInMetricQuery.find(
-        (field) => fieldId(field) === pivotDimension,
+    const activeGroupDimension = items.find(
+        (item) =>
+            (isField(item) ? fieldId(item) : item.name) === pivotDimension,
     );
 
     return (
@@ -210,11 +202,9 @@ const ChartConfigTabs: FC = () => {
                         <InputWrapper label="Group">
                             <FieldRow>
                                 <FieldAutoComplete
-                                    disabled={
-                                        groupDimensionsInMetricQuery.length <= 0
-                                    }
+                                    disabled={items.length <= 0}
                                     activeField={activeGroupDimension}
-                                    fields={groupDimensionsInMetricQuery}
+                                    fields={items}
                                     onChange={(field) => {
                                         if (isField(field)) {
                                             setPivotDimensions([

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -39,10 +39,6 @@ const ChartConfigTabs: FC = () => {
           )
         : [];
 
-    const activeDimension = dimensionsInMetricQuery.find(
-        (field) => fieldId(field) === xField,
-    );
-
     const metricsAndTableCalculations: Array<Metric | TableCalculation> =
         explore
             ? [
@@ -58,7 +54,13 @@ const ChartConfigTabs: FC = () => {
               })
             : [];
 
-    const yOptions = metricsAndTableCalculations.filter(
+    const items = [...dimensionsInMetricQuery, ...metricsAndTableCalculations];
+
+    const activeDimension = items.find(
+        (item) => (isField(item) ? fieldId(item) : item.name) === xField,
+    );
+
+    const yOptions = items.filter(
         (item) => !yFields.includes(isField(item) ? fieldId(item) : item.name),
     );
 
@@ -101,13 +103,13 @@ const ChartConfigTabs: FC = () => {
                                 <FieldAutoComplete
                                     activeField={activeDimension}
                                     fields={dimensionsInMetricQuery}
-                                    onChange={(field) => {
-                                        if (isField(field)) {
-                                            cartesianConfig.setXField(
-                                                fieldId(field),
-                                            );
-                                        }
-                                    }}
+                                    onChange={(item) =>
+                                        cartesianConfig.setXField(
+                                            isField(item)
+                                                ? fieldId(item)
+                                                : item.name,
+                                        )
+                                    }
                                 />
                             </InputWrapper>
                         </>
@@ -131,13 +133,12 @@ const ChartConfigTabs: FC = () => {
 
                             <InputWrapper label="Field(s)">
                                 {yFields.map((yFieldId) => {
-                                    const activeMetric =
-                                        metricsAndTableCalculations.find(
-                                            (item) =>
-                                                (isField(item)
-                                                    ? fieldId(item)
-                                                    : item.name) === yFieldId,
-                                        );
+                                    const activeMetric = items.find(
+                                        (item) =>
+                                            (isField(item)
+                                                ? fieldId(item)
+                                                : item.name) === yFieldId,
+                                    );
                                     if (!activeMetric) {
                                         return null;
                                     }

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -80,10 +80,10 @@ const useCartesianChartConfig = (
     }, []);
 
     const validConfig = useMemo<CartesianChart | undefined>(() => {
-        const availableXFields = resultsData
+        const availableDimensions = resultsData
             ? resultsData.metricQuery.dimensions
             : [];
-        const availableYFields = resultsData
+        const availableMetricsAndTableCalculations = resultsData
             ? [
                   ...resultsData.metricQuery.metrics,
                   ...resultsData.metricQuery.tableCalculations.map(
@@ -91,7 +91,11 @@ const useCartesianChartConfig = (
                   ),
               ]
             : [];
-        if (availableXFields.length <= 0 || availableYFields.length <= 0) {
+        const availableFields = [
+            ...availableDimensions,
+            ...availableMetricsAndTableCalculations,
+        ];
+        if (availableFields.length <= 1) {
             return undefined;
         }
         const validSeries: Series[] =
@@ -99,8 +103,8 @@ const useCartesianChartConfig = (
                 ?.filter(isValidSeries)
                 .filter(
                     ({ xField, yField }) =>
-                        availableXFields.includes(xField) &&
-                        availableYFields.includes(yField),
+                        availableFields.includes(xField) &&
+                        availableFields.includes(yField),
                 ) || [];
 
         if (validSeries.length <= 0) {
@@ -109,8 +113,10 @@ const useCartesianChartConfig = (
                 series: [
                     {
                         type: CartesianSeriesType.BAR,
-                        xField: availableXFields[0],
-                        yField: availableYFields[0],
+                        xField: availableDimensions[0] || availableFields[0],
+                        yField:
+                            availableMetricsAndTableCalculations[0] ||
+                            availableFields[1],
                         flipAxes: false,
                     },
                 ],

--- a/packages/frontend/src/hooks/useEcharts.ts
+++ b/packages/frontend/src/hooks/useEcharts.ts
@@ -214,11 +214,24 @@ const useEcharts = () => {
 
     const [xAxis] = validConfig?.xAxes || [];
     const [yAxis] = validConfig?.yAxes || [];
+
+    const defaultXAxisType = getAxisTypeFromField(explore, series[0].encode.x);
+    const defaultYAxisType = getAxisTypeFromField(explore, series[0].encode.y);
+    let xAxisType: string;
+    let yAxisType: string;
+    if (validConfig?.series[0].flipAxes) {
+        xAxisType = 'value';
+        yAxisType =
+            defaultYAxisType === 'value' ? 'category' : defaultYAxisType;
+    } else {
+        xAxisType =
+            defaultXAxisType === 'value' ? 'category' : defaultXAxisType;
+        yAxisType = 'value';
+    }
+
     return {
         xAxis: {
-            type: validConfig?.series[0].flipAxes
-                ? 'value'
-                : getAxisTypeFromField(explore, series[0].encode.x),
+            type: xAxisType,
             name:
                 xAxis?.name ||
                 getLabelFromField(
@@ -231,9 +244,7 @@ const useEcharts = () => {
             nameTextStyle: { fontWeight: 'bold' },
         },
         yAxis: {
-            type: validConfig?.series[0].flipAxes
-                ? getAxisTypeFromField(explore, series[0].encode.y)
-                : 'value',
+            type: yAxisType,
             name:
                 yAxis?.name ||
                 (series.length === 1

--- a/packages/frontend/src/hooks/useEcharts.ts
+++ b/packages/frontend/src/hooks/useEcharts.ts
@@ -220,13 +220,13 @@ const useEcharts = () => {
     let xAxisType: string;
     let yAxisType: string;
     if (validConfig?.series[0].flipAxes) {
-        xAxisType = 'value';
+        xAxisType = defaultXAxisType;
         yAxisType =
             defaultYAxisType === 'value' ? 'category' : defaultYAxisType;
     } else {
         xAxisType =
             defaultXAxisType === 'value' ? 'category' : defaultXAxisType;
-        yAxisType = 'value';
+        yAxisType = defaultYAxisType;
     }
 
     return {

--- a/packages/frontend/src/hooks/usePivotDimensions.ts
+++ b/packages/frontend/src/hooks/usePivotDimensions.ts
@@ -15,10 +15,22 @@ const usePivotDimensions = (
     const validPivotDimensions = useMemo(() => {
         if (resultsData) {
             const pivotDimension = dirtyPivotDimensions?.[0];
-            if (
-                pivotDimension &&
-                resultsData.metricQuery.dimensions.includes(pivotDimension)
-            ) {
+            const availableDimensions = resultsData
+                ? resultsData.metricQuery.dimensions
+                : [];
+            const availableMetricsAndTableCalculations = resultsData
+                ? [
+                      ...resultsData.metricQuery.metrics,
+                      ...resultsData.metricQuery.tableCalculations.map(
+                          ({ name }) => name,
+                      ),
+                  ]
+                : [];
+            const availableFields = [
+                ...availableDimensions,
+                ...availableMetricsAndTableCalculations,
+            ];
+            if (pivotDimension && availableFields.includes(pivotDimension)) {
                 return [pivotDimension];
             }
             return undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #531<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- allow dimensions/metrics/table calculations to be used in both axis
- allow dimensions/metrics/table calculations to be used to pivot data

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/f89a56c05ff84cdeb538a30826947b19">
    <p>Lightdash - axis independent from field type - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/f89a56c05ff84cdeb538a30826947b19-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
