### PR TITLE
feat: add search to saved charts

### DIFF
--- a/packages/frontend/src/components/common/ActionCardList/ActionCardList.style.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/ActionCardList.style.tsx
@@ -39,3 +39,7 @@ export const ActionCardWrapper = styled.div`
 export const NoIdealStateWrapper = styled.div`
     padding: 50px 0;
 `;
+
+export const SearchWrapper = styled.div`
+    margin-bottom: 20px;
+`;

--- a/packages/frontend/src/components/common/ActionCardList/index.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/index.tsx
@@ -58,7 +58,7 @@ const ActionCardList = <
         actionType: ActionTypeModal.CLOSE,
     });
 
-    const displaySearch = isChart && dataList.length >= 5;
+    const displaySearch = isChart && dataList.length >= 5 && !isHomePage;
 
     const filteredQueries = useMemo(() => {
         const validSearch = search ? search.toLowerCase() : '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1312 

### Description:
This PR adds search to the saved queries pages when there are 5 or more saved charts.

### Preview:

![Screenshot 2022-04-29 at 11 25 38](https://user-images.githubusercontent.com/31137824/165927787-3389909b-1977-411f-9a66-1259d1536dc9.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
