### PR TITLE
fix: update success messages to the correct ones

### DIFF
--- a/packages/e2e/cypress/integration/explore.spec.ts
+++ b/packages/e2e/cypress/integration/explore.spec.ts
@@ -36,7 +36,7 @@ describe('Explore', () => {
         cy.findByText('Save chart').click();
         cy.get('input#chart-name').type('My chart');
         cy.findByText('Save').click();
-        cy.findByText('Success! Chart was updated.');
+        cy.findByText('Success! Chart was saved.');
 
         // FIXME disabling save changes button is currently broken...
         // cy.findByText('Save changes').parent().should('be.disabled');

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -145,7 +145,7 @@ export const useCreateMutation = () => {
             onSuccess: (data) => {
                 queryClient.setQueryData(['saved_query', data.uuid], data);
                 showToastSuccess({
-                    title: `Success! Chart was updated.`,
+                    title: `Success! Chart was saved.`,
                 });
                 history.push({
                     pathname: `/projects/${projectUuid}/saved/${data.uuid}`,
@@ -227,12 +227,12 @@ export const useAddVersionMutation = () => {
 
             queryClient.setQueryData(['saved_query', data.uuid], data);
             showToastSuccess({
-                title: `Success! Chart was saved.`,
+                title: `Success! Chart was updated.`,
             });
         },
         onError: (error) => {
             showToastError({
-                title: `Failed to save chart`,
+                title: `Failed to update chart`,
                 subtitle: error.error.message,
             });
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1809 

### Description:
This PR now displays the correct messages for when saving a new chart it now says `chart was saved` and on save changes it says `chart was updated`

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
