### PR TITLE
fix: fix save changes disabled button for bigint and tables

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -130,10 +130,11 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         ? ({
               tableName,
               metricQuery: {
+                  // order of fields is important for the hasUnsavedChanges method
                   dimensions,
                   metrics,
-                  sorts,
                   filters,
+                  sorts,
                   limit,
                   tableCalculations: tableCalculations.filter((t) =>
                       selectedTableCalculations.includes(t.name),
@@ -222,19 +223,12 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             d: SavedChart | CreateSavedChartVersion | undefined,
         ) => {
             return {
-                //chartConfig
                 chartConfig: d?.chartConfig,
-                //metricQuery
-                dimensions: d?.metricQuery.dimensions,
-                metrics: d?.metricQuery.metrics,
-                filters: d?.metricQuery.filters,
-                sorts: d?.metricQuery.sorts,
-                limit: d?.metricQuery.limit,
-                tableCalculations: d?.metricQuery.tableCalculations,
-                //tableConfig
+                metricQuery: d?.metricQuery,
                 tableConfig: d?.tableConfig,
             };
         };
+
         return (
             JSON.stringify(filterData(data)) ===
             JSON.stringify(filterData(queryData))


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Closes

closes #1706

### Description:
Fixes a bug on save chages button for table and bigint

This is why it happens. For table and bignuberm, the config is set to `undefined` but data comes with `null` 

![image](https://user-images.githubusercontent.com/1983672/162377830-16f739e5-da80-47cb-8e63-16dfa416d405.png)

![image](https://user-images.githubusercontent.com/1983672/162377430-a068f9e8-cb09-47b0-bf62-9b6a94ace4d1.png)

I'm updating the default 

![image](https://user-images.githubusercontent.com/1983672/162377962-7e0611bd-3f1d-414b-a06c-21c34adc5223.png)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
