### PR TITLE
fix: remove options button from the explorer header

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreHeader/ExploreHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreHeader/ExploreHeader.tsx
@@ -1,5 +1,3 @@
-import { Menu, MenuItem } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
 import { FC } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
@@ -9,7 +7,7 @@ import { SectionName } from '../../../types/Events';
 import EditableHeader from '../../common/EditableHeader';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshServerButton from '../../RefreshServer';
-import { OptionsButton, TitleWrapper, Wrapper } from './ExploreHeader.styles';
+import { TitleWrapper, Wrapper } from './ExploreHeader.styles';
 
 const ExploreHeader: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -42,24 +40,6 @@ const ExploreHeader: FC = () => {
                 </TitleWrapper>
                 <RefreshButton />
                 <RefreshServerButton />
-                <Popover2
-                    content={
-                        <Menu>
-                            <MenuItem
-                                icon="cog"
-                                text="Project settings"
-                                href={`/projects/${projectUuid}/settings`}
-                            />
-                        </Menu>
-                    }
-                    placement="bottom"
-                    disabled={!unsavedChartVersion.tableName}
-                >
-                    <OptionsButton
-                        icon="more"
-                        disabled={!unsavedChartVersion.tableName}
-                    />
-                </Popover2>
             </Wrapper>
         </TrackSection>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1688 

### Description:
Remove options menu from the explorer header

### Preview:
![Screenshot 2022-04-29 at 15 02 09](https://user-images.githubusercontent.com/31137824/165960044-4c61c482-78d5-4a7f-ae45-ea6742a8f968.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
