### PR TITLE
fix: persist pivot layout

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -139,7 +139,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                             minimal
                             icon="cross"
                             onClick={() => {
-                                setPivotDimensions(undefined);
+                                setPivotDimensions([]);
                             }}
                         />
                     )}

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -17,7 +17,9 @@ const useCartesianChartConfig = (
     resultsData: ApiQueryResults | undefined,
     isSaved: boolean,
     setVisualizationChartType: (chart: ChartType) => void,
-    setPivotDimensions: (s: string[]) => void,
+    setPivotDimensions: React.Dispatch<
+        React.SetStateAction<string[] | undefined>
+    >,
 ) => {
     const [dirtyChartType, setChartType] = useState<CartesianSeriesType>(
         chartConfigs?.eChartsConfig?.series?.[0]?.type ||
@@ -210,11 +212,17 @@ const useCartesianChartConfig = (
                 yField: validYFields.length > 0 ? validYFields : yField,
             };
         };
+
+        const setPivotField = (pivotField: string) => {
+            setPivotDimensions((currentPivots) => {
+                return currentPivots === undefined
+                    ? [pivotField]
+                    : currentPivots;
+            });
+        };
+
         // Only load this if there are no existing chart configuration (not saved)
         if (isSaved) return;
-
-        setPivotDimensions([]); //reset pivot
-        setVisualizationChartType(ChartType.CARTESIAN); // reset table
 
         // one metric , one dimension
         if (availableMetrics.length === 1 && availableDimensions.length === 1) {
@@ -232,7 +240,7 @@ const useCartesianChartConfig = (
                     availableMetrics[0],
                 ]);
             });
-            setPivotDimensions([availableDimensions[1]]);
+            setPivotField(availableDimensions[1]);
         }
 
         // two metrics, one dimension
@@ -253,7 +261,7 @@ const useCartesianChartConfig = (
                     availableMetrics.slice(0, 4),
                 );
             });
-            setPivotDimensions([availableDimensions[1]]);
+            setPivotField(availableDimensions[1]);
         }
 
         // 2+ metrics with no dimensions


### PR DESCRIPTION
closes #1828

The default pivot is now only applied if the pivot state is `undefined` - some actions in the UI set the pivot state `undefined` but I think that's clearer as `[]` indicating the user has selected no pivots, rather than having no preference (and then invoking defaults).

When switching to table/big number and back to charts, it still sets the `undefined` pivot, which will invoke a new layout again. But I don't think this matters since the whole chart state is lost when switching to/from charts and bignumber/table

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
