### PR TITLE
feat: saved charts should be open by default

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -106,9 +106,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const [filterIsOpen, setFilterIsOpen] = useState<boolean>(false);
     const [resultsIsOpen, setResultsIsOpen] = useState<boolean>(true);
     const [sqlIsOpen, setSqlIsOpen] = useState<boolean>(false);
-    const [vizIsOpen, setVizisOpen] = useState<boolean>(
-        !!savedQueryUuid && location.state?.fromExplorer !== undefined,
-    );
+    const [vizIsOpen, setVizisOpen] = useState<boolean>(!!savedQueryUuid);
     const totalActiveFilters: number = countTotalFilterRules(filters);
     const [activeVizTab, setActiveVizTab] = useState<ChartType>(
         ChartType.CARTESIAN,

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -97,7 +97,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     } = useExplorer();
     const explore = useExplore(tableName);
     const queryResults = useQueryResults();
-    const { data } = useSavedQuery({ id: savedQueryUuid });
+    const { data, isLoading } = useSavedQuery({ id: savedQueryUuid });
     const [validChartConfig, setValidChartConfig] =
         useState<ChartConfig['config']>();
 
@@ -335,7 +335,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     pivotDimensions={data?.pivotConfig?.columns}
                     tableName={tableName}
                     resultsData={queryResults.data}
-                    isLoading={queryResults.isLoading}
+                    isLoading={queryResults.isLoading || isLoading}
                     onChartConfigChange={setValidChartConfig}
                     onBigNumberLabelChange={setValidChartConfig}
                     onChartTypeChange={setActiveVizTab}

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -49,7 +49,7 @@ const EmptyChart = () => (
         />
     </div>
 );
-const LoadingChart = () => (
+export const LoadingChart = () => (
     <div style={{ padding: '50px 0' }}>
         <NonIdealState title="Loading chart" icon={<Spinner />} />
     </div>

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,6 +1,7 @@
 import { NonIdealState } from '@blueprintjs/core';
 import React, { FC } from 'react';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
+import { LoadingChart } from '../SimpleChart';
 import {
     BigNumber,
     BigNumberContainer,
@@ -9,10 +10,12 @@ import {
 } from './SimpleStatistics.styles';
 
 const SimpleStatistic: FC = () => {
-    const { resultsData, bigNumber, bigNumberLabel } =
+    const { resultsData, bigNumber, bigNumberLabel, isLoading } =
         useVisualizationContext();
 
     const validData = bigNumber && resultsData?.rows.length && bigNumberLabel;
+
+    if (isLoading) return <LoadingChart />;
 
     return (
         <>

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -3,6 +3,7 @@ import { friendlyName } from 'common';
 import React, { FC } from 'react';
 import { mapDataToTable, modifiedItem } from '../../utils/tableData';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
+import { LoadingChart } from '../SimpleChart';
 import {
     TableHeader,
     TableInnerWrapper,
@@ -10,11 +11,14 @@ import {
 } from './SimpleTable.styles';
 
 const SimpleTable: FC = () => {
-    const { plotData } = useVisualizationContext();
+    const { plotData, isLoading } = useVisualizationContext();
     const tableItems = plotData ? plotData.slice(0, 25) : [];
 
     const { headers, rows } = mapDataToTable(tableItems);
     const validData = rows && headers;
+
+    if (isLoading) return <LoadingChart />;
+
     return (
         <>
             {validData ? (


### PR DESCRIPTION

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1687

### Description:
Saved charts should be open by default 

I initially started adding `from` arguments to history.state on all components pointing to Explorer, but then I realized that the  behaviour we really  want is to open the chart when is `/saved/` , I confirmed this with @PriPatel 


### Preview:

![Peek 2022-04-11 15-16](https://user-images.githubusercontent.com/1983672/162747976-1e600c1b-d378-4920-a210-03ff21adddd6.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
