### PR TITLE
feat: warn leaving dashboards

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -177,9 +177,44 @@ const Dashboard = () => {
         setDashboardName(name);
     };
 
+    //const cb = React.useRef();
+
+    useEffect(() => {
+        console.log('loading window listener');
+        window.addEventListener('unload', () => {
+            alert('unload');
+            return 'unload';
+        });
+        window.addEventListener('beforeunload', () => {
+            //this.onUnload();
+            alert('beforeunload');
+            return 'You have unsaved changes!';
+        });
+        return () => {
+            window.removeEventListener('beforeunload', () => {});
+        };
+    }, []);
+
     if (dashboard === undefined) {
         return <Spinner />;
     }
+
+    /*
+<Prompt
+      when={true }
+      message={(location, action) => {
+          console.log('location' , location) 
+          console.log('action ', action )
+          return `ask`
+       //return true 
+       // return location.pathname.startsWith("/app")
+         // ? true
+        //  : `Are you sure you want to go to ${location.pathname}?`
+        }}
+        />
+        */
+    //TODO capture navigation,
+    // if there are unsaved changes, throw a warnin f
     return (
         <>
             <DashboardHeader

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import React, {
     useState,
 } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
-import { useHistory, useParams } from 'react-router-dom';
+import { Prompt, useHistory, useParams } from 'react-router-dom';
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import Page from '../components/common/Page/Page';
 import DashboardFilter from '../components/DashboardFilter';
@@ -177,46 +177,37 @@ const Dashboard = () => {
         setDashboardName(name);
     };
 
-    //const cb = React.useRef();
-
-    useEffect(() => {
-        console.log('loading window listener');
-        window.addEventListener('unload', () => {
-            alert('unload');
-            return 'unload';
-        });
-        window.addEventListener('beforeunload', () => {
-            //this.onUnload();
-            alert('beforeunload');
-            return 'You have unsaved changes!';
-        });
-        return () => {
-            window.removeEventListener('beforeunload', () => {});
-        };
-    }, []);
+    // Capture refresh with unsaved changes
+    window.addEventListener('beforeunload', (event) => {
+        if (hasTilesChanged || haveFiltersChanged) {
+            const message =
+                'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
+            event.returnValue = message;
+            return message;
+        }
+    });
 
     if (dashboard === undefined) {
         return <Spinner />;
     }
 
-    /*
-<Prompt
-      when={true }
-      message={(location, action) => {
-          console.log('location' , location) 
-          console.log('action ', action )
-          return `ask`
-       //return true 
-       // return location.pathname.startsWith("/app")
-         // ? true
-        //  : `Are you sure you want to go to ${location.pathname}?`
-        }}
-        />
-        */
-    //TODO capture navigation,
-    // if there are unsaved changes, throw a warnin f
     return (
         <>
+            <Prompt
+                when={hasTilesChanged || haveFiltersChanged}
+                message={(location) => {
+                    if (
+                        location.pathname.includes(
+                            `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                        )
+                    ) {
+                        // Do nothing, we are still in the dashboard
+                        return true;
+                    } else {
+                        return 'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
+                    }
+                }}
+            />
             <DashboardHeader
                 dashboardName={dashboard.name}
                 isEditMode={isEditMode}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -215,25 +215,7 @@ const Dashboard = () => {
     if (dashboard === undefined) {
         return <Spinner />;
     }
-    /*
- <Prompt
-                when={hasTilesChanged || haveFiltersChanged}
-                message={(location) => {
-                    
-                    if (
-                        location.pathname.includes(
-                            `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
-                        )
-                    ) {
-                    setIsSaveWarningModalOpen(true)
-                    setBlockedNavigationLocation(location.pathname)
-                    return false; // blocks navigation
-                //}
-                return true 
-            }}
-        />
 
-*/
     return (
         <>
             <Alert


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1209

### Description:
Show browser confirm popup when trying to leave / refresh the page with unsaved changes 


### Preview:
Capturing navigation using `history.block`

![Peek 2022-04-08 09-59](https://user-images.githubusercontent.com/1983672/162392823-b446d261-0c03-4970-835a-d6d181b4b6ca.gif)

Capturing refresh using `beforeunload` (chromium on linux) 

![Peek 2022-04-08 10-00](https://user-images.githubusercontent.com/1983672/162392908-6bf90c57-9dfe-482a-a309-fdf9b4a138ab.gif)

capturing refresh using `before unload` (chrome on mac) 



![Apr-08-2022 10-01-46](https://user-images.githubusercontent.com/1983672/162393072-f1f1e9ac-76f0-456e-99be-b30ba2270df6.gif)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
