### PR TITLE
fix: dashboard cross filtering cause an error

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -14,9 +14,10 @@ const ActiveFilters: FC = () => {
         dashboardFilters,
         updateDimensionDashboardFilter,
         removeDimensionDashboardFilter,
+        dashboardTiles,
     } = useDashboardContext();
     const { isLoading, data: filterableFields } =
-        useAvailableDashboardFilterTargets(dashboard);
+        useAvailableDashboardFilterTargets(dashboard, dashboardTiles);
 
     return (
         <TagsWrapper>
@@ -26,7 +27,12 @@ const ActiveFilters: FC = () => {
                 );
                 if (!activeField) {
                     return (
-                        <span style={{ width: '100%', color: Colors.GRAY1 }}>
+                        <span
+                            style={{
+                                width: '100%',
+                                color: Colors.GRAY1,
+                            }}
+                        >
                             Tried to reference field with unknown id:{' '}
                             {item.target.fieldId}
                         </span>

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -18,10 +18,14 @@ interface Props {
 
 const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     const [isOpen, setIsOpen] = useState(false);
-    const { dashboard, fieldsWithSuggestions, dashboardFilters } =
-        useDashboardContext();
+    const {
+        dashboard,
+        fieldsWithSuggestions,
+        dashboardFilters,
+        dashboardTiles,
+    } = useDashboardContext();
     const { isLoading, data: filterableFields } =
-        useAvailableDashboardFilterTargets(dashboard);
+        useAvailableDashboardFilterTargets(dashboard, dashboardTiles);
     const hasTiles = dashboard && dashboard.tiles.length >= 1;
 
     return (

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
     ApiError,
     CreateDashboard,
@@ -54,10 +53,10 @@ export const getChartAvailableFilters = async (savedChartUuid: string) =>
 
 export const useAvailableDashboardFilterTargets = (
     dashboard: Dashboard | undefined,
-    availableTiles: any,
+    availableTiles: Dashboard['tiles'],
 ): { isLoading: boolean; data: FilterableField[] } => {
     const availableTilesToFilter =
-        dashboard.tiles.length != 0 ? dashboard.tiles : availableTiles;
+        dashboard?.tiles.length != 0 ? dashboard?.tiles : availableTiles;
     const queries = useMemo(() => {
         const savedChartUuids = (availableTilesToFilter || [])
             .map((tile) =>

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import {
     ApiError,
     CreateDashboard,
@@ -53,9 +54,12 @@ export const getChartAvailableFilters = async (savedChartUuid: string) =>
 
 export const useAvailableDashboardFilterTargets = (
     dashboard: Dashboard | undefined,
+    availableTiles: any,
 ): { isLoading: boolean; data: FilterableField[] } => {
+    const availableTilesToFilter =
+        dashboard.tiles.length != 0 ? dashboard.tiles : availableTiles;
     const queries = useMemo(() => {
-        const savedChartUuids = (dashboard?.tiles || [])
+        const savedChartUuids = (availableTilesToFilter || [])
             .map((tile) =>
                 tile.type === DashboardTileTypes.SAVED_CHART
                     ? tile.properties.savedChartUuid

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
 import { Dashboard as IDashboard, DashboardTileTypes } from 'common';
 import React, {
@@ -59,8 +60,13 @@ const Dashboard = () => {
         dashboardUuid: string;
         mode?: string;
     }>();
-    const { dashboardFilters, haveFiltersChanged, setHaveFiltersChanged } =
-        useDashboardContext();
+    const {
+        dashboardFilters,
+        haveFiltersChanged,
+        setHaveFiltersChanged,
+        dashboardTiles,
+        setDashboardTiles,
+    } = useDashboardContext();
 
     const isEditMode = useMemo(() => mode === 'edit', [mode]);
     const { data: dashboard } = useDashboardQuery(dashboardUuid);
@@ -72,7 +78,7 @@ const Dashboard = () => {
         reset,
         isLoading: isSaving,
     } = useUpdateDashboard(dashboardUuid);
-    const [dashboardTiles, setTiles] = useState<IDashboard['tiles']>([]);
+    //const [dashboardTiles, setDashboardTiles] = useState<IDashboard['tiles']>([]);
     const layouts = useMemo(
         () => ({
             lg: dashboardTiles.map<Layout>((tile) => ({
@@ -90,7 +96,7 @@ const Dashboard = () => {
 
     useEffect(() => {
         if (dashboard?.tiles) {
-            setTiles(dashboard.tiles);
+            setDashboardTiles(dashboard.tiles);
         }
     }, [dashboard]);
 
@@ -113,7 +119,7 @@ const Dashboard = () => {
     ]);
 
     const updateTiles = useCallback((layout: Layout[]) => {
-        setTiles((currentDashboardTiles) =>
+        setDashboardTiles((currentDashboardTiles) =>
             currentDashboardTiles.map((tile) => {
                 const layoutTile = layout.find(({ i }) => i === tile.uuid);
                 if (
@@ -138,10 +144,13 @@ const Dashboard = () => {
     }, []);
     const onAddTile = useCallback((tile: IDashboard['tiles'][number]) => {
         setHasTilesChanged(true);
-        setTiles((currentDashboardTiles) => [...currentDashboardTiles, tile]);
+        setDashboardTiles((currentDashboardTiles) => [
+            ...currentDashboardTiles,
+            tile,
+        ]);
     }, []);
     const onDelete = useCallback((tile: IDashboard['tiles'][number]) => {
-        setTiles((currentDashboardTiles) =>
+        setDashboardTiles((currentDashboardTiles) =>
             currentDashboardTiles.filter(
                 (filteredTile) => filteredTile.uuid !== tile.uuid,
             ),
@@ -149,7 +158,7 @@ const Dashboard = () => {
         setHasTilesChanged(true);
     }, []);
     const onEdit = useCallback((updatedTile: IDashboard['tiles'][number]) => {
-        setTiles((currentDashboardTiles) =>
+        setDashboardTiles((currentDashboardTiles) =>
             currentDashboardTiles.map((tile) =>
                 tile.uuid === updatedTile.uuid ? updatedTile : tile,
             ),
@@ -157,7 +166,7 @@ const Dashboard = () => {
         setHasTilesChanged(true);
     }, []);
     const onCancel = useCallback(() => {
-        setTiles(dashboard?.tiles || []);
+        setDashboardTiles(dashboard?.tiles || []);
         setHasTilesChanged(false);
         history.push(
             `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -77,7 +77,7 @@ const Dashboard = () => {
         reset,
         isLoading: isSaving,
     } = useUpdateDashboard(dashboardUuid);
-    //const [dashboardTiles, setDashboardTiles] = useState<IDashboard['tiles']>([]);
+
     const layouts = useMemo(
         () => ({
             lg: dashboardTiles.map<Layout>((tile) => ({

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
 import { Dashboard as IDashboard, DashboardTileTypes } from 'common';
 import React, {

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -2,6 +2,7 @@ import {
     Dashboard,
     DashboardFilterRule,
     DashboardFilters,
+    DashboardTileTypes,
     fieldId,
 } from 'common';
 import React, {
@@ -29,6 +30,8 @@ const emptyFilters: DashboardFilters = {
 type DashboardContext = {
     dashboard: Dashboard | undefined;
     fieldsWithSuggestions: FieldsWithSuggestions;
+    dashboardTiles: DashboardTileTypes | [];
+    setDashboardTiles: Dispatch<SetStateAction<DashboardTileTypes | []>>;
     dashboardFilters: DashboardFilters;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (filter: DashboardFilterRule) => void;
@@ -51,8 +54,13 @@ export const DashboardProvider: React.FC = ({ children }) => {
     }>();
 
     const { data: dashboard } = useDashboardQuery(dashboardUuid);
-    const { data: filterableFields } =
-        useAvailableDashboardFilterTargets(dashboard);
+    const [dashboardTiles, setDashboardTiles] = useState<
+        DashboardTileTypes | []
+    >([]);
+    const { data: filterableFields } = useAvailableDashboardFilterTargets(
+        dashboard,
+        dashboardTiles,
+    );
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
     const [dashboardFilters, setDashboardFilters] =
@@ -177,6 +185,8 @@ export const DashboardProvider: React.FC = ({ children }) => {
     const value = {
         dashboard,
         fieldsWithSuggestions,
+        dashboardTiles,
+        setDashboardTiles,
         dashboardFilters,
         addDimensionDashboardFilter,
         updateDimensionDashboardFilter,

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -2,7 +2,6 @@ import {
     Dashboard,
     DashboardFilterRule,
     DashboardFilters,
-    DashboardTileTypes,
     fieldId,
 } from 'common';
 import React, {
@@ -30,8 +29,8 @@ const emptyFilters: DashboardFilters = {
 type DashboardContext = {
     dashboard: Dashboard | undefined;
     fieldsWithSuggestions: FieldsWithSuggestions;
-    dashboardTiles: DashboardTileTypes | [];
-    setDashboardTiles: Dispatch<SetStateAction<DashboardTileTypes | []>>;
+    dashboardTiles: Dashboard['tiles'] | [];
+    setDashboardTiles: Dispatch<SetStateAction<Dashboard['tiles'] | []>>;
     dashboardFilters: DashboardFilters;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (filter: DashboardFilterRule) => void;
@@ -55,7 +54,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const { data: dashboard } = useDashboardQuery(dashboardUuid);
     const [dashboardTiles, setDashboardTiles] = useState<
-        DashboardTileTypes | []
+        Dashboard['tiles'] | []
     >([]);
     const { data: filterableFields } = useAvailableDashboardFilterTargets(
         dashboard,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1637 

### Description:
This PR fixes filters labels not displaying properly when dashboard has not saved tiles, and filters are being added on edit mode.

For this i have added a state context in the dashboard provider that will only be used in this situation.

### Preview:
<img width="721" alt="Screenshot 2022-04-01 at 11 00 23" src="https://user-images.githubusercontent.com/31137824/161300054-a3ef98b7-2128-4daa-95cc-14c69414cab5.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
