### PR TITLE
feat: adds commands tooltip to table explorer

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,4 +1,5 @@
-import { useHotkeys } from '@blueprintjs/core';
+import { KeyCombo, useHotkeys } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import React, { useCallback, useMemo } from 'react';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
@@ -45,14 +46,16 @@ export const RefreshButton = () => {
     }, [onClick]);
     useHotkeys(hotkeys);
     return (
-        <BigButton
-            intent="primary"
-            style={{ width: 150, marginRight: '10px' }}
-            onClick={onClick}
-            disabled={!isValidQuery}
-            loading={isFetching || status.data === 'loading'}
-        >
-            Run query
-        </BigButton>
+        <Tooltip2 content={<KeyCombo combo="cmd+enter" />}>
+            <BigButton
+                intent="primary"
+                style={{ width: 150, marginRight: '10px' }}
+                onClick={onClick}
+                disabled={!isValidQuery}
+                loading={isFetching || status.data === 'loading'}
+            >
+                Run query
+            </BigButton>
+        </Tooltip2>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1449 

### Description:
This PR adds tooltip to run query button in the table explorer that displays the commands to rerun

### Preview:
<img width="778" alt="Screenshot 2022-03-02 at 14 05 02" src="https://user-images.githubusercontent.com/31137824/156430733-6997adeb-fb65-423f-b08c-8a2a19ef5808.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
