### PR TITLE
fix: add python3-dev to dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-psycopg2 \
     python3-venv \
+    python3-dev \
     software-properties-common \
     unixodbc-dev \
     unzip \


### PR DESCRIPTION
### Description:
Fixes python3 Header filer error when running docker-compose build 

![image](https://user-images.githubusercontent.com/1983672/159244210-0b913281-3214-44f7-aafe-48fb6e8f7130.png)

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
