### PR TITLE
fix: rollback dbt form reset

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@blueprintjs/core';
 import { ProjectType, ProjectTypeLabels } from 'common';
 import { FC, useMemo, useState } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { useApp } from '../../providers/AppProvider';
 import FormSection from '../ReactHookForm/FormSection';
 import Input from '../ReactHookForm/Input';
@@ -23,8 +23,6 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     disabled,
     defaultType,
 }) => {
-    const { reset } = useFormContext();
-
     const type: ProjectType = useWatch({
         name: 'dbt.type',
         defaultValue: defaultType || ProjectType.GITHUB,
@@ -55,8 +53,6 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     }, [health, type]);
 
     const form = useMemo(() => {
-        reset({ 'dbt.type': type }); // Reset all defaultValues in forms
-
         switch (type) {
             case ProjectType.DBT:
                 return <DbtLocalForm />;
@@ -75,7 +71,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                 return null;
             }
         }
-    }, [disabled, type, reset]);
+    }, [disabled, type]);
 
     const baseDocUrl =
         'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1783

### Description:
There was a bug on this previous code, so I'm rolling back. But ideally we should fix this . I've tried with KeepValues, and a few other things in this  `reset` but that doesn't work https://react-hook-form.com/api/useform/reset

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
