### PR TITLE
fix: save to be active when title changes and send request on save

### DIFF
--- a/packages/common/src/openapi/schemas/UpdateDashboard.json
+++ b/packages/common/src/openapi/schemas/UpdateDashboard.json
@@ -3,6 +3,7 @@
         {
             "title": "Unversioned fields",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "type": "string"
@@ -17,6 +18,7 @@
         {
             "title": "Versioned fields",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "tiles": {
                     "type": "array",
@@ -33,6 +35,7 @@
         {
             "title": "All fields",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "type": "string"

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1682,6 +1682,7 @@
                     {
                         "title": "Unversioned fields",
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "name": {
                                 "type": "string"
@@ -1696,6 +1697,7 @@
                     {
                         "title": "Versioned fields",
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "tiles": {
                                 "type": "array",
@@ -1712,6 +1714,7 @@
                     {
                         "title": "All fields",
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "name": {
                                 "type": "string"

--- a/packages/frontend/src/components/common/EditableHeader.tsx
+++ b/packages/frontend/src/components/common/EditableHeader.tsx
@@ -60,7 +60,6 @@ const EditableHeader: FC<Props> = ({
                     onChange={setTitle}
                     onCancel={onCancel}
                     onEdit={() => setIsEditable(true)}
-                    confirmOnEnterKey={false}
                 />
             </H3>
             {!isEditable && !readonly && (

--- a/packages/frontend/src/components/common/EditableHeader.tsx
+++ b/packages/frontend/src/components/common/EditableHeader.tsx
@@ -60,6 +60,7 @@ const EditableHeader: FC<Props> = ({
                     onChange={setTitle}
                     onCancel={onCancel}
                     onEdit={() => setIsEditable(true)}
+                    confirmOnEnterKey={false}
                 />
             </H3>
             {!isEditable && !readonly && (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -184,7 +184,7 @@ const Dashboard = () => {
                     mutate({
                         tiles: dashboardTiles,
                         filters: dashboardFilters,
-                        name: dashboardName,
+                        name: dashboardName || dashboard.name,
                     })
                 }
                 onSaveTitle={(name) => updateTitle(name)}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -64,7 +64,8 @@ const Dashboard = () => {
 
     const isEditMode = useMemo(() => mode === 'edit', [mode]);
     const { data: dashboard } = useDashboardQuery(dashboardUuid);
-    const [hasTilesChanged, setHasTilesChanged] = useState(false);
+    const [hasTilesChanged, setHasTilesChanged] = useState<boolean>(false);
+    const [dashboardName, setDashboardName] = useState<string>('');
     const {
         mutate,
         isSuccess,
@@ -163,6 +164,11 @@ const Dashboard = () => {
         );
     }, [dashboard, dashboardUuid, history, projectUuid]);
 
+    const updateTitle = (name: string) => {
+        setHasTilesChanged(true);
+        setDashboardName(name);
+    };
+
     if (dashboard === undefined) {
         return <Spinner />;
     }
@@ -178,9 +184,10 @@ const Dashboard = () => {
                     mutate({
                         tiles: dashboardTiles,
                         filters: dashboardFilters,
+                        name: dashboardName,
                     })
                 }
-                onSaveTitle={(name) => mutate({ name })}
+                onSaveTitle={(name) => updateTitle(name)}
                 onCancel={onCancel}
             />
             <Page isContentFullWidth>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1514 

### Description:
This PR updates the logic to edit a dashboard title only when on edit mode and after clicking save.
The component we are currently using from blueprint does not allow for this functionality to happen, this PR work around that and forces the update.

### Preview:
https://www.loom.com/share/e7590b3665ce4536b96a24f540589339

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
