### PR TITLE
fix: show whole tick label on charts (no truncate)

### DIFF
--- a/packages/frontend/src/hooks/useEcharts.ts
+++ b/packages/frontend/src/hooks/useEcharts.ts
@@ -484,6 +484,13 @@ const useEcharts = () => {
             source: plotData,
         },
         tooltip: getEchartsTooltipConfig(series[0].type),
+        grid: {
+            containLabel: true,
+            left: '5%', // small padding
+            right: '5%', // small padding
+            top: 70, // pixels from top (makes room for legend)
+            bottom: 30, // pixels from bottom (makes room for x-axis)
+        },
     };
 };
 


### PR DESCRIPTION

**Explore view (left before, right after)**

<img width="1169" alt="Screenshot 2022-04-01 at 11 39 07" src="https://user-images.githubusercontent.com/11660098/161248150-7eb27f76-f90d-4e83-a1a1-d2825760882c.png">



**Narrow tile (top before, bottom after)**

We take a small hit here because now long labels reduce the chart area greatly in very narrow tiles, we need to be smarter to conditionally truncate the text or something. I think this is a good solution for now.

<img width="811" alt="Screenshot 2022-04-01 at 11 38 48" src="https://user-images.githubusercontent.com/11660098/161248125-27d8c8c2-f9ab-4c8d-b294-afbb4edc76ea.png">


** Wide tile (top before, bottom after)**

<img width="1321" alt="Screenshot 2022-04-01 at 11 39 17" src="https://user-images.githubusercontent.com/11660098/161248162-bfcb5e80-4a46-4b89-b1f9-545d5a569651.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes #1622

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
