### PR TITLE
fix: dont collapse chart on save

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -99,7 +99,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const [resultsIsOpen, setResultsIsOpen] = useState<boolean>(true);
     const [sqlIsOpen, setSqlIsOpen] = useState<boolean>(false);
     const [vizIsOpen, setVizisOpen] = useState<boolean>(
-        !!savedQueryUuid && !location.state?.fromExplorer,
+        !!savedQueryUuid && location.state?.fromExplorer !== undefined,
     );
     const totalActiveFilters: number = countTotalFilterRules(filters);
     const [activeVizTab, setActiveVizTab] = useState<ChartType>(
@@ -193,6 +193,14 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             setActiveVizTab(data.chartConfig.type);
         }
     }, [data]);
+    console.log('PATATA savedQueryUuid', savedQueryUuid, !!savedQueryUuid);
+    console.log(
+        'PATATA location',
+        location.state?.fromExplorer,
+        !location.state?.fromExplorer,
+        location.state?.fromExplorer === undefined,
+    );
+    console.log('PATATA vizIsOpen', vizIsOpen);
 
     return (
         <>

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -193,14 +193,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             setActiveVizTab(data.chartConfig.type);
         }
     }, [data]);
-    console.log('PATATA savedQueryUuid', savedQueryUuid, !!savedQueryUuid);
-    console.log(
-        'PATATA location',
-        location.state?.fromExplorer,
-        !location.state?.fromExplorer,
-        location.state?.fromExplorer === undefined,
-    );
-    console.log('PATATA vizIsOpen', vizIsOpen);
 
     return (
         <>


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1226

### Description:
When a chart is saved (and there are no charts, so `save as` is not affected) it collapses the chart. 
Because it refreshes the `Explorer` componen, initializing the `vizIsOpen` state variable again


### Preview:
![Mar-24-2022 12-01-38](https://user-images.githubusercontent.com/1983672/159903289-7ee64bf7-a559-472c-857b-d23c3bc1ec3d.gif)



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
