### PR TITLE
fix: tooltips on scattered charts, unify tooltip config

### DIFF
--- a/packages/frontend/src/hooks/useEcharts.ts
+++ b/packages/frontend/src/hooks/useEcharts.ts
@@ -99,38 +99,10 @@ const getFormatterValue = (
 };
 
 const valueFormatter =
-    (xFieldId: string, yFieldId: string, explore: Explore) =>
-    (rawValue: any) => {
+    (yFieldId: string, explore: Explore) => (rawValue: any) => {
         const yField = getFields(explore).find(
             (item) => fieldId(item) === yFieldId,
         );
-
-        if (Array.isArray(rawValue)) {
-            const xField = getFields(explore).find(
-                (item) => fieldId(item) === xFieldId,
-            );
-            const formattedXValue =
-                xField?.format || xField?.round
-                    ? formatValue(xField?.format, xField?.round, rawValue[0])
-                    : rawValue[0];
-
-            const xValue = getFormatterValue(
-                formattedXValue,
-                xFieldId,
-                getDimensions(explore),
-            );
-            const formattedYValue =
-                yField?.format || yField?.round
-                    ? formatValue(yField?.format, yField?.round, rawValue[1])
-                    : rawValue[1];
-
-            const yValue = getFormatterValue(
-                formattedYValue,
-                yFieldId,
-                getDimensions(explore),
-            );
-            return `${xValue} ${yValue}`;
-        }
 
         const formattedValue =
             yField?.format || yField?.round
@@ -204,7 +176,6 @@ export const getEchartsSeries = (
                     ],
                     tooltip: {
                         valueFormatter: valueFormatter(
-                            xFieldHash,
                             series.encode.yRef.field,
                             explore,
                         ),
@@ -260,7 +231,7 @@ export const getEchartsSeries = (
                         },
                     ],
                     tooltip: {
-                        valueFormatter: valueFormatter(xField, yField, explore),
+                        valueFormatter: valueFormatter(yField, explore),
                     },
 
                     ...(series.label?.show &&

--- a/packages/frontend/src/hooks/useEcharts.ts
+++ b/packages/frontend/src/hooks/useEcharts.ts
@@ -1,7 +1,6 @@
 import {
     ApiQueryResults,
     CartesianChart,
-    CartesianSeriesType,
     CompiledField,
     convertAdditionalMetric,
     Dimension,
@@ -69,23 +68,6 @@ const getAxisTypeFromField = (item?: Field): string => {
         return 'value';
     }
 };
-
-const getEchartsTooltipConfig = (type: Series['type']) =>
-    type === CartesianSeriesType.BAR
-        ? {
-              show: true,
-              confine: true,
-              trigger: 'axis',
-              axisPointer: {
-                  type: 'shadow',
-                  label: { show: true },
-              },
-          }
-        : {
-              show: true,
-              confine: true,
-              trigger: 'item',
-          };
 
 export type EChartSeries = {
     type: Series['type'];
@@ -200,10 +182,7 @@ export const getEchartsSeries = (
                     encode: {
                         x: flipAxes ? yFieldHash : xFieldHash,
                         y: flipAxes ? xFieldHash : yFieldHash,
-                        tooltip:
-                            series.type === CartesianSeriesType.BAR
-                                ? [yFieldHash]
-                                : [xFieldHash, yFieldHash],
+                        tooltip: [yFieldHash],
                         seriesName: yFieldHash,
                     },
                     dimensions: [
@@ -267,10 +246,7 @@ export const getEchartsSeries = (
                         ...series.encode,
                         x: flipAxes ? yField : xField,
                         y: flipAxes ? xField : yField,
-                        tooltip:
-                            series.type === CartesianSeriesType.BAR
-                                ? [yField]
-                                : [xField, yField],
+                        tooltip: [yField],
                         seriesName: yField,
                     },
                     dimensions: [
@@ -574,7 +550,15 @@ const useEcharts = () => {
             id: 'lightdashResults',
             source: plotData,
         },
-        tooltip: getEchartsTooltipConfig(series[0].type),
+        tooltip: {
+            show: true,
+            confine: true,
+            trigger: 'axis',
+            axisPointer: {
+                type: 'shadow',
+                label: { show: true },
+            },
+        },
         grid: {
             containLabel: true,
             left: '5%', // small padding


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2032

### Description:
Unify tooltip config, do not show multiple tooltips 

### Preview:

Before: 

![image](https://user-images.githubusercontent.com/1983672/167828440-6fd6ade3-0ef0-408d-a78c-9757b08f6668.png)

After: 


![image](https://user-images.githubusercontent.com/1983672/167828408-9478aff0-5930-4007-afd3-150abe5ae10d.png)

![image](https://user-images.githubusercontent.com/1983672/167828584-e081795b-aec0-42a8-b5b0-18c5f7c155a9.png)



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
