### PR TITLE
fix: compare all chart properies to detect unsaved changes

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1247,3 +1247,34 @@ export function formatRows(
         }, {}),
     );
 }
+
+const isObject = (object: any) => object != null && typeof object === 'object';
+export const removeEmptyProperties = (object: Record<string, any>) => {
+    const newObj: Record<string, any> = {};
+    Object.keys(object).forEach((key) => {
+        if (object[key] === Object(object[key]))
+            newObj[key] = removeEmptyProperties(object[key]);
+        else if (object[key] !== undefined && object[key] !== null)
+            newObj[key] = object[key];
+    });
+    return newObj;
+};
+export const deepEqual = (
+    object1: Record<string, any>,
+    object2: Record<string, any>,
+): boolean => {
+    const keys1 = Object.keys(object1);
+    const keys2 = Object.keys(object2);
+    if (keys1.length !== keys2.length) {
+        return false;
+    }
+    return keys1.every((key) => {
+        const val1: any = object1[key];
+        const val2: any = object2[key];
+        const areObjects = isObject(val1) && isObject(val2);
+        return !(
+            (areObjects && !deepEqual(val1, val2)) ||
+            (!areObjects && val1 !== val2)
+        );
+    });
+};

--- a/packages/frontend/src/components/Explorer.tsx
+++ b/packages/frontend/src/components/Explorer.tsx
@@ -15,14 +15,12 @@ import { Popover2 } from '@blueprintjs/popover2';
 import {
     ChartType,
     countTotalFilterRules,
-    CreateSavedChartVersion,
     DashboardBasicDetails,
     DimensionType,
     fieldId,
     getResultValues,
     getVisibleFields,
     isFilterableField,
-    SavedChart,
 } from 'common';
 import { FC, useEffect, useState } from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
@@ -76,7 +74,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         { fromExplorer?: boolean; explore?: boolean } | undefined
     >();
     const {
-        state: { chartName, unsavedChartVersion },
+        state: { chartName, unsavedChartVersion, hasUnsavedChanges },
         queryResults,
         actions: {
             setRowLimit,
@@ -167,22 +165,6 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
         }
     };
 
-    const hasUnsavedChanges = (): boolean => {
-        const filterData = (
-            d: SavedChart | CreateSavedChartVersion | undefined,
-        ) => {
-            return {
-                chartConfig: d?.chartConfig,
-                metricQuery: d?.metricQuery,
-                tableConfig: d?.tableConfig,
-            };
-        };
-
-        return (
-            JSON.stringify(filterData(data)) !==
-            JSON.stringify(filterData(unsavedChartVersion))
-        );
-    };
     return (
         <>
             <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
@@ -334,7 +316,7 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                         }
                                         disabled={
                                             !unsavedChartVersion.tableName ||
-                                            !hasUnsavedChanges()
+                                            !hasUnsavedChanges
                                         }
                                         onClick={
                                             overrideQueryUuid
@@ -353,19 +335,19 @@ export const Explorer: FC<Props> = ({ savedQueryUuid }) => {
                                                 <Menu>
                                                     <MenuItem
                                                         icon={
-                                                            hasUnsavedChanges()
+                                                            hasUnsavedChanges
                                                                 ? 'add'
                                                                 : 'duplicate'
                                                         }
                                                         text={
-                                                            hasUnsavedChanges()
+                                                            hasUnsavedChanges
                                                                 ? 'Save chart as'
                                                                 : 'Duplicate'
                                                         }
                                                         onClick={() => {
                                                             if (
                                                                 savedQueryUuid &&
-                                                                hasUnsavedChanges()
+                                                                hasUnsavedChanges
                                                             ) {
                                                                 setIsQueryModalOpen(
                                                                     true,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -163,9 +163,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                             tableCalculations,
                             additionalMetrics,
                         },
-                        pivotConfig: {
-                            columns: [],
-                        },
+                        pivotConfig: undefined,
                         tableConfig: {
                             columnOrder,
                         },

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -55,6 +55,7 @@ const SavedExplorer = () => {
                       }
                     : undefined
             }
+            savedChart={data}
         >
             <div
                 style={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1782 #1737

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- pass saved chart object into explorer provider ( is also going to be useful for future PRs )
- move logic to detect unsaved changes into explorer provider
- unsaved logic now compares all necessary properties 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
