### PR TITLE
feat: add-new-chart-to-dashboard

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -17,10 +17,8 @@ import {
     countTotalFilterRules,
     CreateSavedChartVersion,
     DashboardBasicDetails,
-    DashboardTileTypes,
     DimensionType,
     fieldId,
-    getDefaultChartTileSize,
     getResultValues,
     getVisibleFields,
     isFilterableField,
@@ -28,7 +26,6 @@ import {
 } from 'common';
 import { FC, useEffect, useState } from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
-import { v4 as uuid4 } from 'uuid';
 import { getDashboards } from '../hooks/dashboard/useDashboards';
 import { useExplore } from '../hooks/useExplore';
 import { useQueryResults } from '../hooks/useQueryResults';
@@ -62,8 +59,6 @@ import { RefreshButton } from './RefreshButton';
 import { RefreshServerButton } from './RefreshServerButton';
 import { RenderedSql } from './RenderedSql';
 import AddTilesToDashboardModal from './SavedDashboards/AddTilesToDashboardModal';
-import CreateSavedDashboardModal from './SavedDashboards/CreateSavedDashboardModal';
-import DashboardForm from './SavedDashboards/DashboardForm';
 import CreateSavedQueryModal from './SavedQueries/CreateSavedQueryModal';
 
 interface Props {
@@ -76,8 +71,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const { mutate: deleteData, isLoading: isDeleting } = useDeleteMutation();
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
     const [isAddToDashboardModalOpen, setIsAddToDashboardModalOpen] =
-        useState<boolean>(false);
-    const [isAddToNewDashboardModalOpen, setIsAddToNewDashboardModalOpen] =
         useState<boolean>(false);
     const location = useLocation<{ fromExplorer?: boolean } | undefined>();
     const {
@@ -415,23 +408,15 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                         }
                                                     />
                                                     <MenuItem
-                                                        icon="circle-arrow-right"
-                                                        text="Add chart to an existing dashboard"
+                                                        icon="control"
+                                                        text="Add to dashboard"
                                                         onClick={() =>
                                                             setIsAddToDashboardModalOpen(
                                                                 true,
                                                             )
                                                         }
                                                     />
-                                                    <MenuItem
-                                                        icon="control"
-                                                        text="Create dashboard with chart"
-                                                        onClick={() =>
-                                                            setIsAddToNewDashboardModalOpen(
-                                                                true,
-                                                            )
-                                                        }
-                                                    />
+
                                                     <MenuItem
                                                         icon="delete"
                                                         text="Delete chart"
@@ -567,26 +552,10 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     onClose={() => setIsQueryModalOpen(false)}
                 />
             )}
