### PR TITLE
refactor: change explorer provider state into saved chart version

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -128,6 +128,15 @@ export const isCompleteEchartsConfig = (
 ): value is CompleteEChartsConfig =>
     !!value && !!value.series && value.series.length > 0;
 
+export const isCartesianChartConfig = (
+    value: ChartConfig['config'],
+): value is CartesianChart =>
+    !!value && 'layout' in value && 'eChartsConfig' in value;
+
+export const isBigNumberConfig = (
+    value: ChartConfig['config'],
+): value is BigNumber => !!value && !isCartesianChartConfig(value);
+
 export const hashFieldReference = (reference: PivotReference) =>
     reference.pivotValues
         ? `${reference.field}.${reference.pivotValues

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -113,7 +113,7 @@ export const ChartDownloadOptions: React.FC<DownloadOptions> = ({
 
     const {
         state: {
-            savedChartVersion: { tableName: activeTableName },
+            unsavedChartVersion: { tableName: activeTableName },
         },
     } = useExplorer();
 

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -112,7 +112,9 @@ export const ChartDownloadOptions: React.FC<DownloadOptions> = ({
     const [type, setType] = useState<DownloadType>(DownloadType.JPEG);
 
     const {
-        state: { tableName: activeTableName },
+        state: {
+            savedChartVersion: { tableName: activeTableName },
+        },
     } = useExplorer();
 
     const isTable = chartType === ChartType.TABLE;

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -76,7 +76,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         { fromExplorer?: boolean; explore?: boolean } | undefined
     >();
     const {
-        state: { chartName, savedChartVersion },
+        state: { chartName, unsavedChartVersion },
         queryResults,
         actions: {
             setRowLimit,
@@ -86,7 +86,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             setChartConfig,
         },
     } = useExplorer();
-    const explore = useExplore(savedChartVersion.tableName);
+    const explore = useExplore(unsavedChartVersion.tableName);
     const { data, isLoading } = useSavedQuery({ id: savedQueryUuid });
 
     const update = useAddVersionMutation();
@@ -96,7 +96,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     const [sqlIsOpen, setSqlIsOpen] = useState<boolean>(false);
     const [vizIsOpen, setVizisOpen] = useState<boolean>(!!savedQueryUuid);
     const totalActiveFilters: number = countTotalFilterRules(
-        savedChartVersion.metricQuery.filters,
+        unsavedChartVersion.metricQuery.filters,
     );
     const chartId = savedQueryUuid || '';
     const { mutate: duplicateChart } = useDuplicateMutation(chartId);
@@ -159,10 +159,10 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
     }, [explore.data, queryResults.data]);
 
     const handleSavedQueryUpdate = () => {
-        if (savedQueryUuid && savedChartVersion) {
+        if (savedQueryUuid && unsavedChartVersion) {
             update.mutate({
                 uuid: savedQueryUuid,
-                payload: savedChartVersion,
+                payload: unsavedChartVersion,
             });
         }
     };
@@ -180,7 +180,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
 
         return (
             JSON.stringify(filterData(data)) !==
-            JSON.stringify(filterData(savedChartVersion))
+            JSON.stringify(filterData(unsavedChartVersion))
         );
     };
     return (
@@ -227,11 +227,11 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                             </Menu>
                         }
                         placement="bottom"
-                        disabled={!savedChartVersion.tableName}
+                        disabled={!unsavedChartVersion.tableName}
                     >
                         <BigButton
                             icon="more"
-                            disabled={!savedChartVersion.tableName}
+                            disabled={!unsavedChartVersion.tableName}
                             style={{
                                 height: 40,
                                 width: 40,
@@ -265,7 +265,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                 <Collapse isOpen={filterIsOpen}>
                     <FiltersProvider fieldsMap={fieldsWithSuggestions}>
                         <FiltersForm
-                            filters={savedChartVersion.metricQuery.filters}
+                            filters={unsavedChartVersion.metricQuery.filters}
                             setFilters={setFilters}
                         />
                     </FiltersProvider>
@@ -276,9 +276,9 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
             <Card style={{ padding: 5, overflowY: 'scroll' }} elevation={1}>
                 <VisualizationProvider
                     chartConfigs={data?.chartConfig}
-                    chartType={savedChartVersion.chartConfig.type}
+                    chartType={unsavedChartVersion.chartConfig.type}
                     pivotDimensions={data?.pivotConfig?.columns}
-                    tableName={savedChartVersion.tableName}
+                    tableName={unsavedChartVersion.tableName}
                     resultsData={queryResults.data}
                     isLoading={queryResults.isLoading || isLoading}
                     onChartConfigChange={setChartConfig}
@@ -318,7 +318,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                 }}
                             >
                                 <VisualizationCardOptions />
-                                {savedChartVersion.chartConfig.type ===
+                                {unsavedChartVersion.chartConfig.type ===
                                 ChartType.BIG_NUMBER ? (
                                     <BigNumberConfigPanel />
                                 ) : (
@@ -333,7 +333,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                 : 'Save chart'
                                         }
                                         disabled={
-                                            !savedChartVersion.tableName ||
+                                            !unsavedChartVersion.tableName ||
                                             !hasUnsavedChanges()
                                         }
                                         onClick={
@@ -347,7 +347,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                         <Popover2
                                             placement="bottom"
                                             disabled={
-                                                !savedChartVersion.tableName
+                                                !unsavedChartVersion.tableName
                                             }
                                             content={
                                                 <Menu>
@@ -416,7 +416,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                             <Button
                                                 icon="more"
                                                 disabled={
-                                                    !savedChartVersion.tableName
+                                                    !unsavedChartVersion.tableName
                                                 }
                                             />
                                         </Popover2>
@@ -465,7 +465,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                         </H5>
                         {resultsIsOpen && (
                             <LimitButton
-                                limit={savedChartVersion.metricQuery.limit}
+                                limit={unsavedChartVersion.metricQuery.limit}
                                 onLimitChange={setRowLimit}
                             />
                         )}
@@ -481,7 +481,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                         >
                             <AddColumnButton />
                             <DownloadCsvButton
-                                fileName={savedChartVersion.tableName}
+                                fileName={unsavedChartVersion.tableName}
                                 rows={
                                     queryResults.data &&
                                     getResultValues(queryResults.data.rows)
@@ -517,10 +517,10 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                     <RenderedSql />
                 </Collapse>
             </Card>
-            {savedChartVersion && (
+            {unsavedChartVersion && (
                 <CreateSavedQueryModal
                     isOpen={isQueryModalOpen}
-                    savedData={savedChartVersion}
+                    savedData={unsavedChartVersion}
                     onClose={() => setIsQueryModalOpen(false)}
                 />
             )}

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -28,7 +28,10 @@ type ExplorePanelProps = {
 };
 export const ExplorerPanel = ({ onBack }: ExplorePanelProps) => {
     const {
-        state: { activeFields, tableName: activeTableName },
+        state: {
+            activeFields,
+            savedChartVersion: { tableName: activeTableName },
+        },
         actions: { toggleActiveField },
     } = useExplorer();
     const status = useServerStatus();

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -30,7 +30,7 @@ export const ExplorerPanel = ({ onBack }: ExplorePanelProps) => {
     const {
         state: {
             activeFields,
-            savedChartVersion: { tableName: activeTableName },
+            unsavedChartVersion: { tableName: activeTableName },
         },
         actions: { toggleActiveField },
     } = useExplorer();

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -147,7 +147,7 @@ const BasePanel = () => {
 const ExploreSideBar = () => {
     const {
         state: {
-            savedChartVersion: { tableName },
+            unsavedChartVersion: { tableName },
         },
         actions: { reset },
     } = useExplorer();

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -146,7 +146,9 @@ const BasePanel = () => {
 
 const ExploreSideBar = () => {
     const {
-        state: { tableName },
+        state: {
+            savedChartVersion: { tableName },
+        },
         actions: { reset },
     } = useExplorer();
     const { projectUuid } = useParams<{ projectUuid: string }>();

--- a/packages/frontend/src/components/Explorer/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerResults.tsx
@@ -18,7 +18,7 @@ export const ExplorerResults = () => {
     const dataColumns = useColumns();
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName: activeTableName,
                 metricQuery: { dimensions, metrics },
                 tableConfig: { columnOrder: explorerColumnOrder },

--- a/packages/frontend/src/components/Explorer/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerResults.tsx
@@ -18,10 +18,11 @@ export const ExplorerResults = () => {
     const dataColumns = useColumns();
     const {
         state: {
-            tableName: activeTableName,
-            columnOrder: explorerColumnOrder,
-            dimensions,
-            metrics,
+            savedChartVersion: {
+                tableName: activeTableName,
+                metricQuery: { dimensions, metrics },
+                tableConfig: { columnOrder: explorerColumnOrder },
+            },
         },
         queryResults,
         actions: { setColumnOrder: setExplorerColumnOrder },

--- a/packages/frontend/src/components/LineageButton.tsx
+++ b/packages/frontend/src/components/LineageButton.tsx
@@ -13,7 +13,7 @@ const Content = () => {
     const [showAll, setShowAll] = useState(false);
     const {
         state: {
-            savedChartVersion: { tableName },
+            unsavedChartVersion: { tableName },
         },
     } = useExplorer();
     const currentExplore = useExplore(tableName);

--- a/packages/frontend/src/components/LineageButton.tsx
+++ b/packages/frontend/src/components/LineageButton.tsx
@@ -12,7 +12,9 @@ import { EventName } from '../types/Events';
 const Content = () => {
     const [showAll, setShowAll] = useState(false);
     const {
-        state: { tableName },
+        state: {
+            savedChartVersion: { tableName },
+        },
     } = useExplorer();
     const currentExplore = useExplore(tableName);
     if (currentExplore.status !== 'success') return null;

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -9,7 +9,12 @@ import { BigButton } from './common/BigButton';
 
 export const RefreshButton = () => {
     const {
-        state: { isValidQuery, sorts },
+        state: {
+            isValidQuery,
+            savedChartVersion: {
+                metricQuery: { sorts },
+            },
+        },
         queryResults: { mutate, isLoading: isLoadingResults },
         actions: { setSortFields },
     } = useExplorer();

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -11,7 +11,7 @@ export const RefreshButton = () => {
     const {
         state: {
             isValidQuery,
-            savedChartVersion: {
+            unsavedChartVersion: {
                 metricQuery: { sorts },
             },
         },

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -44,7 +44,12 @@ const TableCalculationModal: FC<Props> = ({
     const [isFullscreen, toggleFullscreen] = useToggle(false);
     const { showToastError } = useApp();
     const {
-        state: { dimensions, metrics, tableCalculations, tableName },
+        state: {
+            savedChartVersion: {
+                tableName,
+                metricQuery: { dimensions, metrics, tableCalculations },
+            },
+        },
     } = useExplorer();
     const { setAceEditor } = useExplorerAceEditorCompleter();
     const { data: { targetDatabase } = {} } = useExplore(tableName);

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -45,7 +45,7 @@ const TableCalculationModal: FC<Props> = ({
     const { showToastError } = useApp();
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName,
                 metricQuery: { dimensions, metrics, tableCalculations },
             },

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -42,9 +42,10 @@ export const useColumns = (): Column<{ [col: string]: any }>[] => {
     const {
         state: {
             activeFields,
-            sorts: sortFields,
-            tableCalculations,
-            tableName,
+            savedChartVersion: {
+                tableName,
+                metricQuery: { sorts: sortFields, tableCalculations },
+            },
         },
         actions: { toggleSortField },
     } = useExplorer();

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -42,7 +42,7 @@ export const useColumns = (): Column<{ [col: string]: any }>[] => {
     const {
         state: {
             activeFields,
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName,
                 metricQuery: { sorts: sortFields, tableCalculations },
             },

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -20,14 +20,18 @@ export const useCompliedSql = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const {
         state: {
-            tableName: tableId,
-            dimensions,
-            metrics,
-            sorts,
-            filters,
-            limit,
-            tableCalculations,
-            additionalMetrics,
+            savedChartVersion: {
+                tableName: tableId,
+                metricQuery: {
+                    dimensions,
+                    metrics,
+                    sorts,
+                    filters,
+                    limit,
+                    tableCalculations,
+                    additionalMetrics,
+                },
+            },
         },
     } = useExplorer();
     const setErrorResponse = useQueryError();

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -20,7 +20,7 @@ export const useCompliedSql = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName: tableId,
                 metricQuery: {
                     dimensions,

--- a/packages/frontend/src/hooks/useDefaultSortField.tsx
+++ b/packages/frontend/src/hooks/useDefaultSortField.tsx
@@ -11,15 +11,23 @@ import { useExplore } from './useExplore';
 
 const useDefaultSortField = (): SortField | undefined => {
     const {
-        state: { dimensions, metrics, columnOrder, tableName },
+        state: {
+            savedChartVersion: {
+                tableName,
+                metricQuery: { dimensions, metrics },
+                tableConfig: { columnOrder },
+            },
+        },
     } = useExplorer();
     const { data } = useExplore(tableName);
 
     return useMemo(() => {
         if (data) {
+            console.log('aqui', data);
             const dimensionFields = getDimensions(data).filter((field) =>
                 dimensions.includes(getFieldId(field)),
             );
+            console.log('depois', dimensionFields);
             const timeDimension = dimensionFields.find(({ type }) =>
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(type),
             );

--- a/packages/frontend/src/hooks/useDefaultSortField.tsx
+++ b/packages/frontend/src/hooks/useDefaultSortField.tsx
@@ -12,7 +12,7 @@ import { useExplore } from './useExplore';
 const useDefaultSortField = (): SortField | undefined => {
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName,
                 metricQuery: { dimensions, metrics },
                 tableConfig: { columnOrder },

--- a/packages/frontend/src/hooks/useDefaultSortField.tsx
+++ b/packages/frontend/src/hooks/useDefaultSortField.tsx
@@ -23,11 +23,10 @@ const useDefaultSortField = (): SortField | undefined => {
 
     return useMemo(() => {
         if (data) {
-            console.log('aqui', data);
             const dimensionFields = getDimensions(data).filter((field) =>
                 dimensions.includes(getFieldId(field)),
             );
-            console.log('depois', dimensionFields);
+
             const timeDimension = dimensionFields.find(({ type }) =>
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(type),
             );

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -18,7 +18,7 @@ export const useExplore = (activeTableName: string | undefined) => {
     return useQuery<ApiExploreResults, ApiError>({
         queryKey,
         queryFn: () => getExplore(projectUuid, activeTableName || ''),
-        enabled: activeTableName !== undefined,
+        enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
     });

--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
@@ -43,7 +43,7 @@ export const useExplorerAceEditorCompleter = (): {
     const {
         state: {
             activeFields,
-            savedChartVersion: { tableName },
+            unsavedChartVersion: { tableName },
         },
     } = useExplorer();
     const explore = useExplore(tableName);

--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
@@ -41,7 +41,10 @@ export const useExplorerAceEditorCompleter = (): {
     setAceEditor: Dispatch<SetStateAction<Ace.Editor | undefined>>;
 } => {
     const {
-        state: { activeFields, tableName },
+        state: {
+            activeFields,
+            savedChartVersion: { tableName },
+        },
     } = useExplorer();
     const explore = useExplore(tableName);
     const [aceEditor, setAceEditor] = useState<Ace.Editor>();

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -13,7 +13,7 @@ export const useExplorerRoute = () => {
         useParams<{ projectUuid: string; tableId: string | undefined }>();
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 tableName,
                 tableConfig: { columnOrder: stateColumnOrder },
             },
@@ -152,7 +152,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 return {
                     shouldFetchResults: true,
                     chartName: undefined,
-                    savedChartVersion: {
+                    unsavedChartVersion: {
                         tableName: pathParams.tableId,
                         metricQuery: {
                             dimensions,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -12,7 +12,12 @@ export const useExplorerRoute = () => {
     const pathParams =
         useParams<{ projectUuid: string; tableId: string | undefined }>();
     const {
-        state: { tableName, columnOrder: stateColumnOrder },
+        state: {
+            savedChartVersion: {
+                tableName,
+                tableConfig: { columnOrder: stateColumnOrder },
+            },
+        },
         queryResults: { data: queryResultsData },
         actions: { reset, setTableName },
     } = useExplorer();
@@ -147,18 +152,28 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 return {
                     shouldFetchResults: true,
                     chartName: undefined,
-                    tableName: pathParams.tableId,
-                    dimensions,
-                    metrics,
-                    filters,
-                    sorts,
-                    limit,
-                    columnOrder,
-                    tableCalculations,
-                    additionalMetrics,
-                    chartType: ChartType.CARTESIAN,
-                    chartConfig: undefined,
-                    pivotFields: [],
+                    savedChartVersion: {
+                        tableName: pathParams.tableId,
+                        metricQuery: {
+                            dimensions,
+                            metrics,
+                            filters,
+                            sorts,
+                            limit,
+                            tableCalculations,
+                            additionalMetrics,
+                        },
+                        pivotConfig: {
+                            columns: [],
+                        },
+                        tableConfig: {
+                            columnOrder,
+                        },
+                        chartConfig: {
+                            type: ChartType.CARTESIAN,
+                            config: { layout: {}, eChartsConfig: {} },
+                        },
+                    },
                 };
             } catch (e: any) {
                 showToastError({ title: 'Error parsing url', subtitle: e });

--- a/packages/frontend/src/hooks/useField.ts
+++ b/packages/frontend/src/hooks/useField.ts
@@ -11,7 +11,9 @@ export const useField = (
     field: Field | undefined;
 } => {
     const {
-        state: { tableName: activeTableName },
+        state: {
+            savedChartVersion: { tableName: activeTableName },
+        },
     } = useExplorer();
     const { data, isLoading } = useExplore(activeTableName);
     const fields: Field[] = useMemo(

--- a/packages/frontend/src/hooks/useField.ts
+++ b/packages/frontend/src/hooks/useField.ts
@@ -12,7 +12,7 @@ export const useField = (
 } => {
     const {
         state: {
-            savedChartVersion: { tableName: activeTableName },
+            unsavedChartVersion: { tableName: activeTableName },
         },
     } = useExplorer();
     const { data, isLoading } = useExplore(activeTableName);

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -11,7 +11,7 @@ import { useExplorer } from '../providers/ExplorerProvider';
 export const useFilters = () => {
     const {
         state: {
-            savedChartVersion: {
+            unsavedChartVersion: {
                 metricQuery: { filters },
             },
         },

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -10,7 +10,11 @@ import { useExplorer } from '../providers/ExplorerProvider';
 
 export const useFilters = () => {
     const {
-        state: { filters },
+        state: {
+            savedChartVersion: {
+                metricQuery: { filters },
+            },
+        },
         actions: { setFilters },
     } = useExplorer();
 

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -38,19 +38,11 @@ export const useQueryResults = (state: ExplorerState) => {
     });
 
     const mutate = useCallback(() => {
-        if (!!state.tableName && state.isValidQuery) {
+        if (!!state.savedChartVersion.tableName && state.isValidQuery) {
             mutation.mutate({
                 projectUuid,
-                tableId: state.tableName,
-                query: {
-                    dimensions: Array.from(state.dimensions),
-                    metrics: Array.from(state.metrics),
-                    sorts: state.sorts,
-                    filters: state.filters,
-                    limit: state.limit || 500,
-                    tableCalculations: state.tableCalculations,
-                    additionalMetrics: state.additionalMetrics,
-                },
+                tableId: state.savedChartVersion.tableName,
+                query: state.savedChartVersion.metricQuery,
             });
         }
     }, [mutation, projectUuid, state]);

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -38,11 +38,11 @@ export const useQueryResults = (state: ExplorerState) => {
     });
 
     const mutate = useCallback(() => {
-        if (!!state.savedChartVersion.tableName && state.isValidQuery) {
+        if (!!state.unsavedChartVersion.tableName && state.isValidQuery) {
             mutation.mutate({
                 projectUuid,
-                tableId: state.savedChartVersion.tableName,
-                query: state.savedChartVersion.metricQuery,
+                tableId: state.unsavedChartVersion.tableName,
+                query: state.unsavedChartVersion.metricQuery,
             });
         }
     }, [mutation, projectUuid, state]);

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -44,19 +44,14 @@ const SavedExplorer = () => {
                 data
                     ? {
                           shouldFetchResults: true,
-                          chartName: data.name,
-                          tableName: data.tableName,
-                          dimensions: data.metricQuery.dimensions,
-                          metrics: data.metricQuery.metrics,
-                          filters: data.metricQuery.filters,
-                          sorts: data.metricQuery.sorts,
-                          limit: data.metricQuery.limit,
-                          columnOrder: data.tableConfig.columnOrder,
-                          tableCalculations: data.metricQuery.tableCalculations,
-                          additionalMetrics: data.metricQuery.additionalMetrics,
-                          chartType: data.chartConfig.type,
-                          chartConfig: data.chartConfig.config,
-                          pivotFields: data.pivotConfig?.columns || [],
+                          chartName: data?.name,
+                          savedChartVersion: {
+                              tableName: data.tableName,
+                              chartConfig: data.chartConfig,
+                              metricQuery: data.metricQuery,
+                              tableConfig: data.tableConfig,
+                              pivotConfig: data.pivotConfig,
+                          },
                       }
                     : undefined
             }

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -45,7 +45,7 @@ const SavedExplorer = () => {
                     ? {
                           shouldFetchResults: true,
                           chartName: data?.name,
-                          savedChartVersion: {
+                          unsavedChartVersion: {
                               tableName: data.tableName,
                               chartConfig: data.chartConfig,
                               metricQuery: data.metricQuery,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -1,8 +1,10 @@
 import {
-    AdditionalMetric,
     ChartConfig,
     ChartType,
+    CreateSavedChartVersion,
     FieldId,
+    isBigNumberConfig,
+    isCartesianChartConfig,
     Metric,
     MetricQuery,
     SortField,
@@ -99,18 +101,7 @@ type Action =
 export interface ExplorerReduceState {
     shouldFetchResults: boolean;
     chartName: string | undefined;
-    tableName: string | undefined;
-    pivotFields: FieldId[];
-    dimensions: FieldId[];
-    metrics: FieldId[];
-    filters: MetricQuery['filters'];
-    sorts: SortField[];
-    columnOrder: string[];
-    limit: number;
-    tableCalculations: TableCalculation[];
-    additionalMetrics: AdditionalMetric[] | undefined;
-    chartType: ChartType;
-    chartConfig: ChartConfig['config'] | undefined;
+    savedChartVersion: CreateSavedChartVersion;
 }
 
 export interface ExplorerState extends ExplorerReduceState {
@@ -147,23 +138,61 @@ interface ExplorerContext {
     };
 }
 
-const Context = createContext<ExplorerContext>(undefined as any);
+const Context = createContext<ExplorerContext | undefined>(undefined);
 
 const defaultState: ExplorerReduceState = {
     shouldFetchResults: false,
     chartName: '',
-    tableName: undefined,
-    dimensions: [],
-    metrics: [],
-    filters: {},
-    sorts: [],
-    columnOrder: [],
-    limit: 500,
-    tableCalculations: [],
-    additionalMetrics: [],
-    pivotFields: [],
-    chartType: ChartType.CARTESIAN,
-    chartConfig: undefined,
+    savedChartVersion: {
+        tableName: '',
+        metricQuery: {
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        },
+        pivotConfig: {
+            columns: [],
+        },
+        tableConfig: {
+            columnOrder: [],
+        },
+        chartConfig: {
+            type: ChartType.CARTESIAN,
+            config: { layout: {}, eChartsConfig: {} },
+        },
+    },
+};
+
+const getValidChartConfig = (
+    type: ChartType,
+    config: ChartConfig['config'],
+): ChartConfig => {
+    switch (type) {
+        case ChartType.CARTESIAN: {
+            return {
+                type,
+                config: isCartesianChartConfig(config)
+                    ? config
+                    : { layout: {}, eChartsConfig: {} },
+            };
+        }
+        case ChartType.BIG_NUMBER: {
+            return {
+                type,
+                config: isBigNumberConfig(config) ? config : {},
+            };
+        }
+        case ChartType.TABLE: {
+            return {
+                type,
+                config: undefined,
+            };
+        }
+    }
 };
 
 const calcColumnOrder = (
@@ -193,181 +222,321 @@ function reducer(
             return defaultState;
         }
         case ActionType.SET_TABLE_NAME: {
-            return { ...state, tableName: action.payload };
+            return {
+                ...state,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    tableName: action.payload,
+                },
+            };
         }
         case ActionType.SET_FETCH_RESULTS_FALSE: {
             return { ...state, shouldFetchResults: false };
         }
         case ActionType.TOGGLE_DIMENSION: {
             const dimensions = toggleArrayValue(
-                state.dimensions,
+                state.savedChartVersion.metricQuery.dimensions,
                 action.payload,
             );
             return {
                 ...state,
-                dimensions,
-                sorts: state.sorts.filter((s) => s.fieldId !== action.payload),
-                columnOrder: calcColumnOrder(state.columnOrder, [
-                    ...dimensions,
-                    ...state.metrics,
-                    ...state.tableCalculations.map(({ name }) => name),
-                ]),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        dimensions,
+                        sorts: state.savedChartVersion.metricQuery.sorts.filter(
+                            (s) => s.fieldId !== action.payload,
+                        ),
+                    },
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder: calcColumnOrder(
+                            state.savedChartVersion.tableConfig.columnOrder,
+                            [
+                                ...dimensions,
+                                ...state.savedChartVersion.metricQuery.metrics,
+                                ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                                    ({ name }) => name,
+                                ),
+                            ],
+                        ),
+                    },
+                },
             };
         }
         case ActionType.TOGGLE_METRIC: {
-            const metrics = toggleArrayValue(state.metrics, action.payload);
+            const metrics = toggleArrayValue(
+                state.savedChartVersion.metricQuery.metrics,
+                action.payload,
+            );
             return {
                 ...state,
-                metrics,
-                sorts: state.sorts.filter((s) => s.fieldId !== action.payload),
-                columnOrder: calcColumnOrder(state.columnOrder, [
-                    ...state.dimensions,
-                    ...metrics,
-                    ...state.tableCalculations.map(({ name }) => name),
-                ]),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        metrics,
+                        sorts: state.savedChartVersion.metricQuery.sorts.filter(
+                            (s) => s.fieldId !== action.payload,
+                        ),
+                    },
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder: calcColumnOrder(
+                            state.savedChartVersion.tableConfig.columnOrder,
+                            [
+                                ...state.savedChartVersion.metricQuery
+                                    .dimensions,
+                                ...metrics,
+                                ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                                    ({ name }) => name,
+                                ),
+                            ],
+                        ),
+                    },
+                },
             };
         }
         case ActionType.TOGGLE_SORT_FIELD: {
             const sortFieldId = action.payload;
             const activeFields = new Set([
-                ...state.dimensions,
-                ...state.metrics,
+                ...state.savedChartVersion.metricQuery.dimensions,
+                ...state.savedChartVersion.metricQuery.metrics,
             ]);
             if (!activeFields.has(sortFieldId)) {
                 return state;
             }
-            const sortField = state.sorts.find(
+            const sortField = state.savedChartVersion.metricQuery.sorts.find(
                 (sf) => sf.fieldId === sortFieldId,
             );
             return {
                 ...state,
-                sorts: !sortField
-                    ? [
-                          ...state.sorts,
-                          {
-                              fieldId: sortFieldId,
-                              descending: false,
-                          },
-                      ]
-                    : state.sorts.reduce<SortField[]>((acc, sf) => {
-                          if (sf.fieldId !== sortFieldId) {
-                              return [...acc, sf];
-                          }
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        sorts: !sortField
+                            ? [
+                                  ...state.savedChartVersion.metricQuery.sorts,
+                                  {
+                                      fieldId: sortFieldId,
+                                      descending: false,
+                                  },
+                              ]
+                            : state.savedChartVersion.metricQuery.sorts.reduce<
+                                  SortField[]
+                              >((acc, sf) => {
+                                  if (sf.fieldId !== sortFieldId) {
+                                      return [...acc, sf];
+                                  }
 
-                          if (sf.descending) {
-                              return acc;
-                          }
-                          return [
-                              ...acc,
-                              {
-                                  ...sf,
-                                  descending: true,
-                              },
-                          ];
-                      }, []),
-            } as ExplorerReduceState;
+                                  if (sf.descending) {
+                                      return acc;
+                                  }
+                                  return [
+                                      ...acc,
+                                      {
+                                          ...sf,
+                                          descending: true,
+                                      },
+                                  ];
+                              }, []),
+                    },
+                },
+            };
         }
         case ActionType.SET_SORT_FIELDS: {
             const activeFields = new Set([
-                ...state.dimensions,
-                ...state.metrics,
+                ...state.savedChartVersion.metricQuery.dimensions,
+                ...state.savedChartVersion.metricQuery.metrics,
             ]);
             return {
                 ...state,
-                sorts: action.payload.filter((sf) =>
-                    activeFields.has(sf.fieldId),
-                ),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        sorts: action.payload.filter((sf) =>
+                            activeFields.has(sf.fieldId),
+                        ),
+                    },
+                },
             };
         }
         case ActionType.SET_ROW_LIMIT: {
             return {
                 ...state,
-                limit: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        limit: action.payload,
+                    },
+                },
             };
         }
         case ActionType.SET_FILTERS: {
             return {
                 ...state,
-                filters: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        filters: action.payload,
+                    },
+                },
             };
         }
         case ActionType.SET_ADDITIONAL_METRICS: {
             return {
                 ...state,
-                additionalMetrics: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        additionalMetrics: action.payload,
+                    },
+                },
             };
         }
         case ActionType.SET_COLUMN_ORDER: {
             return {
                 ...state,
-                columnOrder: calcColumnOrder(action.payload, [
-                    ...state.dimensions,
-                    ...state.metrics,
-                    ...state.tableCalculations.map(({ name }) => name),
-                ]),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder: calcColumnOrder(action.payload, [
+                            ...state.savedChartVersion.metricQuery.dimensions,
+                            ...state.savedChartVersion.metricQuery.metrics,
+                            ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                                ({ name }) => name,
+                            ),
+                        ]),
+                    },
+                },
             };
         }
         case ActionType.ADD_TABLE_CALCULATION: {
             const newTableCalculations = [
-                ...state.tableCalculations,
+                ...state.savedChartVersion.metricQuery.tableCalculations,
                 action.payload,
             ];
             return {
                 ...state,
-                tableCalculations: newTableCalculations,
-                columnOrder: calcColumnOrder(state.columnOrder, [
-                    ...state.dimensions,
-                    ...state.metrics,
-                    ...newTableCalculations.map(({ name }) => name),
-                ]),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        tableCalculations: newTableCalculations,
+                    },
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder: calcColumnOrder(
+                            state.savedChartVersion.tableConfig.columnOrder,
+                            [
+                                ...state.savedChartVersion.metricQuery
+                                    .dimensions,
+                                ...state.savedChartVersion.metricQuery.metrics,
+                                ...newTableCalculations.map(({ name }) => name),
+                            ],
+                        ),
+                    },
+                },
             };
         }
         case ActionType.UPDATE_TABLE_CALCULATION: {
             return {
                 ...state,
-                tableCalculations: state.tableCalculations.map(
-                    (tableCalculation) =>
-                        tableCalculation.name === action.payload.oldName
-                            ? action.payload.tableCalculation
-                            : tableCalculation,
-                ),
-                columnOrder: state.columnOrder.map((column) =>
-                    column === action.payload.oldName
-                        ? action.payload.tableCalculation.name
-                        : column,
-                ),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        tableCalculations:
+                            state.savedChartVersion.metricQuery.tableCalculations.map(
+                                (tableCalculation) =>
+                                    tableCalculation.name ===
+                                    action.payload.oldName
+                                        ? action.payload.tableCalculation
+                                        : tableCalculation,
+                            ),
+                    },
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder:
+                            state.savedChartVersion.tableConfig.columnOrder.map(
+                                (column) =>
+                                    column === action.payload.oldName
+                                        ? action.payload.tableCalculation.name
+                                        : column,
+                            ),
+                    },
+                },
             };
         }
         case ActionType.DELETE_TABLE_CALCULATION: {
-            const newTableCalculations = state.tableCalculations.filter(
-                (tableCalculation) => tableCalculation.name !== action.payload,
-            );
+            const newTableCalculations =
+                state.savedChartVersion.metricQuery.tableCalculations.filter(
+                    (tableCalculation) =>
+                        tableCalculation.name !== action.payload,
+                );
             return {
                 ...state,
-                tableCalculations: newTableCalculations,
-                columnOrder: calcColumnOrder(state.columnOrder, [
-                    ...state.dimensions,
-                    ...state.metrics,
-                    ...newTableCalculations.map(({ name }) => name),
-                ]),
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    metricQuery: {
+                        ...state.savedChartVersion.metricQuery,
+                        tableCalculations: newTableCalculations,
+                    },
+                    tableConfig: {
+                        ...state.savedChartVersion.tableConfig,
+                        columnOrder: calcColumnOrder(
+                            state.savedChartVersion.tableConfig.columnOrder,
+                            [
+                                ...state.savedChartVersion.metricQuery
+                                    .dimensions,
+                                ...state.savedChartVersion.metricQuery.metrics,
+                                ...newTableCalculations.map(({ name }) => name),
+                            ],
+                        ),
+                    },
+                },
             };
         }
         case ActionType.SET_PIVOT_FIELDS: {
             return {
                 ...state,
-                pivotFields: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    pivotConfig: {
+                        columns: action.payload,
+                    },
+                },
             };
         }
         case ActionType.SET_CHART_TYPE: {
             return {
                 ...state,
-                chartType: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    chartConfig: getValidChartConfig(
+                        action.payload,
+                        state.savedChartVersion.chartConfig.config,
+                    ),
+                },
             };
         }
         case ActionType.SET_CHART_CONFIG: {
             return {
                 ...state,
-                chartConfig: action.payload,
+                savedChartVersion: {
+                    ...state.savedChartVersion,
+                    chartConfig: getValidChartConfig(
+                        state.savedChartVersion.chartConfig.type,
+                        action.payload,
+                    ),
+                },
             };
         }
         default: {
@@ -388,9 +557,11 @@ export const ExplorerProvider: FC<{
         [Set<FieldId>, boolean]
     >(() => {
         const fields = new Set([
-            ...reducerState.dimensions,
-            ...reducerState.metrics,
-            ...reducerState.tableCalculations.map(({ name }) => name),
+            ...reducerState.savedChartVersion.metricQuery.dimensions,
+            ...reducerState.savedChartVersion.metricQuery.metrics,
+            ...reducerState.savedChartVersion.metricQuery.tableCalculations.map(
+                ({ name }) => name,
+            ),
         ]);
         return [fields, fields.size > 0];
     }, [reducerState]);
@@ -495,7 +666,7 @@ export const ExplorerProvider: FC<{
     const addTableCalculation = useCallback(
         (tableCalculation: TableCalculation) => {
             if (
-                reducerState.tableCalculations.findIndex(
+                reducerState.savedChartVersion.metricQuery.tableCalculations.findIndex(
                     ({ name }) => name === tableCalculation.name,
                 ) > -1
             ) {
@@ -514,7 +685,7 @@ export const ExplorerProvider: FC<{
         (oldName: string, tableCalculation: TableCalculation) => {
             if (
                 oldName !== tableCalculation.name &&
-                reducerState.tableCalculations.findIndex(
+                reducerState.savedChartVersion.metricQuery.tableCalculations.findIndex(
                     ({ name }) => name === tableCalculation.name,
                 ) > -1
             ) {

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -101,7 +101,7 @@ type Action =
 export interface ExplorerReduceState {
     shouldFetchResults: boolean;
     chartName: string | undefined;
-    savedChartVersion: CreateSavedChartVersion;
+    unsavedChartVersion: CreateSavedChartVersion;
 }
 
 export interface ExplorerState extends ExplorerReduceState {
@@ -143,7 +143,7 @@ const Context = createContext<ExplorerContext | undefined>(undefined);
 const defaultState: ExplorerReduceState = {
     shouldFetchResults: false,
     chartName: '',
-    savedChartVersion: {
+    unsavedChartVersion: {
         tableName: '',
         metricQuery: {
             dimensions: [],
@@ -224,8 +224,8 @@ function reducer(
         case ActionType.SET_TABLE_NAME: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     tableName: action.payload,
                 },
             };
@@ -235,28 +235,29 @@ function reducer(
         }
         case ActionType.TOGGLE_DIMENSION: {
             const dimensions = toggleArrayValue(
-                state.savedChartVersion.metricQuery.dimensions,
+                state.unsavedChartVersion.metricQuery.dimensions,
                 action.payload,
             );
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         dimensions,
-                        sorts: state.savedChartVersion.metricQuery.sorts.filter(
+                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
                             (s) => s.fieldId !== action.payload,
                         ),
                     },
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder: calcColumnOrder(
-                            state.savedChartVersion.tableConfig.columnOrder,
+                            state.unsavedChartVersion.tableConfig.columnOrder,
                             [
                                 ...dimensions,
-                                ...state.savedChartVersion.metricQuery.metrics,
-                                ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                                ...state.unsavedChartVersion.metricQuery
+                                    .metrics,
+                                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
                                     ({ name }) => name,
                                 ),
                             ],
@@ -267,29 +268,29 @@ function reducer(
         }
         case ActionType.TOGGLE_METRIC: {
             const metrics = toggleArrayValue(
-                state.savedChartVersion.metricQuery.metrics,
+                state.unsavedChartVersion.metricQuery.metrics,
                 action.payload,
             );
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         metrics,
-                        sorts: state.savedChartVersion.metricQuery.sorts.filter(
+                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
                             (s) => s.fieldId !== action.payload,
                         ),
                     },
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder: calcColumnOrder(
-                            state.savedChartVersion.tableConfig.columnOrder,
+                            state.unsavedChartVersion.tableConfig.columnOrder,
                             [
-                                ...state.savedChartVersion.metricQuery
+                                ...state.unsavedChartVersion.metricQuery
                                     .dimensions,
                                 ...metrics,
-                                ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
                                     ({ name }) => name,
                                 ),
                             ],
@@ -301,30 +302,31 @@ function reducer(
         case ActionType.TOGGLE_SORT_FIELD: {
             const sortFieldId = action.payload;
             const activeFields = new Set([
-                ...state.savedChartVersion.metricQuery.dimensions,
-                ...state.savedChartVersion.metricQuery.metrics,
+                ...state.unsavedChartVersion.metricQuery.dimensions,
+                ...state.unsavedChartVersion.metricQuery.metrics,
             ]);
             if (!activeFields.has(sortFieldId)) {
                 return state;
             }
-            const sortField = state.savedChartVersion.metricQuery.sorts.find(
+            const sortField = state.unsavedChartVersion.metricQuery.sorts.find(
                 (sf) => sf.fieldId === sortFieldId,
             );
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         sorts: !sortField
                             ? [
-                                  ...state.savedChartVersion.metricQuery.sorts,
+                                  ...state.unsavedChartVersion.metricQuery
+                                      .sorts,
                                   {
                                       fieldId: sortFieldId,
                                       descending: false,
                                   },
                               ]
-                            : state.savedChartVersion.metricQuery.sorts.reduce<
+                            : state.unsavedChartVersion.metricQuery.sorts.reduce<
                                   SortField[]
                               >((acc, sf) => {
                                   if (sf.fieldId !== sortFieldId) {
@@ -348,15 +350,15 @@ function reducer(
         }
         case ActionType.SET_SORT_FIELDS: {
             const activeFields = new Set([
-                ...state.savedChartVersion.metricQuery.dimensions,
-                ...state.savedChartVersion.metricQuery.metrics,
+                ...state.unsavedChartVersion.metricQuery.dimensions,
+                ...state.unsavedChartVersion.metricQuery.metrics,
             ]);
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         sorts: action.payload.filter((sf) =>
                             activeFields.has(sf.fieldId),
                         ),
@@ -367,10 +369,10 @@ function reducer(
         case ActionType.SET_ROW_LIMIT: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         limit: action.payload,
                     },
                 },
@@ -379,10 +381,10 @@ function reducer(
         case ActionType.SET_FILTERS: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         filters: action.payload,
                     },
                 },
@@ -391,10 +393,10 @@ function reducer(
         case ActionType.SET_ADDITIONAL_METRICS: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         additionalMetrics: action.payload,
                     },
                 },
@@ -403,14 +405,14 @@ function reducer(
         case ActionType.SET_COLUMN_ORDER: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder: calcColumnOrder(action.payload, [
-                            ...state.savedChartVersion.metricQuery.dimensions,
-                            ...state.savedChartVersion.metricQuery.metrics,
-                            ...state.savedChartVersion.metricQuery.tableCalculations.map(
+                            ...state.unsavedChartVersion.metricQuery.dimensions,
+                            ...state.unsavedChartVersion.metricQuery.metrics,
+                            ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
                                 ({ name }) => name,
                             ),
                         ]),
@@ -420,25 +422,26 @@ function reducer(
         }
         case ActionType.ADD_TABLE_CALCULATION: {
             const newTableCalculations = [
-                ...state.savedChartVersion.metricQuery.tableCalculations,
+                ...state.unsavedChartVersion.metricQuery.tableCalculations,
                 action.payload,
             ];
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         tableCalculations: newTableCalculations,
                     },
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder: calcColumnOrder(
-                            state.savedChartVersion.tableConfig.columnOrder,
+                            state.unsavedChartVersion.tableConfig.columnOrder,
                             [
-                                ...state.savedChartVersion.metricQuery
+                                ...state.unsavedChartVersion.metricQuery
                                     .dimensions,
-                                ...state.savedChartVersion.metricQuery.metrics,
+                                ...state.unsavedChartVersion.metricQuery
+                                    .metrics,
                                 ...newTableCalculations.map(({ name }) => name),
                             ],
                         ),
@@ -449,12 +452,12 @@ function reducer(
         case ActionType.UPDATE_TABLE_CALCULATION: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         tableCalculations:
-                            state.savedChartVersion.metricQuery.tableCalculations.map(
+                            state.unsavedChartVersion.metricQuery.tableCalculations.map(
                                 (tableCalculation) =>
                                     tableCalculation.name ===
                                     action.payload.oldName
@@ -463,9 +466,9 @@ function reducer(
                             ),
                     },
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder:
-                            state.savedChartVersion.tableConfig.columnOrder.map(
+                            state.unsavedChartVersion.tableConfig.columnOrder.map(
                                 (column) =>
                                     column === action.payload.oldName
                                         ? action.payload.tableCalculation.name
@@ -477,26 +480,27 @@ function reducer(
         }
         case ActionType.DELETE_TABLE_CALCULATION: {
             const newTableCalculations =
-                state.savedChartVersion.metricQuery.tableCalculations.filter(
+                state.unsavedChartVersion.metricQuery.tableCalculations.filter(
                     (tableCalculation) =>
                         tableCalculation.name !== action.payload,
                 );
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     metricQuery: {
-                        ...state.savedChartVersion.metricQuery,
+                        ...state.unsavedChartVersion.metricQuery,
                         tableCalculations: newTableCalculations,
                     },
                     tableConfig: {
-                        ...state.savedChartVersion.tableConfig,
+                        ...state.unsavedChartVersion.tableConfig,
                         columnOrder: calcColumnOrder(
-                            state.savedChartVersion.tableConfig.columnOrder,
+                            state.unsavedChartVersion.tableConfig.columnOrder,
                             [
-                                ...state.savedChartVersion.metricQuery
+                                ...state.unsavedChartVersion.metricQuery
                                     .dimensions,
-                                ...state.savedChartVersion.metricQuery.metrics,
+                                ...state.unsavedChartVersion.metricQuery
+                                    .metrics,
                                 ...newTableCalculations.map(({ name }) => name),
                             ],
                         ),
@@ -507,8 +511,8 @@ function reducer(
         case ActionType.SET_PIVOT_FIELDS: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     pivotConfig: {
                         columns: action.payload,
                     },
@@ -518,11 +522,11 @@ function reducer(
         case ActionType.SET_CHART_TYPE: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     chartConfig: getValidChartConfig(
                         action.payload,
-                        state.savedChartVersion.chartConfig.config,
+                        state.unsavedChartVersion.chartConfig.config,
                     ),
                 },
             };
@@ -530,10 +534,10 @@ function reducer(
         case ActionType.SET_CHART_CONFIG: {
             return {
                 ...state,
-                savedChartVersion: {
-                    ...state.savedChartVersion,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
                     chartConfig: getValidChartConfig(
-                        state.savedChartVersion.chartConfig.type,
+                        state.unsavedChartVersion.chartConfig.type,
                         action.payload,
                     ),
                 },
@@ -557,9 +561,9 @@ export const ExplorerProvider: FC<{
         [Set<FieldId>, boolean]
     >(() => {
         const fields = new Set([
-            ...reducerState.savedChartVersion.metricQuery.dimensions,
-            ...reducerState.savedChartVersion.metricQuery.metrics,
-            ...reducerState.savedChartVersion.metricQuery.tableCalculations.map(
+            ...reducerState.unsavedChartVersion.metricQuery.dimensions,
+            ...reducerState.unsavedChartVersion.metricQuery.metrics,
+            ...reducerState.unsavedChartVersion.metricQuery.tableCalculations.map(
                 ({ name }) => name,
             ),
         ]);
@@ -666,7 +670,7 @@ export const ExplorerProvider: FC<{
     const addTableCalculation = useCallback(
         (tableCalculation: TableCalculation) => {
             if (
-                reducerState.savedChartVersion.metricQuery.tableCalculations.findIndex(
+                reducerState.unsavedChartVersion.metricQuery.tableCalculations.findIndex(
                     ({ name }) => name === tableCalculation.name,
                 ) > -1
             ) {
@@ -685,7 +689,7 @@ export const ExplorerProvider: FC<{
         (oldName: string, tableCalculation: TableCalculation) => {
             if (
                 oldName !== tableCalculation.name &&
-                reducerState.savedChartVersion.metricQuery.tableCalculations.findIndex(
+                reducerState.unsavedChartVersion.metricQuery.tableCalculations.findIndex(
                     ({ name }) => name === tableCalculation.name,
                 ) > -1
             ) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- make the explorer provider state as close as possible as the saved chart version

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
