### PR TITLE
feat: add colour palette on organization settings

### DIFF
--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -6,7 +6,7 @@ export type DbOrganization = {
     organization_name: string;
     allowed_email_domains: any; // jsonb
     created_at: Date;
-    chart_colors: string[];
+    chart_colors?: string[];
 };
 
 export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;

--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -6,11 +6,15 @@ export type DbOrganization = {
     organization_name: string;
     allowed_email_domains: any; // jsonb
     created_at: Date;
+    chart_colors: string[];
 };
 
 export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;
 export type DbOrganizationUpdate = Partial<
-    Pick<DbOrganization, 'organization_name' | 'allowed_email_domains'>
+    Pick<
+        DbOrganization,
+        'organization_name' | 'allowed_email_domains' | 'chart_colors'
+    >
 >;
 
 export type OrganizationTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20220330140655_alter_organisation_add_chart_colours.ts
+++ b/packages/backend/src/database/migrations/20220330140655_alter_organisation_add_chart_colours.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TABLE organizations
-        ADD COLUMN chart_colors _text ;`);
+        ADD COLUMN chart_colors TEXT[] ;`);
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/packages/backend/src/database/migrations/20220330140655_alter_organisation_add_chart_colours.ts
+++ b/packages/backend/src/database/migrations/20220330140655_alter_organisation_add_chart_colours.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE organizations
+        ADD COLUMN chart_colors _text ;`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE organizations 
+    DROP COLUMN chart_colors CASCADE;`);
+}

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -17,6 +17,7 @@ export class OrganizationModel {
         return {
             name: data.organization_name,
             allowedEmailDomains: data.allowed_email_domains,
+            chartColors: data.chart_colors,
         };
     }
 
@@ -49,6 +50,7 @@ export class OrganizationModel {
             .update({
                 organization_name: data.name,
                 allowed_email_domains: JSON.stringify(data.allowedEmailDomains),
+                chart_colors: data.chartColors,
             })
             .returning('*');
         return OrganizationModel.mapDBObjectToOrganisation(org);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -653,6 +653,7 @@ export type OnboardingStatus = IncompleteOnboarding | CompleteOnboarding;
 export type Organisation = {
     name: string;
     allowedEmailDomains: string[];
+    chartColors?: string[];
 };
 
 export type UpdateOrganisation = Partial<Organisation>;


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1572

### Description:
Add backend, db migration for storing chart_colors inside organization table

### Preview:

GET

![image](https://user-images.githubusercontent.com/1983672/160841647-13b3205a-2514-4fda-aecb-cfe6740f867e.png)



PATCH 

![image](https://user-images.githubusercontent.com/1983672/160841477-5bafe1f0-aba5-4945-b824-820426fd6b08.png)


### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
