### PR TITLE
feat: update sql runner page with new subheader

### DIFF
--- a/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
+++ b/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
@@ -9,8 +9,9 @@ const RunSqlQueryButton: FC<{
 }> = ({ onSubmit, isLoading }) => (
     <Tooltip2 content={<KeyCombo combo="cmd+enter" />}>
         <BigButton
+            icon="play"
             intent="primary"
-            style={{ width: 150, marginRight: '10px' }}
+            style={{ width: 150 }}
             onClick={onSubmit}
             loading={isLoading}
         >

--- a/packages/frontend/src/pages/SqlRunner.css
+++ b/packages/frontend/src/pages/SqlRunner.css
@@ -1,3 +1,0 @@
-.missing-tables-info {
-    width: 100%;
-}

--- a/packages/frontend/src/pages/SqlRunner.styles.ts
+++ b/packages/frontend/src/pages/SqlRunner.styles.ts
@@ -1,0 +1,38 @@
+import { Callout, H5 } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
+import styled from 'styled-components';
+
+export const Title = styled(H5)`
+    padding-left: 10px;
+`;
+
+export const SideBarWrapper = styled.div`
+    overflow-y: auto;
+`;
+
+export const ContentContainer = styled.div`
+    padding: 10px 20px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    max-width: 100vw;
+`;
+
+export const MissingTablesInfo = styled(Tooltip2)`
+    width: 100%;
+`;
+
+export const ButtonsWrapper = styled.div`
+    height: 60px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    button {
+        margin: 0;
+    }
+`;
+
+export const SqlCallout = styled(Callout)`
+    margin-top: 20px;
+`;

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,16 +1,14 @@
-import { Callout, H5, useHotkeys } from '@blueprintjs/core';
+import { useHotkeys } from '@blueprintjs/core';
 import { TreeNodeInfo } from '@blueprintjs/core/src/components/tree/treeNode';
-import { Tooltip2 } from '@blueprintjs/popover2';
 import { TableBase } from 'common';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { CollapsableCard } from '../components/common/CollapsableCard';
-import Content from '../components/common/Page/Content';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
 import SideBarLoadingState from '../components/common/SideBarLoadingState';
 import { Tree } from '../components/common/Tree';
-import RefreshServerButton from '../components/RefreshServer';
+import RefreshDbtButton from '../components/RefreshDbtButton';
 import RunSqlQueryButton from '../components/SqlRunner/RunSqlQueryButton';
 import SqlRunnerInput from '../components/SqlRunner/SqlRunnerInput';
 import SqlRunnerResultsTable from '../components/SqlRunner/SqlRunnerResultsTable';
@@ -19,7 +17,14 @@ import { useProjectCatalogTree } from '../hooks/useProjectCatalogTree';
 import { useSqlQueryMutation } from '../hooks/useSqlQuery';
 import { TrackSection } from '../providers/TrackingProvider';
 import { SectionName } from '../types/Events';
-import './SqlRunner.css';
+import {
+    ButtonsWrapper,
+    ContentContainer,
+    MissingTablesInfo,
+    SideBarWrapper,
+    SqlCallout,
+    Title,
+} from './SqlRunner.styles';
 
 const CardDivider = styled('div')`
     padding-top: 10px;
@@ -78,8 +83,8 @@ const SqlRunnerPage = () => {
     return (
         <PageWithSidebar>
             <Sidebar title="SQL runner">
-                <H5 style={{ paddingLeft: 10 }}>Warehouse schema</H5>
-                <div style={{ overflowY: 'auto' }}>
+                <Title>Warehouse schema</Title>
+                <SideBarWrapper>
                     {isCatalogLoading ? (
                         <SideBarLoadingState />
                     ) : (
@@ -89,36 +94,22 @@ const SqlRunnerPage = () => {
                             onNodeClick={handleNodeClick}
                         />
                     )}
-                </div>
-                <Tooltip2
-                    content="Currently we only display tables that are declared in the dbt project."
-                    className="missing-tables-info"
-                >
-                    <Callout
-                        intent="none"
-                        icon="info-sign"
-                        style={{ marginTop: 20 }}
-                    >
+                </SideBarWrapper>
+                <MissingTablesInfo content="Currently we only display tables that are declared in the dbt project.">
+                    <SqlCallout intent="none" icon="info-sign">
                         Tables missing?
-                    </Callout>
-                </Tooltip2>
+                    </SqlCallout>
+                </MissingTablesInfo>
             </Sidebar>
-            <Content>
+            <ContentContainer>
                 <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
-                    <div
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            justifyContent: 'flex-end',
-                            alignItems: 'center',
-                        }}
-                    >
+                    <ButtonsWrapper>
+                        <RefreshDbtButton />
                         <RunSqlQueryButton
                             onSubmit={onSubmit}
                             isLoading={isLoading}
                         />
-                        <RefreshServerButton />
-                    </div>
+                    </ButtonsWrapper>
                 </TrackSection>
                 <CardDivider />
                 <CollapsableCard title="SQL" isOpenByDefault>
@@ -136,7 +127,7 @@ const SqlRunnerPage = () => {
                         sqlQueryMutation={sqlQueryMutation}
                     />
                 </CollapsableCard>
-            </Content>
+            </ContentContainer>
         </PageWithSidebar>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2144 

### Description:
This PR updates the sql runner page with the new subheader

### Preview:
<img width="1436" alt="Screenshot 2022-05-17 at 17 58 12" src="https://user-images.githubusercontent.com/31137824/168869914-574e7d48-9214-449d-a2f8-5765cfa69c93.png">

### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
