### PR TITLE
feat: navigate to chart when duplicated 2

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -387,7 +387,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                 : 'Save chart'
                                         }
                                         disabled={
-                                            !tableName || hasUnsavedChanges()
+                                            !tableName || !hasUnsavedChanges()
                                         }
                                         onClick={
                                             overrideQueryUuid

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -233,7 +233,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
 
         if (!overrideQueryUuid) return false;
         return (
-            JSON.stringify(filterData(data)) ===
+            JSON.stringify(filterData(data)) !==
             JSON.stringify(filterData(queryData))
         );
     };
@@ -405,25 +405,25 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                     <MenuItem
                                                         icon={
                                                             hasUnsavedChanges()
-                                                                ? 'duplicate'
-                                                                : 'add'
+                                                                ? 'add'
+                                                                : 'duplicate'
                                                         }
                                                         text={
                                                             hasUnsavedChanges()
-                                                                ? 'Duplicate'
-                                                                : 'Save as new chart'
+                                                                ? 'Save chart as'
+                                                                : 'Duplicate'
                                                         }
                                                         onClick={() => {
                                                             if (
                                                                 savedQueryUuid &&
                                                                 hasUnsavedChanges()
                                                             ) {
-                                                                duplicateChart(
-                                                                    chartId,
-                                                                );
-                                                            } else {
                                                                 setIsQueryModalOpen(
                                                                     true,
+                                                                );
+                                                            } else {
+                                                                duplicateChart(
+                                                                    chartId,
                                                                 );
                                                             }
                                                         }}

--- a/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
+++ b/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
@@ -22,9 +22,11 @@ const ModalActionButtons = ({
 }: ModalActionButtonsProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [itemId, setItemId] = useState<string>('');
-    const { mutate: duplicateChart } = useDuplicateMutation(itemId);
-    const { mutate: duplicateDashboard } =
-        useDuplicateDashboardMutation(itemId);
+    const { mutate: duplicateChart } = useDuplicateMutation(itemId, true);
+    const { mutate: duplicateDashboard } = useDuplicateDashboardMutation(
+        itemId,
+        true,
+    );
     const isDashboardPage = url.includes('/dashboards');
 
     useEffect(() => {

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -220,7 +220,11 @@ export const useCreateMutation = (
     );
 };
 
-export const useDuplicateDashboardMutation = (dashboardUuid: string) => {
+export const useDuplicateDashboardMutation = (
+    dashboardUuid: string,
+    showRedirectButton: boolean = false,
+) => {
+    const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useApp();
@@ -228,10 +232,20 @@ export const useDuplicateDashboardMutation = (dashboardUuid: string) => {
         () => duplicateDashboard(projectUuid, dashboardUuid),
         {
             mutationKey: ['dashboard_create', projectUuid],
-            onSuccess: async () => {
+            onSuccess: async (data) => {
                 await queryClient.invalidateQueries('dashboards');
                 showToastSuccess({
-                    title: `Success! Dashboard was duplicated.`,
+                    title: `Dashboard successfully duplicated!`,
+                    action: showRedirectButton
+                        ? {
+                              text: 'Open dashboard',
+                              icon: 'arrow-right',
+                              onClick: () =>
+                                  history.push(
+                                      `/projects/${projectUuid}/dashboards/${data.uuid}`,
+                                  ),
+                          }
+                        : undefined,
                 });
             },
             onError: (error) => {

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -163,7 +163,11 @@ export const useCreateMutation = () => {
     );
 };
 
-export const useDuplicateMutation = (chartUuid: string) => {
+export const useDuplicateMutation = (
+    chartUuid: string,
+    showRedirectButton: boolean = false,
+) => {
+    const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useApp();
@@ -171,10 +175,20 @@ export const useDuplicateMutation = (chartUuid: string) => {
         () => duplicateSavedQuery(projectUuid, chartUuid),
         {
             mutationKey: ['saved_query_create', projectUuid],
-            onSuccess: async () => {
+            onSuccess: async (data) => {
                 await queryClient.invalidateQueries('spaces');
                 showToastSuccess({
-                    title: `Success! Chart was duplicated.`,
+                    title: `Chart successfully duplicated!`,
+                    action: showRedirectButton
+                        ? {
+                              text: 'Open chart',
+                              icon: 'arrow-right',
+                              onClick: () =>
+                                  history.push(
+                                      `/projects/${projectUuid}/saved/${data.uuid}`,
+                                  ),
+                          }
+                        : undefined,
                 });
             },
             onError: (error) => {

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -177,6 +177,17 @@ export const useDuplicateMutation = (
             mutationKey: ['saved_query_create', projectUuid],
             onSuccess: async (data) => {
                 await queryClient.invalidateQueries('spaces');
+
+                if (!showRedirectButton) {
+                    history.push({
+                        pathname: `/projects/${projectUuid}/saved/${data.uuid}`,
+
+                        state: {
+                            fromExplorer: true,
+                        },
+                    });
+                }
+
                 showToastSuccess({
                     title: `Chart successfully duplicated!`,
                     action: showRedirectButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1767 

### Description:
This PR adds a link to the new duplicated chart/dashboard in the success message when it is duplicated from a dashboard/chart saved list.

However the user will be automatically redirected to the new duplicated chart when one is duplicated from within the explorer.

### Preview:
https://www.loom.com/share/2dab4eaa887b4d8caac7b3b01c40f049

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
