### PR TITLE
fix: show formatted values in big number and table

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -144,10 +144,10 @@ describe('ProjectService', () => {
             expect(formatValue('percent', undefined, 0.05)).toEqual('5%');
             expect(formatValue('percent', undefined, '5')).toEqual('500%');
             expect(formatValue('percent', undefined, 'foo')).toEqual('foo');
-            expect(formatValue('percent', undefined, false)).toEqual(false);
+            expect(formatValue('percent', undefined, false)).toEqual('false');
 
-            expect(formatValue('', undefined, 5)).toEqual(5);
-            expect(formatValue(undefined, undefined, 5)).toEqual(5);
+            expect(formatValue('', undefined, 5)).toEqual('5');
+            expect(formatValue(undefined, undefined, 5)).toEqual('5');
         });
         test('formatValue should return the right round', async () => {
             expect(formatValue(undefined, 2, 5)).toEqual('5.00');
@@ -161,10 +161,10 @@ describe('ProjectService', () => {
             expect(formatValue(undefined, 0, 5.9999999)).toEqual('6');
 
             // negative rounding not supported
-            expect(formatValue(undefined, -1, 5)).toEqual(5);
+            expect(formatValue(undefined, -1, 5)).toEqual('5');
 
             expect(formatValue(undefined, 2, 'foo')).toEqual('foo');
-            expect(formatValue(undefined, 2, false)).toEqual(false);
+            expect(formatValue(undefined, 2, false)).toEqual('false');
 
             expect(formatValue(undefined, 10, 5)).toEqual('5.0000000000');
             expect(formatValue(undefined, 10, 5.001)).toEqual('5.0010000000');
@@ -187,7 +187,7 @@ describe('ProjectService', () => {
             expect(formatValue('percent', 2, 0.0511)).toEqual('5.11%');
             expect(formatValue('percent', 4, 0.0511)).toEqual('5.1100%');
             expect(formatValue('percent', 2, 'foo')).toEqual('foo');
-            expect(formatValue('percent', 2, false)).toEqual(false);
+            expect(formatValue('percent', 2, false)).toEqual('false');
             expect(formatValue('', 2, 5)).toEqual('5.00');
         });
 

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -68,9 +68,8 @@ export interface CompiledDimension extends Dimension {
 }
 
 export type CompiledField = CompiledDimension | CompiledMetric;
-export const isDimension = (
-    field: Pick<Field, 'fieldType'>,
-): field is Dimension => field.fieldType === FieldType.DIMENSION;
+export const isDimension = (field: any): field is Dimension =>
+    isField(field) && field.fieldType === FieldType.DIMENSION;
 
 export interface CompiledMetric extends Metric {
     compiledSql: string;

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,0 +1,164 @@
+import moment from 'moment';
+import {
+    Dimension,
+    DimensionType,
+    isDimension,
+    Metric,
+    MetricType,
+} from '../types/field';
+import { AdditionalMetric } from '../types/metricQuery';
+import { NumberStyle } from '../types/savedCharts';
+
+const formatBoolean = <T>(v: T) =>
+    ['True', 'true', 'yes', 'Yes', '1', 'T'].includes(`${v}`) ? 'Yes' : 'No';
+
+function formatDate<T = string | Date>(
+    date: T,
+    timeInterval: string | undefined = 'DAY',
+): string {
+    let dateForm: string;
+    switch (timeInterval.toUpperCase()) {
+        case 'YEAR':
+            dateForm = 'YYYY';
+            break;
+        case 'MONTH':
+            dateForm = 'YYYY-MM';
+            break;
+        default:
+            dateForm = 'YYYY-MM-DD';
+            break;
+    }
+    return moment(date).format(dateForm);
+}
+
+function formatTimestamp<T = string | Date>(
+    value: T,
+    timeInterval: string | undefined = 'MILLISECOND',
+): string {
+    let timeFormat: string;
+    switch (timeInterval.toUpperCase()) {
+        case 'HOUR':
+            timeFormat = 'HH';
+            break;
+        case 'MINUTE':
+            timeFormat = 'HH:mm';
+            break;
+        case 'SECOND':
+            timeFormat = 'HH:mm:ss';
+            break;
+        default:
+            timeFormat = 'HH:mm:ss:SSS';
+            break;
+    }
+
+    return moment(value).format(`YYYY-MM-DD, ${timeFormat} (Z)`);
+}
+
+export function formatValue<T>(
+    format: string | undefined,
+    round: number | undefined,
+    value: T,
+    numberStyle?: NumberStyle, // for bigNumbers
+): string {
+    function valueIsNaN(val: T) {
+        if (typeof val === 'boolean') return true;
+        return Number.isNaN(Number(val));
+    }
+
+    function roundNumber(number: T): string | T {
+        if (round === undefined || round < 0) return number;
+        if (valueIsNaN(number)) {
+            return number;
+        }
+        return Number(number).toFixed(round);
+    }
+
+    if (value === null) return '∅';
+    if (value === undefined) return '-';
+
+    function styleNumber(number: T): string | T {
+        if (valueIsNaN(number)) {
+            return number;
+        }
+        switch (numberStyle) {
+            case NumberStyle.THOUSANDS:
+                return `${roundNumber((Number(number) / 1000) as any)}K`;
+            case NumberStyle.MILLIONS:
+                return `${roundNumber((Number(number) / 1000000) as any)}M`;
+            case NumberStyle.BILLIONS:
+                return `${roundNumber((Number(number) / 1000000000) as any)}B`;
+            default:
+                return number;
+        }
+    }
+
+    const styledValue = numberStyle
+        ? (styleNumber(value) as any)
+        : roundNumber(value);
+    switch (format) {
+        case 'km':
+        case 'mi':
+            return `${styledValue} ${format}`;
+        case 'usd':
+            return `$${styledValue}`;
+        case 'gbp':
+            return `£${styledValue}`;
+        case 'eur':
+            return `€${styledValue}`;
+        case 'percent':
+            if (valueIsNaN(value)) {
+                return `${value}`;
+            }
+
+            // Fix rounding issue
+            return `${(Number(value) * 100).toFixed(round)}%`;
+
+        case '': // no format
+            return styledValue;
+        default:
+            // unrecognized format
+            return styledValue;
+    }
+}
+
+export function formatFieldValue<T>(
+    field: Dimension | Metric | AdditionalMetric,
+    value: T,
+): string {
+    const { type, round, format } = field;
+    if (value === null) return '∅';
+    if (value === undefined) return '-';
+    switch (type) {
+        case DimensionType.STRING:
+        case MetricType.STRING:
+            return `${value}`;
+        case DimensionType.NUMBER:
+        case MetricType.NUMBER:
+        case MetricType.AVERAGE:
+        case MetricType.COUNT:
+        case MetricType.COUNT_DISTINCT:
+        case MetricType.SUM:
+        case MetricType.MIN:
+        case MetricType.MAX:
+            return formatValue(format, round, value);
+        case DimensionType.BOOLEAN:
+        case MetricType.BOOLEAN:
+            return formatBoolean(value);
+        case DimensionType.DATE:
+        case MetricType.DATE:
+            return formatDate(
+                value,
+                isDimension(field) ? field.timeInterval : undefined,
+            );
+        case DimensionType.TIMESTAMP:
+            return formatTimestamp(
+                value,
+                isDimension(field) ? field.timeInterval : undefined,
+            );
+        default: {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const nope: never = type;
+            throw new Error(`Unexpected type while formatting value: ${type}`);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1722 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Blocked by: https://github.com/lightdash/lightdash/pull/2033

This is one of many PR's to move all the value formatting logic from `packages/frontend/src/utils/resultFormatter.tsx` to this util function. The FE should use the formatted values, that BE returns, where possible.

Both the big number and table visualizations should now show formatted values independently of their type.

Changes:
- formatted value is always a string
- format all value types ( undefined, null, string, number, boolean, date, timestamp )
- fix big number to use formatted value when selected field isn't of type number

TODO: 
- add tests

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

<a href="https://www.loom.com/share/06f66ca2d6974732bfbe0063e488de88">
    <p>Lightdash - formatted values in big number and table - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/06f66ca2d6974732bfbe0063e488de88-with-play.gif">
  </a>

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
