### PR TITLE
fix: table calculation reload

### DIFF
--- a/packages/frontend/src/components/TableCalculationHeaderButton.tsx
+++ b/packages/frontend/src/components/TableCalculationHeaderButton.tsx
@@ -24,7 +24,7 @@ const TableCalculationHeaderButton: FC<{
     const { track } = useTracking();
 
     return (
-        <div style={{ float: 'right' }}>
+        <div style={{ float: 'right' }} onClick={(e) => e.stopPropagation()}>
             <Popover2
                 isOpen={isOpen === undefined ? false : isOpen}
                 onInteraction={setIsOpen}

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -81,9 +81,6 @@ const TableCalculationModal: FC<Props> = ({
             <FlexForm
                 name="table_calculation"
                 methods={methods}
-                onClick={(e: any) => {
-                    e.stopPropagation();
-                }}
                 onSubmit={(data: TableCalculationFormInputs) => {
                     const { name, sql } = data;
                     try {

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -81,6 +81,9 @@ const TableCalculationModal: FC<Props> = ({
             <FlexForm
                 name="table_calculation"
                 methods={methods}
+                onClick={(e: any) => {
+                    e.stopPropagation();
+                }}
                 onSubmit={(data: TableCalculationFormInputs) => {
                     const { name, sql } = data;
                     try {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1905

### Description:

This is only affecting `updated table calculations` not on `create`
The problem is that on each click we make new queries to RunSQL , the popup is reloaded here https://github.com/lightdash/lightdash/blob/main/packages/frontend/src/components/ResultsTable/ResultsTable.tsx#L154

I simply stopped event propagation on the popup 

### Preview:
Before: 
![Peek 2022-05-04 12-15](https://user-images.githubusercontent.com/1983672/166663474-b8f9b87a-e9f4-49c8-88d4-928326995fb2.gif)


After: 


![Peek 2022-05-04 12-16](https://user-images.githubusercontent.com/1983672/166663481-543d66f8-b965-4b5b-9556-dfe33929b09d.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
