### PR TITLE
feat: group chart types in a dropdown

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/VisualizationCardOptions.style.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/VisualizationCardOptions.style.tsx
@@ -1,0 +1,13 @@
+import { Button } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const ChartOptionsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+`;
+
+export const ChartOption = styled(Button)`
+    width: 100%;
+    justify-content: flex-start;
+`;

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,8 +1,12 @@
-import { Button } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
+import { Button, IconName } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
 import { CartesianSeriesType, ChartType } from 'common';
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
+import {
+    ChartOption,
+    ChartOptionsWrapper,
+} from './VisualizationCardOptions.style';
 
 const VisualizationCardOptions: FC = () => {
     const {
@@ -16,137 +20,160 @@ const VisualizationCardOptions: FC = () => {
     const disabled = isLoading || plotData.length <= 0;
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [activeChartType, setActiveChartType] = useState({
+        text: 'Column chart',
+        icon: 'timeline-bar-chart',
+    });
+
     return (
-        <>
-            <Tooltip2
-                content="Column"
-                placement="top"
-                interactionKind="hover"
+        <Popover2
+            content={
+                <ChartOptionsWrapper>
+                    <ChartOption
+                        minimal
+                        active={
+                            chartType === ChartType.CARTESIAN &&
+                            cartesianType === CartesianSeriesType.BAR &&
+                            !cartesianFlipAxis
+                        }
+                        icon="timeline-bar-chart"
+                        onClick={() => {
+                            setChartType(ChartType.CARTESIAN);
+                            cartesianConfig.setType(
+                                CartesianSeriesType.BAR,
+                                false,
+                            );
+                            setActiveChartType({
+                                text: 'Column chart',
+                                icon: 'timeline-bar-chart',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Column"
+                        text="Column chart"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={
+                            chartType === ChartType.CARTESIAN &&
+                            cartesianType === CartesianSeriesType.BAR &&
+                            cartesianFlipAxis
+                        }
+                        icon="horizontal-bar-chart"
+                        onClick={() => {
+                            setChartType(ChartType.CARTESIAN);
+                            cartesianConfig.setType(
+                                CartesianSeriesType.BAR,
+                                true,
+                            );
+                            setActiveChartType({
+                                text: 'Bar chart',
+                                icon: 'horizontal-bar-chart',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Bar"
+                        text="Bar chart"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={
+                            chartType === ChartType.CARTESIAN &&
+                            cartesianType === CartesianSeriesType.LINE
+                        }
+                        icon="timeline-line-chart"
+                        onClick={() => {
+                            setChartType(ChartType.CARTESIAN);
+                            cartesianConfig.setType(
+                                CartesianSeriesType.LINE,
+                                false,
+                            );
+                            setActiveChartType({
+                                text: 'Line chart',
+                                icon: 'timeline-line-chart',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Line"
+                        text="Line chart"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={
+                            chartType === ChartType.CARTESIAN &&
+                            cartesianType === CartesianSeriesType.SCATTER
+                        }
+                        icon="scatter-plot"
+                        onClick={() => {
+                            setChartType(ChartType.CARTESIAN);
+                            cartesianConfig.setType(
+                                CartesianSeriesType.SCATTER,
+                                false,
+                            );
+                            setActiveChartType({
+                                text: 'Scatter chart',
+                                icon: 'scatter-plot',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Scatter"
+                        text="Scatter chart"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={chartType === ChartType.TABLE}
+                        icon="panel-table"
+                        onClick={() => {
+                            setChartType(ChartType.TABLE);
+                            setPivotDimensions(undefined);
+                            setActiveChartType({
+                                text: 'Table',
+                                icon: 'panel-table',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Table"
+                        text="Table"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={chartType === ChartType.BIG_NUMBER}
+                        icon="numerical"
+                        onClick={() => {
+                            setChartType(ChartType.BIG_NUMBER);
+                            setPivotDimensions(undefined);
+                            setActiveChartType({
+                                text: 'Big number',
+                                icon: 'numerical',
+                            });
+                        }}
+                        disabled={disabled}
+                        name="Big Number"
+                        text="Big Number"
+                    />
+                </ChartOptionsWrapper>
+            }
+            interactionKind="click"
+            isOpen={isOpen}
+            onInteraction={setIsOpen}
+            position="bottom"
+            lazy={false}
+            disabled={disabled}
+        >
+            <Button
+                minimal
+                icon={activeChartType.icon as IconName}
+                rightIcon="caret-down"
+                text={activeChartType.text}
                 disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={
-                        chartType === ChartType.CARTESIAN &&
-                        cartesianType === CartesianSeriesType.BAR &&
-                        !cartesianFlipAxis
-                    }
-                    icon="timeline-bar-chart"
-                    onClick={() => {
-                        setChartType(ChartType.CARTESIAN);
-                        cartesianConfig.setType(CartesianSeriesType.BAR, false);
-                    }}
-                    disabled={disabled}
-                    name="Column"
-                />
-            </Tooltip2>
-            <Tooltip2
-                content="Bar"
-                placement="top"
-                interactionKind="hover"
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={
-                        chartType === ChartType.CARTESIAN &&
-                        cartesianType === CartesianSeriesType.BAR &&
-                        cartesianFlipAxis
-                    }
-                    icon="horizontal-bar-chart"
-                    onClick={() => {
-                        setChartType(ChartType.CARTESIAN);
-                        cartesianConfig.setType(CartesianSeriesType.BAR, true);
-                    }}
-                    disabled={disabled}
-                    name="Bar"
-                />
-            </Tooltip2>
-            <Tooltip2
-                content="Line"
-                placement="top"
-                interactionKind="hover"
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={
-                        chartType === ChartType.CARTESIAN &&
-                        cartesianType === CartesianSeriesType.LINE
-                    }
-                    icon="timeline-line-chart"
-                    onClick={() => {
-                        setChartType(ChartType.CARTESIAN);
-                        cartesianConfig.setType(
-                            CartesianSeriesType.LINE,
-                            false,
-                        );
-                    }}
-                    disabled={disabled}
-                    name="Line"
-                />
-            </Tooltip2>
-            <Tooltip2
-                content="Scatter"
-                placement="top"
-                interactionKind="hover"
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={
-                        chartType === ChartType.CARTESIAN &&
-                        cartesianType === CartesianSeriesType.SCATTER
-                    }
-                    icon="scatter-plot"
-                    onClick={() => {
-                        setChartType(ChartType.CARTESIAN);
-                        cartesianConfig.setType(
-                            CartesianSeriesType.SCATTER,
-                            false,
-                        );
-                    }}
-                    disabled={disabled}
-                    name="Scatter"
-                />
-            </Tooltip2>
-            <Tooltip2
-                content="Table"
-                placement="top"
-                interactionKind="hover"
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={chartType === ChartType.TABLE}
-                    icon="panel-table"
-                    onClick={() => {
-                        setChartType(ChartType.TABLE);
-                        setPivotDimensions(undefined);
-                    }}
-                    disabled={disabled}
-                    name="Table"
-                />
-            </Tooltip2>
-            <Tooltip2
-                content="Big number"
-                placement="top"
-                interactionKind="hover"
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    active={chartType === ChartType.BIG_NUMBER}
-                    icon="numerical"
-                    onClick={() => {
-                        setChartType(ChartType.BIG_NUMBER);
-                        setPivotDimensions(undefined);
-                    }}
-                    disabled={disabled}
-                    name="Big Number"
-                />
-            </Tooltip2>
-        </>
+            />
+        </Popover2>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -54,8 +54,6 @@ const VisualizationCardOptions: FC = () => {
         }
     };
 
-    const [activeChartType, setActiveChartType] = useState(selectChartType());
-
     return (
         <Popover2
             content={
@@ -74,7 +72,6 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.BAR,
                                 false,
                             );
-                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Column"
@@ -95,7 +92,6 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.BAR,
                                 true,
                             );
-                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Bar"
@@ -115,7 +111,6 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.LINE,
                                 false,
                             );
-                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Line"
@@ -135,7 +130,6 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.SCATTER,
                                 false,
                             );
-                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Scatter"
@@ -149,7 +143,6 @@ const VisualizationCardOptions: FC = () => {
                         onClick={() => {
                             setChartType(ChartType.TABLE);
                             setPivotDimensions(undefined);
-                             setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Table"
@@ -163,7 +156,6 @@ const VisualizationCardOptions: FC = () => {
                         onClick={() => {
                             setChartType(ChartType.BIG_NUMBER);
                             setPivotDimensions(undefined);
-                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Big Number"

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -21,10 +21,40 @@ const VisualizationCardOptions: FC = () => {
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);
-    const [activeChartType, setActiveChartType] = useState({
-        text: 'Column chart',
-        icon: 'timeline-bar-chart',
-    });
+
+    const selectChartType = () => {
+        if (chartType === ChartType.CARTESIAN) {
+            switch (cartesianType) {
+                case 'line':
+                    return { text: 'Line chart', icon: 'timeline-line-chart' };
+                case 'bar':
+                    return cartesianFlipAxis
+                        ? { text: 'Bar chart', icon: 'horizontal-bar-chart' }
+                        : { text: 'Column chart', icon: 'timeline-bar-chart' };
+                case 'scatter':
+                    return { text: 'Scatter chart', icon: 'scatter-plot' };
+                default:
+                    break;
+            }
+        }
+        if (chartType === ChartType.TABLE) {
+            return {
+                text: 'Table',
+                icon: 'panel-table',
+            };
+        }
+
+        if (chartType === ChartType.BIG_NUMBER) {
+            return {
+                text: 'Big number',
+                icon: 'numerical',
+            };
+        } else {
+            return { text: 'Bar chart', icon: 'horizontal-bar-chart' };
+        }
+    };
+
+    const [activeChartType, setActiveChartType] = useState(selectChartType());
 
     return (
         <Popover2
@@ -44,10 +74,7 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.BAR,
                                 false,
                             );
-                            setActiveChartType({
-                                text: 'Column chart',
-                                icon: 'timeline-bar-chart',
-                            });
+                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Column"
@@ -68,10 +95,7 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.BAR,
                                 true,
                             );
-                            setActiveChartType({
-                                text: 'Bar chart',
-                                icon: 'horizontal-bar-chart',
-                            });
+                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Bar"
@@ -91,10 +115,7 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.LINE,
                                 false,
                             );
-                            setActiveChartType({
-                                text: 'Line chart',
-                                icon: 'timeline-line-chart',
-                            });
+                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Line"
@@ -114,10 +135,7 @@ const VisualizationCardOptions: FC = () => {
                                 CartesianSeriesType.SCATTER,
                                 false,
                             );
-                            setActiveChartType({
-                                text: 'Scatter chart',
-                                icon: 'scatter-plot',
-                            });
+                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Scatter"
@@ -131,10 +149,7 @@ const VisualizationCardOptions: FC = () => {
                         onClick={() => {
                             setChartType(ChartType.TABLE);
                             setPivotDimensions(undefined);
-                            setActiveChartType({
-                                text: 'Table',
-                                icon: 'panel-table',
-                            });
+                             setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Table"
@@ -148,14 +163,11 @@ const VisualizationCardOptions: FC = () => {
                         onClick={() => {
                             setChartType(ChartType.BIG_NUMBER);
                             setPivotDimensions(undefined);
-                            setActiveChartType({
-                                text: 'Big number',
-                                icon: 'numerical',
-                            });
+                            setActiveChartType(selectChartType);
                         }}
                         disabled={disabled}
                         name="Big Number"
-                        text="Big Number"
+                        text="Big number"
                     />
                 </ChartOptionsWrapper>
             }
@@ -168,9 +180,9 @@ const VisualizationCardOptions: FC = () => {
         >
             <Button
                 minimal
-                icon={activeChartType.icon as IconName}
+                icon={selectChartType().icon as IconName}
                 rightIcon="caret-down"
-                text={activeChartType.text}
+                text={selectChartType().text}
                 disabled={disabled}
             />
         </Popover2>

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,7 +1,7 @@
 import { Button, IconName } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import { CartesianSeriesType, ChartType } from 'common';
-import React, { FC, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import {
     ChartOption,
@@ -22,37 +22,48 @@ const VisualizationCardOptions: FC = () => {
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);
 
-    const selectChartType = () => {
-        if (chartType === ChartType.CARTESIAN) {
-            switch (cartesianType) {
-                case 'line':
-                    return { text: 'Line chart', icon: 'timeline-line-chart' };
-                case 'bar':
-                    return cartesianFlipAxis
-                        ? { text: 'Bar chart', icon: 'horizontal-bar-chart' }
-                        : { text: 'Column chart', icon: 'timeline-bar-chart' };
-                case 'scatter':
-                    return { text: 'Scatter chart', icon: 'scatter-plot' };
-                default:
-                    break;
+    const selectedChartType = useMemo<{ text: string; icon: IconName }>(() => {
+        switch (chartType) {
+            case ChartType.CARTESIAN: {
+                switch (cartesianType) {
+                    case CartesianSeriesType.LINE:
+                        return {
+                            text: 'Line chart',
+                            icon: 'timeline-line-chart',
+                        };
+                    case CartesianSeriesType.BAR:
+                        return cartesianFlipAxis
+                            ? {
+                                  text: 'Bar chart',
+                                  icon: 'horizontal-bar-chart',
+                              }
+                            : {
+                                  text: 'Column chart',
+                                  icon: 'timeline-bar-chart',
+                              };
+                    case CartesianSeriesType.SCATTER:
+                        return { text: 'Scatter chart', icon: 'scatter-plot' };
+                    default:
+                        const never: never = cartesianType;
+                        throw new Error('Cartesian type not supported');
+                }
+            }
+            case ChartType.TABLE:
+                return {
+                    text: 'Table',
+                    icon: 'panel-table',
+                };
+            case ChartType.BIG_NUMBER:
+                return {
+                    text: 'Big number',
+                    icon: 'numerical',
+                };
+            default: {
+                const never: never = chartType;
+                throw new Error('Chart type not supported');
             }
         }
-        if (chartType === ChartType.TABLE) {
-            return {
-                text: 'Table',
-                icon: 'panel-table',
-            };
-        }
-
-        if (chartType === ChartType.BIG_NUMBER) {
-            return {
-                text: 'Big number',
-                icon: 'numerical',
-            };
-        } else {
-            return { text: 'Bar chart', icon: 'horizontal-bar-chart' };
-        }
-    };
+    }, [cartesianFlipAxis, cartesianType, chartType]);
 
     return (
         <Popover2
@@ -172,9 +183,9 @@ const VisualizationCardOptions: FC = () => {
         >
             <Button
                 minimal
-                icon={selectChartType().icon as IconName}
+                icon={selectedChartType.icon}
                 rightIcon="caret-down"
-                text={selectChartType().text}
+                text={selectedChartType.text}
                 disabled={disabled}
             />
         </Popover2>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1445 

### Description:
This PR groups the chart types in a dropdown

### Preview:
<img width="248" alt="Screenshot 2022-03-23 at 09 16 34" src="https://user-images.githubusercontent.com/31137824/159720225-02d4de84-a310-4eed-9652-a5907b7c28f2.png">
<img width="180" alt="Screenshot 2022-03-23 at 09 16 41" src="https://user-images.githubusercontent.com/31137824/159720235-f8d0f6b6-61e4-4cfc-b070-5e17ff3695c8.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
