### PR TITLE
style: update max height of sql input on full screen

### DIFF
--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.styles.ts
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.styles.ts
@@ -1,5 +1,5 @@
 import { Dialog } from '@blueprintjs/core';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import Form from '../ReactHookForm/Form';
 
 export const FlexForm = styled(Form)`
@@ -28,7 +28,9 @@ export const DialogBody = styled.div`
     flex-direction: column;
 `;
 
-export const TableCalculationSqlInputWrapper = styled.div`
+export const TableCalculationSqlInputWrapper = styled.div<{
+    $isFullScreen: boolean;
+}>`
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -40,9 +42,18 @@ export const TableCalculationSqlInputWrapper = styled.div`
             flex: 1;
             min-height: 100px;
 
-            .ace_editor {
-                min-height: 100px;
-            }
+            ${({ $isFullScreen }) =>
+                $isFullScreen
+                    ? css`
+                          .ace_editor {
+                              height: 100% !important;
+                          }
+                      `
+                    : css`
+                          .ace_editor {
+                              min-height: 100%;
+                          }
+                      `}
         }
     }
 `;

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -176,25 +176,23 @@ const TableCalculationModal: FC<Props> = ({
                             placeholder={SQL_PLACEHOLDER}
                         />
                     </TableCalculationSqlInputWrapper>
-                    <div className={Classes.DIALOG_FOOTER}>
-                        <DialogButtons
-                            className={Classes.DIALOG_FOOTER_ACTIONS}
-                        >
-                            <Switch
-                                checked={isFullscreen}
-                                label="Fullscreen"
-                                onChange={toggleFullscreen}
-                            />
-                            <Button onClick={onClose}>Cancel</Button>
-                            <Button
-                                type="submit"
-                                intent={Intent.PRIMARY}
-                                text="Save"
-                                loading={isDisabled}
-                            />
-                        </DialogButtons>
-                    </div>
                 </DialogBody>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <DialogButtons className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Switch
+                            checked={isFullscreen}
+                            label="Fullscreen"
+                            onChange={toggleFullscreen}
+                        />
+                        <Button onClick={onClose}>Cancel</Button>
+                        <Button
+                            type="submit"
+                            intent={Intent.PRIMARY}
+                            text="Save"
+                            loading={isDisabled}
+                        />
+                    </DialogButtons>
+                </div>
             </FlexForm>
         </TableCalculationDialog>
     );

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -155,7 +155,9 @@ const TableCalculationModal: FC<Props> = ({
                             </p>
                         </Callout>
                     )}
-                    <TableCalculationSqlInputWrapper>
+                    <TableCalculationSqlInputWrapper
+                        $isFullScreen={isFullscreen}
+                    >
                         <SqlInput
                             name="sql"
                             label="SQL"
@@ -174,23 +176,25 @@ const TableCalculationModal: FC<Props> = ({
                             placeholder={SQL_PLACEHOLDER}
                         />
                     </TableCalculationSqlInputWrapper>
+                    <div className={Classes.DIALOG_FOOTER}>
+                        <DialogButtons
+                            className={Classes.DIALOG_FOOTER_ACTIONS}
+                        >
+                            <Switch
+                                checked={isFullscreen}
+                                label="Fullscreen"
+                                onChange={toggleFullscreen}
+                            />
+                            <Button onClick={onClose}>Cancel</Button>
+                            <Button
+                                type="submit"
+                                intent={Intent.PRIMARY}
+                                text="Save"
+                                loading={isDisabled}
+                            />
+                        </DialogButtons>
+                    </div>
                 </DialogBody>
-                <div className={Classes.DIALOG_FOOTER}>
-                    <DialogButtons className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <Switch
-                            checked={isFullscreen}
-                            label="Fullscreen"
-                            onChange={toggleFullscreen}
-                        />
-                        <Button onClick={onClose}>Cancel</Button>
-                        <Button
-                            type="submit"
-                            intent={Intent.PRIMARY}
-                            text="Save"
-                            loading={isDisabled}
-                        />
-                    </DialogButtons>
-                </div>
             </FlexForm>
         </TableCalculationDialog>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1961 

### Description:
This PR fixes the creating table calculations not being able to exit full screen, the problem was that the sql input was taking full width which was pushing the modal's footer down.

### Preview:
![Screenshot 2022-05-04 at 16 46 08](https://user-images.githubusercontent.com/31137824/166719998-56251c1b-fc36-4037-b3d6-84fd792af7c6.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
