### PR TITLE
fix: refresh explores after project update

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -39,10 +39,10 @@ projectRouter.patch(
     async (req, res, next) => {
         projectService
             .update(req.params.projectUuid, req.user!, req.body)
-            .then((data) => {
+            .then((results) => {
                 res.json({
                     status: 'ok',
-                    results: data,
+                    results,
                 });
             })
             .catch(next);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -193,6 +193,10 @@ export class ProjectService {
         );
 
         const adapter = await ProjectService.testProjectAdapter(updatedProject);
+        const explores = await adapter.compileAllExplores();
+
+        await this.projectModel.saveExploresToCache(projectUuid, explores);
+
         await this.projectModel.update(projectUuid, updatedProject);
         analytics.track({
             event: 'project.updated',

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import { ProjectType, ProjectTypeLabels } from 'common';
+import { ProjectType, ProjectTypeLabels, WarehouseTypes } from 'common';
 import { FC, useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useApp } from '../../providers/AppProvider';
@@ -13,6 +13,10 @@ import DbtCloudForm from './DbtForms/DbtCloudForm';
 import DbtLocalForm from './DbtForms/DbtLocalForm';
 import GithubForm from './DbtForms/GithubForm';
 import GitlabForm from './DbtForms/GitlabForm';
+import { BigQuerySchemaInput } from './WarehouseForms/BigQueryForm';
+import { PostgresSchemaInput } from './WarehouseForms/PostgresForm';
+import { RedshiftSchemaInput } from './WarehouseForms/RedshiftForm';
+import { SnowflakeSchemaInput } from './WarehouseForms/SnowflakeForm';
 
 interface DbtSettingsFormProps {
     disabled: boolean;
@@ -26,6 +30,10 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     const type: ProjectType = useWatch({
         name: 'dbt.type',
         defaultValue: defaultType || ProjectType.GITHUB,
+    });
+    const warehouseType: WarehouseTypes = useWatch({
+        name: 'warehouse.type',
+        defaultValue: WarehouseTypes.BIGQUERY,
     });
     const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] =
         useState<boolean>(false);
@@ -101,6 +109,25 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
             env: `environment-variables`,
         },
     };
+
+    const warehouseSchemaInput = useMemo(() => {
+        switch (warehouseType) {
+            case WarehouseTypes.BIGQUERY:
+                return <BigQuerySchemaInput disabled={disabled} />;
+            case WarehouseTypes.POSTGRES:
+                return <PostgresSchemaInput disabled={disabled} />;
+            case WarehouseTypes.REDSHIFT:
+                return <RedshiftSchemaInput disabled={disabled} />;
+            case WarehouseTypes.SNOWFLAKE:
+                return <SnowflakeSchemaInput disabled={disabled} />;
+            case WarehouseTypes.DATABRICKS:
+                return <></>;
+            default: {
+                const never: never = warehouseType;
+                return <></>;
+            }
+        }
+    }, [disabled, warehouseType]);
     return (
         <div
             style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
@@ -116,7 +143,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                 defaultValue={ProjectType.GITHUB}
             />
             {form}
-            <FormSection name={'Advanced'} isOpen={isAdvancedSettingsOpen}>
+            <FormSection name="target">
                 <Input
                     name="dbt.target"
                     label="Target name"
@@ -124,12 +151,16 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                     disabled={disabled}
                     placeholder="prod"
                 />
+                {warehouseSchemaInput}
+            </FormSection>
+            <FormSection name={'Advanced'} isOpen={isAdvancedSettingsOpen}>
                 <MultiKeyValuePairsInput
                     name="dbt.environment"
                     label="Environment variables"
                     documentationUrl={`${baseDocUrl}${typeDocUrls[type].env}`}
                     disabled={disabled}
                 />
+                <></>
             </FormSection>
             <div
                 style={{

--- a/packages/frontend/src/components/ProjectConnection/ProjectStatusCallout.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectStatusCallout.tsx
@@ -17,18 +17,18 @@ const ProjectStatusCallout: FC<
     if (isLoading) {
         stateProps = {
             intent: 'primary',
-            title: 'Testing connection',
+            title: 'Updating project settings...',
             icon: <Spinner size={20} className={Classes.ICON} />,
         };
     } else if (isSuccess) {
         stateProps = {
             intent: 'success',
-            title: 'Successfully connected! Updated project settings.',
+            title: 'Project settings updated!',
         };
     } else if (isError) {
         stateProps = {
             intent: 'danger',
-            title: 'There was an error getting connected',
+            title: 'There was an error updating the project...',
             children: error ? (
                 <MDEditor.Markdown
                     source={error.error.message.replaceAll('\n', '\n\n')}
@@ -39,7 +39,7 @@ const ProjectStatusCallout: FC<
     } else {
         stateProps = {
             intent: 'primary',
-            title: 'Testing connection',
+            title: 'Updating project settings...',
             icon: <Spinner size={20} className={Classes.ICON} />,
         };
     }

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -10,6 +10,24 @@ import NumericInput from '../../ReactHookForm/NumericInput';
 import SelectField from '../../ReactHookForm/Select';
 import { useProjectFormContext } from '../ProjectFormProvider';
 
+export const BigQuerySchemaInput: FC<{
+    disabled: boolean;
+}> = ({ disabled }) => {
+    return (
+        <Input
+            name="warehouse.dataset"
+            label="Data set"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#data-set"
+            rules={{
+                required: 'Required field',
+                validate: {
+                    hasNoWhiteSpaces: hasNoWhiteSpaces('Data set'),
+                },
+            }}
+            disabled={disabled}
+        />
+    );
+};
 const BigQueryForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
@@ -31,18 +49,7 @@ const BigQueryForm: FC<{
                 }}
                 disabled={disabled}
             />
-            <Input
-                name="warehouse.dataset"
-                label="Data set"
-                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#data-set"
-                rules={{
-                    required: 'Required field',
-                    validate: {
-                        hasNoWhiteSpaces: hasNoWhiteSpaces('Data set'),
-                    },
-                }}
-                disabled={disabled}
-            />
+
             <Input
                 name="warehouse.location"
                 label="Location"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -10,6 +10,25 @@ import PasswordInput from '../../ReactHookForm/PasswordInput';
 import Select from '../../ReactHookForm/Select';
 import { useProjectFormContext } from '../ProjectFormProvider';
 
+export const PostgresSchemaInput: FC<{
+    disabled: boolean;
+}> = ({ disabled }) => {
+    return (
+        <Input
+            name="warehouse.schema"
+            label="Schema"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema"
+            rules={{
+                required: 'Required field',
+                validate: {
+                    hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
+                },
+            }}
+            disabled={disabled}
+        />
+    );
+};
+
 const PostgresForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
@@ -70,18 +89,7 @@ const PostgresForm: FC<{
                 }}
                 disabled={disabled}
             />
-            <Input
-                name="warehouse.schema"
-                label="Schema"
-                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema"
-                rules={{
-                    required: 'Required field',
-                    validate: {
-                        hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
-                    },
-                }}
-                disabled={disabled}
-            />
+
             <FormSection isOpen={isOpen} name="advanced">
                 <NumericInput
                     name="warehouse.port"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -11,6 +11,25 @@ import PasswordInput from '../../ReactHookForm/PasswordInput';
 import Select from '../../ReactHookForm/Select';
 import { useProjectFormContext } from '../ProjectFormProvider';
 
+export const RedshiftSchemaInput: FC<{
+    disabled: boolean;
+}> = ({ disabled }) => {
+    return (
+        <Input
+            name="warehouse.schema"
+            label="Schema"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-1"
+            rules={{
+                required: 'Required field',
+                validate: {
+                    hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
+                },
+            }}
+            disabled={disabled}
+        />
+    );
+};
+
 const RedshiftForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
@@ -71,18 +90,7 @@ const RedshiftForm: FC<{
                 }}
                 disabled={disabled}
             />
-            <Input
-                name="warehouse.schema"
-                label="Schema"
-                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-1"
-                rules={{
-                    required: 'Required field',
-                    validate: {
-                        hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
-                    },
-                }}
-                disabled={disabled}
-            />
+
             <FormSection isOpen={isOpen} name="advanced">
                 <NumericInput
                     name="warehouse.port"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -10,6 +10,25 @@ import NumericInput from '../../ReactHookForm/NumericInput';
 import PasswordInput from '../../ReactHookForm/PasswordInput';
 import { useProjectFormContext } from '../ProjectFormProvider';
 
+export const SnowflakeSchemaInput: FC<{
+    disabled: boolean;
+}> = ({ disabled }) => {
+    return (
+        <Input
+            name="warehouse.schema"
+            label="Schema"
+            documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-2"
+            rules={{
+                required: 'Required field',
+                validate: {
+                    hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
+                },
+            }}
+            disabled={disabled}
+        />
+    );
+};
+
 const SnowflakeForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
@@ -93,18 +112,7 @@ const SnowflakeForm: FC<{
                 }}
                 disabled={disabled}
             />
-            <Input
-                name="warehouse.schema"
-                label="Schema"
-                documentationUrl="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#schema-2"
-                rules={{
-                    required: 'Required field',
-                    validate: {
-                        hasNoWhiteSpaces: hasNoWhiteSpaces('Schema'),
-                    },
-                }}
-                disabled={disabled}
-            />
+
             <FormSection isOpen={isOpen} name="advanced">
                 <NumericInput
                     name="warehouse.threads"

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -81,6 +81,24 @@ const ProjectForm: FC<Props> = ({
                 marginBottom: '20px',
                 display: 'flex',
                 flexDirection: 'row',
+            }}
+            elevation={1}
+        >
+            <div style={{ flex: 1 }}>
+                <H5 style={{ display: 'inline', marginRight: 5 }}>
+                    Warehouse connection
+                </H5>
+                <DocumentationHelpButton url="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse-connection" />
+            </div>
+            <div style={{ flex: 1 }}>
+                <WarehouseSettingsForm disabled={disabled} />
+            </div>
+        </Card>
+        <Card
+            style={{
+                marginBottom: '20px',
+                display: 'flex',
+                flexDirection: 'row',
                 gap: 20,
             }}
             elevation={1}
@@ -118,24 +136,6 @@ const ProjectForm: FC<Props> = ({
                     disabled={disabled}
                     defaultType={defaultType}
                 />
-            </div>
-        </Card>
-        <Card
-            style={{
-                marginBottom: '20px',
-                display: 'flex',
-                flexDirection: 'row',
-            }}
-            elevation={1}
-        >
-            <div style={{ flex: 1 }}>
-                <H5 style={{ display: 'inline', marginRight: 5 }}>
-                    Warehouse connection
-                </H5>
-                <DocumentationHelpButton url="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse-connection" />
-            </div>
-            <div style={{ flex: 1 }}>
-                <WarehouseSettingsForm disabled={disabled} />
             </div>
         </Card>
     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2084

### Description:
Updates explores and cache after project update 

### Preview:

Fixes compileExplores
![Peek 2022-05-12 10-13](https://user-images.githubusercontent.com/1983672/168026680-80d458f1-dfae-4fbd-be33-4c7e57bc9c84.gif)


![Peek 2022-05-12 12-20](https://user-images.githubusercontent.com/1983672/168050263-c0de18b9-8985-4b43-85b1-09cfb55df008.gif)




### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
