### PR TITLE
style: update view all button on the charts panel in home page

### DIFF
--- a/packages/frontend/src/components/Home/LatestSavedCharts/LatestSavedCharts.style.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/LatestSavedCharts.style.tsx
@@ -1,0 +1,25 @@
+import { Colors } from '@blueprintjs/core';
+import styled, { css } from 'styled-components';
+import LinkButton from '../../common/LinkButton';
+
+const ButtonStyle = css`
+    width: 100%;
+    justify-content: left;
+    margin-bottom: 10px;
+`;
+
+export const ChartName = styled(LinkButton)`
+    ${ButtonStyle}
+    color: ${Colors.DARK_GRAY1};
+    font-weight: 600;
+`;
+
+export const CreateChartButton = styled(LinkButton)`
+    ${ButtonStyle}
+    font-weight: 500;
+`;
+
+export const ViewAllButton = styled(LinkButton)`
+    color: ${Colors.BLUE3} !important;
+    width: 7.143em;
+`;

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -1,8 +1,12 @@
-import { AnchorButton, Colors } from '@blueprintjs/core';
+import { AnchorButton } from '@blueprintjs/core';
 import React, { FC } from 'react';
-import { useSavedCharts } from '../../hooks/useSpaces';
-import LinkButton from '../common/LinkButton';
-import LatestCard from './LatestCard';
+import { useSavedCharts } from '../../../hooks/useSpaces';
+import LatestCard from '../LatestCard';
+import {
+    ChartName,
+    CreateChartButton,
+    ViewAllButton,
+} from './LatestSavedCharts.style';
 
 const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const savedChartsRequest = useSavedCharts(projectUuid);
@@ -10,15 +14,14 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     return (
         <LatestCard
             isLoading={savedChartsRequest.isLoading}
-            title={`Browse saved charts (${savedCharts.length})`}
+            title="Browse saved charts"
             headerAction={
                 savedCharts.length > 0 ? (
-                    <LinkButton
-                        text="View all"
+                    <ViewAllButton
+                        text={`View all ${savedCharts.length}`}
                         minimal
                         outlined
                         href={`/projects/${projectUuid}/saved`}
-                        style={{ width: 100 }}
                     />
                 ) : (
                     <AnchorButton
@@ -40,35 +43,22 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 )
                 .slice(0, 5)
                 .map(({ uuid, name }) => (
-                    <LinkButton
+                    <ChartName
                         minimal
                         href={`/projects/${projectUuid}/saved/${uuid}`}
-                        style={{
-                            width: '100%',
-                            justifyContent: 'left',
-                            color: Colors.DARK_GRAY1,
-                            fontWeight: 600,
-                            marginBottom: 10,
-                        }}
                         alignText="left"
                     >
                         {name}
-                    </LinkButton>
+                    </ChartName>
                 ))}
             {savedCharts.length === 0 && (
-                <LinkButton
+                <CreateChartButton
                     minimal
                     href={`/projects/${projectUuid}/tables`}
-                    style={{
-                        width: '100%',
-                        justifyContent: 'left',
-                        fontWeight: 500,
-                        marginBottom: 10,
-                    }}
                     intent="primary"
                 >
                     + Create a saved chart
-                </LinkButton>
+                </CreateChartButton>
             )}
         </LatestCard>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Description:
Quick update in the view all button and title of the saved charts panel in the home page

### Preview:
<img width="877" alt="Screenshot 2022-03-04 at 09 43 19" src="https://user-images.githubusercontent.com/31137824/156783907-226a1ad2-a19f-4f99-a913-b605d5da3c74.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
