### PR TITLE
chore: new delete dashboard

### DIFF
--- a/packages/e2e/cypress/integration/savedDashboards.spec.ts
+++ b/packages/e2e/cypress/integration/savedDashboards.spec.ts
@@ -17,18 +17,6 @@ describe('Dashboard List', () => {
         cy.findByText('Jaffle dashboard').should('exist');
     });
 
-    it('Should delete dashboards', () => {
-        cy.visit('/');
-        cy.findByRole('button', { name: 'Browse' }).click();
-        cy.findByRole('button', { name: 'Dashboards' }).click();
-        // click on delete
-        cy.get('[data-icon=more]').click();
-        cy.findByRole('button', { name: 'Delete' }).click();
-        // click on delete in the popup
-        cy.findByText('Delete').click();
-        cy.findByText('No results available');
-    });
-
     it('Should create a new dashboard', () => {
         cy.visit('/');
         cy.findByRole('button', { name: 'Browse' }).click();
@@ -47,13 +35,25 @@ describe('Dashboard List', () => {
         cy.findByRole('button', { name: 'Browse' }).click();
         cy.findByRole('button', { name: 'Dashboards' }).click();
         // click on rename
-        cy.get('[data-icon=more]').click();
+        cy.contains('Untitled dashboard').children().eq(1).click();
         cy.findByRole('button', { name: 'Rename' }).click();
-        cy.findByLabelText('Name *').clear().type('Jaffle dashboard');
+        cy.findByLabelText('Name *').clear().type('e2e dashboard');
         // click on save
         cy.findByRole('button', { name: 'Save' }).click();
 
         // verify dashboard name has been updated in the list
-        cy.findByText('Jaffle dashboard').should('exist');
+        cy.findByText('e2e dashboard').should('exist');
+    });
+
+    it('Should delete dashboards', () => {
+        cy.visit('/');
+        cy.findByRole('button', { name: 'Browse' }).click();
+        cy.findByRole('button', { name: 'Dashboards' }).click();
+        // click on delete
+        cy.contains('e2e dashboard').children().eq(1).click();
+        cy.findByRole('button', { name: 'Delete' }).click();
+        // click on delete in the popup
+        cy.findByText('Delete').click();
+        cy.findByText('Jaffle dashboard'); // still exists
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: [<!-- reference the related issue e.g. #150 -->
](https://github.com/lightdash/lightdash-internal-work/issues/291#issuecomment-1109487860)
### Description:
Allow multiple test runs by deleting a previously created dashbaord, instead of deleting `jaffle shop` dashboard 

### Preview:
![Peek 2022-04-26 10-52](https://user-images.githubusercontent.com/1983672/165262584-b17952fb-0696-446d-be50-196db32b549e.gif)


### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [x] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
