### PR TITLE
chore: refactor visualization provider to handle initial values

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -61,8 +61,8 @@ const ValidDashboardChartTile: FC<{
     return (
         <VisualizationProvider
             chartType={data.chartConfig.type}
-            chartConfigs={data?.chartConfig}
-            pivotDimensions={data.pivotConfig?.columns}
+            initialChartConfig={data.chartConfig}
+            initialPivotDimensions={data.pivotConfig?.columns}
             resultsData={resultData}
             tableName={data.tableName}
             isLoading={isLoading}
@@ -102,8 +102,10 @@ const DashboardChartTile: FC<Props> = (props) => {
     const { dashboardFilters, addDimensionDashboardFilter } =
         useDashboardContext();
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
-    const [contextMenuTargetOffset, setContextMenuTargetOffset] =
-        useState<{ left: number; top: number }>();
+    const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
+        left: number;
+        top: number;
+    }>();
     const contextMenuRenderTarget = useCallback(
         ({ ref }: Popover2TargetProps) => (
             <Portal>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -65,9 +65,11 @@ const VisualizationCard: FC = () => {
         <>
             <Card style={{ padding: 5, overflowY: 'scroll' }} elevation={1}>
                 <VisualizationProvider
-                    chartConfigs={savedChart?.chartConfig}
+                    initialChartConfig={unsavedChartVersion.chartConfig}
                     chartType={unsavedChartVersion.chartConfig.type}
-                    pivotDimensions={savedChart?.pivotConfig?.columns}
+                    initialPivotDimensions={
+                        unsavedChartVersion.pivotConfig?.columns
+                    }
                     tableName={unsavedChartVersion.tableName}
                     resultsData={queryResults.data}
                     isLoading={queryResults.isLoading}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -38,8 +38,8 @@ const Context = createContext<VisualizationContext | undefined>(undefined);
 
 type Props = {
     chartType: ChartType;
-    chartConfigs: ChartConfig | undefined;
-    pivotDimensions: string[] | undefined;
+    initialChartConfig: ChartConfig | undefined;
+    initialPivotDimensions: string[] | undefined;
     tableName: string | undefined;
     resultsData: ApiQueryResults | undefined;
     isLoading: boolean;
@@ -50,9 +50,9 @@ type Props = {
 };
 
 export const VisualizationProvider: FC<Props> = ({
-    chartConfigs,
+    initialChartConfig,
     chartType,
-    pivotDimensions,
+    initialPivotDimensions,
     tableName,
     resultsData,
     isLoading,
@@ -65,7 +65,7 @@ export const VisualizationProvider: FC<Props> = ({
     const chartRef = useRef<EChartsReact>(null);
     const { data: explore } = useExplore(tableName);
     const { validPivotDimensions, setPivotDimensions } = usePivotDimensions(
-        pivotDimensions,
+        initialPivotDimensions,
         resultsData,
     );
     const setChartType = useCallback(
@@ -81,16 +81,16 @@ export const VisualizationProvider: FC<Props> = ({
         setBigNumberLabel,
         validBigNumberConfig,
     } = useBigNumberConfig(
-        chartConfigs?.type === ChartType.BIG_NUMBER
-            ? chartConfigs.config
+        initialChartConfig?.type === ChartType.BIG_NUMBER
+            ? initialChartConfig.config
             : undefined,
         resultsData,
         explore,
     );
 
     const cartesianConfig = useCartesianChartConfig(
-        chartConfigs?.type === ChartType.CARTESIAN
-            ? chartConfigs.config
+        initialChartConfig?.type === ChartType.CARTESIAN
+            ? initialChartConfig.config
             : undefined,
         validPivotDimensions?.[0],
         resultsData,

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -11,37 +11,28 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const useCartesianChartConfig = (
-    chartConfigs: CartesianChart | undefined,
+    initialChartConfig: CartesianChart | undefined,
     pivotKey: string | undefined,
     resultsData: ApiQueryResults | undefined,
     setPivotDimensions: React.Dispatch<
         React.SetStateAction<string[] | undefined>
     >,
 ) => {
-    const hasInitialValue = !!chartConfigs;
+    const hasInitialValue = !!initialChartConfig;
     const [dirtyChartType, setChartType] = useState<CartesianSeriesType>(
-        chartConfigs?.eChartsConfig?.series?.[0]?.type ||
+        initialChartConfig?.eChartsConfig?.series?.[0]?.type ||
             CartesianSeriesType.BAR,
     );
     const [dirtyLayout, setDirtyLayout] = useState<
         Partial<CartesianChart['layout']> | undefined
-    >(chartConfigs?.layout);
+    >(initialChartConfig?.layout);
     const [dirtyEchartsConfig, setDirtyEchartsConfig] = useState<
         Partial<CartesianChart['eChartsConfig']> | undefined
-    >(chartConfigs?.eChartsConfig);
+    >(initialChartConfig?.eChartsConfig);
 
     const isStacked = (dirtyEchartsConfig?.series || []).some(
         (series: Series) => series.stack !== undefined,
     );
-
-    useEffect(() => {
-        setChartType(
-            chartConfigs?.eChartsConfig?.series?.[0]?.type ||
-                CartesianSeriesType.BAR,
-        );
-        setDirtyLayout(chartConfigs?.layout);
-        setDirtyEchartsConfig(chartConfigs?.eChartsConfig);
-    }, [chartConfigs]);
 
     const setXAxisName = useCallback((name: string) => {
         setDirtyEchartsConfig((prevState) => {

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -18,7 +18,11 @@ const useCartesianChartConfig = (
         React.SetStateAction<string[] | undefined>
     >,
 ) => {
-    const hasInitialValue = !!initialChartConfig;
+    const hasInitialValue =
+        !!initialChartConfig &&
+        isCompleteLayout(initialChartConfig.layout) &&
+        isCompleteEchartsConfig(initialChartConfig.eChartsConfig);
+
     const [dirtyChartType, setChartType] = useState<CartesianSeriesType>(
         initialChartConfig?.eChartsConfig?.series?.[0]?.type ||
             CartesianSeriesType.BAR,

--- a/packages/frontend/src/hooks/usePivotDimensions.ts
+++ b/packages/frontend/src/hooks/usePivotDimensions.ts
@@ -1,16 +1,13 @@
 import { ApiQueryResults, fieldId } from 'common';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 const usePivotDimensions = (
-    pivotDimensions: string[] | undefined,
+    initialPivotDimensions: string[] | undefined,
     resultsData: ApiQueryResults | undefined,
 ) => {
-    const [dirtyPivotDimensions, setPivotDimensions] =
-        useState(pivotDimensions);
-
-    useEffect(() => {
-        setPivotDimensions(pivotDimensions);
-    }, [pivotDimensions]);
+    const [dirtyPivotDimensions, setPivotDimensions] = useState(
+        initialPivotDimensions,
+    );
 
     const validPivotDimensions = useMemo(() => {
         if (resultsData) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Rename args to have accurate meaning
- The visualization provider and its internal hooks are responsible for managing the visualization state, after the initial load, so they shouldn't update their internal state based on arguments change. This removes the possibility of an infinite loop.

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
