### PR TITLE
refactor: remove pristine state from explorer provider

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -1,11 +1,4 @@
-import {
-    ApiQueryResults,
-    BigNumber,
-    CartesianChart,
-    ChartConfig,
-    ChartType,
-    Explore,
-} from 'common';
+import { ApiQueryResults, ChartConfig, ChartType, Explore } from 'common';
 import EChartsReact from 'echarts-for-react';
 import React, {
     createContext,
@@ -51,7 +44,6 @@ type Props = {
     resultsData: ApiQueryResults | undefined;
     isLoading: boolean;
     onSeriesContextMenu?: (e: EchartSeriesClickEvent) => void;
-    onBigNumberLabelChange?: (value: ChartConfig['config']) => void;
     onChartConfigChange?: (value: ChartConfig['config']) => void;
     onChartTypeChange?: (value: ChartType) => void;
     onPivotDimensionsChange?: (value: string[] | undefined) => void;
@@ -66,7 +58,6 @@ export const VisualizationProvider: FC<Props> = ({
     isLoading,
     onSeriesContextMenu,
     onChartConfigChange,
-    onBigNumberLabelChange,
     onChartTypeChange,
     onPivotDimensionsChange,
     children,
@@ -84,18 +75,23 @@ export const VisualizationProvider: FC<Props> = ({
         [onChartTypeChange],
     );
 
-    const chartTypeConfig =
-        chartType === chartConfigs?.type ? chartConfigs.config : undefined;
-
     const {
         bigNumber,
         bigNumberLabel,
         setBigNumberLabel,
         validBigNumberConfig,
-    } = useBigNumberConfig(chartTypeConfig as BigNumber, resultsData, explore);
+    } = useBigNumberConfig(
+        chartConfigs?.type === ChartType.BIG_NUMBER
+            ? chartConfigs.config
+            : undefined,
+        resultsData,
+        explore,
+    );
 
     const cartesianConfig = useCartesianChartConfig(
-        chartTypeConfig as CartesianChart,
+        chartConfigs?.type === ChartType.CARTESIAN
+            ? chartConfigs.config
+            : undefined,
         validPivotDimensions?.[0],
         resultsData,
         chartConfigs !== undefined,
@@ -113,8 +109,27 @@ export const VisualizationProvider: FC<Props> = ({
     );
 
     useEffect(() => {
-        onChartConfigChange?.(validCartesianConfig);
-    }, [validCartesianConfig, onChartConfigChange]);
+        let validConfig: ChartConfig['config'];
+        switch (chartType) {
+            case ChartType.CARTESIAN:
+                validConfig = validCartesianConfig;
+                break;
+            case ChartType.BIG_NUMBER:
+                validConfig = validBigNumberConfig;
+                break;
+            case ChartType.TABLE:
+                break;
+            default:
+                const never: never = chartType;
+                throw new Error(`Unexpected chart type: ${chartType}`);
+        }
+        onChartConfigChange?.(validConfig);
+    }, [
+        validCartesianConfig,
+        onChartConfigChange,
+        chartType,
+        validBigNumberConfig,
+    ]);
 
     useEffect(() => {
         onPivotDimensionsChange?.(validPivotDimensions);
@@ -123,10 +138,6 @@ export const VisualizationProvider: FC<Props> = ({
     useEffect(() => {
         onPivotDimensionsChange?.(validPivotDimensions);
     }, [validPivotDimensions, onPivotDimensionsChange]);
-
-    useEffect(() => {
-        onBigNumberLabelChange?.(validBigNumberConfig);
-    }, [validBigNumberConfig, onBigNumberLabelChange]);
 
     return (
         <Context.Provider

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -11,20 +11,25 @@ import { BigButton } from './common/BigButton';
 export const RefreshButton = () => {
     const {
         state: { isValidQuery, sorts },
-        queryResults,
-        actions: { syncState },
+        queryResults: { mutate, isLoading: isLoadingResults },
+        actions: { setSortFields },
     } = useExplorer();
     const status = useServerStatus();
     const { track } = useTracking();
     const defaultSort = useDefaultSortField();
     const isDisabled = !isValidQuery;
-    const isLoading = queryResults.isLoading || status.data === 'loading';
+    const isLoading = isLoadingResults || status.data === 'loading';
     const onClick = useCallback(async () => {
-        syncState(sorts.length === 0 ? defaultSort : undefined);
+        if (sorts.length <= 0 && defaultSort) {
+            setSortFields([defaultSort]);
+        } else {
+            mutate();
+        }
+
         track({
             name: EventName.RUN_QUERY_BUTTON_CLICKED,
         });
-    }, [defaultSort, sorts, syncState, track]);
+    }, [defaultSort, mutate, setSortFields, sorts, track]);
     const hotkeys = useMemo(() => {
         const runQueryHotkey = {
             combo: 'ctrl+enter',

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -25,7 +25,7 @@ import SimplifiedFilterGroupForm from './SimplifiedFilterGroupForm';
 
 type Props = {
     filters: Filters;
-    setFilters: (value: Filters, syncState: boolean) => void;
+    setFilters: (value: Filters, shouldFetchResults: boolean) => void;
 };
 
 const FiltersForm: FC<Props> = ({ filters, setFilters }) => {

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -12,7 +12,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const useCartesianChartConfig = (
-    chartConfigs: CartesianChart,
+    chartConfigs: CartesianChart | undefined,
     pivotKey: string | undefined,
     resultsData: ApiQueryResults | undefined,
     isSaved: boolean,

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -28,8 +28,11 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any, syncState?: boolean) =>
-            setFilters(addFilterRule({ filters, field, value }), !!syncState),
+        (field: FilterableField, value: any, shouldFetchResults?: boolean) =>
+            setFilters(
+                addFilterRule({ filters, field, value }),
+                !!shouldFetchResults,
+            ),
         [filters, setFilters],
     );
 

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -33,7 +33,7 @@ export const useQueryResults = (state: ExplorerState) => {
             query: MetricQuery;
         }
     >(getQueryResults, {
-        mutationKey: ['queryResults', projectUuid],
+        mutationKey: ['queryResults'],
         onError: (result) => setErrorResponse(result),
     });
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -24,8 +24,8 @@ const SavedExplorer = () => {
     useEffect(() => {
         if (data) {
             setState({
+                shouldFetchResults: true,
                 chartName: data.name,
-                sorting: false,
                 tableName: data.tableName,
                 dimensions: data.metricQuery.dimensions,
                 metrics: data.metricQuery.metrics,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -34,7 +34,7 @@ export enum ActionType {
     ADD_TABLE_CALCULATION,
     UPDATE_TABLE_CALCULATION,
     DELETE_TABLE_CALCULATION,
-    RESET_SHOULD_FETCH_RESULTS,
+    SET_FETCH_RESULTS_FALSE,
     SET_ADDITIONAL_METRICS,
     SET_PIVOT_FIELDS,
     SET_CHART_TYPE,
@@ -43,7 +43,7 @@ export enum ActionType {
 
 type Action =
     | { type: ActionType.RESET }
-    | { type: ActionType.RESET_SHOULD_FETCH_RESULTS }
+    | { type: ActionType.SET_FETCH_RESULTS_FALSE }
     | {
           type: ActionType.SET_STATE;
           payload: Omit<
@@ -222,7 +222,7 @@ function reducer(
         case ActionType.SET_TABLE_NAME: {
             return { ...state, tableName: action.payload };
         }
-        case ActionType.RESET_SHOULD_FETCH_RESULTS: {
+        case ActionType.SET_FETCH_RESULTS_FALSE: {
             return { ...state, shouldFetchResults: false };
         }
         case ActionType.TOGGLE_DIMENSION: {
@@ -600,7 +600,7 @@ export const ExplorerProvider: FC = ({ children }) => {
         if (state.shouldFetchResults) {
             mutate();
             dispatch({
-                type: ActionType.RESET_SHOULD_FETCH_RESULTS,
+                type: ActionType.SET_FETCH_RESULTS_FALSE,
             });
         }
     }, [mutate, state]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- remove logic around pristine state in explorer provider
- any provider action can now set `shouldFetchResults` to `true` so the query results are fetched after the reducer calculates the state
- there is also a direct way to fetch the query results ( previously we had to sync the pristine state )
- explorer url params now update based on the MetricQuery returned by the query results 
- move states from component into provider
- removed big number callback which was causing unwanted behaviour

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
