### PR TITLE
feat: explore from here saved

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -256,6 +256,11 @@ const DashboardChartTile: FC<Props> = (props) => {
                             text="Edit chart"
                             href={`/projects/${projectUuid}/saved/${savedChartUuid}`}
                         />
+                        <MenuItem
+                            icon="series-search"
+                            text="Explore from here"
+                            href={`/projects/${projectUuid}/saved/${savedChartUuid}?explore=true`}
+                        />
                     </>
                 )
             }

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -229,7 +229,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             };
         };
 
-        if (!overrideQueryUuid) return false; // allow saving changes
+        if (!overrideQueryUuid) return false;
         return (
             JSON.stringify(filterData(data)) ===
             JSON.stringify(filterData(queryData))

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -72,7 +72,9 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
     const [isAddToDashboardModalOpen, setIsAddToDashboardModalOpen] =
         useState<boolean>(false);
-    const location = useLocation<{ fromExplorer?: boolean } | undefined>();
+    const location = useLocation<
+        { fromExplorer?: boolean; explore?: boolean } | undefined
+    >();
     const {
         state: {
             chartName,
@@ -107,6 +109,11 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         ChartType.CARTESIAN,
     );
 
+    const searchParams = new URLSearchParams(location.search);
+
+    const overrideQueryUuid: string | undefined = searchParams.get('explore')
+        ? undefined
+        : savedQueryUuid;
     const [pivotDimensions, setPivotDimensions] = useState<string[]>();
 
     const validConfig = () => {
@@ -222,6 +229,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             };
         };
 
+        if (!overrideQueryUuid) return false; // allow saving changes
         return (
             JSON.stringify(filterData(data)) ===
             JSON.stringify(filterData(queryData))
@@ -248,7 +256,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                             marginRight: 10,
                         }}
                     >
-                        {chartName && (
+                        {overrideQueryUuid && chartName && (
                             <EditableHeader
                                 value={chartName}
                                 isDisabled={updateSavedChart.isLoading}
@@ -372,7 +380,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                 <ButtonGroup>
                                     <Button
                                         text={
-                                            savedQueryUuid
+                                            overrideQueryUuid
                                                 ? 'Save changes'
                                                 : 'Save chart'
                                         }
@@ -380,13 +388,13 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                             !tableName || hasUnsavedChanges()
                                         }
                                         onClick={
-                                            savedQueryUuid
+                                            overrideQueryUuid
                                                 ? handleSavedQueryUpdate
                                                 : () =>
                                                       setIsQueryModalOpen(true)
                                         }
                                     />
-                                    {savedQueryUuid && (
+                                    {overrideQueryUuid && (
                                         <Popover2
                                             placement="bottom"
                                             disabled={!tableName}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -182,15 +182,18 @@ const Dashboard = () => {
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
 
-    // Capture refresh with unsaved changes
-    window.addEventListener('beforeunload', (event) => {
+    const checkReload = (event: BeforeUnloadEvent) => {
         if (hasTilesChanged || haveFiltersChanged) {
             const message =
                 'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
             event.returnValue = message;
             return message;
         }
-    });
+    };
+    useEffect(() => {
+        window.addEventListener('beforeunload', checkReload);
+        return () => window.removeEventListener('beforeunload', checkReload);
+    }, [hasTilesChanged, haveFiltersChanged]);
 
     useEffect(() => {
         history.block((prompt) => {


### PR DESCRIPTION

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1732

### Description:
Explore from here on dashboards

This time I'm loadign a savedChart and don't allow overrides .

See this other PR for more details https://github.com/lightdash/lightdash/pull/1747#issuecomment-1096280877

### Preview:

![Peek 2022-04-12 10-28](https://user-images.githubusercontent.com/1983672/162917346-e96a8588-3911-4b31-b010-a3a4e88b00ce.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
