### PR TITLE
Feat/explore from here dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -226,25 +226,8 @@ const DashboardChartTile: FC<Props> = (props) => {
         [explore],
     );
 
-    /*
-    // http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customers?
-    dimensions=customers_customer_id%2Ccustomers_days_between_created_and_first_order
-    &metrics=customers_unique_customer_count%2Ccustomers_date_of_first_created_customer
-    &sort=%5B%7B"fieldId"%3A"customers_unique_customer_count"%2C"descending"%3Atrue%7D%2C%7B"fieldId"%3A"customers_customer_id"%2C"descending"%3Afalse%7D%5D
-    &filters=%7B"dimensions"%3A%7B"id"%3A"1abdd3f7-9680-41a6-af46-6bd544f74175"%2C"and"%3A%5B%7B"id"%3A"2342d7c8-4604-46e1-93a2-2b965c183a76"%2C"target"%3A%7B"fieldId"%3A"customers_customer_id"%7D%2C"operator"%3A"equals"%2C"values"%3A%5B"4"%5D%7D%5D%7D%7D
-    &limit=500
-    &column_order=customers_unique_customer_count%2Ccustomers_customer_id%2Ccustomers_days_between_created_and_first_order%2Ccustomers_date_of_first_created_customer
-    */
     let exploreUrl = '';
