### PR TITLE
style: apply final styling to chart config

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -2,6 +2,7 @@ import { Button, ButtonGroup, Colors, FormGroup } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const InputWrapper = styled(FormGroup)`
+    margin: 1.357em 0 0;
     & label.bp3-label {
         font-weight: 500;
         display: inline-flex;

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -1,4 +1,4 @@
-import { Button, Colors, FormGroup } from '@blueprintjs/core';
+import { Button, ButtonGroup, Colors, FormGroup } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const InputWrapper = styled(FormGroup)`
@@ -74,4 +74,21 @@ export const DeleteFieldButton = styled(Button)`
         height: 13px;
         fill: ${Colors.GRAY1};
     }
+`;
+
+export const StackingWrapper = styled(ButtonGroup)`
+    padding: 0.357em 0;
+    display: grid !important;
+    grid-template-columns: 1fr 1fr;
+
+    .bp3-active {
+        background: #4b86be !important;
+        color: ${Colors.WHITE};
+    }
+`;
+
+export const StackButton = styled(Button)`
+    background-color: #fcfdfe !important;
+    border: 0.5px solid #cdced0;
+    box-shadow: none !important;
 `;

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -12,7 +12,7 @@ export const InputWrapper = styled(FormGroup)`
 export const Wrapper = styled.div`
     max-width: 28.571em;
     min-width: 25em;
-    padding: 1.429em;
+    padding: 1.429em 1.429em 2.143em;
 `;
 
 export const FieldsGrid = styled.div`
