### PR TITLE
feat: Chart unsaved changes alert

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -8,7 +8,7 @@ import {
     MenuItem,
 } from '@blueprintjs/core';
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import {
     useDuplicateMutation,
@@ -61,7 +61,7 @@ const SavedChartsHeader: FC = () => {
 
     useEffect(() => {
         const checkReload = (event: BeforeUnloadEvent) => {
-            if (hasUnsavedChanges) {
+            if (hasUnsavedChanges && isEditMode) {
                 const message =
                     'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
                 event.returnValue = message;
@@ -70,11 +70,12 @@ const SavedChartsHeader: FC = () => {
         };
         window.addEventListener('beforeunload', checkReload);
         return () => window.removeEventListener('beforeunload', checkReload);
-    }, [hasUnsavedChanges]);
+    }, [hasUnsavedChanges, isEditMode]);
     useEffect(() => {
         history.block((prompt) => {
             if (
                 hasUnsavedChanges &&
+                isEditMode &&
                 !prompt.pathname.includes(
                     `/projects/${projectUuid}/saved/${savedChart?.uuid}`,
                 )
@@ -95,6 +96,7 @@ const SavedChartsHeader: FC = () => {
         savedChart,
         hasUnsavedChanges,
         setIsSaveWarningModalOpen,
+        isEditMode,
     ]);
 
     return (


### PR DESCRIPTION
…en updated

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2090 

### Description:
This PR adds an alert when a chart has been changed and the user is navigating away from the page.

### Preview:
<img width="723" alt="Screenshot 2022-05-13 at 14 54 42" src="https://user-images.githubusercontent.com/31137824/168305515-e21a16ef-67d6-4882-be04-f0e13a71e97b.png">



### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