-
     if (savedQuery) {
-        // Reversing method in useExplorerRoute to convert savedChart into explore URL
-        /*const metric = savedQuery.metricQuery
-        const queryDimensions = encodeURIComponent(metric.dimensions.join(','))
-        const queryMetrics = encodeURIComponent(metric.metrics.join(',')) 
-        const querySort= JSON.stringify(metric.sorts)
-        const queryFilters= JSON.stringify(metric.filters)
-*/
         const explorerState: ExplorerReduceState = {
             ...savedQuery.metricQuery,
             chartName: savedQuery.name,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -237,7 +237,10 @@ const DashboardChartTile: FC<Props> = (props) => {
             columnOrder: savedQuery.tableConfig.columnOrder,
             tableCalculations: savedQuery.metricQuery.tableCalculations,
         };
-        const exploreParams = convertExplorerStateToExploreUrl(explorerState);
+        const exploreParams = convertExplorerStateToExploreUrl(
+            explorerState,
+            savedQuery.chartConfig,
+        );
 
         exploreUrl = `/projects/${projectUuid}/tables/${
             savedQuery.tableName

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -18,9 +18,11 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { useExplore } from '../../hooks/useExplore';
+import { convertExplorerStateToExploreUrl } from '../../hooks/useExplorerRoute';
 import { useSavedChartResults } from '../../hooks/useQueryResults';
 import { useSavedQuery } from '../../hooks/useSavedQuery';
 import { useDashboardContext } from '../../providers/DashboardProvider';
+import { ExplorerReduceState } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import { getFilterRuleLabel } from '../common/Filters/configs';
@@ -224,6 +226,41 @@ const DashboardChartTile: FC<Props> = (props) => {
         [explore],
     );
 
+    /*
+    // http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customers?
+    dimensions=customers_customer_id%2Ccustomers_days_between_created_and_first_order
+    &metrics=customers_unique_customer_count%2Ccustomers_date_of_first_created_customer
+    &sort=%5B%7B"fieldId"%3A"customers_unique_customer_count"%2C"descending"%3Atrue%7D%2C%7B"fieldId"%3A"customers_customer_id"%2C"descending"%3Afalse%7D%5D
+    &filters=%7B"dimensions"%3A%7B"id"%3A"1abdd3f7-9680-41a6-af46-6bd544f74175"%2C"and"%3A%5B%7B"id"%3A"2342d7c8-4604-46e1-93a2-2b965c183a76"%2C"target"%3A%7B"fieldId"%3A"customers_customer_id"%7D%2C"operator"%3A"equals"%2C"values"%3A%5B"4"%5D%7D%5D%7D%7D
+    &limit=500
+    &column_order=customers_unique_customer_count%2Ccustomers_customer_id%2Ccustomers_days_between_created_and_first_order%2Ccustomers_date_of_first_created_customer
+    */
+    let exploreUrl = '';
+
+    if (savedQuery) {
+        // Reversing method in useExplorerRoute to convert savedChart into explore URL
+        /*const metric = savedQuery.metricQuery
+        const queryDimensions = encodeURIComponent(metric.dimensions.join(','))
+        const queryMetrics = encodeURIComponent(metric.metrics.join(',')) 
+        const querySort= JSON.stringify(metric.sorts)
+        const queryFilters= JSON.stringify(metric.filters)
+*/
+        const explorerState: ExplorerReduceState = {
+            ...savedQuery.metricQuery,
+            chartName: savedQuery.name,
+            tableName: savedQuery.tableName,
+            sorting: true,
+            selectedTableCalculations: [],
+            columnOrder: [],
+            limit: savedQuery.metricQuery.limit,
+            tableCalculations: savedQuery.metricQuery.tableCalculations,
+        };
+        const exploreParams = convertExplorerStateToExploreUrl(explorerState);
+
+        exploreUrl = `/projects/${projectUuid}/tables/${
+            savedQuery.tableName
+        }?${exploreParams.toString()}`;
+    }
     return (
         <TileBase
             isChart
@@ -255,6 +292,11 @@ const DashboardChartTile: FC<Props> = (props) => {
                             icon="document-open"
                             text="Edit chart"
                             href={`/projects/${projectUuid}/saved/${savedChartUuid}`}
+                        />
+                        <MenuItem
+                            icon="series-search"
+                            text="Explore from here"
+                            href={exploreUrl}
                         />
                     </>
                 )

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -234,8 +234,7 @@ const DashboardChartTile: FC<Props> = (props) => {
             tableName: savedQuery.tableName,
             sorting: true,
             selectedTableCalculations: [],
-            columnOrder: [],
-            limit: savedQuery.metricQuery.limit,
+            columnOrder: savedQuery.tableConfig.columnOrder,
             tableCalculations: savedQuery.metricQuery.tableCalculations,
         };
         const exploreParams = convertExplorerStateToExploreUrl(explorerState);

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -1,4 +1,4 @@
-import { countTotalFilterRules } from 'common';
+import { ChartConfig, countTotalFilterRules } from 'common';
 import { useEffect } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
@@ -10,6 +10,7 @@ import {
 
 export const convertExplorerStateToExploreUrl = (
     state: ExplorerReduceState,
+    chartConfig?: ChartConfig,
 ) => {
     const newParams = new URLSearchParams();
 
@@ -54,6 +55,11 @@ export const convertExplorerStateToExploreUrl = (
             'table_calculations',
             JSON.stringify(state.tableCalculations),
         );
+    }
+
+    if (chartConfig) {
+        console.log('chart config', JSON.stringify(chartConfig));
+        newParams.set('chart_config', JSON.stringify(chartConfig));
     }
     return newParams;
 };

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -3,8 +3,60 @@ import { useEffect } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 import { useApp } from '../providers/AppProvider';
-import { useExplorer } from '../providers/ExplorerProvider';
+import {
+    ExplorerReduceState,
+    useExplorer,
+} from '../providers/ExplorerProvider';
 
+export const convertExplorerStateToExploreUrl = (
+    state: ExplorerReduceState,
+) => {
+    const newParams = new URLSearchParams();
+
+    if (state.dimensions.length === 0) {
+        newParams.delete('dimensions');
+    } else {
+        newParams.set('dimensions', state.dimensions.join(','));
+    }
+    if (state.metrics.length === 0) {
+        newParams.delete('metrics');
+    } else {
+        newParams.set('metrics', state.metrics.join(','));
+    }
+    if (state.sorts.length === 0) {
+        newParams.delete('sort');
+    } else {
+        newParams.set('sort', JSON.stringify(state.sorts));
+    }
+    if (countTotalFilterRules(state.filters) === 0) {
+        newParams.delete('filters');
+    } else {
+        newParams.set('filters', JSON.stringify(state.filters));
+    }
+    newParams.set('limit', `${state.limit}`);
+    if (state.columnOrder.length === 0) {
+        newParams.delete('column_order');
+    } else {
+        newParams.set('column_order', state.columnOrder.join(','));
+    }
+    if (state.selectedTableCalculations.length === 0) {
+        newParams.delete('selected_table_calculations');
+    } else {
+        newParams.set(
+            'selected_table_calculations',
+            state.selectedTableCalculations.join(','),
+        );
+    }
+    if (state.tableCalculations.length === 0) {
+        newParams.delete('table_calculations');
+    } else {
+        newParams.set(
+            'table_calculations',
+            JSON.stringify(state.tableCalculations),
+        );
+    }
+    return newParams;
+};
 export const useExplorerRoute = () => {
     const { showToastError } = useApp();
     const { search } = useLocation();
@@ -71,52 +123,8 @@ export const useExplorerRoute = () => {
     // Update url params based on pristine state
     useEffect(() => {
         if (pristineState.tableName) {
-            const newParams = new URLSearchParams();
-            if (pristineState.dimensions.length === 0) {
-                newParams.delete('dimensions');
-            } else {
-                newParams.set('dimensions', pristineState.dimensions.join(','));
-            }
-            if (pristineState.metrics.length === 0) {
-                newParams.delete('metrics');
-            } else {
-                newParams.set('metrics', pristineState.metrics.join(','));
-            }
-            if (pristineState.sorts.length === 0) {
-                newParams.delete('sort');
-            } else {
-                newParams.set('sort', JSON.stringify(pristineState.sorts));
-            }
-            if (countTotalFilterRules(pristineState.filters) === 0) {
-                newParams.delete('filters');
-            } else {
-                newParams.set('filters', JSON.stringify(pristineState.filters));
-            }
-            newParams.set('limit', `${pristineState.limit}`);
-            if (pristineState.columnOrder.length === 0) {
-                newParams.delete('column_order');
-            } else {
-                newParams.set(
-                    'column_order',
-                    pristineState.columnOrder.join(','),
-                );
-            }
-            if (pristineState.selectedTableCalculations.length === 0) {
-                newParams.delete('selected_table_calculations');
-            } else {
-                newParams.set(
-                    'selected_table_calculations',
-                    pristineState.selectedTableCalculations.join(','),
-                );
-            }
-            if (pristineState.tableCalculations.length === 0) {
-                newParams.delete('table_calculations');
-            } else {
-                newParams.set(
-                    'table_calculations',
-                    JSON.stringify(pristineState.tableCalculations),
-                );
-            }
+            const newParams = convertExplorerStateToExploreUrl(pristineState);
+
             history.replace({
                 pathname: `/projects/${pathParams.projectUuid}/tables/${pristineState.tableName}`,
                 search: newParams.toString(),

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -75,7 +75,7 @@ type Action =
           type: ActionType.RESET_SORTING;
       };
 
-interface ExplorerReduceState {
+export interface ExplorerReduceState {
     chartName: string | undefined;
     tableName: string | undefined;
     selectedTableCalculations: FieldId[];


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1732

### Description:
Explore from here on dashboards 

I'm reusing an existing method from usEExplorerRoute to convert the savedChart (explorerState) into list of URL params 


### Preview:
This SavedChart

```
results: {uuid: "748685fd-bf91-40cd-95c4-7e70fb39194b", projectUuid: "3675b69e-8324-4110-bdca-059031aa8da3",…}
chartConfig: {type: "cartesian",…}
config: {layout: {xField: "customers_customer_id", yField: ["customers_unique_customer_count"]},…}
type: "cartesian"
metricQuery: {dimensions: ["customers_customer_id"], metrics: ["customers_unique_customer_count"], filters: {},…}
dimensions: ["customers_customer_id"]
filters: {}
limit: 500
metrics: ["customers_unique_customer_count"]
sorts: [{fieldId: "customers_unique_customer_count", descending: true}]
tableCalculations: []
name: "test"
projectUuid: "3675b69e-8324-4110-bdca-059031aa8da3"
tableConfig: {columnOrder: ["customers_unique_customer_count", "customers_customer_id"]}
columnOrder: ["customers_unique_customer_count", "customers_customer_id"]
tableName: "customers"
updatedAt: "2022-04-11T08:18:57.995Z"
uuid: "748685fd-bf91-40cd-95c4-7e70fb39194b"
```

Generates the following URL 

http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customers?dimensions=customers_customer_id&metrics=customers_unique_customer_count&sort=%5B%7B"fieldId"%3A"customers_unique_customer_count"%2C"descending"%3Atrue%7D%5D&limit=500&column_order=customers_unique_customer_count%2Ccustomers_customer_id


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
