### PR TITLE
feat: add tracking to notifications button

### DIFF
--- a/packages/frontend/src/components/NavBar/HelpMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/index.tsx
@@ -6,6 +6,10 @@ import {
 } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import React, { FC, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useApp } from '../../../providers/AppProvider';
+import { useTracking } from '../../../providers/TrackingProvider';
+import { EventName } from '../../../types/Events';
 import {
     ButtonWrapper,
     HelpItem,
@@ -19,10 +23,43 @@ import {
 } from './HelpMenu.styles';
 
 const HelpMenu: FC = () => {
+    const { track } = useTracking();
+    const { user } = useApp();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    const trackNotifications = {
+        user_id: user.data?.userUuid,
+        project_id: projectUuid,
+        organization_id: user.data?.organizationUuid,
+    };
+
     useEffect(() => {
         (window as any).Headway.init({
             selector: '#headway-badge',
             account: '7L3Bzx',
+            callbacks: {
+                onShowWidget: () => {
+                    track({
+                        name: EventName.NOTIFICATIONS_CLICKED,
+                        properties: { ...trackNotifications },
+                    });
+                },
+                onShowDetails: (changelog: any) => {
+                    track({
+                        name: EventName.NOTIFICATIONS_ITEM_CLICKED,
+                        properties: {
+                            ...trackNotifications,
+                            item: changelog.title,
+                        },
+                    });
+                },
+                onReadMore: () => {
+                    track({
+                        name: EventName.NOTIFICATIONS_CLICKED,
+                        properties: { ...trackNotifications },
+                    });
+                },
+            },
         });
     }, []);
 

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -36,7 +36,10 @@ type GenericEvent = {
         | EventName.UPDATE_PROJECT_BUTTON_CLICKED
         | EventName.UPDATE_TABLE_CALCULATION_BUTTON_CLICKED
         | EventName.CREATE_TABLE_CALCULATION_BUTTON_CLICKED
-        | EventName.ADD_FILTER_CLICKED;
+        | EventName.ADD_FILTER_CLICKED
+        | EventName.NOTIFICATIONS_CLICKED
+        | EventName.NOTIFICATIONS_ITEM_CLICKED
+        | EventName.NOTIFICATIONS_READ_MORE_CLICKED;
     properties?: {};
 };
 

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -67,4 +67,7 @@ export enum EventName {
     SETUP_STEP_CLICKED = 'setup_step.click',
     FORM_STATE_CHANGED = 'form-state.changed',
     ADD_FILTER_CLICKED = 'add_filter.click',
+    NOTIFICATIONS_CLICKED = 'notifications.clicked',
+    NOTIFICATIONS_ITEM_CLICKED = 'notifications_item.clicked',
+    NOTIFICATIONS_READ_MORE_CLICKED = 'notifications_read_more.clicked',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1775 

### Description:
this PR adds tracking events to the new notifications headway for when the notifications button is clicked, when the user clicks in one of the items, and when the user clicks on the _Lightdash updates_ button

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
