### PR TITLE
fix: updating saved visualization type no longer breaks UI

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -163,3 +163,7 @@ export const ECHARTS_DEFAULT_COLORS = [
 
 export const getDefaultSeriesColor = (index: number) =>
     ECHARTS_DEFAULT_COLORS[index % ECHARTS_DEFAULT_COLORS.length];
+
+export const isSeriesWithMixedChartTypes = (
+    series: Series[] | undefined,
+): boolean => new Set(series?.map(({ type }) => type)).size >= 2;

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -8,6 +8,7 @@ import {
     getSeriesId,
     isDimension,
     isField,
+    isSeriesWithMixedChartTypes,
     Series,
     TableCalculation,
 } from 'common';
@@ -126,7 +127,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         .size === 1;
 
                 const isChartTypeTheSameForAllSeries: boolean =
-                    new Set(seriesGroup.map(({ type }) => type)).size === 1;
+                    !isSeriesWithMixedChartTypes(seriesGroup);
 
                 const hasDivider = layout?.yField?.length !== i + 1;
 

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,6 +1,10 @@
 import { Button, IconName } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { CartesianSeriesType, ChartType } from 'common';
+import {
+    CartesianSeriesType,
+    ChartType,
+    isSeriesWithMixedChartTypes,
+} from 'common';
 import React, { FC, useMemo, useState } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import {
@@ -22,9 +26,9 @@ const VisualizationCardOptions: FC = () => {
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const isChartTypeTheSameForAllSeries: boolean =
-        new Set(
-            cartesianConfig.dirtyEchartsConfig?.series?.map(({ type }) => type),
-        ).size === 1;
+        !isSeriesWithMixedChartTypes(
+            cartesianConfig.dirtyEchartsConfig?.series,
+        );
 
     const selectedChartType = useMemo<{ text: string; icon: IconName }>(() => {
         switch (chartType) {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -94,7 +94,6 @@ export const VisualizationProvider: FC<Props> = ({
             : undefined,
         validPivotDimensions?.[0],
         resultsData,
-        chartConfigs !== undefined,
         setPivotDimensions,
     );
 

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -14,11 +14,11 @@ const useCartesianChartConfig = (
     chartConfigs: CartesianChart | undefined,
     pivotKey: string | undefined,
     resultsData: ApiQueryResults | undefined,
-    isSaved: boolean,
     setPivotDimensions: React.Dispatch<
         React.SetStateAction<string[] | undefined>
     >,
 ) => {
+    const hasInitialValue = !!chartConfigs;
     const [dirtyChartType, setChartType] = useState<CartesianSeriesType>(
         chartConfigs?.eChartsConfig?.series?.[0]?.type ||
             CartesianSeriesType.BAR,
@@ -220,7 +220,7 @@ const useCartesianChartConfig = (
         };
 
         // Only load this if there are no existing chart configuration (not saved)
-        if (isSaved) return;
+        if (hasInitialValue) return;
 
         // one metric , one dimension
         if (availableMetrics.length === 1 && availableDimensions.length === 1) {
@@ -309,7 +309,7 @@ const useCartesianChartConfig = (
         availableDimensions,
         availableMetrics,
         availableTableCalculations,
-        isSaved,
+        hasInitialValue,
         setPivotDimensions,
         setType,
     ]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1821

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/91080fe0b1dc487488b99b904aa21024">
    <p>Lightdash - fix changing chart type - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/91080fe0b1dc487488b99b904aa21024-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
