### PR TITLE
fix: close apptoaster on error

### DIFF
--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -223,6 +223,7 @@ export const AppProvider: FC = ({ children }) => {
                         });
                         break;
                     case 'ERROR':
+                        AppToaster.dismiss(TOAST_KEY_FOR_REFRESH_JOB);
                         setIsJobsDrawerOpen(true);
                 }
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2069

### Description:
Close toaster on error

### Preview:
Create
![Peek 2022-05-11 15-29](https://user-images.githubusercontent.com/1983672/167862439-b49b99db-e9bc-48e9-9a42-ccbb11d89c11.gif)


Refresh

![Peek 2022-05-11 15-31](https://user-images.githubusercontent.com/1983672/167862475-3efeb676-64e5-462a-b13d-ea60798f4ccd.gif)

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
