### PR TITLE
refactor: expose saved chart in explorer provider

### DIFF
--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -103,7 +103,7 @@ const SavedExplorer = () => {
                         minWidth: 0,
                     }}
                 >
-                    <Explorer savedQueryUuid={pathParams.savedQueryUuid} />
+                    <Explorer />
                 </div>
             </div>
         </ExplorerProvider>

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -111,6 +111,7 @@ export interface ExplorerState extends ExplorerReduceState {
     activeFields: Set<FieldId>;
     isValidQuery: boolean;
     hasUnsavedChanges: boolean;
+    savedChart: SavedChart | undefined;
 }
 
 interface ExplorerContext {
@@ -739,8 +740,15 @@ export const ExplorerProvider: FC<{
             activeFields,
             isValidQuery,
             hasUnsavedChanges,
+            savedChart,
         }),
-        [reducerState, activeFields, isValidQuery, hasUnsavedChanges],
+        [
+            reducerState,
+            activeFields,
+            isValidQuery,
+            hasUnsavedChanges,
+            savedChart,
+        ],
     );
     const queryResults = useQueryResults(state);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- expose the saved chart in explorer provider
- clean explorer component props/state related to saved chart

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
