### PR TITLE
chore: add tooltip to filter panel chevron on view mode

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -130,7 +130,7 @@ const FiltersCard: FC = () => {
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>
                 <Tooltip2
-                    content={`You must be in 'edit chart' or 'Explore from here' mode to view this panel`}
+                    content={`You must be in 'edit chart' mode 'Explore from here' to view this panel`}
                     interactionKind="hover"
                     placement={'bottom-start'}
                     disabled={isEditMode}

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -130,7 +130,7 @@ const FiltersCard: FC = () => {
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>
                 <Tooltip2
-                    content={`You must be in 'edit chart' mode to view this panel`}
+                    content={`You must be in 'edit chart' or 'Explore from here' mode to view this panel`}
                     interactionKind="hover"
                     placement={'bottom-start'}
                     disabled={isEditMode}

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -129,14 +129,21 @@ const FiltersCard: FC = () => {
     return (
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>
-                <Button
-                    icon={filterIsOpen ? 'chevron-down' : 'chevron-right'}
-                    minimal
-                    disabled={!isEditMode}
-                    onClick={() =>
-                        toggleExpandedSection(ExplorerSection.FILTERS)
-                    }
-                />
+                <Tooltip2
+                    content={`You must be in 'edit chart' mode to view this panel`}
+                    interactionKind="hover"
+                    placement={'bottom-start'}
+                    disabled={isEditMode}
+                >
+                    <Button
+                        icon={filterIsOpen ? 'chevron-down' : 'chevron-right'}
+                        minimal
+                        disabled={!isEditMode}
+                        onClick={() =>
+                            toggleExpandedSection(ExplorerSection.FILTERS)
+                        }
+                    />
+                </Tooltip2>
                 <H5>Filters</H5>
                 {totalActiveFilters > 0 && !filterIsOpen ? (
                     <Tooltip2

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -130,7 +130,7 @@ const FiltersCard: FC = () => {
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>
                 <Tooltip2
-                    content={`You must be in 'edit chart' mode or 'Explore from here' to view this panel`}
+                    content={`You must be in 'edit' or 'explore' mode to view this panel`}
                     interactionKind="hover"
                     placement={'bottom-start'}
                     disabled={isEditMode}

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -130,7 +130,7 @@ const FiltersCard: FC = () => {
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>
                 <Tooltip2
-                    content={`You must be in 'edit chart' mode 'Explore from here' to view this panel`}
+                    content={`You must be in 'edit chart' mode or 'Explore from here' to view this panel`}
                     interactionKind="hover"
                     placement={'bottom-start'}
                     disabled={isEditMode}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2113 

### Description:
This PR adds a tooltip to the disabled filters panel on view mode, to instruct the user that to view it they will need to go to edit mode

### Preview:
<img width="706" alt="Screenshot 2022-05-16 at 11 58 53" src="https://user-images.githubusercontent.com/31137824/168578514-b8788309-05b6-42fb-ae34-8e3767e54366.png">


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
