### PR TITLE
feat: bring consistency around chart ations 2

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -5,6 +5,7 @@ import {
     Classes,
     Collapse,
     Dialog,
+    Divider,
     H5,
     Menu,
     MenuItem,
@@ -436,10 +437,10 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                             )
                                                         }
                                                     />
-
+                                                    <Divider />
                                                     <MenuItem
-                                                        icon="delete"
-                                                        text="Delete chart"
+                                                        icon="trash"
+                                                        text="Delete"
                                                         intent="danger"
                                                         onClick={() => {
                                                             getDashboards(

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -410,7 +410,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                         text={
                                                             hasUnsavedChanges()
                                                                 ? 'Duplicate'
-                                                                : 'Save chart as'
+                                                                : 'Save as new chart'
                                                         }
                                                         onClick={() => {
                                                             if (

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -14,6 +14,13 @@ import { CreateChartButton, ViewAllButton } from './LatestSavedCharts.style';
 const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const savedChartsRequest = useSavedCharts(projectUuid);
     const savedCharts = savedChartsRequest.data || [];
+    const featuredCharts = savedCharts
+        .sort(
+            (a, b) =>
+                new Date(b.updatedAt).getTime() -
+                new Date(a.updatedAt).getTime(),
+        )
+        .slice(0, 5);
     return (
         <LatestCard
             isLoading={savedChartsRequest.isLoading}
@@ -42,7 +49,7 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 title="Saved charts"
                 useUpdate={useUpdateMutation}
                 useDelete={useDeleteMutation()}
-                dataList={savedCharts}
+                dataList={featuredCharts}
                 getURL={(savedQuery: SpaceQuery) => {
                     const { uuid } = savedQuery;
                     return `/projects/${projectUuid}/saved/${uuid}`;
@@ -51,6 +58,7 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 isHomePage
                 isChart
             />
+
             {savedCharts.length === 0 && (
                 <CreateChartButton
                     minimal

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -49,6 +49,7 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 }}
                 ModalContent={SavedQueryForm}
                 isHomePage
+                isChart
             />
             {savedCharts.length === 0 && (
                 <CreateChartButton

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -1,12 +1,15 @@
 import { AnchorButton } from '@blueprintjs/core';
+import { SpaceQuery } from 'common';
 import React, { FC } from 'react';
-import { useSavedCharts } from '../../../hooks/useSpaces';
-import LatestCard from '../LatestCard';
 import {
-    ChartName,
-    CreateChartButton,
-    ViewAllButton,
-} from './LatestSavedCharts.style';
+    useDeleteMutation,
+    useUpdateMutation,
+} from '../../../hooks/useSavedQuery';
+import { useSavedCharts } from '../../../hooks/useSpaces';
+import ActionCardList from '../../common/ActionCardList';
+import SavedQueryForm from '../../SavedQueries/SavedQueryForm';
+import LatestCard from '../LatestCard';
+import { CreateChartButton, ViewAllButton } from './LatestSavedCharts.style';
 
 const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const savedChartsRequest = useSavedCharts(projectUuid);
@@ -35,23 +38,18 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 )
             }
         >
-            {savedCharts
-                .sort(
-                    (a, b) =>
-                        new Date(b.updatedAt).getTime() -
-                        new Date(a.updatedAt).getTime(),
-                )
-                .slice(0, 5)
-                .map(({ uuid, name }) => (
-                    <ChartName
-                        key={uuid}
-                        minimal
-                        href={`/projects/${projectUuid}/saved/${uuid}`}
-                        alignText="left"
-                    >
-                        {name}
-                    </ChartName>
-                ))}
+            <ActionCardList
+                title="Saved charts"
+                useUpdate={useUpdateMutation}
+                useDelete={useDeleteMutation()}
+                dataList={savedCharts}
+                getURL={(savedQuery: SpaceQuery) => {
+                    const { uuid } = savedQuery;
+                    return `/projects/${projectUuid}/saved/${uuid}`;
+                }}
+                ModalContent={SavedQueryForm}
+                isHomePage
+            />
             {savedCharts.length === 0 && (
                 <CreateChartButton
                     minimal

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -21,12 +21,12 @@ import {
     useUpdateDashboard,
 } from '../../hooks/dashboard/useDashboard';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
+import { useSavedQuery } from '../../hooks/useSavedQuery';
 import { CreateNewText } from './AddTilesToDashboardModal.styles';
 
 interface AddTilesToDashboardModalProps {
     isOpen: boolean;
-
-    savedChart: SavedChart;
+    savedChart: SavedChart | any;
     onClose?: () => void;
 }
 
@@ -53,6 +53,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     const [name, setName] = useState<string>('');
     const [showNewDashboardInput, setShowNewDashboardInput] =
         useState<boolean>(false);
+    const { data: completeSavedChart } = useSavedQuery(savedChart.uuid);
 
     useEffect(() => {
         if (dashboards && !dashboardData && !isLoading) {
@@ -148,7 +149,10 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                                         savedChart.uuid,
                                                 },
                                                 ...getDefaultChartTileSize(
-                                                    savedChart.chartConfig.type,
+                                                    savedChart.chartConfig
+                                                        ?.type ||
+                                                        completeSavedChart
+                                                            ?.chartConfig.type,
                                                 ),
                                             },
                                         ],
@@ -167,7 +171,10 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                                         savedChart.uuid,
                                                 },
                                                 ...getDefaultChartTileSize(
-                                                    savedChart.chartConfig.type,
+                                                    savedChart.chartConfig
+                                                        ?.type ||
+                                                        completeSavedChart
+                                                            ?.chartConfig.type,
                                                 ),
                                             },
                                         ],

--- a/packages/frontend/src/components/common/ActionCardList.tsx
+++ b/packages/frontend/src/components/common/ActionCardList.tsx
@@ -97,7 +97,12 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
                 )}
           
             {actionState.actionType === ActionTypeModal.ADD_TO_DASHBOARD && (
-                <AddTilesToDashboardModal savedChart={actionState.data} />
+                <AddTilesToDashboardModal
+                    savedChart={actionState.data}
+                    onClose={() =>
+                        setActionState({ actionType: ActionTypeModal.CLOSE })
+                    }
+                />
             )}
 
             {dataList.length <= 0 && (

--- a/packages/frontend/src/components/common/ActionCardList.tsx
+++ b/packages/frontend/src/components/common/ActionCardList.tsx
@@ -99,6 +99,10 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
             {actionState.actionType === ActionTypeModal.ADD_TO_DASHBOARD && (
                 <AddTilesToDashboardModal
                     savedChart={actionState.data}
+                    isOpen={
+                        actionState.actionType ===
+                        ActionTypeModal.ADD_TO_DASHBOARD
+                    }
                     onClose={() =>
                         setActionState({ actionType: ActionTypeModal.CLOSE })
                     }

--- a/packages/frontend/src/components/common/ActionCardList.tsx
+++ b/packages/frontend/src/components/common/ActionCardList.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
 import styled from 'styled-components';
 import { DeleteDashboardModal } from '../SavedDashboards/DeleteDashboardModal';
+import AddTilesToDashboardModal from '../SavedDashboards/AddTilesToDashboardModal';
 import ActionCard from './ActionCard';
 import { ActionModalProps, ActionTypeModal } from './modal/ActionModal';
 import UpdateActionModal from './modal/UpdateActionModal';
@@ -94,6 +95,10 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
                         name={actionState.data.name}
                     />
                 )}
+          
+            {actionState.actionType === ActionTypeModal.ADD_TO_DASHBOARD && (
+                <AddTilesToDashboardModal savedChart={actionState.data} />
+            )}
 
             {dataList.length <= 0 && (
                 <div style={{ padding: '50px 0' }}>

--- a/packages/frontend/src/components/common/ActionCardList/ActionCardList.style.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/ActionCardList.style.tsx
@@ -1,0 +1,41 @@
+import { Card, Colors, Divider, H3 } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const ActionCardListWrapper = styled(Card)<{ $isHomePage?: boolean }>`
+    width: 768px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    ${({ $isHomePage }) =>
+        $isHomePage &&
+        `
+        width: 100%;
+        padding: 0;
+        box-shadow: none;
+  `}
+`;
+
+export const HeaderCardListWrapper = styled.div`
+    width: 100%;
+    display: flex;
+    align-items: flex-end;
+`;
+
+export const TitleWrapper = styled(H3)`
+    flex: 1;
+    margin: 0;
+    color: ${Colors.GRAY1};
+`;
+
+export const CardDivider = styled(Divider)`
+    margin: 20px 0;
+`;
+
+export const ActionCardWrapper = styled.div`
+    margin-bottom: 10px;
+`;
+
+export const NoIdealStateWrapper = styled.div`
+    padding: 50px 0;
+`;

--- a/packages/frontend/src/components/common/ActionCardList/index.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/index.tsx
@@ -1,13 +1,21 @@
-import { Card, Colors, Divider, H3, NonIdealState } from '@blueprintjs/core';
+import { NonIdealState } from '@blueprintjs/core';
 import { ApiError } from 'common';
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
-import styled from 'styled-components';
+import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import { DeleteDashboardModal } from '../SavedDashboards/DeleteDashboardModal';
-import AddTilesToDashboardModal from '../SavedDashboards/AddTilesToDashboardModal';
-import ActionCard from './ActionCard';
-import { ActionModalProps, ActionTypeModal } from './modal/ActionModal';
-import UpdateActionModal from './modal/UpdateActionModal';
+import ActionCard from '../ActionCard';
+import { ActionModalProps, ActionTypeModal } from '../modal/ActionModal';
+import DeleteActionModal from '../modal/DeleteActionModal';
+import UpdateActionModal from '../modal/UpdateActionModal';
+import {
+    ActionCardListWrapper,
+    ActionCardWrapper,
+    CardDivider,
+    HeaderCardListWrapper,
+    NoIdealStateWrapper,
+    TitleWrapper,
+} from './ActionCardList.style';
 
 type ActionCardListProps<T extends { uuid: string; name: string }> = {
     title: string;
@@ -20,14 +28,8 @@ type ActionCardListProps<T extends { uuid: string; name: string }> = {
     ) => JSX.Element;
     headerAction?: React.ReactNode;
     isChart?: boolean;
+    isHomePage?: boolean;
 };
-
-const ActionCardListWrapper = styled(Card)`
-    width: 768px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-`;
 
 const ActionCardList = <T extends { uuid: string; name: string }>({
     dataList,
@@ -38,6 +40,7 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
     title,
     headerAction,
     isChart,
+    isHomePage,
 }: ActionCardListProps<T>) => {
     const [actionState, setActionState] = useState<{
         actionType: number;
@@ -47,30 +50,24 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
     });
 
     return (
-        <ActionCardListWrapper>
-            <div
-                style={{
-                    width: '100%',
-                    display: 'flex',
-                    alignItems: 'flex-end',
-                }}
-            >
-                <H3 style={{ flex: 1, margin: 0, color: Colors.GRAY1 }}>
-                    {title}
-                </H3>
-                {headerAction}
-            </div>
-            <Divider style={{ margin: '20px 0' }} />
+        <ActionCardListWrapper $isHomePage={isHomePage}>
+            {!isHomePage && (
+                <HeaderCardListWrapper>
+                    <TitleWrapper>{title}</TitleWrapper>
+                    {headerAction}
+                </HeaderCardListWrapper>
+            )}
+            {!isHomePage && <CardDivider />}
             <div>
                 {dataList.map((data) => (
-                    <div key={data.uuid} style={{ marginBottom: 10 }}>
+                    <ActionCardWrapper key={data.uuid}>
                         <ActionCard
                             data={data}
                             url={getURL(data)}
                             setActionState={setActionState}
                             isChart={isChart}
                         />
-                    </div>
+                    </ActionCardWrapper>
                 ))}
             </div>
             {actionState.actionType === ActionTypeModal.UPDATE && (
@@ -110,9 +107,9 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
             )}
 
             {dataList.length <= 0 && (
-                <div style={{ padding: '50px 0' }}>
+                <NoIdealStateWrapper>
                     <NonIdealState title="No results available" icon="search" />
-                </div>
+                </NoIdealStateWrapper>
             )}
         </ActionCardListWrapper>
     );
@@ -121,6 +118,7 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
 ActionCardList.defaultProps = {
     headerAction: null,
     isChart: false,
+    isHomePage: false,
 };
 
 export default ActionCardList;

--- a/packages/frontend/src/components/common/ActionCardList/index.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/index.tsx
@@ -3,10 +3,9 @@ import { ApiError } from 'common';
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
-import { DeleteDashboardModal } from '../SavedDashboards/DeleteDashboardModal';
+import { DeleteDashboardModal } from '../../SavedDashboards/DeleteDashboardModal';
 import ActionCard from '../ActionCard';
 import { ActionModalProps, ActionTypeModal } from '../modal/ActionModal';
-import DeleteActionModal from '../modal/DeleteActionModal';
 import UpdateActionModal from '../modal/UpdateActionModal';
 import {
     ActionCardListWrapper,
@@ -92,7 +91,7 @@ const ActionCardList = <T extends { uuid: string; name: string }>({
                         name={actionState.data.name}
                     />
                 )}
-          
+
             {actionState.actionType === ActionTypeModal.ADD_TO_DASHBOARD && (
                 <AddTilesToDashboardModal
                     savedChart={actionState.data}

--- a/packages/frontend/src/components/common/modal/ActionModal.tsx
+++ b/packages/frontend/src/components/common/modal/ActionModal.tsx
@@ -7,6 +7,7 @@ import BaseModal from './BaseModal';
 export enum ActionTypeModal {
     CLOSE,
     UPDATE,
+    ADD_TO_DASHBOARD,
     DELETE,
 }
 

--- a/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
+++ b/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu, MenuItem } from '@blueprintjs/core';
+import { Button, Divider, Menu, MenuItem } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useDuplicateDashboardMutation } from '../../../hooks/dashboard/useDashboard';
@@ -68,11 +68,22 @@ const ModalActionButtons = ({
                             setIsOpen(false);
                         }}
                     />
-                    <MenuItem
-                        icon="insert"
-                        text="Add to Dashboard"
-                        onClick={() => setIsAddToDashboardModalOpen(true)}
-                    />
+                  {!isDashboardPage && (
+                            <MenuItem
+                                icon="insert"
+                                text="Add to Dashboard"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    setIsOpen(false);
+                                    setActionState({
+                                        actionType:
+                                            ActionTypeModal.ADD_TO_DASHBOARD,
+                                        data,
+                                    });
+                                }}
+                            />
+                        )}
                     <MenuItem
                         role="button"
                         icon="delete"

--- a/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
+++ b/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
@@ -69,6 +69,11 @@ const ModalActionButtons = ({
                         }}
                     />
                     <MenuItem
+                        icon="insert"
+                        text="Add to Dashboard"
+                        onClick={() => setIsAddToDashboardModalOpen(true)}
+                    />
+                    <MenuItem
                         role="button"
                         icon="delete"
                         text="Delete"

--- a/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
+++ b/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
@@ -25,6 +25,7 @@ const ModalActionButtons = ({
     const { mutate: duplicateChart } = useDuplicateMutation(itemId);
     const { mutate: duplicateDashboard } =
         useDuplicateDashboardMutation(itemId);
+    const isDashboardPage = url.includes('/dashboards');
 
     useEffect(() => {
         setItemId(data.uuid);
@@ -68,25 +69,26 @@ const ModalActionButtons = ({
                             setIsOpen(false);
                         }}
                     />
-                  {!isDashboardPage && (
-                            <MenuItem
-                                icon="insert"
-                                text="Add to Dashboard"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    setIsOpen(false);
-                                    setActionState({
-                                        actionType:
-                                            ActionTypeModal.ADD_TO_DASHBOARD,
-                                        data,
-                                    });
-                                }}
-                            />
-                        )}
+                    {!isDashboardPage && (
+                        <MenuItem
+                            icon="insert"
+                            text="Add to Dashboard"
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setIsOpen(false);
+                                setActionState({
+                                    actionType:
+                                        ActionTypeModal.ADD_TO_DASHBOARD,
+                                    data,
+                                });
+                            }}
+                        />
+                    )}
+                    <Divider />
                     <MenuItem
                         role="button"
-                        icon="delete"
+                        icon="trash"
                         text="Delete"
                         intent="danger"
                         onClick={(e) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1667 

### Description:
This PR brings more consistency in the copy of the option menu across the site.
It also adds the possibility to add a chart to a dashboard from within the saved queries page.

### Preview:

## Dashboard page
![Screenshot 2022-04-08 at 17 20 19](https://user-images.githubusercontent.com/31137824/162482638-ff15afae-8252-4d5f-bd7f-498c916cda4b.png)

## Options when chart has been modified
![Screenshot 2022-04-08 at 17 20 08](https://user-images.githubusercontent.com/31137824/162482642-0e52f9c9-7acc-494d-b477-4b5977267bf1.png)

## Options when chart has not been modified
![Screenshot 2022-04-08 at 17 19 57](https://user-images.githubusercontent.com/31137824/162482644-ffa5448e-0919-496f-b174-6b52f96a18cf.png)

## saved charts page
![Screenshot 2022-04-08 at 17 19 44](https://user-images.githubusercontent.com/31137824/162482645-bbb92d7a-c495-4a6c-a172-e17193bd116a.png)


### Scope of the changes (select all that apply):
- [X] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
