### PR TITLE
fix: add hover state to level 1 & 2 items in the tree

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -17,12 +17,13 @@ code {
 }
 
 /*sidebar-menus*/
-.bp4-tree-node-content-0:hover,
-.bp4-tree-node-content-1:hover {
+.bp4-tree-node-content-0:hover {
     background: none;
 }
 
-.bp4-tree-node-content-2 {
+.bp4-tree-node-content-1:hover,
+.bp4-tree-node-content-2:hover {
+    background: rgba(143, 153, 168, 0.15);
     cursor: pointer;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1962 

### Description:
This PR fixes the hover state missing from the explorer tree in the side bar when there is only 1 table available

### Preview:

![Screenshot 2022-05-04 at 15 07 43](https://user-images.githubusercontent.com/31137824/166699289-70219201-3835-4d8b-a971-60d3269b362d.png)
![Screenshot 2022-05-04 at 15 07 38](https://user-images.githubusercontent.com/31137824/166699294-8bf00e34-6f38-4363-8be8-996edeb50288.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
