### PR TITLE
fix: updates default colours to be colourblind friendly

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -157,12 +157,12 @@ export const getSeriesId = (series: Series) =>
 
 export const ECHARTS_DEFAULT_COLORS = [
     '#5470c6',
+    '#fc8452',
     '#91cc75',
     '#fac858',
     '#ee6666',
     '#73c0de',
     '#3ba272',
-    '#fc8452',
     '#9a60b4',
     '#ea7ccc',
 ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1049 

### Description:
Switches the second default colour from green --> orange.

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
