### PR TITLE
refactor: explorer initial state

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -36,7 +36,6 @@ import SqlRunner from './pages/SqlRunner';
 import Welcome from './pages/Welcome';
 import { AppProvider } from './providers/AppProvider';
 import { DashboardProvider } from './providers/DashboardProvider';
-import { ExplorerProvider } from './providers/ExplorerProvider';
 import { TrackingProvider, TrackPage } from './providers/TrackingProvider';
 import { PageName } from './types/Events';
 
@@ -154,9 +153,7 @@ const App = () => (
                                                                     PageName.SAVED_QUERY_EXPLORER
                                                                 }
                                                             >
-                                                                <ExplorerProvider>
-                                                                    <SavedExplorer />
-                                                                </ExplorerProvider>
+                                                                <SavedExplorer />
                                                             </TrackPage>
                                                         </Route>
                                                         <Route path="/projects/:projectUuid/saved">
@@ -208,9 +205,7 @@ const App = () => (
                                                                     PageName.EXPLORER
                                                                 }
                                                             >
-                                                                <ExplorerProvider>
-                                                                    <Explorer />
-                                                                </ExplorerProvider>
+                                                                <Explorer />
                                                             </TrackPage>
                                                         </Route>
                                                         <Route path="/projects/:projectUuid/tables">
@@ -220,9 +215,7 @@ const App = () => (
                                                                     PageName.EXPLORE_TABLES
                                                                 }
                                                             >
-                                                                <ExplorerProvider>
-                                                                    <Explorer />
-                                                                </ExplorerProvider>
+                                                                <Explorer />
                                                             </TrackPage>
                                                         </Route>
                                                         <Route

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -215,12 +215,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         }
     };
 
