### PR TITLE
fix: remove overridequeryuuid condition on save changes

### DIFF
--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -116,6 +116,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const overrideQueryUuid: string | undefined = searchParams.get('explore')
         ? undefined
         : savedQueryUuid;
+
     const [pivotDimensions, setPivotDimensions] = useState<string[]>();
 
     const validConfig = () => {
@@ -141,6 +142,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                   tableCalculations: tableCalculations.filter((t) =>
                       selectedTableCalculations.includes(t.name),
                   ),
+                  additionalMetrics: [],
               },
               pivotConfig: pivotDimensions
                   ? { columns: pivotDimensions }
@@ -231,7 +233,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             };
         };
 
-        if (!overrideQueryUuid) return false;
         return (
             JSON.stringify(filterData(data)) !==
             JSON.stringify(filterData(queryData))


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #[1805](https://github.com/lightdash/lightdash/issues/1805)

### Description:
Remove overrideQueryUuid condition on save changes 
This hasUnsavedChanges has changed recently, causing this special case to break the "disabled" property on the button 

This could potentially cause that a saved chart from Explore can't be saved without changes, but the comparison is a bit broken at the moment because of chartConfig being overwritten. 


### Preview:
![Peek 2022-04-19 15-36](https://user-images.githubusercontent.com/1983672/164016559-0101c3b7-ec35-4199-9728-9dc86d276763.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
