### PR TITLE
fix: cancel unsaved filter on dashboard

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -65,6 +65,7 @@ const Dashboard = () => {
         setHaveFiltersChanged,
         dashboardTiles,
         setDashboardTiles,
+        setDashboardFilters,
     } = useDashboardContext();
 
     const isEditMode = useMemo(() => mode === 'edit', [mode]);
@@ -176,14 +177,23 @@ const Dashboard = () => {
         },
         [setDashboardTiles],
     );
-
     const onCancel = useCallback(() => {
         setDashboardTiles(dashboard?.tiles || []);
         setHasTilesChanged(false);
+        if (dashboard) setDashboardFilters(dashboard.filters);
+        setHaveFiltersChanged(false);
         history.push(
             `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
         );
-    }, [dashboard, dashboardUuid, history, projectUuid, setDashboardTiles]);
+    }, [
+        dashboard,
+        dashboardUuid,
+        history,
+        projectUuid,
+        setDashboardTiles,
+        setHaveFiltersChanged,
+        setDashboardFilters,
+    ]);
 
     const updateTitle = (name: string) => {
         setHasTilesChanged(true);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1516

### Description:
When clicking cancel, revert filters to the last saved dashboard 

### Preview:
![Peek 2022-05-09 15-08](https://user-images.githubusercontent.com/1983672/167422066-d1419d74-e06e-406b-a3b4-973c89bdede6.gif)
![Peek 2022-05-09 15-14](https://user-images.githubusercontent.com/1983672/167422071-ba2212c8-a843-43c6-9cec-1286c7c15827.gif)



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
