### PR TITLE
feat: save changes button on charts + disabled button

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -197,6 +197,12 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         }
     }, [data]);
 
+    const hasUnsavedChanges = (): boolean => {
+        return (
+            JSON.stringify(data?.chartConfig) ===
+            JSON.stringify(queryData?.chartConfig)
+        );
+    };
     return (
         <>
             <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
@@ -336,8 +342,14 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                 <ChartDownloadMenu />
                                 <ButtonGroup>
                                     <Button
-                                        text="Save chart"
-                                        disabled={!tableName}
+                                        text={
+                                            savedQueryUuid
+                                                ? 'Save changes'
+                                                : 'Save chart'
+                                        }
+                                        disabled={
+                                            !tableName || hasUnsavedChanges()
+                                        }
                                         onClick={
                                             savedQueryUuid
                                                 ? handleSavedQueryUpdate


### PR DESCRIPTION

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1653

### Description:
Show `save changes` instead of `save chart` when applies. Disable save button if no changes have been made. 


### Preview:
![Peek 2022-04-05 13-27](https://user-images.githubusercontent.com/1983672/161744611-fac7f503-f8be-4b58-8a9c-d326516abe18.gif)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
