### PR TITLE
feat: add message and button to create new charts when none are saved

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -1,5 +1,6 @@
 import { Intent, NonIdealState } from '@blueprintjs/core';
 import React, { FC } from 'react';
+import { useParams } from 'react-router-dom';
 import { useSavedCharts } from '../../../hooks/useSpaces';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -32,23 +33,25 @@ const RunQueryButton: FC<{ projectId: string }> = ({ projectId }) => (
     </ButtonWrapper>
 );
 
-const NoSavedChartsAvailable = () => (
+const NoSavedChartsAvailable = ({ isChart = false }) => (
     <EmptyStateWrapper>
         <EmptyStateIcon icon="grouped-bar-chart" size={59} />
         <Title>You haven’t saved any charts yet.</Title>
         <p>
-            Create a saved chart from your queries so you can add it to this
-            dashboard!
+            {`Create a saved chart from your queries so you can ${
+                isChart ? 'find it here!' : 'add it to this dashboard!'
+            }`}
         </p>
     </EmptyStateWrapper>
 );
 
 interface Props {
-    projectId: string;
+    isChart?: boolean;
 }
 
-const EmptyStateNoTiles: FC<Props> = ({ projectId }) => {
-    const savedChartsRequest = useSavedCharts(projectId);
+const EmptyStateNoTiles: FC<Props> = ({ isChart }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const savedChartsRequest = useSavedCharts(projectUuid);
     const savedCharts = savedChartsRequest.data || [];
     const hasSavedCharts = savedCharts.length > 0;
 
@@ -60,18 +63,22 @@ const EmptyStateNoTiles: FC<Props> = ({ projectId }) => {
                         hasSavedCharts ? (
                             <SavedChartsAvailable />
                         ) : (
-                            <NoSavedChartsAvailable />
+                            <NoSavedChartsAvailable isChart={isChart} />
                         )
                     }
                     action={
                         !hasSavedCharts ? (
-                            <RunQueryButton projectId={projectId} />
+                            <RunQueryButton projectId={projectUuid} />
                         ) : undefined
                     }
                 />
             </div>
         </TrackSection>
     );
+};
+
+EmptyStateNoTiles.defaultProps = {
+    isChart: false,
 };
 
 export default EmptyStateNoTiles;

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -33,23 +33,18 @@ const RunQueryButton: FC<{ projectId: string }> = ({ projectId }) => (
     </ButtonWrapper>
 );
 
-const NoSavedChartsAvailable = ({ isChart = false }) => (
+const NoSavedChartsAvailable = () => (
     <EmptyStateWrapper>
         <EmptyStateIcon icon="grouped-bar-chart" size={59} />
         <Title>You haven’t saved any charts yet.</Title>
         <p>
-            {`Create a saved chart from your queries so you can ${
-                isChart ? 'find it here!' : 'add it to this dashboard!'
-            }`}
+            Create a saved chart from your queries so you can add it to this
+            dashboard!
         </p>
     </EmptyStateWrapper>
 );
 
-interface Props {
-    isChart?: boolean;
-}
-
-const EmptyStateNoTiles: FC<Props> = ({ isChart }) => {
+const EmptyStateNoTiles: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const savedChartsRequest = useSavedCharts(projectUuid);
     const savedCharts = savedChartsRequest.data || [];
@@ -63,7 +58,7 @@ const EmptyStateNoTiles: FC<Props> = ({ isChart }) => {
                         hasSavedCharts ? (
                             <SavedChartsAvailable />
                         ) : (
-                            <NoSavedChartsAvailable isChart={isChart} />
+                            <NoSavedChartsAvailable />
                         )
                     }
                     action={
@@ -75,10 +70,6 @@ const EmptyStateNoTiles: FC<Props> = ({ isChart }) => {
             </div>
         </TrackSection>
     );
-};
-
-EmptyStateNoTiles.defaultProps = {
-    isChart: false,
 };
 
 export default EmptyStateNoTiles;

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -9,7 +9,7 @@ import { useSavedCharts } from '../../../hooks/useSpaces';
 import ActionCardList from '../../common/ActionCardList';
 import SavedQueryForm from '../../SavedQueries/SavedQueryForm';
 import LatestCard from '../LatestCard';
-import { CreateChartButton, ViewAllButton } from './LatestSavedCharts.style';
+import { ViewAllButton } from './LatestSavedCharts.style';
 
 const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const savedChartsRequest = useSavedCharts(projectUuid);
@@ -58,16 +58,6 @@ const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 isHomePage
                 isChart
             />
-
-            {savedCharts.length === 0 && (
-                <CreateChartButton
-                    minimal
-                    href={`/projects/${projectUuid}/tables`}
-                    intent="primary"
-                >
-                    + Create a saved chart
-                </CreateChartButton>
-            )}
         </LatestCard>
     );
 };

--- a/packages/frontend/src/components/SavedQueries/EmptySavedChartsState/EmptySavedChartsState.styles.tsx
+++ b/packages/frontend/src/components/SavedQueries/EmptySavedChartsState/EmptySavedChartsState.styles.tsx
@@ -1,0 +1,25 @@
+import { AnchorButton, Colors, H4, Icon } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const EmptyStateWrapper = styled.div`
+    max-width: 22em;
+`;
+
+export const EmptyStateIcon = styled(Icon)`
+    path {
+        fill: ${Colors.GRAY3};
+    }
+`;
+
+export const Title = styled(H4)`
+    margin: 1em auto;
+`;
+
+export const ButtonWrapper = styled.div`
+    width: 100%;
+`;
+
+export const CTA = styled(AnchorButton)`
+    background: ${Colors.BLUE3};
+    border: none;
+`;

--- a/packages/frontend/src/components/SavedQueries/EmptySavedChartsState/index.tsx
+++ b/packages/frontend/src/components/SavedQueries/EmptySavedChartsState/index.tsx
@@ -1,0 +1,49 @@
+import { Intent, NonIdealState } from '@blueprintjs/core';
+import React, { FC } from 'react';
+import { useParams } from 'react-router-dom';
+import { TrackSection } from '../../../providers/TrackingProvider';
+import { SectionName } from '../../../types/Events';
+import {
+    ButtonWrapper,
+    CTA,
+    EmptyStateIcon,
+    EmptyStateWrapper,
+    Title,
+} from './EmptySavedChartsState.styles';
+
+const EmptySavedChartsState: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    return (
+        <TrackSection name={SectionName.EMPTY_RESULTS_TABLE}>
+            <div style={{ padding: '50px 0' }}>
+                <NonIdealState
+                    description={
+                        <EmptyStateWrapper>
+                            <EmptyStateIcon
+                                icon="grouped-bar-chart"
+                                size={59}
+                            />
+                            <Title>You haven’t saved any charts yet.</Title>
+                            <p>
+                                Create a saved chart from your queries so you
+                                can find it here!
+                            </p>
+                        </EmptyStateWrapper>
+                    }
+                    action={
+                        <ButtonWrapper>
+                            <CTA
+                                text="Run a query"
+                                intent={Intent.PRIMARY}
+                                href={`/projects/${projectUuid}/tables`}
+                            />
+                        </ButtonWrapper>
+                    }
+                />
+            </div>
+        </TrackSection>
+    );
+};
+
+export default EmptySavedChartsState;

