### PR TITLE
fix: remove unsupported dbt nodes from from lineage graphs

### DIFF
--- a/packages/backend/src/dbt/translator.ts
+++ b/packages/backend/src/dbt/translator.ts
@@ -306,14 +306,10 @@ const modelGraph = (
         if (type === 'model') {
             depGraph.addNode(name, { type, name });
         }
-        // Only use models, seeds, and sources for graph.
+        // Only use models for graph.
         model.depends_on.nodes.forEach((nodeId) => {
             const [nodeType, nodeProject, nodeName] = nodeId.split('.');
-            if (
-                nodeType === 'model' ||
-                nodeType === 'seed' ||
-                nodeType === 'source'
-            ) {
+            if (nodeType === 'model') {
                 depGraph.addNode(nodeName, { type: nodeType, name: nodeName });
                 depGraph.addDependency(model.name, nodeName);
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

We currently include models, seeds, and sources in our lineage graph.

However, the current implementation uses the model/seed/source **name** not the model/seed/source **unique_id** for each node in the lineage graph. Although dbt models must have unique names, a model and a seed may have the same name. That means that our lineage graph can end up with a circular dependency:

```
{ name: 'node1', type: 'model'} -> { name: 'node2', type: 'model' } -> { name: 'node1', type: 'seed'}
```

^ if you build a graph of the names, you end up with a loop (from `node1` back to `node1`


**quick fix** - remove seeds and sources from the graph. Long term we should use the `unique_id` to build the graph.

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