@@ -37,7 +37,7 @@ export const GridFieldLabel = styled.span`
 `;
 
 export const AxisGroup = styled.div`
-    padding-bottom: 1.286em;
+    margin-top: 1.286em;
 `;
 export const AxisTitleWrapper = styled.div`
     display: flex;

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
 import { Field, getItemId, TableCalculation } from 'common';
 import React, { FC, useMemo } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
@@ -11,6 +11,8 @@ import {
     AxisTitleWrapper,
     DeleteFieldButton,
     GridLabel,
+    StackButton,
+    StackingWrapper,
 } from './ChartConfigPanel.styles';
 
 type Props = {
@@ -144,20 +146,20 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 {pivotDimension && (
                     <>
                         <GridLabel>Stacking</GridLabel>
-                        <ButtonGroup fill>
-                            <Button
+                        <StackingWrapper fill>
+                            <StackButton
                                 onClick={() => setStacking(false)}
                                 active={!isStacked}
                             >
                                 No stacking
-                            </Button>
-                            <Button
+                            </StackButton>
+                            <StackButton
                                 onClick={() => setStacking(true)}
                                 active={isStacked}
                             >
                                 Stack
-                            </Button>
-                        </ButtonGroup>
+                            </StackButton>
+                        </StackingWrapper>
                     </>
                 )}
             </AxisGroup>

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -142,27 +142,25 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                     />
                 </AxisFieldDropdown>
             </AxisGroup>
-            <AxisGroup>
-                {pivotDimension && (
-                    <>
-                        <GridLabel>Stacking</GridLabel>
-                        <StackingWrapper fill>
-                            <StackButton
-                                onClick={() => setStacking(false)}
-                                active={!isStacked}
-                            >
-                                No stacking
-                            </StackButton>
-                            <StackButton
-                                onClick={() => setStacking(true)}
-                                active={isStacked}
-                            >
-                                Stack
-                            </StackButton>
-                        </StackingWrapper>
-                    </>
-                )}
-            </AxisGroup>
+            {pivotDimension && (
+                <AxisGroup>
+                    <GridLabel>Stacking</GridLabel>
+                    <StackingWrapper fill>
+                        <StackButton
+                            onClick={() => setStacking(false)}
+                            active={!isStacked}
+                        >
+                            No stacking
+                        </StackButton>
+                        <StackButton
+                            onClick={() => setStacking(true)}
+                            active={isStacked}
+                        >
+                            Stack
+                        </StackButton>
+                    </StackingWrapper>
+                </AxisGroup>
+            )}
         </>
     );
 };

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -128,6 +128,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 <AxisFieldDropdown>
                     <FieldAutoComplete
                         fields={items}
+                        placeholder="Select a field to group by"
                         activeField={groupSelectedField}
                         onChange={(item) => {
                             setPivotDimensions([getItemId(item)]);

--- a/packages/frontend/src/components/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -9,7 +9,7 @@ import {
     TableCalculation,
 } from 'common';
 import React, { FC } from 'react';
-import { SeriesBlock, SeriesTitle } from './Series.styles';
+import { SeriesBlock, SeriesDivider, SeriesTitle } from './Series.styles';
 import SingleSeriesConfiguration from './SingleSeriesConfiguration';
 
 type BasicSeriesConfigurationProps = {
@@ -29,7 +29,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
 }) => {
     return (
         <>
-            {allSeries?.map((series) => {
+            {allSeries?.map((series, i) => {
                 const field = items.find(
                     (item) => getItemId(item) === series.encode.yRef.field,
                 );
@@ -48,6 +48,9 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                         </SeriesBlock>
                     );
                 }
+
+                const hasDivider = allSeries.length !== i + 1;
+
                 return (
                     <SeriesBlock key={getSeriesId(series)}>
                         <SeriesTitle>{getItemLabel(field)}</SeriesTitle>
@@ -58,6 +61,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                             fallbackColor={getSeriesColor(getSeriesId(series))}
                             updateSingleSeries={updateSingleSeries}
                         />
+                        {hasDivider && <SeriesDivider />}
                     </SeriesBlock>
                 );
             })}

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -1,4 +1,4 @@
-import { Colors, HTMLSelect } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import {
     CartesianChartLayout,
     CartesianSeriesType,
@@ -14,11 +14,14 @@ import {
 import React, { FC, useMemo } from 'react';
 import { getDimensionFormatter } from '../../../utils/resultFormatter';
 import {
+    GroupedSeriesConfigWrapper,
     GroupSeriesBlock,
     GroupSeriesInputs,
     GroupSeriesWrapper,
     SeriesBlock,
+    SeriesDivider,
     SeriesExtraInputWrapper,
+    SeriesExtraSelect,
     SeriesTitle,
 } from './Series.styles';
 import SingleSeriesConfiguration from './SingleSeriesConfiguration';
@@ -92,7 +95,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     );
     return (
         <>
-            {Object.entries(groupedSeries).map(([fieldKey, seriesGroup]) => {
+            {Object.entries(groupedSeries).map(([fieldKey, seriesGroup], i) => {
                 const field = items.find(
                     (item) => getItemId(item) === fieldKey,
                 );
@@ -121,141 +124,152 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
 
                 const isChartTypeTheSameForAllSeries: boolean =
                     new Set(seriesGroup.map(({ type }) => type)).size === 1;
+                console.log({ length: layout?.yField?.length, index: i });
+
+                const hasDivider = layout?.yField?.length !== i + 1;
 
                 return (
-                    <GroupSeriesBlock key={fieldKey}>
-                        <SeriesTitle>
-                            {getItemLabel(field)} (grouped)
-                        </SeriesTitle>
-                        <GroupSeriesInputs>
-                            <SeriesExtraInputWrapper label="Chart type">
-                                <HTMLSelect
-                                    fill
-                                    value={
-                                        isChartTypeTheSameForAllSeries
-                                            ? seriesGroup[0].type
-                                            : 'mixed'
-                                    }
-                                    options={
-                                        isChartTypeTheSameForAllSeries
-                                            ? CHART_TYPE_OPTIONS
-                                            : [
-                                                  ...CHART_TYPE_OPTIONS,
-                                                  {
-                                                      value: 'mixed',
-                                                      label: 'Mixed',
-                                                  },
-                                              ]
-                                    }
-                                    onChange={(e) => {
-                                        updateAllGroupedSeries(fieldKey, {
-                                            type: e.target
-                                                .value as Series['type'],
-                                        });
-                                    }}
-                                />
-                            </SeriesExtraInputWrapper>
-                            <SeriesExtraInputWrapper label="Axis">
-                                <HTMLSelect
-                                    fill
-                                    value={
-                                        isAxisTheSameForAllSeries
-                                            ? seriesGroup[0].yAxisIndex
-                                            : 'mixed'
-                                    }
-                                    options={
-                                        isAxisTheSameForAllSeries
-                                            ? layout?.flipAxes
-                                                ? FLIPPED_AXIS_OPTIONS
-                                                : AXIS_OPTIONS
-                                            : [
-                                                  ...(layout?.flipAxes
-                                                      ? FLIPPED_AXIS_OPTIONS
-                                                      : AXIS_OPTIONS),
-                                                  {
-                                                      value: 'mixed',
-                                                      label: 'Mixed',
-                                                  },
-                                              ]
-                                    }
-                                    onChange={(e) => {
-                                        updateAllGroupedSeries(fieldKey, {
-                                            yAxisIndex: parseInt(
-                                                e.target.value,
-                                                10,
-                                            ),
-                                        });
-                                    }}
-                                />
-                            </SeriesExtraInputWrapper>
-                            <SeriesExtraInputWrapper label="Value labels">
-                                <HTMLSelect
-                                    fill
-                                    value={
-                                        isLabelTheSameForAllSeries
-                                            ? seriesGroup[0].label?.position ||
-                                              'hidden'
-                                            : 'mixed'
-                                    }
-                                    options={
-                                        isLabelTheSameForAllSeries
-                                            ? VALUE_LABELS_OPTIONS
-                                            : [
-                                                  ...VALUE_LABELS_OPTIONS,
-                                                  {
-                                                      value: 'mixed',
-                                                      label: 'Mixed',
-                                                  },
-                                              ]
-                                    }
-                                    onChange={(e) => {
-                                        const option = e.target.value;
-                                        updateAllGroupedSeries(fieldKey, {
-                                            label:
-                                                option === 'hidden'
-                                                    ? { show: false }
-                                                    : {
-                                                          show: true,
-                                                          position:
-                                                              option as any,
-                                                      },
-                                        });
-                                    }}
-                                />
-                            </SeriesExtraInputWrapper>
-                        </GroupSeriesInputs>
-                        <GroupSeriesWrapper>
-                            {seriesGroup?.map((singleSeries) => {
-                                const formattedValue = getFormatterValue(
-                                    singleSeries.encode.yRef.pivotValues![0]
-                                        .value,
-                                    singleSeries.encode.yRef.pivotValues![0]
-                                        .field,
-                                    items,
-                                );
-                                return (
-                                    <SingleSeriesConfiguration
-                                        key={getSeriesId(singleSeries)}
-                                        isCollapsable
-                                        layout={layout}
-                                        series={singleSeries}
-                                        placeholderName={
-                                            layout?.yField &&
-                                            layout.yField.length > 1
-                                                ? `[${formattedValue}] ${getItemLabel(
-                                                      field,
-                                                  )}`
-                                                : formattedValue
+                    <>
+                        <GroupSeriesBlock key={fieldKey}>
+                            <SeriesTitle>
+                                {getItemLabel(field)} (grouped)
+                            </SeriesTitle>
+                            <GroupSeriesInputs>
+                                <SeriesExtraInputWrapper label="Chart type">
+                                    <SeriesExtraSelect
+                                        fill
+                                        value={
+                                            isChartTypeTheSameForAllSeries
+                                                ? seriesGroup[0].type
+                                                : 'mixed'
                                         }
-                                        fallbackColor={getSeriesColor(
-                                            getSeriesId(singleSeries),
-                                        )}
-                                        updateSingleSeries={updateSingleSeries}
+                                        options={
+                                            isChartTypeTheSameForAllSeries
+                                                ? CHART_TYPE_OPTIONS
+                                                : [
+                                                      ...CHART_TYPE_OPTIONS,
+                                                      {
+                                                          value: 'mixed',
+                                                          label: 'Mixed',
+                                                      },
+                                                  ]
+                                        }
+                                        onChange={(e) => {
+                                            updateAllGroupedSeries(fieldKey, {
+                                                type: e.target
+                                                    .value as Series['type'],
+                                            });
+                                        }}
                                     />
-                                );
-                            })}
-                        </GroupSeriesWrapper>
-                    </GroupSeriesBlock>
+                                </SeriesExtraInputWrapper>
+                                <SeriesExtraInputWrapper label="Axis">
+                                    <SeriesExtraSelect
+                                        fill
+                                        value={
+                                            isAxisTheSameForAllSeries
+                                                ? seriesGroup[0].yAxisIndex
+                                                : 'mixed'
+                                        }
+                                        options={
+                                            isAxisTheSameForAllSeries
+                                                ? layout?.flipAxes
+                                                    ? FLIPPED_AXIS_OPTIONS
+                                                    : AXIS_OPTIONS
+                                                : [
+                                                      ...(layout?.flipAxes
+                                                          ? FLIPPED_AXIS_OPTIONS
+                                                          : AXIS_OPTIONS),
+                                                      {
+                                                          value: 'mixed',
+                                                          label: 'Mixed',
+                                                      },
+                                                  ]
+                                        }
+                                        onChange={(e) => {
+                                            updateAllGroupedSeries(fieldKey, {
+                                                yAxisIndex: parseInt(
+                                                    e.target.value,
+                                                    10,
+                                                ),
+                                            });
+                                        }}
+                                    />
+                                </SeriesExtraInputWrapper>
+                                <SeriesExtraInputWrapper label="Value labels">
+                                    <SeriesExtraSelect
+                                        fill
+                                        value={
+                                            isLabelTheSameForAllSeries
+                                                ? seriesGroup[0].label
+                                                      ?.position || 'hidden'
+                                                : 'mixed'
+                                        }
+                                        options={
+                                            isLabelTheSameForAllSeries
+                                                ? VALUE_LABELS_OPTIONS
+                                                : [
+                                                      ...VALUE_LABELS_OPTIONS,
+                                                      {
+                                                          value: 'mixed',
+                                                          label: 'Mixed',
+                                                      },
+                                                  ]
+                                        }
+                                        onChange={(e) => {
+                                            const option = e.target.value;
+                                            updateAllGroupedSeries(fieldKey, {
+                                                label:
+                                                    option === 'hidden'
+                                                        ? { show: false }
+                                                        : {
+                                                              show: true,
+                                                              position:
+                                                                  option as any,
+                                                          },
+                                            });
+                                        }}
+                                    />
+                                </SeriesExtraInputWrapper>
+                            </GroupSeriesInputs>
+                            <GroupSeriesWrapper>
+                                {seriesGroup?.map((singleSeries) => {
+                                    const formattedValue = getFormatterValue(
+                                        singleSeries.encode.yRef.pivotValues![0]
+                                            .value,
+                                        singleSeries.encode.yRef.pivotValues![0]
+                                            .field,
+                                        items,
+                                    );
+                                    return (
+                                        <GroupedSeriesConfigWrapper>
+                                            <SingleSeriesConfiguration
+                                                key={getSeriesId(singleSeries)}
+                                                isCollapsable
+                                                layout={layout}
+                                                series={singleSeries}
+                                                placeholderName={
+                                                    layout?.yField &&
+                                                    layout.yField.length > 1
+                                                        ? `[${formattedValue}] ${getItemLabel(
+                                                              field,
+                                                          )}`
+                                                        : formattedValue
+                                                }
+                                                fallbackColor={getSeriesColor(
+                                                    getSeriesId(singleSeries),
+                                                )}
+                                                updateSingleSeries={
+                                                    updateSingleSeries
+                                                }
+                                                isGrouped
+                                            />
+                                        </GroupedSeriesConfigWrapper>
+                                    );
+                                })}
+                            </GroupSeriesWrapper>
+                        </GroupSeriesBlock>
+                        {hasDivider && <SeriesDivider />}
+                    </>
                 );
             })}
         </>

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -124,7 +124,6 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
 
                 const isChartTypeTheSameForAllSeries: boolean =
                     new Set(seriesGroup.map(({ type }) => type)).size === 1;
-                console.log({ length: layout?.yField?.length, index: i });
 
                 const hasDivider = layout?.yField?.length !== i + 1;
 

--- a/packages/frontend/src/components/ChartConfigPanel/Series/Series.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/Series.styles.ts
@@ -1,5 +1,29 @@
-import { Colors, FormGroup } from '@blueprintjs/core';
-import styled from 'styled-components';
+import {
+    Collapse,
+    Colors,
+    FormGroup,
+    HTMLSelect,
+    InputGroup,
+} from '@blueprintjs/core';
+import styled, { css } from 'styled-components';
+
+const InputStyle = css`
+    background: ${Colors.WHITE};
+    border: 0.7px solid ${Colors.LIGHT_GRAY1};
+    box-sizing: border-box;
+    box-shadow: inset 0px 1px 1px rgba(16, 22, 26, 0.2);
+`;
+
+const GridTemplate = css`
+    display: grid;
+    grid-template-columns: 2.143em auto;
+    column-gap: 0.714em;
+`;
+
+const FlexTemplate = css`
+    display: flex;
+    flex-direction: column;
+`;
 
 export const InputWrapper = styled(FormGroup)`
     & label.bp3-label {
@@ -10,33 +34,34 @@ export const InputWrapper = styled(FormGroup)`
 `;
 
 export const GroupSeriesBlock = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 20px;
+    ${FlexTemplate}
 `;
 
 export const GroupSeriesWrapper = styled.div`
-    padding: 10px;
+    padding: 1em;
+    margin-top: 0.714em;
     background: ${Colors.LIGHT_GRAY5};
+    border-radius: 0.286em;
+`;
+
+export const GroupedSeriesConfigWrapper = styled.div`
+    margin-bottom: 0.357em;
 `;
 
 export const GroupSeriesInputs = styled.div`
     display: flex;
     flex: 1;
-    gap: 10px;
+    gap: 0.714em;
     justify-content: space-between;
 `;
 
 export const SeriesBlock = styled.div`
     display: flex;
     flex-direction: column;
-    margin-bottom: 10px;
 `;
 
 export const SeriesWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 20px;
+    ${FlexTemplate}
 
     &:last-child {
         margin-bottom: 0;
@@ -44,32 +69,57 @@ export const SeriesWrapper = styled.div`
 `;
 
 export const SeriesTitle = styled.p`
-    color: ${Colors.GRAY1};
-    font-weight: bold;
-    margin-bottom: 10px;
+    color: ${Colors.DARK_GRAY1};
+    font-weight: 600;
+    margin-bottom: 0.286em;
 `;
 
-export const SeriesMainInputs = styled.div`
-    display: flex;
-    flex: 1;
-    gap: 10px;
+export const SeriesMainInputs = styled.div<{ $isGrouped?: boolean }>`
+    ${GridTemplate}
+
+    ${({ $isGrouped }) =>
+        $isGrouped &&
+        `
+     grid-template-columns: 2.143em auto 2.143em;
+     column-gap: 0.357em;
+     
+  `}
+`;
+
+export const SeriesInputField = styled(InputGroup)`
+    ${InputStyle}
 `;
 
 export const SeriesExtraInputs = styled.div`
     display: flex;
     flex: 1;
-    gap: 10px;
-    margin-top: 10px;
+    gap: 0.714em;
+    margin-top: 0.714em;
     justify-content: space-between;
 `;
 
+export const SeriesOptionsWrapper = styled(Collapse)`
+    ${GridTemplate}
+
+    .bp3-collapse-body {
+        grid-column: 2 !important;
+    }
+`;
+
 export const SeriesExtraInputWrapper = styled(FormGroup)`
+    margin: 0;
     & label.bp3-label {
         font-weight: 500;
         display: inline-flex;
         gap: 0.214em;
         color: ${Colors.GRAY3};
-        font-size: 12px;
+        font-size: 0.857em;
+    }
+`;
+
+export const SeriesExtraSelect = styled(HTMLSelect)`
+    select {
+        ${InputStyle}
     }
 `;
 
@@ -80,8 +130,8 @@ export const Wrapper = styled.div`
 `;
 
 export const ColorButton = styled.button`
-    height: 30px;
-    width: 30px;
+    height: 2.143em;
+    width: 2.143em;
     cursor: pointer;
     border: none;
     background-color: transparent;
@@ -89,11 +139,19 @@ export const ColorButton = styled.button`
     box-sizing: border-box;
     box-shadow: 0 0 0 0 rgb(19 124 189 / 0%), 0 0 0 0 rgb(19 124 189 / 0%),
         inset 0 0 0 1px rgb(16 22 26 / 15%), inset 0 1px 1px rgb(16 22 26 / 20%);
-    border-radius: 3px;
-    padding: 4px;
+    border-radius: 0.214em;
+    padding: 0.286em;
 `;
 
 export const ColorButtonInner = styled.div`
     height: 100%;
     width: 100%;
+`;
+
+export const SeriesDivider = styled.hr`
+    height: 0.071em;
+    width: 100%;
+    background: ${Colors.LIGHT_GRAY2};
+    border: none;
+    margin: 1.857em 0;
 `;

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -1,11 +1,13 @@
-import { Button, Collapse, HTMLSelect, InputGroup } from '@blueprintjs/core';
+import { Button, InputGroup } from '@blueprintjs/core';
 import { CartesianChartLayout, CartesianSeriesType, Series } from 'common';
 import React, { FC } from 'react';
 import { useToggle } from 'react-use';
 import {
     SeriesExtraInputs,
     SeriesExtraInputWrapper,
+    SeriesExtraSelect,
     SeriesMainInputs,
+    SeriesOptionsWrapper,
     SeriesWrapper,
 } from './Series.styles';
 import SeriesColorPicker from './SeriesColorPicker';
@@ -16,6 +18,7 @@ type Props = {
     layout?: CartesianChartLayout;
     series: Series;
     fallbackColor?: string;
+    isGrouped?: boolean;
     updateSingleSeries: (updatedSeries: Series) => void;
 };
 
@@ -26,11 +29,12 @@ const SingleSeriesConfiguration: FC<Props> = ({
     series,
     fallbackColor,
     updateSingleSeries,
+    isGrouped,
 }) => {
     const [isOpen, toggleIsOpen] = useToggle(false);
     return (
         <SeriesWrapper>
-            <SeriesMainInputs>
+            <SeriesMainInputs $isGrouped={isGrouped}>
                 <SeriesColorPicker
                     color={series.color || fallbackColor}
                     onChange={(color) => {
@@ -58,10 +62,10 @@ const SingleSeriesConfiguration: FC<Props> = ({
                     />
                 )}
             </SeriesMainInputs>
-            <Collapse isOpen={!isCollapsable || isOpen}>
+            <SeriesOptionsWrapper isOpen={!isCollapsable || isOpen}>
                 <SeriesExtraInputs>
                     <SeriesExtraInputWrapper label="Chart type">
-                        <HTMLSelect
+                        <SeriesExtraSelect
                             fill
                             value={series.type}
                             options={[
@@ -87,7 +91,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         />
                     </SeriesExtraInputWrapper>
                     <SeriesExtraInputWrapper label="Axis">
-                        <HTMLSelect
+                        <SeriesExtraSelect
                             fill
                             value={series.yAxisIndex}
                             options={[
@@ -109,7 +113,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         />
                     </SeriesExtraInputWrapper>
                     <SeriesExtraInputWrapper label="Value labels">
-                        <HTMLSelect
+                        <SeriesExtraSelect
                             fill
                             value={series.label?.position || 'hidden'}
                             options={[
@@ -135,9 +139,13 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         />
                     </SeriesExtraInputWrapper>
                 </SeriesExtraInputs>
-            </Collapse>
+            </SeriesOptionsWrapper>
         </SeriesWrapper>
     );
+};
+
+SingleSeriesConfiguration.defaultProps = {
+    isGrouped: false,
 };
 
 export default SingleSeriesConfiguration;

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -48,6 +48,7 @@ type Props = {
     disabled?: boolean;
     autoFocus?: boolean;
     activeField?: Item;
+    placeholder?: string;
     fields: Array<Item>;
     onChange: (value: Item) => void;
     onClosed?: () => void;
@@ -60,6 +61,7 @@ const FieldAutoComplete: FC<Props> = ({
     fields,
     onChange,
     onClosed,
+    placeholder,
 }) => (
     <>
         <AutocompleteMaxHeight />
@@ -68,7 +70,7 @@ const FieldAutoComplete: FC<Props> = ({
             disabled={disabled}
             inputProps={{
                 autoFocus,
-                placeholder: 'Search field...',
+                placeholder: placeholder || 'Search field...',
                 leftIcon: activeField && (
                     <Icon
                         icon={getItemIcon(activeField)}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1591 

### Description:
This PR updates the styling for all the chart config tabs to mirror designs

### Preview:
https://www.loom.com/share/066acae274a548f9bc1f7b2c5136ea34

## Layout tab
<img width="379" alt="Screenshot 2022-03-29 at 10 40 29" src="https://user-images.githubusercontent.com/31137824/160664475-18d8b582-3eb5-4087-95f3-5b0bb7a805a3.png">
<img width="388" alt="Screenshot 2022-03-29 at 11 43 53" src="https://user-images.githubusercontent.com/31137824/160664483-5543a151-5edc-495d-95b2-7ce6661c39c5.png">

## Series tab
<img width="413" alt="Screenshot 2022-03-29 at 10 35 43" src="https://user-images.githubusercontent.com/31137824/160664553-cd16bb95-ce30-4480-8248-2e46a6f0746e.png">
<img width="388" alt="Screenshot 2022-03-29 at 11 28 14" src="https://user-images.githubusercontent.com/31137824/160664558-3fbbef83-fef6-47df-aedf-bc5c277a5e6a.png">
<img width="386" alt="Screenshot 2022-03-29 at 11 29 11" src="https://user-images.githubusercontent.com/31137824/160664560-8db6defc-8190-4f20-b3e9-1f7faf7ed984.png">

## Axes tab
<img width="412" alt="Screenshot 2022-03-29 at 11 48 00" src="https://user-images.githubusercontent.com/31137824/160664604-e4bd2e87-f895-4d79-95c7-0806f01876fc.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