--- a/packages/frontend/src/components/common/ActionCardList/index.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/index.tsx
@@ -3,8 +3,8 @@ import { ApiError, UpdatedByUser } from 'common';
 import Fuse from 'fuse.js';
 import React, { useMemo, useState } from 'react';
 import { UseMutationResult } from 'react-query';
-import EmptyStateNoTiles from '../../DashboardTiles/EmptyStateNoTiles';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
+import EmptySavedChartsState from '../../SavedQueries/EmptySavedChartsState';
 import ActionCard from '../ActionCard';
 import { ActionModalProps, ActionTypeModal } from '../modal/ActionModal';
 import DeleteActionModal from '../modal/DeleteActionModal';
@@ -157,13 +157,13 @@ const ActionCardList = <
 
             {dataList.length <= 0 && (
                 <NoIdealStateWrapper>
-                    {!isChart ? (
+                    {isChart ? (
+                        <EmptySavedChartsState />
+                    ) : (
                         <NonIdealState
                             title="No results available"
                             icon="search"
                         />
-                    ) : (
-                        <EmptyStateNoTiles isChart />
                     )}
                 </NoIdealStateWrapper>
             )}

--- a/packages/frontend/src/components/common/ActionCardList/index.tsx
+++ b/packages/frontend/src/components/common/ActionCardList/index.tsx
@@ -3,6 +3,7 @@ import { ApiError, UpdatedByUser } from 'common';
 import Fuse from 'fuse.js';
 import React, { useMemo, useState } from 'react';
 import { UseMutationResult } from 'react-query';
+import EmptyStateNoTiles from '../../DashboardTiles/EmptyStateNoTiles';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import ActionCard from '../ActionCard';
 import { ActionModalProps, ActionTypeModal } from '../modal/ActionModal';
@@ -156,7 +157,14 @@ const ActionCardList = <
 
             {dataList.length <= 0 && (
                 <NoIdealStateWrapper>
-                    <NonIdealState title="No results available" icon="search" />
+                    {!isChart ? (
+                        <NonIdealState
+                            title="No results available"
+                            icon="search"
+                        />
+                    ) : (
+                        <EmptyStateNoTiles isChart />
+                    )}
                 </NoIdealStateWrapper>
             )}
         </ActionCardListWrapper>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -302,9 +302,7 @@ const Dashboard = () => {
                         );
                     })}
                 </ResponsiveGridLayout>
-                {dashboardTiles.length <= 0 && (
-                    <EmptyStateNoTiles projectId={projectUuid} />
-                )}
+                {dashboardTiles.length <= 0 && <EmptyStateNoTiles />}
             </Page>
         </>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1674 

### Description:
This PR adds a message and run a query button when there are no available charts in the saved charts section

### Preview:
![Screenshot 2022-05-04 at 13 58 10](https://user-images.githubusercontent.com/31137824/166686658-eb9471e7-066f-47ba-baa9-44b0933724bc.png)
![Screenshot 2022-05-04 at 13 58 02](https://user-images.githubusercontent.com/31137824/166686663-65d87b0e-49c2-4953-884d-10a02bf3bed6.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
