### PR TITLE
fix: explore from here

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -80,10 +80,10 @@ export const hasIntersection = (tags: string[], tags2: string[]): boolean => {
     return intersection.length > 0;
 };
 
-export const toggleArrayValue = (
-    initialArray: string[],
-    value: string,
-): string[] => {
+export const toggleArrayValue = <T = string>(
+    initialArray: T[],
+    value: T,
+): T[] => {
     const array = [...initialArray];
     const index = array.indexOf(value);
     if (index === -1) {

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -18,6 +18,7 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { useExplore } from '../../hooks/useExplore';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useSavedChartResults } from '../../hooks/useQueryResults';
 import { useSavedQuery } from '../../hooks/useSavedQuery';
 import { useDashboardContext } from '../../providers/DashboardProvider';
@@ -226,6 +227,17 @@ const DashboardChartTile: FC<Props> = (props) => {
         [explore],
     );
 
+    const exploreFromHereUrl = useMemo(() => {
+        if (savedQuery) {
+            const { pathname, search } =
+                getExplorerUrlFromCreateSavedChartVersion(
+                    savedQuery.projectUuid,
+                    savedQuery,
+                );
+            return `${pathname}?${search}`;
+        }
+    }, [savedQuery]);
+
     return (
         <TileBase
             isChart
@@ -262,7 +274,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                         <MenuItem
                             icon="series-search"
                             text="Explore from here"
-                            href={`/projects/${projectUuid}/saved/${savedChartUuid}?explore=true`}
+                            href={exploreFromHereUrl}
                         />
                     </>
                 )

--- a/packages/frontend/src/components/Explorer/ExploreHeader/ExploreHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreHeader/ExploreHeader.tsx
@@ -1,7 +1,6 @@
 import { Button, Classes } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import React, { FC, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import { useExplorer } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
@@ -12,25 +11,17 @@ import RenameSavedChartModal from '../../SavedQueries/RenameSavedChartModal';
 import { ChartName, TitleWrapper, Wrapper } from './ExploreHeader.styles';
 
 const ExploreHeader: FC = () => {
-    const location = useLocation<
-        { fromExplorer?: boolean; explore?: boolean } | undefined
-    >();
     const {
         state: { savedChart },
     } = useExplorer();
     const [isRenamingChart, setIsRenamingChart] = useState(false);
     const updateSavedChart = useUpdateMutation(savedChart?.uuid);
 
-    const searchParams = new URLSearchParams(location.search);
-
-    const overrideQueryUuid: string | undefined = searchParams.get('explore')
-        ? undefined
-        : savedChart?.uuid;
     return (
         <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
             <Wrapper>
                 <TitleWrapper>
-                    {overrideQueryUuid && savedChart && (
+                    {savedChart && (
                         <>
                             <ChartName
                                 className={Classes.TEXT_OVERFLOW_ELLIPSIS}
@@ -52,7 +43,7 @@ const ExploreHeader: FC = () => {
                                 minimal
                             />
                             <RenameSavedChartModal
-                                savedChartUuid={overrideQueryUuid}
+                                savedChartUuid={savedChart.uuid}
                                 isOpen={isRenamingChart}
                                 onClose={() => setIsRenamingChart(false)}
                             />

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -11,7 +11,10 @@ import {
 } from 'common';
 import { FC, useEffect, useState } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorer,
+} from '../../../providers/ExplorerProvider';
 import FiltersForm from '../../common/Filters';
 import {
     FieldsWithSuggestions,
@@ -22,16 +25,17 @@ import { CardHeader } from './FiltersCard.styles';
 const FiltersCard: FC = () => {
     const {
         state: {
+            expandedSections,
             unsavedChartVersion: {
                 tableName,
                 metricQuery: { filters, additionalMetrics },
             },
         },
         queryResults,
-        actions: { setFilters },
+        actions: { setFilters, toggleExpandedSection },
     } = useExplorer();
     const explore = useExplore(tableName);
-    const [filterIsOpen, setFilterIsOpen] = useState<boolean>(false);
+    const filterIsOpen = expandedSections.includes(ExplorerSection.FILTERS);
     const totalActiveFilters: number = countTotalFilterRules(filters);
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
@@ -100,7 +104,9 @@ const FiltersCard: FC = () => {
                 <Button
                     icon={filterIsOpen ? 'chevron-down' : 'chevron-right'}
                     minimal
-                    onClick={() => setFilterIsOpen((f) => !f)}
+                    onClick={() =>
+                        toggleExpandedSection(ExplorerSection.FILTERS)
+                    }
                 />
                 <H5>Filters</H5>
                 {totalActiveFilters > 0 && !filterIsOpen ? (

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,7 +1,10 @@
 import { Button, Card, Collapse, H5 } from '@blueprintjs/core';
 import { getResultValues } from 'common';
-import { FC, useState } from 'react';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { FC } from 'react';
+import {
+    ExplorerSection,
+    useExplorer,
+} from '../../../providers/ExplorerProvider';
 import AddColumnButton from '../../AddColumnButton';
 import DownloadCsvButton from '../../DownloadCsvButton';
 import LimitButton from '../../LimitButton';
@@ -14,11 +17,11 @@ import {
 
 const ResultsCard: FC = () => {
     const {
-        state: { unsavedChartVersion },
+        state: { unsavedChartVersion, expandedSections },
         queryResults,
-        actions: { setRowLimit },
+        actions: { setRowLimit, toggleExpandedSection },
     } = useExplorer();
-    const [resultsIsOpen, setResultsIsOpen] = useState<boolean>(true);
+    const resultsIsOpen = expandedSections.includes(ExplorerSection.RESULTS);
 
     return (
         <Card style={{ padding: 5 }} elevation={1}>
@@ -27,7 +30,9 @@ const ResultsCard: FC = () => {
                     <Button
                         icon={resultsIsOpen ? 'chevron-down' : 'chevron-right'}
                         minimal
-                        onClick={() => setResultsIsOpen((f) => !f)}
+                        onClick={() =>
+                            toggleExpandedSection(ExplorerSection.RESULTS)
+                        }
                     />
                     <H5>Results</H5>
                     {resultsIsOpen && (

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,17 +1,25 @@
 import { Button, Collapse, H5 } from '@blueprintjs/core';
-import { FC, useState } from 'react';
+import { FC } from 'react';
+import {
+    ExplorerSection,
+    useExplorer,
+} from '../../../providers/ExplorerProvider';
 import { RenderedSql } from '../../RenderedSql';
 import { CardHeader, StyledCard } from './SqlCard.styles';
 
 const SqlCard: FC = () => {
-    const [sqlIsOpen, setSqlIsOpen] = useState<boolean>(false);
+    const {
+        state: { expandedSections },
+        actions: { toggleExpandedSection },
+    } = useExplorer();
+    const sqlIsOpen = expandedSections.includes(ExplorerSection.SQL);
     return (
         <StyledCard isOpen={sqlIsOpen} elevation={1}>
             <CardHeader>
                 <Button
                     icon={sqlIsOpen ? 'chevron-down' : 'chevron-right'}
                     minimal
-                    onClick={() => setSqlIsOpen((f) => !f)}
+                    onClick={() => toggleExpandedSection(ExplorerSection.SQL)}
                 />
                 <H5>SQL</H5>
             </CardHeader>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -11,12 +11,14 @@ import {
 import { Popover2 } from '@blueprintjs/popover2';
 import { ChartType } from 'common';
 import { FC, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import {
     useAddVersionMutation,
     useDuplicateMutation,
 } from '../../../hooks/useSavedQuery';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorer,
+} from '../../../providers/ExplorerProvider';
 import BigNumberConfigPanel from '../../BigNumberConfig';
 import ChartConfigPanel from '../../ChartConfigPanel';
 import { ChartDownloadMenu } from '../../ChartDownload';
@@ -33,24 +35,25 @@ const VisualizationCard: FC = () => {
         useState<boolean>(false);
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] =
         useState<boolean>(false);
-    const location = useLocation<
-        { fromExplorer?: boolean; explore?: boolean } | undefined
-    >();
     const {
-        state: { unsavedChartVersion, hasUnsavedChanges, savedChart },
+        state: {
+            unsavedChartVersion,
+            hasUnsavedChanges,
+            savedChart,
+            expandedSections,
+        },
         queryResults,
-        actions: { setPivotFields, setChartType, setChartConfig },
+        actions: {
+            setPivotFields,
+            setChartType,
+            setChartConfig,
+            toggleExpandedSection,
+        },
     } = useExplorer();
     const update = useAddVersionMutation();
-    const [vizIsOpen, setVizisOpen] = useState<boolean>(!!savedChart?.uuid);
+    const vizIsOpen = expandedSections.includes(ExplorerSection.VISUALIZATION);
     const chartId = savedChart?.uuid || '';
     const { mutate: duplicateChart } = useDuplicateMutation(chartId);
-
-    const searchParams = new URLSearchParams(location.search);
-
-    const overrideQueryUuid: string | undefined = searchParams.get('explore')
-        ? undefined
-        : savedChart?.uuid;
 
     const handleSavedQueryUpdate = () => {
         if (savedChart?.uuid && unsavedChartVersion) {
@@ -96,7 +99,11 @@ const VisualizationCard: FC = () => {
                                     vizIsOpen ? 'chevron-down' : 'chevron-right'
                                 }
                                 minimal
-                                onClick={() => setVizisOpen((f) => !f)}
+                                onClick={() =>
+                                    toggleExpandedSection(
+                                        ExplorerSection.VISUALIZATION,
+                                    )
+                                }
                             />
                             <H5 style={{ margin: 0, padding: 0 }}>Charts</H5>
                         </div>
@@ -120,7 +127,7 @@ const VisualizationCard: FC = () => {
                                 <ButtonGroup>
                                     <Button
                                         text={
-                                            overrideQueryUuid
+                                            savedChart
                                                 ? 'Save changes'
                                                 : 'Save chart'
                                         }
@@ -129,13 +136,13 @@ const VisualizationCard: FC = () => {
                                             !hasUnsavedChanges
                                         }
                                         onClick={
-                                            overrideQueryUuid
+                                            savedChart
                                                 ? handleSavedQueryUpdate
                                                 : () =>
                                                       setIsQueryModalOpen(true)
                                         }
                                     />
-                                    {overrideQueryUuid && (
+                                    {savedChart && (
                                         <Popover2
                                             placement="bottom"
                                             disabled={

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -4,10 +4,11 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useApp } from '../providers/AppProvider';
 import {
     ExplorerReduceState,
+    ExplorerSection,
     useExplorer,
 } from '../providers/ExplorerProvider';
 
-const getExplorerUrlFromCreateSavedChartVersion = (
+export const getExplorerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
     createSavedChart: CreateSavedChartVersion,
 ): { pathname: string; search: string } => {
@@ -102,10 +103,17 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
 
     return useMemo(() => {
         if (pathParams.tableId) {
+            const unsavedChartVersion = parseExplorerSearchParams(search);
             try {
                 return {
                     shouldFetchResults: true,
-                    unsavedChartVersion: parseExplorerSearchParams(search),
+                    expandedSections: unsavedChartVersion
+                        ? [
+                              ExplorerSection.VISUALIZATION,
+                              ExplorerSection.RESULTS,
+                          ]
+                        : [ExplorerSection.RESULTS],
+                    unsavedChartVersion,
                 };
             } catch (e: any) {
                 showToastError({ title: 'Error parsing url', subtitle: e });

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -149,9 +149,6 @@ export const useCreateMutation = () => {
                 });
                 history.push({
                     pathname: `/projects/${projectUuid}/saved/${data.uuid}`,
-                    state: {
-                        fromExplorer: true,
-                    },
                 });
             },
             onError: (error) => {
@@ -182,10 +179,6 @@ export const useDuplicateMutation = (
                 if (!showRedirectButton) {
                     history.push({
                         pathname: `/projects/${projectUuid}/saved/${data.uuid}`,
-
-                        state: {
-                            fromExplorer: true,
-                        },
                     });
                 }
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -4,12 +4,17 @@ import { useHistory, useParams } from 'react-router-dom';
 import Explorer from '../components/Explorer';
 import ExplorePanel from '../components/Explorer/ExplorePanel/index';
 import { useSavedQuery } from '../hooks/useSavedQuery';
-import { ExplorerProvider } from '../providers/ExplorerProvider';
+import {
+    ExplorerProvider,
+    ExplorerSection,
+} from '../providers/ExplorerProvider';
 
 const SavedExplorer = () => {
     const history = useHistory();
-    const pathParams =
-        useParams<{ savedQueryUuid: string; projectUuid: string }>();
+    const pathParams = useParams<{
+        savedQueryUuid: string;
+        projectUuid: string;
+    }>();
     const { data, isLoading, error } = useSavedQuery({
         id: pathParams.savedQueryUuid,
     });
@@ -43,6 +48,10 @@ const SavedExplorer = () => {
                 data
                     ? {
                           shouldFetchResults: true,
+                          expandedSections: [
+                              ExplorerSection.VISUALIZATION,
+                              ExplorerSection.RESULTS,
+                          ],
                           unsavedChartVersion: {
                               tableName: data.tableName,
                               chartConfig: data.chartConfig,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1889 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- remove `fromExplore` tech debt. This wasn't being used anymore
- 'explore from here' now uses the correct explore url using url params
- expanded section state is now in the explorer provider/context
- decide what sections are expanded when we initialise the explorer provider 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/3343ac29187947d3b88ace3aee96b72c">
    <p>Lightdash - explore from here - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/3343ac29187947d3b88ace3aee96b72c-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
