### PR TITLE
fix: replace history on enter dashboard edit mode

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -98,7 +98,7 @@ const DashboardHeader = ({
                         icon="edit"
                         text="Edit dashboard"
                         onClick={() => {
-                            history.push(
+                            history.replace(
                                 `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
                             );
                         }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Prevents creating a history entry when entering edit mode.

Without this, the back button in the browser takes you out edit mode back to view mode but doesn't actually save your changes.
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
