### PR TITLE
feat: order saved charts in saved queries page

### DIFF
--- a/packages/frontend/src/components/SavedQueries/SavedQueriesContent.tsx
+++ b/packages/frontend/src/components/SavedQueries/SavedQueriesContent.tsx
@@ -17,19 +17,25 @@ const SavedQueriesContent = ({
     savedQueries,
     projectUuid,
     isChart,
-}: SavedQueriesContentProps) => (
-    <ActionCardList
-        title="Saved charts"
-        useUpdate={useUpdateMutation}
-        useDelete={useDeleteMutation()}
-        dataList={savedQueries}
-        getURL={(savedQuery: SpaceQuery) => {
-            const { uuid } = savedQuery;
-            return `/projects/${projectUuid}/saved/${uuid}`;
-        }}
-        ModalContent={SavedQueryForm}
-        isChart={isChart}
-    />
-);
+}: SavedQueriesContentProps) => {
+    const orderedCharts = savedQueries.sort(
+        (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+    return (
+        <ActionCardList
+            title="Saved charts"
+            useUpdate={useUpdateMutation}
+            useDelete={useDeleteMutation()}
+            dataList={orderedCharts}
+            getURL={(savedQuery: SpaceQuery) => {
+                const { uuid } = savedQuery;
+                return `/projects/${projectUuid}/saved/${uuid}`;
+            }}
+            ModalContent={SavedQueryForm}
+            isChart={isChart}
+        />
+    );
+};
 
 export default SavedQueriesContent;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2012 

### Description:
This PR orders the saved charts in the saved queries page by the latest edited/added

### Preview:

![Screenshot 2022-05-06 at 10 46 37](https://user-images.githubusercontent.com/31137824/167108486-77e4bf15-d726-4395-b2da-849392fd231d.png)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
