### PR TITLE
fix: unstable table tree menus

### DIFF
--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -2,6 +2,7 @@ import { LightdashMode } from 'common';
 import React, {
     createContext,
     FC,
+    memo,
     useCallback,
     useContext,
     useEffect,
@@ -277,8 +278,11 @@ export const TrackPage: FC<PageData> = ({ children, ...rest }) => {
     );
 };
 
-export const TrackSection: FC<SectionData> = ({ children, ...rest }) => (
-    <NestedTrackingProvider section={rest}>
-        {children || null}
-    </NestedTrackingProvider>
-);
+export const TrackSection: FC<SectionData> = memo(({ children, name }) => {
+    const section = useMemo(() => ({ name }), [name]);
+    return (
+        <NestedTrackingProvider section={section}>
+            {children || null}
+        </NestedTrackingProvider>
+    );
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1931 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

This was a hard one to find. 
The menu would disappear because the menuitems array was being rebuild when it shouldn't so the element references would change and the menu would close.
I found out that the problem was in the `<TrackSection />` since it was always marking the section as changed when it wasn't. The menuitems `useMemo` was dependent on the `track` method which was constantly being changed, triggering the hook. 


### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
