### PR TITLE
fix: show chart updated by user & save user that saved chart for firs…

### DIFF
--- a/packages/backend/src/database/seeds/development/02_saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/02_saved_queries.ts
@@ -1,10 +1,21 @@
-import { CartesianSeriesType, ChartType, SEED_PROJECT } from 'common';
+import {
+    CartesianSeriesType,
+    ChartType,
+    SEED_PROJECT,
+    SEED_USER,
+} from 'common';
 import { Knex } from 'knex';
 import { savedChartModel } from '../../../models/models';
 
 export async function seed(knex: Knex): Promise<void> {
     // Deletes ALL existing entries
     await knex('saved_queries').del();
+
+    const updatedByUser = {
+        userUuid: SEED_USER.user_uuid,
+        firstName: SEED_USER.first_name,
+        lastName: SEED_USER.last_name,
+    };
 
     // Inserts seed entries
     await savedChartModel.create(SEED_PROJECT.project_uuid, {
@@ -68,6 +79,7 @@ export async function seed(knex: Knex): Promise<void> {
                 'payments_unique_payment_count',
             ],
         },
+        updatedByUser,
     });
 
     await savedChartModel.create(SEED_PROJECT.project_uuid, {
@@ -106,6 +118,7 @@ export async function seed(knex: Knex): Promise<void> {
                 'total_revenue',
             ],
         },
+        updatedByUser,
     });
 
     await savedChartModel.create(SEED_PROJECT.project_uuid, {
@@ -169,6 +182,7 @@ export async function seed(knex: Knex): Promise<void> {
                 'cumulative_order_count',
             ],
         },
+        updatedByUser,
     });
 
     await savedChartModel.create(SEED_PROJECT.project_uuid, {
@@ -207,6 +221,7 @@ export async function seed(knex: Knex): Promise<void> {
         tableConfig: {
             columnOrder: ['customers_customer_id', 'orders_average_order_size'],
         },
+        updatedByUser,
     });
 
     await savedChartModel.create(SEED_PROJECT.project_uuid, {
@@ -247,5 +262,6 @@ export async function seed(knex: Knex): Promise<void> {
                 'payments_unique_payment_count',
             ],
         },
+        updatedByUser,
     });
 }

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -8,6 +8,7 @@ import {
     SessionUser,
     SortField,
     Space,
+    UpdatedByUser,
     UpdateSavedChart,
 } from 'common';
 import { Knex } from 'knex';
@@ -34,6 +35,9 @@ type DbSavedChartDetails = {
     chart_config: ChartConfig['config'] | undefined;
     pivot_dimensions: string[] | undefined;
     created_at: Date;
+    user_uuid: string;
+    first_name: string;
+    last_name: string;
 };
 
 const createSavedChartVersionField = async (
@@ -215,7 +219,8 @@ export class SavedChartModel {
             chartConfig,
             tableConfig,
             pivotConfig,
-        }: CreateSavedChart,
+            updatedByUser,
+        }: CreateSavedChart & { updatedByUser: UpdatedByUser },
     ): Promise<SavedChart> {
         const newSavedChartUuid = await this.database.transaction(
             async (trx) => {
@@ -233,6 +238,7 @@ export class SavedChartModel {
                             chartConfig,
                             tableConfig,
                             pivotConfig,
+                            updatedByUser,
                         },
                     );
                     return newSavedChart.saved_query_uuid;
@@ -297,6 +303,11 @@ export class SavedChartModel {
                 'saved_queries.saved_query_id',
                 'saved_queries_versions.saved_query_id',
             )
+            .leftJoin(
+                'users',
+                'saved_queries_versions.updated_by_user_uuid',
+                'users.user_uuid',
+            )
             .select<DbSavedChartDetails[]>([
                 'projects.project_uuid',
                 'saved_queries.saved_query_id',
@@ -311,6 +322,9 @@ export class SavedChartModel {
                 'saved_queries_versions.created_at',
                 'saved_queries_versions.chart_config',
                 'saved_queries_versions.pivot_dimensions',
+                'users.user_uuid',
+                'users.first_name',
+                'users.last_name',
             ])
             .where('saved_query_uuid', savedChartUuid)
             .orderBy('saved_queries_versions.created_at', 'desc')
@@ -398,6 +412,11 @@ export class SavedChartModel {
             description: savedQuery.description,
             tableName: savedQuery.explore_name,
             updatedAt: savedQuery.created_at,
+            updatedByUser: {
+                userUuid: savedQuery.user_uuid,
+                firstName: savedQuery.first_name,
+                lastName: savedQuery.last_name,
+            },
             metricQuery: {
                 dimensions,
                 metrics,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -137,10 +137,10 @@ export class SavedChartService {
         if (user.ability.cannot('create', 'SavedChart')) {
             throw new ForbiddenError();
         }
-        const newSavedChart = await this.savedChartModel.create(
-            projectUuid,
-            savedChart,
-        );
+        const newSavedChart = await this.savedChartModel.create(projectUuid, {
+            ...savedChart,
+            updatedByUser: user,
+        });
         analytics.track({
             event: 'saved_chart.created',
             userId: user.userUuid,
@@ -162,6 +162,7 @@ export class SavedChartService {
         const duplicatedChart = {
             ...chart,
             name: `Copy of ${chart.name}`,
+            updatedByUser: user,
         };
         const newSavedChart = await this.savedChartModel.create(
             projectUuid,

--- a/packages/common/src/openapi/schemas/SavedChart/SavedChart.json
+++ b/packages/common/src/openapi/schemas/SavedChart/SavedChart.json
@@ -12,7 +12,8 @@
             "type": "string"
         },
         "description": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
         },
         "tableName": {
             "type": "string"
@@ -39,6 +40,9 @@
         "updatedAt": {
             "type": "string",
             "format": "date-time"
+        },
+        "updatedByUser": {
+            "$ref": "../UpdatedByUser.json"
         },
         "pivotConfig": {
             "type": "object",

--- a/packages/common/src/openapi/schemas/UpdatedByUser.json
+++ b/packages/common/src/openapi/schemas/UpdatedByUser.json
@@ -1,0 +1,16 @@
+{
+    "type": "object",
+    "properties": {
+        "userUuid": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "firstName": {
+            "type": "string"
+        },
+        "lastName": {
+            "type": "string"
+        }
+    },
+    "required": ["userUuid", "firstName", "lastName"]
+}

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1881,6 +1881,22 @@
                     }
                 }
             },
+            "UpdatedByUser": {
+                "type": "object",
+                "properties": {
+                    "userUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["userUuid", "firstName", "lastName"]
+            },
             "SavedChart": {
                 "type": "object",
                 "additionalProperties": false,
@@ -1895,7 +1911,8 @@
                         "type": "string"
                     },
                     "description": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "tableName": {
                         "type": "string"
@@ -1922,6 +1939,9 @@
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
                     },
                     "pivotConfig": {
                         "type": "object",


### PR DESCRIPTION
…t time

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2126 <!-- reference the related issue e.g. #150 --> 
Closes: #2000

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- get user that last updated chart
- save what user saved the chart for the first time
- update open api schema

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

![Screenshot 2022-05-16 at 16 43 52](https://user-images.githubusercontent.com/9117144/168635501-14ec8512-a1c5-4691-806c-16d9321af684.png)


### Scope of the changes (select all that apply):
- [ ] Frontend  
- [x] Backend  
- [x] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