+
             {data && (
-                <CreateSavedDashboardModal
-                    isOpen={isAddToNewDashboardModalOpen}
-                    tiles={[
-                        {
-                            uuid: uuid4(),
-                            type: DashboardTileTypes.SAVED_CHART,
-                            properties: {
-                                savedChartUuid: data.uuid,
-                            },
-                            ...getDefaultChartTileSize(activeVizTab),
-                        },
-                    ]}
-                    showRedirectButton
-                    onClose={() => setIsAddToNewDashboardModalOpen(false)}
-                    ModalContent={DashboardForm}
-                />
-            )}
-            {data && isAddToDashboardModalOpen && (
                 <AddTilesToDashboardModal
+                    isOpen={isAddToDashboardModalOpen}
                     savedChart={data}
                     onClose={() => setIsAddToDashboardModalOpen(false)}
                 />

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.styles.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.styles.tsx
@@ -1,0 +1,9 @@
+import { Colors } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const CreateNewText = styled.p`
+    font-weight: bold;
+    color: ${Colors.BLUE3};
+    cursor: pointer;
+    margin-top: 1em;
+`;

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -1,118 +1,198 @@
 import {
+    Button,
+    Classes,
+    Dialog,
+    FormGroup,
+    HTMLSelect,
+    InputGroup,
+    Intent,
+} from '@blueprintjs/core';
+import {
     DashboardTileTypes,
     getDefaultChartTileSize,
     SavedChart,
 } from 'common';
-import React, { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
 import {
+    useCreateMutation,
     useDashboardQuery,
     useUpdateDashboard,
 } from '../../hooks/dashboard/useDashboard';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
-import ActionModal, {
-    ActionModalProps,
-    ActionTypeModal,
-} from '../common/modal/ActionModal';
-import SelectField from '../ReactHookForm/Select';
 
-const Form = ({
-    isDisabled,
-}: Pick<
-    ActionModalProps<{ dashboardUuid: string }>,
-    'useActionModalState' | 'isDisabled'
->) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data, isLoading } = useDashboards(projectUuid);
-    return (
-        <>
-            <SelectField
-                key={data?.[0]?.uuid} // Note: force re-render when data load
-                name="dashboardUuid"
-                label="Select a dashboard"
-                options={(data || []).map(({ uuid, name }) => ({
-                    value: uuid,
-                    label: name,
-                }))}
-                rules={{
-                    required: 'Required field',
-                }}
-                defaultValue={data?.[0]?.uuid}
-                disabled={isDisabled || isLoading}
-            />
-        </>
-    );
-};
+interface AddTilesToDashboardModalProps {
+    isOpen: boolean;
+
+    savedChart: SavedChart;
+    onClose?: () => void;
+}
 
 const useUpdateMutation = (id?: string) => {
     const hook = useUpdateDashboard(id || '', true);
     if (id) {
         return hook;
     }
-    return { mutate: undefined, isIdle: undefined, isSuccess: undefined };
+    return { mutate: undefined };
 };
 
-interface Props {
-    savedChart: SavedChart;
-    onClose?: () => void;
-}
-
-const AddTilesToDashboardModal: FC<Props> = ({ savedChart, onClose }) => {
-    const [selectedDashboardUuid, setSelectedDashboardUuid] =
-        useState<string>();
-    const { data } = useDashboardQuery(selectedDashboardUuid);
-    const { mutate, isSuccess, isIdle } = useUpdateMutation(
-        selectedDashboardUuid,
-    );
-    const [actionState, setActionState] = useState<{
-        actionType: number;
-    }>({
-        actionType: ActionTypeModal.UPDATE,
-    });
-    const [completedMutation, setCompletedMutation] = useState(false);
-
-    const onSubmitForm = (properties: { dashboardUuid: string }) => {
-        setCompletedMutation(false);
-        setSelectedDashboardUuid(properties.dashboardUuid);
-    };
+const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
+    isOpen,
+    savedChart,
+    onClose,
+}) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const useCreate = useCreateMutation(projectUuid, true);
+    const { mutate: mutateCreate } = useCreate;
+    const { data: dashboards, isLoading } = useDashboards(projectUuid);
+    const [selectedDashboard, setSelectedDashboard] = useState<string>();
+    const { data: dashboardData } = useDashboardQuery(selectedDashboard);
+    const { mutate: updateMutation } = useUpdateMutation(selectedDashboard);
+    const [name, setName] = useState<string>('');
+    const [showNewDashboardInput, setShowNewDashboardInput] =
+        useState<boolean>(false);
 
     useEffect(() => {
-        if (data && mutate && isIdle) {
-            mutate({
-                tiles: [
-                    ...data.tiles,
-                    {
-                        uuid: uuid4(),
-                        type: DashboardTileTypes.SAVED_CHART,
-                        properties: {
-                            savedChartUuid: savedChart.uuid,
-                        },
-                        ...getDefaultChartTileSize(savedChart.chartConfig.type),
-                    },
-                ],
-                filters: data.filters,
-            });
+        if (dashboards && !dashboardData && !isLoading) {
+            if (dashboards.length > 0) setSelectedDashboard(dashboards[0].uuid);
         }
-    }, [data, mutate, isIdle, savedChart]);
-
-    useEffect(() => {
-        if (isSuccess) {
-            setCompletedMutation(true);
+        // If no dashboards, we always show the ""
+        if (
+            dashboards &&
+            dashboards.length == 0 &&
+            !isLoading &&
+            !showNewDashboardInput
+        ) {
+            setShowNewDashboardInput(true);
         }
-    }, [isSuccess]);
+    }, [dashboards, isLoading]);
 
     return (
-        <ActionModal
-            title="Add chart to dashboard"
-            confirmButtonLabel="Add"
-            useActionModalState={[actionState, setActionState]}
-            isDisabled={false}
-            onSubmitForm={onSubmitForm}
-            completedMutation={completedMutation}
-            ModalContent={Form}
+        <Dialog
+            isOpen={isOpen}
             onClose={onClose}
-        />
+            lazy
+            title="Add chart to dashboard"
+        >
+            <form>
+                <div className={Classes.DIALOG_BODY}>
+                    {!showNewDashboardInput && (
+                        <>
+                            <p>
+                                <b>Select a dashboard</b>
+                            </p>
+                            <HTMLSelect
+                                id="select-dashboard"
+                                fill={true}
+                                value={selectedDashboard}
+                                style={{ marginBottom: 15 }}
+                                onChange={(e) =>
+                                    setSelectedDashboard(e.currentTarget.value)
+                                }
+                                options={
+                                    dashboards
+                                        ? dashboards.map((dashboard) => ({
+                                              value: dashboard.uuid,
+                                              label: dashboard.name,
+                                          }))
+                                        : []
+                                }
+                            />
+                            <div
+                                style={{ cursor: 'pointer' }}
+                                onClick={() => setShowNewDashboardInput(true)}
+                            >
+                                <b style={{ color: '#267dbf' }}>
+                                    {' '}
+                                    + Create new
+                                </b>
+                            </div>
+                        </>
+                    )}
+
+                    {showNewDashboardInput && (
+                        <FormGroup
+                            label="Name"
+                            labelFor="chart-name"
+                            style={{ fontWeight: 'bold' }}
+                        >
+                            <InputGroup
+                                id="chart-name"
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder="eg. KPI dashboard"
+                            />
+                        </FormGroup>
+                    )}
+                </div>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Button
+                            onClick={() => {
+                                if (onClose) onClose();
+                                setShowNewDashboardInput(false);
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            data-cy="submit-base-modal"
+                            intent={Intent.SUCCESS}
+                            text={'Add'}
+                            type="submit"
+                            onClick={(e) => {
+                                if (showNewDashboardInput) {
+                                    mutateCreate({
+                                        name,
+                                        tiles: [
+                                            {
+                                                uuid: uuid4(),
+                                                type: DashboardTileTypes.SAVED_CHART,
+                                                properties: {
+                                                    savedChartUuid:
+                                                        savedChart.uuid,
+                                                },
+                                                ...getDefaultChartTileSize(
+                                                    savedChart.chartConfig.type,
+                                                ),
+                                            },
+                                        ],
+                                    });
+                                } else if (dashboardData && updateMutation) {
+                                    updateMutation({
+                                        name: dashboardData.name,
+                                        filters: dashboardData.filters,
+                                        tiles: [
+                                            ...dashboardData.tiles,
+                                            {
+                                                uuid: uuid4(),
+                                                type: DashboardTileTypes.SAVED_CHART,
+                                                properties: {
+                                                    savedChartUuid:
+                                                        savedChart.uuid,
+                                                },
+                                                ...getDefaultChartTileSize(
+                                                    savedChart.chartConfig.type,
+                                                ),
+                                            },
+                                        ],
+                                    });
+                                }
+
+                                if (onClose) onClose();
+                                setShowNewDashboardInput(false);
+                                setName('');
+
+                                e.preventDefault();
+                            }}
+                            disabled={showNewDashboardInput && name === ''}
+                        />
+                    </div>
+                </div>
+            </form>
+        </Dialog>
     );
 };
 

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -21,6 +21,7 @@ import {
     useUpdateDashboard,
 } from '../../hooks/dashboard/useDashboard';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
+import { CreateNewText } from './AddTilesToDashboardModal.styles';
 
 interface AddTilesToDashboardModalProps {
     isOpen: boolean;
@@ -86,7 +87,6 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                 id="select-dashboard"
                                 fill={true}
                                 value={selectedDashboard}
-                                style={{ marginBottom: 15 }}
                                 onChange={(e) =>
                                     setSelectedDashboard(e.currentTarget.value)
                                 }
@@ -99,24 +99,17 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                         : []
                                 }
                             />
-                            <div
-                                style={{ cursor: 'pointer' }}
+
+                            <CreateNewText
                                 onClick={() => setShowNewDashboardInput(true)}
                             >
-                                <b style={{ color: '#267dbf' }}>
-                                    {' '}
-                                    + Create new
-                                </b>
-                            </div>
+                                + Create new
+                            </CreateNewText>
                         </>
                     )}
 
                     {showNewDashboardInput && (
-                        <FormGroup
-                            label="Name"
-                            labelFor="chart-name"
-                            style={{ fontWeight: 'bold' }}
-                        >
+                        <FormGroup label="Name" labelFor="chart-name">
                             <InputGroup
                                 id="chart-name"
                                 type="text"


### PR DESCRIPTION

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1665

### Description:
New modal for adding charts to dashboards (add new + add to existing dashboard) 


### Preview:
![Screenshot from 2022-04-11 09-50-20](https://user-images.githubusercontent.com/1983672/162690825-7d6795d1-3b65-4fe0-a898-9809e80b953b.png)

![Peek 2022-04-11 09-36](https://user-images.githubusercontent.com/1983672/162690875-5fcdc465-ce97-4f95-a142-cb4d98bed93b.gif)

Edge case: adding with no dashboards (will always show the "add new" first) 

![Peek 2022-04-11 09-49](https://user-images.githubusercontent.com/1983672/162690971-92b1535a-5c90-4567-a64e-6fc21242737b.gif)



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
