### PR TITLE
fix: default chart colors

### DIFF
--- a/packages/frontend/src/components/UserSettingsModal/AppearancePanel/AppearancePanel.styles.ts
+++ b/packages/frontend/src/components/UserSettingsModal/AppearancePanel/AppearancePanel.styles.ts
@@ -6,21 +6,26 @@ export const AppearancePanelWrapper = styled.div`
     flex-direction: column;
 `;
 
-export const Title = styled.div``;
+export const Title = styled.h3`
+    margin: 0;
+`;
 export const ColorPalette = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    margin-top: 2em;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 20px;
 `;
 
-export const AppearanceColorWrapper = styled.div`
-    margin: 0 0.8em 1.5em 0;
-    line-height: 0.5em;
+export const ColorSquare = styled.div`
+    height: 30px;
+    width: 30px;
+    padding: 0.286em;
 `;
-export const ColorLabel = styled.input`
-    background-color: white;
-    padding: 0.313em;
-    border: 1px solid lightgray;
-    border-radius: 0 5px 5px 0px;
-    width: 5em;
+
+export const ColorSquareInner = styled.div`
+    height: 100%;
+    width: 100%;
+    border-radius: 1px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1885 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Had a chat with @PriPatel and we decided to make some UX changes here since we were fixing bugs.

Changes: 
- no more tooltip color picker. We know we need to pick a new color picket library but for now this doesn't seem useful in this page
- re-style elements to be similar to the rest of the app
- make sure we use the org colors after loading

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/502b6d3fc38e485197bb80c8e20a9093">
    <p>Lightdash - default chart colors - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/502b6d3fc38e485197bb80c8e20a9093-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
