### PR TITLE
fix: wrap table calculation sql + expand modal

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,7 +52,9 @@
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "lint": "eslint ./src",
-        "format": "prettier --check --ignore-unknown ./src"
+        "fix-lint": "eslint --fix ./src",
+        "format": "prettier --check --ignore-unknown ./src",
+        "fix-format": "prettier --write --ignore-unknown ./src"
     },
     "eslintConfig": {
         "extends": [

--- a/packages/frontend/src/components/AddColumnButton.tsx
+++ b/packages/frontend/src/components/AddColumnButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
 import SimpleButton from './common/SimpleButton';
-import { CreateTableCalculationModal } from './TableCalculationModal';
+import { CreateTableCalculationModal } from './TableCalculationModels';
 
 const AddColumnButton: FC = () => {
     const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/packages/frontend/src/components/ReactHookForm/Form.tsx
+++ b/packages/frontend/src/components/ReactHookForm/Form.tsx
@@ -5,6 +5,7 @@ import {
     SubmitErrorHandler,
     SubmitHandler,
 } from 'react-hook-form/dist/types/form';
+import { StyledProps } from 'styled-components';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 
@@ -16,13 +17,14 @@ interface FormProps<T extends object = any> {
     onError?: SubmitErrorHandler<T>;
 }
 
-const Form: FC<FormProps> = ({
+const Form: FC<FormProps & StyledProps<any>> = ({
     name,
     disableSubmitOnEnter,
     methods,
     children,
     onSubmit,
     onError,
+    ...rest
 }) => {
     const { handleSubmit, formState } = methods;
     const { track } = useTracking();
@@ -61,6 +63,7 @@ const Form: FC<FormProps> = ({
                         e.preventDefault();
                     }
                 }}
+                {...rest}
             >
                 {children}
             </form>

--- a/packages/frontend/src/components/TableCalculationHeaderButton.tsx
+++ b/packages/frontend/src/components/TableCalculationHeaderButton.tsx
@@ -13,7 +13,7 @@ import { EventName } from '../types/Events';
 import {
     DeleteTableCalculationModal,
     UpdateTableCalculationModal,
-} from './TableCalculationModal';
+} from './TableCalculationModels';
 
 const TableCalculationHeaderButton: FC<{
     tableCalculation: TableCalculation;

--- a/packages/frontend/src/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModal.tsx
@@ -105,7 +105,7 @@ const TableCalculationModal: FC<Props> = ({
                                                 ),
                                         )
                                         .some(
-                                            (fieldName, index) =>
+                                            (fieldName) =>
                                                 fieldName ===
                                                 snakeCaseName(columnName),
                                         ) ||

--- a/packages/frontend/src/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModal.tsx
@@ -146,6 +146,7 @@ const TableCalculationModal: FC<Props> = ({
                             enableBasicAutocompletion: true,
                             enableLiveAutocompletion: true,
                             onLoad: setAceEditor,
+                            wrapEnabled: true,
                         }}
                         placeholder={SQL_PLACEHOLDER}
                     />
@@ -171,30 +172,29 @@ interface CreateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const CreateTableCalculationModal: FC<
-    CreateTableCalculationModalProps
-> = ({ isOpen, onClose }) => {
-    const {
-        actions: { addTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
-    const onCreate = (value: TableCalculation) => {
-        addTableCalculation(value);
-        track({
-            name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
+export const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> =
+    ({ isOpen, onClose }) => {
+        const {
+            actions: { addTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
+        const onCreate = (value: TableCalculation) => {
+            addTableCalculation(value);
+            track({
+                name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
 
-    return (
-        <TableCalculationModal
-            isOpen={isOpen}
-            isDisabled={false}
-            onSave={onCreate}
-            onClose={onClose}
-        />
-    );
-};
+        return (
+            <TableCalculationModal
+                isOpen={isOpen}
+                isDisabled={false}
+                onSave={onCreate}
+                onClose={onClose}
+            />
+        );
+    };
 
 interface UpdateTableCalculationModalProps {
     isOpen: boolean;
@@ -202,31 +202,30 @@ interface UpdateTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const UpdateTableCalculationModal: FC<
-    UpdateTableCalculationModalProps
-> = ({ isOpen, tableCalculation, onClose }) => {
-    const {
-        actions: { updateTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
-    const onUpdate = (value: TableCalculation) => {
-        updateTableCalculation(tableCalculation.name, value);
-        track({
-            name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
+export const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> =
+    ({ isOpen, tableCalculation, onClose }) => {
+        const {
+            actions: { updateTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
+        const onUpdate = (value: TableCalculation) => {
+            updateTableCalculation(tableCalculation.name, value);
+            track({
+                name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
 
-    return (
-        <TableCalculationModal
-            isOpen={isOpen}
-            isDisabled={false}
-            tableCalculation={tableCalculation}
-            onSave={onUpdate}
-            onClose={onClose}
-        />
-    );
-};
+        return (
+            <TableCalculationModal
+                isOpen={isOpen}
+                isDisabled={false}
+                tableCalculation={tableCalculation}
+                onSave={onUpdate}
+                onClose={onClose}
+            />
+        );
+    };
 
 interface DeleteTableCalculationModalProps {
     isOpen: boolean;
@@ -234,43 +233,44 @@ interface DeleteTableCalculationModalProps {
     onClose: () => void;
 }
 
-export const DeleteTableCalculationModal: FC<
-    DeleteTableCalculationModalProps
-> = ({ isOpen, tableCalculation, onClose }) => {
-    const {
-        actions: { deleteTableCalculation },
-    } = useExplorer();
-    const { track } = useTracking();
+export const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> =
+    ({ isOpen, tableCalculation, onClose }) => {
+        const {
+            actions: { deleteTableCalculation },
+        } = useExplorer();
+        const { track } = useTracking();
 
-    const onConfirm = () => {
-        deleteTableCalculation(tableCalculation.name);
-        track({
-            name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
-        });
-        onClose();
-    };
-    return (
-        <Dialog
-            isOpen={isOpen}
-            icon="cog"
-            onClose={onClose}
-            title="Settings"
-            lazy
-            canOutsideClickClose={false}
-        >
-            <div className={Classes.DIALOG_BODY}>
-                <p>Are you sure you want to delete this table calculation ?</p>
-            </div>
-            <div className={Classes.DIALOG_FOOTER}>
-                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                    <Button onClick={onClose}>Cancel</Button>
-                    <Button intent="danger" onClick={onConfirm}>
-                        Delete
-                    </Button>
+        const onConfirm = () => {
+            deleteTableCalculation(tableCalculation.name);
+            track({
+                name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
+            });
+            onClose();
+        };
+        return (
+            <Dialog
+                isOpen={isOpen}
+                icon="cog"
+                onClose={onClose}
+                title="Settings"
+                lazy
+                canOutsideClickClose={false}
+            >
+                <div className={Classes.DIALOG_BODY}>
+                    <p>
+                        Are you sure you want to delete this table calculation ?
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    );
-};
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Button onClick={onClose}>Cancel</Button>
+                        <Button intent="danger" onClick={onConfirm}>
+                            Delete
+                        </Button>
+                    </div>
+                </div>
+            </Dialog>
+        );
+    };
 
 export default TableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
@@ -1,0 +1,39 @@
+import { TableCalculation } from 'common';
+import React, { FC } from 'react';
+import { useExplorer } from '../../providers/ExplorerProvider';
+import { useTracking } from '../../providers/TrackingProvider';
+import { EventName } from '../../types/Events';
+import TableCalculationModal from './TableCalculationModal';
+
+interface CreateTableCalculationModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    const {
+        actions: { addTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
+    const onCreate = (value: TableCalculation) => {
+        addTableCalculation(value);
+        track({
+            name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
+    };
+
+    return (
+        <TableCalculationModal
+            isOpen={isOpen}
+            isDisabled={false}
+            onSave={onCreate}
+            onClose={onClose}
+        />
+    );
+};
+
+export default CreateTableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
@@ -1,0 +1,55 @@
+import { Button, Classes, Dialog } from '@blueprintjs/core';
+import { TableCalculation } from 'common';
+import React, { FC } from 'react';
+import { useExplorer } from '../../providers/ExplorerProvider';
+import { useTracking } from '../../providers/TrackingProvider';
+import { EventName } from '../../types/Events';
+
+interface DeleteTableCalculationModalProps {
+    isOpen: boolean;
+    tableCalculation: TableCalculation;
+    onClose: () => void;
+}
+
+const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> = ({
+    isOpen,
+    tableCalculation,
+    onClose,
+}) => {
+    const {
+        actions: { deleteTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
+
+    const onConfirm = () => {
+        deleteTableCalculation(tableCalculation.name);
+        track({
+            name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
+    };
+    return (
+        <Dialog
+            isOpen={isOpen}
+            icon="cog"
+            onClose={onClose}
+            title="Settings"
+            lazy
+            canOutsideClickClose={false}
+        >
+            <div className={Classes.DIALOG_BODY}>
+                <p>Are you sure you want to delete this table calculation ?</p>
+            </div>
+            <div className={Classes.DIALOG_FOOTER}>
+                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                    <Button onClick={onClose}>Cancel</Button>
+                    <Button intent="danger" onClick={onConfirm}>
+                        Delete
+                    </Button>
+                </div>
+            </div>
+        </Dialog>
+    );
+};
+
+export default DeleteTableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.styles.ts
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.styles.ts
@@ -1,0 +1,48 @@
+import { Dialog } from '@blueprintjs/core';
+import styled from 'styled-components';
+import Form from '../ReactHookForm/Form';
+
+export const FlexForm = styled(Form)`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+`;
+
+export const TableCalculationDialog = styled(Dialog)`
+    width: 700px;
+`;
+
+export const DialogButtons = styled.div`
+    align-items: center;
+
+    .bp3-switch {
+        margin: 0;
+    }
+`;
+
+export const DialogBody = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+`;
+
+export const TableCalculationSqlInputWrapper = styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
+    .bp3-form-group {
+        flex: 1;
+
+        .bp3-form-content {
+            flex: 1;
+            min-height: 100px;
+
+            .ace_editor {
+                min-height: 100px;
+            }
+        }
+    }
+`;

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -1,16 +1,21 @@
-import { Button, Callout, Classes, Dialog, Intent } from '@blueprintjs/core';
+import { Button, Callout, Classes, Intent, Switch } from '@blueprintjs/core';
 import { hasSpecialCharacters, snakeCaseName, TableCalculation } from 'common';
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
-import { useExplore } from '../hooks/useExplore';
-import { useExplorerAceEditorCompleter } from '../hooks/useExplorerAceEditorCompleter';
-import { useApp } from '../providers/AppProvider';
-import { useExplorer } from '../providers/ExplorerProvider';
-import { useTracking } from '../providers/TrackingProvider';
-import { EventName } from '../types/Events';
-import Form from './ReactHookForm/Form';
-import Input from './ReactHookForm/Input';
-import SqlInput from './ReactHookForm/SqlInput';
+import { useToggle } from 'react-use';
+import { useExplore } from '../../hooks/useExplore';
+import { useExplorerAceEditorCompleter } from '../../hooks/useExplorerAceEditorCompleter';
+import { useApp } from '../../providers/AppProvider';
+import { useExplorer } from '../../providers/ExplorerProvider';
+import Input from '../ReactHookForm/Input';
+import SqlInput from '../ReactHookForm/SqlInput';
+import {
+    DialogBody,
+    DialogButtons,
+    FlexForm,
+    TableCalculationDialog,
+    TableCalculationSqlInputWrapper,
+} from './TableCalculationModal.styles';
 
 const SQL_PLACEHOLDER =
     // eslint-disable-next-line no-template-curly-in-string
@@ -36,6 +41,7 @@ const TableCalculationModal: FC<Props> = ({
     onSave,
     onClose,
 }) => {
+    const [isFullscreen, toggleFullscreen] = useToggle(false);
     const { showToastError } = useApp();
     const {
         state: { dimensions, metrics, tableCalculations, tableName },
@@ -51,17 +57,26 @@ const TableCalculationModal: FC<Props> = ({
     });
 
     return (
-        <Dialog
+        <TableCalculationDialog
             isOpen={isOpen}
             onClose={() => (!isDisabled ? onClose() : undefined)}
             title="Save"
             lazy
             canOutsideClickClose
+            style={
+                isFullscreen
+                    ? {
+                          position: 'absolute',
+                          width: '100%',
+                          height: '100%',
+                      }
+                    : undefined
+            }
         >
-            <Form
+            <FlexForm
                 name="table_calculation"
                 methods={methods}
-                onSubmit={(data) => {
+                onSubmit={(data: TableCalculationFormInputs) => {
                     const { name, sql } = data;
                     try {
                         onSave({
@@ -77,7 +92,7 @@ const TableCalculationModal: FC<Props> = ({
                     }
                 }}
             >
-                <div className={Classes.DIALOG_BODY}>
+                <DialogBody className={Classes.DIALOG_BODY}>
                     <Input
                         label="Name"
                         name="name"
@@ -135,24 +150,33 @@ const TableCalculationModal: FC<Props> = ({
                             </p>
                         </Callout>
                     )}
-                    <SqlInput
-                        name="sql"
-                        label="SQL"
-                        attributes={{
-                            readOnly: isDisabled,
-                            height: '100px',
-                            width: '100%',
-                            editorProps: { $blockScrolling: true },
-                            enableBasicAutocompletion: true,
-                            enableLiveAutocompletion: true,
-                            onLoad: setAceEditor,
-                            wrapEnabled: true,
-                        }}
-                        placeholder={SQL_PLACEHOLDER}
-                    />
-                </div>
+                    <TableCalculationSqlInputWrapper>
+                        <SqlInput
+                            name="sql"
+                            label="SQL"
+                            attributes={{
+                                readOnly: isDisabled,
+                                height: '100%',
+                                width: '100%',
+                                maxLines: isFullscreen ? 40 : 20,
+                                minLines: isFullscreen ? 40 : 8,
+                                editorProps: { $blockScrolling: true },
+                                enableBasicAutocompletion: true,
+                                enableLiveAutocompletion: true,
+                                onLoad: setAceEditor,
+                                wrapEnabled: true,
+                            }}
+                            placeholder={SQL_PLACEHOLDER}
+                        />
+                    </TableCalculationSqlInputWrapper>
+                </DialogBody>
                 <div className={Classes.DIALOG_FOOTER}>
-                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                    <DialogButtons className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Switch
+                            checked={isFullscreen}
+                            label="Fullscreen"
+                            onChange={toggleFullscreen}
+                        />
                         <Button onClick={onClose}>Cancel</Button>
                         <Button
                             type="submit"
@@ -160,117 +184,11 @@ const TableCalculationModal: FC<Props> = ({
                             text="Save"
                             loading={isDisabled}
                         />
-                    </div>
+                    </DialogButtons>
                 </div>
-            </Form>
-        </Dialog>
+            </FlexForm>
+        </TableCalculationDialog>
     );
 };
-
-interface CreateTableCalculationModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-}
-
-export const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> =
-    ({ isOpen, onClose }) => {
-        const {
-            actions: { addTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
-        const onCreate = (value: TableCalculation) => {
-            addTableCalculation(value);
-            track({
-                name: EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-
-        return (
-            <TableCalculationModal
-                isOpen={isOpen}
-                isDisabled={false}
-                onSave={onCreate}
-                onClose={onClose}
-            />
-        );
-    };
-
-interface UpdateTableCalculationModalProps {
-    isOpen: boolean;
-    tableCalculation: TableCalculation;
-    onClose: () => void;
-}
-
-export const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> =
-    ({ isOpen, tableCalculation, onClose }) => {
-        const {
-            actions: { updateTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
-        const onUpdate = (value: TableCalculation) => {
-            updateTableCalculation(tableCalculation.name, value);
-            track({
-                name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-
-        return (
-            <TableCalculationModal
-                isOpen={isOpen}
-                isDisabled={false}
-                tableCalculation={tableCalculation}
-                onSave={onUpdate}
-                onClose={onClose}
-            />
-        );
-    };
-
-interface DeleteTableCalculationModalProps {
-    isOpen: boolean;
-    tableCalculation: TableCalculation;
-    onClose: () => void;
-}
-
-export const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> =
-    ({ isOpen, tableCalculation, onClose }) => {
-        const {
-            actions: { deleteTableCalculation },
-        } = useExplorer();
-        const { track } = useTracking();
-
-        const onConfirm = () => {
-            deleteTableCalculation(tableCalculation.name);
-            track({
-                name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
-            });
-            onClose();
-        };
-        return (
-            <Dialog
-                isOpen={isOpen}
-                icon="cog"
-                onClose={onClose}
-                title="Settings"
-                lazy
-                canOutsideClickClose={false}
-            >
-                <div className={Classes.DIALOG_BODY}>
-                    <p>
-                        Are you sure you want to delete this table calculation ?
-                    </p>
-                </div>
-                <div className={Classes.DIALOG_FOOTER}>
-                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <Button onClick={onClose}>Cancel</Button>
-                        <Button intent="danger" onClick={onConfirm}>
-                            Delete
-                        </Button>
-                    </div>
-                </div>
-            </Dialog>
-        );
-    };
 
 export default TableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
@@ -1,0 +1,42 @@
+import { TableCalculation } from 'common';
+import React, { FC } from 'react';
+import { useExplorer } from '../../providers/ExplorerProvider';
+import { useTracking } from '../../providers/TrackingProvider';
+import { EventName } from '../../types/Events';
+import TableCalculationModal from './TableCalculationModal';
+
+interface UpdateTableCalculationModalProps {
+    isOpen: boolean;
+    tableCalculation: TableCalculation;
+    onClose: () => void;
+}
+
+const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> = ({
+    isOpen,
+    tableCalculation,
+    onClose,
+}) => {
+    const {
+        actions: { updateTableCalculation },
+    } = useExplorer();
+    const { track } = useTracking();
+    const onUpdate = (value: TableCalculation) => {
+        updateTableCalculation(tableCalculation.name, value);
+        track({
+            name: EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED,
+        });
+        onClose();
+    };
+
+    return (
+        <TableCalculationModal
+            isOpen={isOpen}
+            isDisabled={false}
+            tableCalculation={tableCalculation}
+            onSave={onUpdate}
+            onClose={onClose}
+        />
+    );
+};
+
+export default UpdateTableCalculationModal;

--- a/packages/frontend/src/components/TableCalculationModels/index.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/index.tsx
@@ -1,0 +1,3 @@
+export { default as CreateTableCalculationModal } from './CreateTableCalculationModal';
+export { default as DeleteTableCalculationModal } from './DeleteTableCalculationModal';
+export { default as UpdateTableCalculationModal } from './UpdateTableCalculationModal';

--- a/packages/frontend/src/components/common/modal/BaseModal.tsx
+++ b/packages/frontend/src/components/common/modal/BaseModal.tsx
@@ -31,7 +31,7 @@ const BaseModal = ({
                         <Form
                             name={modalProps.title}
                             methods={methods}
-                            onSubmit={(data) => handleSubmit(data)}
+                            onSubmit={(data: any) => handleSubmit(data)}
                         >
                             {children}
                         </Form>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #492 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Wrap sql into multiple lines.
- Expand modal to edit really big sql queries. The library we use for edit sql doesn't have responsive feature :'(  so I couldn't have the input height match the modal height.

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->
![Screenshot 2022-03-21 at 12 29 30](https://user-images.githubusercontent.com/9117144/159261140-93aaa57f-e2ac-4a63-be10-89e606e6dca4.png)

<a href="https://www.loom.com/share/4364f461e8bd436db2e919e5cb98a068">
    <p>Lightdash - expand table calculation modal - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/4364f461e8bd436db2e919e5cb98a068-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
