### PR TITLE
fix: health dockerhub call

### DIFF
--- a/packages/backend/src/clients/DockerHub/DockerHub.ts
+++ b/packages/backend/src/clients/DockerHub/DockerHub.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import Logger from '../../logger';
 
 let dockerHubVersion: string | undefined;
 
@@ -31,7 +32,9 @@ async function updateDockerHubVersion() {
     if (version) dockerHubVersion = version;
 }
 setInterval(updateDockerHubVersion, 10 * 60 * 1000); // 10 minutes
-updateDockerHubVersion();
+updateDockerHubVersion().catch((e) =>
+    Logger.error(`Unable to update DockerHub version: ${e}`),
+);
 
 export function getDockerHubVersion(): string | undefined {
     return dockerHubVersion;

--- a/packages/backend/src/clients/DockerHub/DockerHub.ts
+++ b/packages/backend/src/clients/DockerHub/DockerHub.ts
@@ -1,0 +1,38 @@
+import fetch from 'node-fetch';
+
+let dockerHubVersion: string | undefined;
+
+const filterByName = (result: { name: string }): boolean =>
+    /[0-9.]+$/.test(result.name);
+
+const sorterByDate = (
+    a: { last_updated: string },
+    b: { last_updated: string },
+): number =>
+    Number(new Date(b.last_updated)) - Number(new Date(a.last_updated));
+
+async function fetchDockerHubVersion(): Promise<string | undefined> {
+    try {
+        const response = await fetch(
+            'https://hub.docker.com/v2/repositories/lightdash/lightdash/tags',
+            { method: 'GET' },
+        );
+        const version = (await response.json()).results
+            .filter(filterByName)
+            .sort(sorterByDate)[0].name;
+        return version;
+    } catch {
+        return undefined;
+    }
+}
+
+async function updateDockerHubVersion() {
+    const version = await fetchDockerHubVersion();
+    if (version) dockerHubVersion = version;
+}
+setInterval(updateDockerHubVersion, 10 * 60 * 1000); // 10 minutes
+updateDockerHubVersion();
+
+export function getDockerHubVersion(): string | undefined {
+    return dockerHubVersion;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1553

### Description:
Store version and refretch it every 10 mins in the background, making /health not blocking

### Preview:

![image](https://user-images.githubusercontent.com/1983672/166645082-0ca09eb6-567a-464c-bb55-3f7753579e47.png)


### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
