### PR TITLE
fix: back button to always point to the tables page

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -150,13 +150,11 @@ const ExploreSideBar = () => {
         },
         actions: { reset },
     } = useExplorer();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const history = useHistory();
+
     const onBack = () => {
         reset();
-        history.push({
-            pathname: `/projects/${projectUuid}/tables`,
-        });
+        history.goBack();
     };
 
     return (

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -15,7 +15,7 @@ const SavedExplorer = () => {
     });
     const onBack = () => {
         history.push({
-            pathname: `/projects/${pathParams.projectUuid}/home`,
+            pathname: `/projects/${pathParams.projectUuid}/tables`,
         });
     };
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -14,9 +14,7 @@ const SavedExplorer = () => {
         id: pathParams.savedQueryUuid,
     });
     const onBack = () => {
-        history.push({
-            pathname: `/projects/${pathParams.projectUuid}/tables`,
-        });
+        history.goBack();
     };
 
     if (isLoading) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #979 

### Description:
This PR makes the back button on the explorer to always redirect to the referrer page.

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
