### PR TITLE
chore: remove http dockerhub breadcrumb

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -77,6 +77,16 @@ Sentry.init({
     ],
     ignoreErrors: ['WarehouseQueryError'],
     tracesSampler,
+    beforeBreadcrumb(breadcrumb) {
+        if (
+            breadcrumb.category === 'http' &&
+            breadcrumb?.data?.url &&
+            breadcrumb.data.url.startsWith('https://hub.docker.com')
+        ) {
+            return null;
+        }
+        return breadcrumb;
+    },
 });
 app.use(
     Sentry.Handlers.requestHandler({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Removes http logs from dockerhub 

https://sentry.io/organizations/lightdash/issues/?project=5959292&query=&statsPeriod=1h

### Preview:
Before: 
![Screenshot from 2022-05-09 11-27-42](https://user-images.githubusercontent.com/1983672/167381656-7dcbcaae-4f2b-4830-b850-d8c43af9b126.png)



AFter: 
![Screenshot from 2022-05-09 11-26-46](https://user-images.githubusercontent.com/1983672/167381663-d64648e3-0873-4c3a-9523-142165dd3da7.png)


### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
