### PR TITLE
fix: fix format decimals

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1258,7 +1258,7 @@ export function formatValue<T>(format: string, value: T): string | T {
                 return value;
             }
             // Fix rounding issue
-            return `${Number((parseFloat(value as any) * 100).toFixed(2))}%`;
+            return `${(parseFloat(value as any) * 100).toFixed(2)}%`;
 
         case '': // no format
             return value;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1257,7 +1257,8 @@ export function formatValue<T>(format: string, value: T): string | T {
             if (Number.isNaN(value as any)) {
                 return value;
             }
-            return `${parseFloat(value as any) * 100}%`;
+            // Fix rounding issue
+            return `${Number((parseFloat(value as any) * 100).toFixed(2))}%`;
 
         case '': // no format
             return value;


### PR DESCRIPTION

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1751

### Description:
Fixes JS rounding issue with `percent` format

### Preview:

Raw
![Screenshot from 2022-04-12 13-16-17](https://user-images.githubusercontent.com/1983672/162949297-97009329-c376-4672-a8f4-b53a1f99129f.png)

With format
![Screenshot from 2022-04-12 13-17-13](https://user-images.githubusercontent.com/1983672/162949323-059ee6aa-a2b7-48b7-afef-542cf41dc692.png)



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
