### PR TITLE
style: give hover state and update notification widget

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -353,13 +353,15 @@ export class SavedChartModel {
             );
 
         // Filters out "null" fields
-        const additionalMetricsFiltered = additionalMetrics.map((addMetric) => Object.keys(addMetric).reduce(
+        const additionalMetricsFiltered = additionalMetrics.map((addMetric) =>
+            Object.keys(addMetric).reduce(
                 (acc, key) => ({
                     ...acc,
                     [key]: addMetric[key] !== null ? addMetric[key] : undefined,
                 }),
                 { ...addMetric },
-            ));
+            ),
+        );
 
         const [dimensions, metrics]: [string[], string[]] = fields.reduce<
             [string[], string[]]

--- a/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
@@ -74,13 +74,22 @@ export const ItemDescription = styled.p`
 `;
 
 export const NotificationWrapper = styled.div`
+    padding: 0.357em 0.571em;
+    border-radius: 0.214em;
     position: relative;
     color: ${Colors.GRAY5} !important;
+    margin-right: 0.357em;
 
-    margin-right: 0.625em;
+    :hover {
+        background: rgba(138, 155, 168, 0.15) !important;
+    }
 `;
 export const NotificationWidget = styled.div`
     position: absolute;
-    left: 0;
-    top: 0;
+    left: 0.571em;
+    top: 0.214em;
+
+    .HW_badge.HW_softHidden {
+        background: transparent;
+    }
 `;

--- a/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
@@ -81,6 +81,7 @@ export const NotificationWrapper = styled.div`
     margin-right: 0.357em;
 
     :hover {
+        cursor: pointer;
         background: rgba(138, 155, 168, 0.15) !important;
     }
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1779 

### Description:
Update styling on the notifications icon:
- Remove grey icons when there are no notifications to see
- Reduced margin between help and notification icon
- Added hover state to the notifications button

### Preview:
![Screenshot 2022-04-19 at 09 59 17](https://user-images.githubusercontent.com/31137824/163969330-7f2bd255-b9ec-4379-9673-36ca0898f1f0.png)
![Screenshot 2022-04-19 at 09 59 12](https://user-images.githubusercontent.com/31137824/163969334-1b48e6af-1a4c-4e4c-93b0-3bb0d6747575.png)
![Screenshot 2022-04-19 at 09 58 52](https://user-images.githubusercontent.com/31137824/163969338-f856e2bb-91ab-4f49-8c16-67b4282418f5.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
