### PR TITLE
fix: fix bignumber and table saved charts

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -98,6 +98,7 @@ export const VisualizationProvider: FC<Props> = ({
         chartTypeConfig as CartesianChart,
         validPivotDimensions?.[0],
         resultsData,
+        chartConfigs !== undefined,
         setChartType,
         setPivotDimensions,
     );

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -15,6 +15,7 @@ const useCartesianChartConfig = (
     chartConfigs: CartesianChart,
     pivotKey: string | undefined,
     resultsData: ApiQueryResults | undefined,
+    isSaved: boolean,
     setVisualizationChartType: (chart: ChartType) => void,
     setPivotDimensions: (s: string[]) => void,
 ) => {
@@ -209,6 +210,8 @@ const useCartesianChartConfig = (
                 yField: validYFields.length > 0 ? validYFields : yField,
             };
         };
+        // Only load this if there are no existing chart configuration (not saved)
+        if (isSaved) return;
 
         setPivotDimensions([]); //reset pivot
         setVisualizationChartType(ChartType.CARTESIAN); // reset table


### PR DESCRIPTION
### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1765

### Description:
fix bignumber and table saved charts

This was because we try to load the default chart, we should only do that if the chart doesn't have chartConfig -> is not saved 

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