-    useEffect(() => {
-        if (data) {
-            setChartType(data.chartConfig.type);
-        }
-    }, [data, setChartType]);
-
     const hasUnsavedChanges = (): boolean => {
         const filterData = (
             d: SavedChart | CreateSavedChartVersion | undefined,

--- a/packages/frontend/src/pages/Explorer.styles.ts
+++ b/packages/frontend/src/pages/Explorer.styles.ts
@@ -1,0 +1,32 @@
+import { Card } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const PageContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: stretch;
+    align-items: flex-start;
+`;
+
+export const SideBar = styled(Card)`
+    height: calc(100vh - 50px);
+    flex-basis: 400px;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-right: 10px;
+    overflow: hidden;
+    position: sticky;
+    top: 50px;
+    padding-bottom: 0;
+`;
+
+export const Main = styled.div`
+    padding: 10px 10px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    min-width: 0;
+`;

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@blueprintjs/core';
 import React from 'react';
 import { Explorer } from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
@@ -7,6 +6,7 @@ import {
     useExplorerUrlState,
 } from '../hooks/useExplorerRoute';
 import { ExplorerProvider } from '../providers/ExplorerProvider';
+import { Main, PageContainer, SideBar } from './Explorer.styles';
 
 const ExplorerWithUrlParams = () => {
     useExplorerRoute();
@@ -17,45 +17,14 @@ const ExplorerPage = () => {
     const explorerUrlState = useExplorerUrlState();
     return (
         <ExplorerProvider initialState={explorerUrlState}>
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    flexWrap: 'nowrap',
-                    justifyContent: 'stretch',
-                    alignItems: 'flex-start',
-                }}
-            >
-                <Card
-                    style={{
-                        height: 'calc(100vh - 50px)',
-                        flexBasis: '400px',
-                        flexGrow: 0,
-                        flexShrink: 0,
-                        marginRight: '10px',
-                        overflow: 'hidden',
-                        position: 'sticky',
-                        top: '50px',
-                        paddingBottom: 0,
-                    }}
-                    elevation={1}
-                >
+            <PageContainer>
+                <SideBar elevation={1}>
                     <ExploreSideBar />
-                </Card>
-                <div
-                    style={{
-                        padding: '10px 10px',
-                        flexGrow: 1,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'flex-start',
-                        alignItems: 'stretch',
-                        minWidth: 0,
-                    }}
-                >
+                </SideBar>
+                <Main>
                     <ExplorerWithUrlParams />
-                </div>
-            </div>
+                </Main>
+            </PageContainer>
         </ExplorerProvider>
     );
 };

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -2,51 +2,61 @@ import { Card } from '@blueprintjs/core';
 import React from 'react';
 import { Explorer } from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
-import { useExplorerRoute } from '../hooks/useExplorerRoute';
+import {
+    useExplorerRoute,
+    useExplorerUrlState,
+} from '../hooks/useExplorerRoute';
+import { ExplorerProvider } from '../providers/ExplorerProvider';
+
+const ExplorerWithUrlParams = () => {
+    useExplorerRoute();
+    return <Explorer />;
+};
 
 const ExplorerPage = () => {
-    useExplorerRoute();
-
+    const explorerUrlState = useExplorerUrlState();
     return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'row',
-                flexWrap: 'nowrap',
-                justifyContent: 'stretch',
-                alignItems: 'flex-start',
-            }}
-        >
-            <Card
-                style={{
-                    height: 'calc(100vh - 50px)',
-                    flexBasis: '400px',
-                    flexGrow: 0,
-                    flexShrink: 0,
-                    marginRight: '10px',
-                    overflow: 'hidden',
-                    position: 'sticky',
-                    top: '50px',
-                    paddingBottom: 0,
-                }}
-                elevation={1}
-            >
-                <ExploreSideBar />
-            </Card>
+        <ExplorerProvider initialState={explorerUrlState}>
             <div
                 style={{
-                    padding: '10px 10px',
-                    flexGrow: 1,
                     display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    alignItems: 'stretch',
-                    minWidth: 0,
+                    flexDirection: 'row',
+                    flexWrap: 'nowrap',
+                    justifyContent: 'stretch',
+                    alignItems: 'flex-start',
                 }}
             >
-                <Explorer />
+                <Card
+                    style={{
+                        height: 'calc(100vh - 50px)',
+                        flexBasis: '400px',
+                        flexGrow: 0,
+                        flexShrink: 0,
+                        marginRight: '10px',
+                        overflow: 'hidden',
+                        position: 'sticky',
+                        top: '50px',
+                        paddingBottom: 0,
+                    }}
+                    elevation={1}
+                >
+                    <ExploreSideBar />
+                </Card>
+                <div
+                    style={{
+                        padding: '10px 10px',
+                        flexGrow: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'flex-start',
+                        alignItems: 'stretch',
+                        minWidth: 0,
+                    }}
+                >
+                    <ExplorerWithUrlParams />
+                </div>
             </div>
-        </div>
+        </ExplorerProvider>
     );
 };
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,96 +1,120 @@
-import { Card } from '@blueprintjs/core';
-import React, { useEffect } from 'react';
+import { Card, NonIdealState, Spinner } from '@blueprintjs/core';
+import React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import AboutFooter from '../components/AboutFooter';
 import { Explorer } from '../components/Explorer';
 import ExplorePanel from '../components/Explorer/ExplorePanel/index';
 import { useSavedQuery } from '../hooks/useSavedQuery';
-import { useExplorer } from '../providers/ExplorerProvider';
+import { ExplorerProvider } from '../providers/ExplorerProvider';
 
 const SavedExplorer = () => {
     const history = useHistory();
-    const pathParams = useParams<{ savedQueryUuid: string }>();
-    const {
-        actions: { setState, reset },
-    } = useExplorer();
-    const { data } = useSavedQuery({ id: pathParams.savedQueryUuid });
+    const pathParams =
+        useParams<{ savedQueryUuid: string; projectUuid: string }>();
+    const { data, isLoading, error } = useSavedQuery({
+        id: pathParams.savedQueryUuid,
+    });
     const onBack = () => {
-        reset();
         history.push({
-            pathname: `/saved`,
+            pathname: `/projects/${pathParams.projectUuid}/home`,
         });
     };
 
-    useEffect(() => {
-        if (data) {
-            setState({
-                shouldFetchResults: true,
-                chartName: data.name,
-                tableName: data.tableName,
-                dimensions: data.metricQuery.dimensions,
-                metrics: data.metricQuery.metrics,
-                filters: data.metricQuery.filters,
-                sorts: data.metricQuery.sorts,
-                limit: data.metricQuery.limit,
-                columnOrder: data.tableConfig.columnOrder,
-                selectedTableCalculations:
-                    data.metricQuery.tableCalculations.map((t) => t.name),
-                tableCalculations: data.metricQuery.tableCalculations,
-                additionalMetrics: data.metricQuery.additionalMetrics,
-            });
-        }
-    }, [data, setState]);
+    if (isLoading) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <NonIdealState title="Loading..." icon={<Spinner />} />
+            </div>
+        );
+    }
+    if (error) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <NonIdealState
+                    title="Unexpected error"
+                    description={error.error.message}
+                />
+            </div>
+        );
+    }
 
     return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'row',
-                flexWrap: 'nowrap',
-                justifyContent: 'stretch',
-                alignItems: 'flex-start',
-            }}
+        <ExplorerProvider
+            initialState={
+                data
+                    ? {
+                          shouldFetchResults: true,
+                          chartName: data.name,
+                          tableName: data.tableName,
+                          dimensions: data.metricQuery.dimensions,
+                          metrics: data.metricQuery.metrics,
+                          filters: data.metricQuery.filters,
+                          sorts: data.metricQuery.sorts,
+                          limit: data.metricQuery.limit,
+                          columnOrder: data.tableConfig.columnOrder,
+                          selectedTableCalculations:
+                              data.metricQuery.tableCalculations.map(
+                                  (t) => t.name,
+                              ),
+                          tableCalculations: data.metricQuery.tableCalculations,
+                          additionalMetrics: data.metricQuery.additionalMetrics,
+                          chartType: data.chartConfig.type,
+                          chartConfig: data.chartConfig.config,
+                          pivotFields: data.pivotConfig?.columns || [],
+                      }
+                    : undefined
+            }
         >
-            <Card
-                style={{
-                    height: 'calc(100vh - 50px)',
-                    flexBasis: '400px',
-                    flexGrow: 0,
-                    flexShrink: 0,
-                    marginRight: '10px',
-                    overflow: 'hidden',
-                    position: 'sticky',
-                    top: '50px',
-                    paddingBottom: 0,
-                }}
-                elevation={1}
-            >
-                <div
-                    style={{
-                        height: '100%',
-                        overflow: 'hidden',
-                        display: 'flex',
-                        flexDirection: 'column',
-                    }}
-                >
-                    <ExplorePanel onBack={onBack} />
-                    <AboutFooter minimal />
-                </div>
-            </Card>
             <div
                 style={{
-                    padding: '10px 10px',
-                    flexGrow: 1,
                     display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'flex-start',
-                    alignItems: 'stretch',
-                    minWidth: 0,
+                    flexDirection: 'row',
+                    flexWrap: 'nowrap',
+                    justifyContent: 'stretch',
+                    alignItems: 'flex-start',
                 }}
             >
-                <Explorer savedQueryUuid={pathParams.savedQueryUuid} />
+                <Card
+                    style={{
+                        height: 'calc(100vh - 50px)',
+                        flexBasis: '400px',
+                        flexGrow: 0,
+                        flexShrink: 0,
+                        marginRight: '10px',
+                        overflow: 'hidden',
+                        position: 'sticky',
+                        top: '50px',
+                        paddingBottom: 0,
+                    }}
+                    elevation={1}
+                >
+                    <div
+                        style={{
+                            height: '100%',
+                            overflow: 'hidden',
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                    >
+                        <ExplorePanel onBack={onBack} />
+                        <AboutFooter minimal />
+                    </div>
+                </Card>
+                <div
+                    style={{
+                        padding: '10px 10px',
+                        flexGrow: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'flex-start',
+                        alignItems: 'stretch',
+                        minWidth: 0,
+                    }}
+                >
+                    <Explorer savedQueryUuid={pathParams.savedQueryUuid} />
+                </div>
             </div>
-        </div>
+        </ExplorerProvider>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- explorer initial state is now set via a prop in the provider. This means both `saved chart` and `state via url` is set in the same way in the respective page component
- remove hook that set the saved chart type since it is now done in the initial state
- remove setState action since we should use the initial state
- add loading and error UI in the saved chart page
- split useExplorerRouter into 2 hooks: 1 updates the url params based on the explorer provider, 1 reads the explore state from the url params ( which is applied as the initial state on the explorer provider ) 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
