### PR TITLE
feat: duplicate chart endpoint

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -114,7 +114,10 @@ type TrackSavedChart = BaseTrack & {
 };
 
 export type CreateSavedChartOrVersionEvent = BaseTrack & {
-    event: 'saved_chart.created' | 'saved_chart_version.created';
+    event:
+        | 'saved_chart.created'
+        | 'saved_chart_version.created'
+        | 'saved_chart.duplicated';
     properties: {
         projectId: string;
         savedQueryId: string;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -114,13 +114,32 @@ type TrackSavedChart = BaseTrack & {
 };
 
 export type CreateSavedChartOrVersionEvent = BaseTrack & {
-    event:
-        | 'saved_chart.created'
-        | 'saved_chart_version.created'
-        | 'saved_chart.duplicated';
+    event: 'saved_chart.created' | 'saved_chart_version.created';
     properties: {
         projectId: string;
         savedQueryId: string;
+        dimensionsCount: number;
+        metricsCount: number;
+        filtersCount: number;
+        sortsCount: number;
+        tableCalculationsCount: number;
+        pivotCount: number;
+        chartType: ChartType;
+        cartesian?: {
+            xAxisCount: number;
+            yAxisCount: number;
+            seriesCount: number;
+            seriesTypes: CartesianSeriesType[];
+        };
+        duplicated?: boolean;
+    };
+};
+
+export type DuplicatedChartCreatedEvent = BaseTrack & {
+    event: 'duplicated_chart_created';
+    properties: {
+        projectId: string;
+        newSavedQueryId: string;
         dimensionsCount: number;
         metricsCount: number;
         filtersCount: number;
@@ -247,7 +266,8 @@ type Track =
     | TrackOrganizationEvent
     | LoginEvent
     | IdentityLinkedEvent
-    | SqlExecutedEvent;
+    | SqlExecutedEvent
+    | DuplicatedChartCreatedEvent;
 
 export class LightdashAnalytics extends Analytics {
     static lightdashContext = {

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -184,15 +184,31 @@ projectRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
-            .create(req.user!, req.params.projectUuid, req.body)
-            .then((results) => {
-                res.json({
-                    status: 'ok',
-                    results,
-                });
-            })
-            .catch(next);
+        if (req.params.duplicateFrom) {
+            savedChartsService
+                .duplicate(
+                    req.user!,
+                    req.params.projectUuid,
+                    req.params.duplicateFrom,
+                )
+                .then((results) => {
+                    res.json({
+                        status: 'ok',
+                        results,
+                    });
+                })
+                .catch(next);
+        } else {
+            savedChartsService
+                .create(req.user!, req.params.projectUuid, req.body)
+                .then((results) => {
+                    res.json({
+                        status: 'ok',
+                        results,
+                    });
+                })
+                .catch(next);
+        }
     },
 );
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -148,4 +148,30 @@ export class SavedChartService {
         });
         return newSavedChart;
     }
+
+    async duplicate(
+        user: SessionUser,
+        projectUuid: string,
+        chartUuid: string,
+    ): Promise<SavedChart> {
+        if (user.ability.cannot('create', 'SavedChart')) {
+            throw new ForbiddenError();
+        }
+        const chart = await this.savedChartModel.get(chartUuid);
+        const duplicatedChart = {
+            ...chart,
+            name: `Copy of ${chart.name}`,
+        };
+        const newSavedChart = await this.savedChartModel.create(
+            projectUuid,
+            duplicatedChart,
+        );
+        analytics.track({
+            event: 'saved_chart.duplicated',
+            userId: user.userUuid,
+            properties:
+                SavedChartService.getCreateEventProperties(newSavedChart),
+        });
+        return newSavedChart;
+    }
 }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -166,11 +166,26 @@ export class SavedChartService {
             projectUuid,
             duplicatedChart,
         );
+        const newSavedChartProperties =
+            SavedChartService.getCreateEventProperties(newSavedChart);
+
         analytics.track({
-            event: 'saved_chart.duplicated',
+            event: 'saved_chart.created',
             userId: user.userUuid,
-            properties:
-                SavedChartService.getCreateEventProperties(newSavedChart),
+            properties: {
+                ...newSavedChartProperties,
+                duplicated: true,
+            },
+        });
+
+        analytics.track({
+            event: 'duplicated_chart_created',
+            userId: user.userUuid,
+            properties: {
+                ...newSavedChartProperties,
+                newSavedQueryId: newSavedChartProperties.savedQueryId,
+                duplicateOfSavedQueryId: chartUuid,
+            },
         });
         return newSavedChart;
     }

--- a/packages/common/src/openapi/paths/projectSavedCharts.json
+++ b/packages/common/src/openapi/paths/projectSavedCharts.json
@@ -12,6 +12,15 @@
                     "format": "uuid"
                 },
                 "required": true
+            },
+            {
+                "in": "query",
+                "name": "duplicateFrom",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "required": false
             }
         ],
         "requestBody": {

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -893,6 +893,15 @@
                             "format": "uuid"
                         },
                         "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "duplicateFrom",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": false
                     }
                 ],
                 "requestBody": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1717

### Description:
Take optional parameter `duplicateFrom` on the save endpoint to save new chart using existing chartUuid

### Preview:
```
curl 'http://localhost:3000/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved?duplicateFrom=b14c8165-3874-4076-8258-e599398e9d35' -H 'Content-Type: application/json' 
```

```
{"status":"ok","results":{"uuid":"8b2e39b3-dbe8-4059-aa7f-1eae1459a12a","projectUuid":"3675b69e-8324-4110-bdca-059031aa8da3","name":"test","tableName":"customers","updatedAt":"2022-04-08T14:49:00.042Z","metricQuery":{"dimensions":["customers_customer_id"],"metrics":["customers_unique_customer_count"],"filters":{},"sorts":[{"fieldId":"customers_unique_customer_count","descending":true}],"limit":500,"tableCalculations":[]},"chartConfig":{"type":"cartesian","config":{"layout":{"xField":"customers_customer_id","yField":["customers_unique_customer_count"]},"eChartsConfig":{"series":[{"type":"bar","encode":{"xRef":{"field":"customers_customer_id"},"yRef":{"field":"customers_unique_customer_count"}}}]}}},"tableConfig":{"columnOrder":["customers_unique_customer_count","customers_customer_id"]}}}
```
### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
