### PR TITLE
fix: do not close color picker on change

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
@@ -26,7 +26,6 @@ const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
                     colors={colors}
                     onChange={(result: ColorResult) => {
                         onChange(result.hex);
-                        toggle(false);
                     }}
                 />
             }


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1531

### Description:
Don't close the popup on change (see related bug) 

### Preview:

![Peek 2022-04-01 16-51](https://user-images.githubusercontent.com/1983672/161288789-f5504937-9ee8-4ae3-b777-aa96f29f0e96.gif)
![Peek 2022-04-01 16-52](https://user-images.githubusercontent.com/1983672/161288794-ea1a078e-67cf-4e36-9f7d-ff887a4a310b.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
