### PR TITLE
fix: disabled add filter button on dashboard with tiles

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -27,7 +27,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     } = useDashboardContext();
     const { isLoading, data: filterableFields } =
         useAvailableDashboardFilterTargets(dashboard, dashboardTiles);
-    const hasTiles =
+    const hasChartTiles =
         dashboardTiles.filter(
             (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
         ).length >= 1;
@@ -48,7 +48,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     onInteraction={setIsOpen}
                     position="bottom-right"
                     lazy={false}
-                    disabled={!hasTiles || isLoading}
+                    disabled={!hasChartTiles || isLoading}
                 >
                     <Tooltip2
                         content={
@@ -65,7 +65,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                             minimal
                             icon="filter-list"
                             loading={isLoading}
-                            disabled={!hasTiles || isLoading}
+                            disabled={!hasChartTiles || isLoading}
                         >
                             Add filter
                         </FilterTrigger>

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -1,4 +1,5 @@
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
+import { DashboardTileTypes } from 'common';
 import React, { FC, useState } from 'react';
 import { useAvailableDashboardFilterTargets } from '../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../providers/DashboardProvider';
@@ -26,8 +27,10 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     } = useDashboardContext();
     const { isLoading, data: filterableFields } =
         useAvailableDashboardFilterTargets(dashboard, dashboardTiles);
-    const hasTiles = dashboard && dashboard.tiles.length >= 1;
-
+    const hasTiles =
+        dashboardTiles.filter(
+            (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+        ).length >= 1;
     return (
         <FiltersProvider fieldsMap={fieldsWithSuggestions}>
             <DashboardFilterWrapper>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -240,6 +240,10 @@ const Dashboard = () => {
         return <Spinner />;
     }
 
+    const dashboardChartTiles = dashboardTiles.filter(
+        (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+    );
+
     return (
         <>
             <Alert
@@ -277,7 +281,7 @@ const Dashboard = () => {
                 onCancel={onCancel}
             />
             <Page isContentFullWidth>
-                {dashboardTiles.length > 0 && (
+                {dashboardChartTiles.length > 0 && (
                     <DashboardFilter isEditMode={isEditMode} />
                 )}
                 <ResponsiveGridLayout


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1677

### Description:
Allow adding filter before dashboard is saved

Also, remove the filter button when there are no `chart` tiles (eg: markdown) 

### Preview:
![Peek 2022-05-06 09-27](https://user-images.githubusercontent.com/1983672/167087091-76759d8f-c944-4934-9447-2d126e368dc3.gif)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
