### PR TITLE
feat: add description tooltip to charts in a dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -247,7 +247,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                 )
             }
             title={savedQueryWithDashboardFilters?.name || ''}
-            description={savedQuery?.description && savedQuery.description}
+            description={savedQuery?.description}
             isLoading={isLoading}
             extraMenuItems={
                 savedChartUuid !== null && (

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -247,6 +247,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                 )
             }
             title={savedQueryWithDashboardFilters?.name || ''}
+            description={savedQuery?.description && savedQuery.description}
             isLoading={isLoading}
             extraMenuItems={
                 savedChartUuid !== null && (

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -15,6 +15,12 @@ export const HeaderContainer = styled.div`
     gap: 20px;
 `;
 
+export const TitleWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+`;
+
 export const Title = styled(H5)`
     margin: 0;
 `;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -17,11 +17,13 @@ import {
     HeaderWrapper,
     TileBaseWrapper,
     Title,
+    TitleWrapper,
 } from './TileBase.styles';
 
 type Props<T> = {
     isEditMode: boolean;
     title: string;
+    description?: string;
     tile: T;
     isLoading?: boolean;
     extraMenuItems?: React.ReactNode;
@@ -35,6 +37,7 @@ type Props<T> = {
 const TileBase = <T extends Dashboard['tiles'][number]>({
     isEditMode,
     title,
+    description,
     tile,
     isLoading,
     extraMenuItems,
@@ -50,7 +53,14 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         <TileBaseWrapper className={isLoading ? Classes.SKELETON : undefined}>
             <HeaderContainer>
                 <HeaderWrapper>
-                    <Title className="non-draggable">{title}</Title>
+                    <TitleWrapper>
+                        <Title className="non-draggable">{title}</Title>
+                        {description && (
+                            <Tooltip2 content={description} position="bottom">
+                                <Button icon="info-sign" minimal />
+                            </Tooltip2>
+                        )}
+                    </TitleWrapper>
                     {extraHeaderElement}
                 </HeaderWrapper>
                 {(isEditMode || (!isEditMode && extraMenuItems)) && (
@@ -107,6 +117,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 TileBase.defaultProps = {
     isLoading: false,
     extraMenuItems: null,
+    description: null,
     isChart: false,
     hasFilters: false,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1941 

### Description:
this PR adds description tooltips to the charts in the dashboard tiles

### Preview:
![Screenshot 2022-05-05 at 15 41 36](https://user-images.githubusercontent.com/31137824/166948831-5815eb63-a3ad-4534-8334-f8f07d7b0f83.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
