### PR TITLE
fix: Redirect user to the home pack when a chart is deleted from the …

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -320,7 +320,7 @@ const VisualizationCard: FC = () => {
 
                                 if (savedChart?.uuid) {
                                     deleteData(savedChart.uuid);
-                                    history.goBack();
+                                    history.push('/');
                                 }
 
                                 setIsDeleteDialogOpen(false);


### PR DESCRIPTION
…explorer

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1853 

### Description:
This PR will fix the issue on deleting duplicated charts, after a chart is duplicated and deleted from within the explorer, the user will be redirected to the home page.

### Preview:
https://www.loom.com/share/e71cd1dd312746b5bbc4a9de03cec80a

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
