### PR TITLE
fix: related dashboards

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -138,6 +138,9 @@ export const useUpdateDashboard = (
             mutationKey: ['dashboard_update'],
             onSuccess: async (_, variables) => {
                 await queryClient.invalidateQueries('dashboards');
+                await queryClient.invalidateQueries(
+                    'dashboards-containing-chart',
+                );
                 await queryClient.invalidateQueries([
                     'saved_dashboard_query',
                     id,
@@ -196,6 +199,9 @@ export const useCreateMutation = (
             mutationKey: ['dashboard_create', projectUuid],
             onSuccess: async (result) => {
                 await queryClient.invalidateQueries('dashboards');
+                await queryClient.invalidateQueries(
+                    'dashboards-containing-chart',
+                );
                 showToastSuccess({
                     title: `Success! Dashboard was created.`,
                     action: showRedirectButton
@@ -234,6 +240,9 @@ export const useDuplicateDashboardMutation = (
             mutationKey: ['dashboard_create', projectUuid],
             onSuccess: async (data) => {
                 await queryClient.invalidateQueries('dashboards');
+                await queryClient.invalidateQueries(
+                    'dashboards-containing-chart',
+                );
                 showToastSuccess({
                     title: `Dashboard successfully duplicated!`,
                     action: showRedirectButton
@@ -264,6 +273,7 @@ export const useDeleteMutation = () => {
     return useMutation<undefined, ApiError, string>(deleteDashboard, {
         onSuccess: async () => {
             await queryClient.invalidateQueries('dashboards');
+            await queryClient.invalidateQueries('dashboards-containing-chart');
             showToastSuccess({
                 title: `Deleted! Dashboard was deleted.`,
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1894 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

In our select we a combination of all dashboards and versions order by latest created version and then have a `distinct on` that makes sure the final results are just the latest dashboard versions.
But the new ‘where’ clause that filters by chart uuid ( so we can detect where the chart is being used ) happens at the start so it filters out the latest versions before the `distinct on`.
We want to get the latest dashboard versions and then do the filtering by chart id. 

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->
<a href="https://www.loom.com/share/4b14b1533ee04e3795a89ebbb10d351f">
    <p>Lightdash - fix related dashboards - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/4b14b1533ee04e3795a89ebbb10d351f-with-play.gif">
  </a>


### Scope of the changes (select all that apply):
- [x] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
