### PR TITLE
feat: add chart vizualization to sql runner

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -185,7 +185,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         }
     }
 
-    public async runQuery(sql: string): Promise<Record<string, any>[]> {
+    public async runQuery(sql: string) {
         Logger.debug(`Run query against warehouse`);
         // Possible error if query is ran before dependencies are installed
         return this.warehouseClient.runQuery(sql);

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -58,6 +58,7 @@ export const updateTablesConfiguration: TablesConfiguration = {
 };
 
 export const expectedSqlResults: ApiSqlQueryResults = {
+    fields: {},
     rows: [{ col1: 'val1' }],
 };
 
@@ -66,7 +67,7 @@ export const projectAdapterMock: ProjectAdapter = {
     getDbtPackages: jest.fn(),
     test: jest.fn(),
     destroy: jest.fn(),
-    runQuery: jest.fn(async () => expectedSqlResults.rows),
+    runQuery: jest.fn(async () => expectedSqlResults),
 };
 
 export const validExplore: Explore = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -437,7 +437,7 @@ export class ProjectService {
         const explore = await this.getExplore(user, projectUuid, exploreName);
 
         const adapter = await this.getAdapter(projectUuid);
-        const rows = await adapter.runQuery(query);
+        const { rows } = await adapter.runQuery(query);
 
         const formattedRows = formatRows(
             rows,
@@ -477,10 +477,7 @@ export class ProjectService {
             },
         });
         const adapter = await this.getAdapter(projectUuid);
-        const rows = await adapter.runQuery(sql);
-        return {
-            rows,
-        };
+        return adapter.runQuery(sql);
     }
 
     async refreshAllTables(

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -2,6 +2,7 @@ import {
     DbtPackages,
     DbtRpcDocsGenerateResults,
     DbtRpcGetManifestResults,
+    DimensionType,
     Explore,
     ExploreError,
 } from '@lightdash/common';
@@ -10,7 +11,10 @@ import { WarehouseCatalog } from '@lightdash/warehouses';
 export interface ProjectAdapter {
     compileAllExplores(): Promise<(Explore | ExploreError)[]>;
     getDbtPackages(): Promise<DbtPackages | undefined>;
-    runQuery(sql: string): Promise<Record<string, any>[]>;
+    runQuery(sql: string): Promise<{
+        fields: Record<string, { type: DimensionType }>;
+        rows: Record<string, any>[];
+    }>;
     test(): Promise<void>;
     destroy(): Promise<void>;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -476,6 +476,7 @@ export type ApiQueryResults = {
 };
 
 export type ApiSqlQueryResults = {
+    fields: Record<string, { type: DimensionType }>;
     rows: { [col: string]: any }[];
 };
 

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -13,7 +13,6 @@ import EChartsReact from 'echarts-for-react';
 import JsPDF from 'jspdf';
 import React, { RefObject, useCallback, useState } from 'react';
 import { CSVLink } from 'react-csv';
-import { useExplorer } from '../providers/ExplorerProvider';
 import { useVisualizationContext } from './LightdashVisualization/VisualizationProvider';
 
 const FILE_NAME = 'lightdash_chart';
@@ -110,13 +109,6 @@ export const ChartDownloadOptions: React.FC<DownloadOptions> = ({
     tableData,
 }) => {
     const [type, setType] = useState<DownloadType>(DownloadType.JPEG);
-
-    const {
-        state: {
-            unsavedChartVersion: { tableName: activeTableName },
-        },
-    } = useExplorer();
-
     const isTable = chartType === ChartType.TABLE;
     const onDownload = useCallback(async () => {
         const echartsInstance = chartRef.current?.getEchartsInstance();
@@ -178,9 +170,9 @@ export const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                         tabIndex={0}
                         className="bp4-button"
                         data={tableData.map((row: {}) => row)}
-                        filename={`lightdash-${
-                            activeTableName || 'export'
-                        }-${new Date().toISOString().slice(0, 10)}.csv`}
+                        filename={`lightdash-export-${new Date()
+                            .toISOString()
+                            .slice(0, 10)}.csv`}
                         target="_blank"
                     >
                         <Icon icon="export" />

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -40,6 +40,7 @@ const ValidDashboardChartTile: FC<{
 }> = ({ data, project, onSeriesContextMenu }) => {
     const { data: resultData, isLoading } = useSavedChartResults(project, data);
     const { addSuggestions } = useDashboardContext();
+    const { data: explore } = useExplore(data.tableName);
 
     useEffect(() => {
         if (resultData) {
@@ -65,7 +66,7 @@ const ValidDashboardChartTile: FC<{
             initialChartConfig={data.chartConfig}
             initialPivotDimensions={data.pivotConfig?.columns}
             resultsData={resultData}
-            tableName={data.tableName}
+            explore={explore}
             isLoading={isLoading}
             onSeriesContextMenu={onSeriesContextMenu}
             columnOrder={data.tableConfig.columnOrder}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Collapse, H5 } from '@blueprintjs/core';
 import { ChartType } from '@lightdash/common';
 import { FC } from 'react';
+import { useExplore } from '../../../hooks/useExplore';
 import {
     ExplorerSection,
     useExplorer,
@@ -23,6 +24,7 @@ const VisualizationCard: FC = () => {
             toggleExpandedSection,
         },
     } = useExplorer();
+    const { data: explore } = useExplore(unsavedChartVersion.tableName);
     const vizIsOpen = expandedSections.includes(ExplorerSection.VISUALIZATION);
 
     return (
@@ -34,7 +36,7 @@ const VisualizationCard: FC = () => {
                     initialPivotDimensions={
                         unsavedChartVersion.pivotConfig?.columns
                     }
-                    tableName={unsavedChartVersion.tableName}
+                    explore={explore}
                     resultsData={queryResults.data}
                     isLoading={queryResults.isLoading}
                     onChartConfigChange={setChartConfig}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -17,7 +17,6 @@ import React, {
 } from 'react';
 import useBigNumberConfig from '../../hooks/useBigNumberConfig';
 import useCartesianChartConfig from '../../hooks/useCartesianChartConfig';
-import { useExplore } from '../../hooks/useExplore';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import usePlottedData from '../../hooks/usePlottedData';
 import { EchartSeriesClickEvent } from '../SimpleChart';
@@ -45,7 +44,6 @@ type Props = {
     chartType: ChartType;
     initialChartConfig: ChartConfig | undefined;
     initialPivotDimensions: string[] | undefined;
-    tableName: string | undefined;
     resultsData: ApiQueryResults | undefined;
     isLoading: boolean;
     columnOrder: string[];
@@ -53,13 +51,13 @@ type Props = {
     onChartConfigChange?: (value: ChartConfig['config']) => void;
     onChartTypeChange?: (value: ChartType) => void;
     onPivotDimensionsChange?: (value: string[] | undefined) => void;
+    explore: Explore | undefined;
 };
 
 export const VisualizationProvider: FC<Props> = ({
     initialChartConfig,
     chartType,
     initialPivotDimensions,
-    tableName,
     resultsData,
     isLoading,
     columnOrder,
@@ -67,10 +65,10 @@ export const VisualizationProvider: FC<Props> = ({
     onChartConfigChange,
     onChartTypeChange,
     onPivotDimensionsChange,
+    explore,
     children,
 }) => {
     const chartRef = useRef<EChartsReact>(null);
-    const { data: explore } = useExplore(tableName);
 
     const [lastValidResultsData, setLastValidResultsData] =
         useState<ApiQueryResults>();

--- a/packages/frontend/src/hooks/useSqlQueryVisualization.ts
+++ b/packages/frontend/src/hooks/useSqlQueryVisualization.ts
@@ -55,10 +55,14 @@ const useSqlQueryVisualization = ({ sqlQueryMutation: { data } }: Args) => {
         [data],
     );
 
+    const dimensions: string[] = useMemo(() => {
+        return Object.keys(sqlQueryDimensions);
+    }, [sqlQueryDimensions]);
+
     const resultsData: ApiQueryResults = useMemo(
         () => ({
             metricQuery: {
-                dimensions: Object.keys(sqlQueryDimensions),
+                dimensions: dimensions,
                 metrics: [],
                 filters: {},
                 sorts: [],
@@ -73,14 +77,14 @@ const useSqlQueryVisualization = ({ sqlQueryMutation: { data } }: Args) => {
                         [`${SQL_RESULTS_TABLE_NAME}_${columnName}`]: {
                             value: {
                                 raw,
-                                formatted: raw,
+                                formatted: `${raw}`,
                             },
                         },
                     };
                 }, {}),
             ),
         }),
-        [data?.rows, sqlQueryDimensions],
+        [data?.rows, dimensions],
     );
     const explore: Explore = useMemo(
         () => ({
@@ -112,6 +116,7 @@ const useSqlQueryVisualization = ({ sqlQueryMutation: { data } }: Args) => {
         explore,
         resultsData,
         chartType,
+        columnOrder: dimensions,
         setChartType,
     };
 };

--- a/packages/frontend/src/hooks/useSqlQueryVisualization.ts
+++ b/packages/frontend/src/hooks/useSqlQueryVisualization.ts
@@ -1,0 +1,119 @@
+import {
+    ApiQueryResults,
+    ChartType,
+    CompiledDimension,
+    DimensionType,
+    Explore,
+    fieldId,
+    FieldId,
+    FieldType,
+    friendlyName,
+    SupportedDbtAdapter,
+} from '@lightdash/common';
+import moment from 'moment';
+import { useMemo, useState } from 'react';
+import { useSqlQueryMutation } from './useSqlQuery';
+
+const SQL_RESULTS_TABLE_NAME = 'sql_runner';
+
+type Args = {
+    sqlQueryMutation: ReturnType<typeof useSqlQueryMutation>;
+};
+
+const useSqlQueryVisualization = ({ sqlQueryMutation: { data } }: Args) => {
+    const sqlQueryDimensions: Record<FieldId, CompiledDimension> = useMemo(
+        () =>
+            Object.entries((data?.rows || [])[0] || {}).reduce(
+                (acc, [key, value]) => {
+                    let type = DimensionType.STRING;
+                    if (typeof value === 'number' || !isNaN(value)) {
+                        type = DimensionType.NUMBER;
+                    } else if (typeof value === 'boolean') {
+                        type = DimensionType.BOOLEAN;
+                    } else if (
+                        typeof value === 'string' &&
+                        moment(value).isValid()
+                    ) {
+                        type = DimensionType.TIMESTAMP;
+                    }
+
+                    const dimension: CompiledDimension = {
+                        fieldType: FieldType.DIMENSION,
+                        type,
+                        name: key,
+                        label: friendlyName(key),
+                        table: SQL_RESULTS_TABLE_NAME,
+                        tableLabel: '',
+                        sql: '',
+                        compiledSql: '',
+                        hidden: false,
+                    };
+                    return { ...acc, [fieldId(dimension)]: dimension };
+                },
+                {},
+            ),
+        [data],
+    );
+
+    const resultsData: ApiQueryResults = useMemo(
+        () => ({
+            metricQuery: {
+                dimensions: Object.keys(sqlQueryDimensions),
+                metrics: [],
+                filters: {},
+                sorts: [],
+                limit: 0,
+                tableCalculations: [],
+            },
+            rows: (data?.rows || []).map((row) =>
+                Object.keys(row).reduce((acc, columnName) => {
+                    const raw = row[columnName];
+                    return {
+                        ...acc,
+                        [`${SQL_RESULTS_TABLE_NAME}_${columnName}`]: {
+                            value: {
+                                raw,
+                                formatted: raw,
+                            },
+                        },
+                    };
+                }, {}),
+            ),
+        }),
+        [data?.rows, sqlQueryDimensions],
+    );
+    const explore: Explore = useMemo(
+        () => ({
+            name: SQL_RESULTS_TABLE_NAME,
+            label: '',
+            tags: [],
+            baseTable: SQL_RESULTS_TABLE_NAME,
+            joinedTables: [],
+            tables: {
+                [SQL_RESULTS_TABLE_NAME]: {
+                    name: SQL_RESULTS_TABLE_NAME,
+                    label: '',
+                    database: '',
+                    schema: '',
+                    sqlTable: '',
+                    dimensions: sqlQueryDimensions,
+                    metrics: {},
+                    lineageGraph: {},
+                },
+            },
+            targetDatabase: SupportedDbtAdapter.POSTGRES,
+        }),
+        [sqlQueryDimensions],
+    );
+
+    const [chartType, setChartType] = useState<ChartType>(ChartType.CARTESIAN);
+
+    return {
+        explore,
+        resultsData,
+        chartType,
+        setChartType,
+    };
+};
+
+export default useSqlQueryVisualization;

--- a/packages/frontend/src/hooks/useSqlQueryVisualization.ts
+++ b/packages/frontend/src/hooks/useSqlQueryVisualization.ts
@@ -2,7 +2,6 @@ import {
     ApiQueryResults,
     ChartType,
     CompiledDimension,
-    DimensionType,
     Explore,
     fieldId,
     FieldId,
@@ -10,7 +9,6 @@ import {
     friendlyName,
     SupportedDbtAdapter,
 } from '@lightdash/common';
-import moment from 'moment';
 import { useMemo, useState } from 'react';
 import { useSqlQueryMutation } from './useSqlQuery';
 
@@ -23,20 +21,8 @@ type Args = {
 const useSqlQueryVisualization = ({ sqlQueryMutation: { data } }: Args) => {
     const sqlQueryDimensions: Record<FieldId, CompiledDimension> = useMemo(
         () =>
-            Object.entries((data?.rows || [])[0] || {}).reduce(
-                (acc, [key, value]) => {
-                    let type = DimensionType.STRING;
-                    if (typeof value === 'number' || !isNaN(value)) {
-                        type = DimensionType.NUMBER;
-                    } else if (typeof value === 'boolean') {
-                        type = DimensionType.BOOLEAN;
-                    } else if (
-                        typeof value === 'string' &&
-                        moment(value).isValid()
-                    ) {
-                        type = DimensionType.TIMESTAMP;
-                    }
-
+            Object.entries(data?.fields || []).reduce(
+                (acc, [key, { type }]) => {
                     const dimension: CompiledDimension = {
                         fieldType: FieldType.DIMENSION,
                         type,

--- a/packages/frontend/src/pages/SqlRunner.styles.ts
+++ b/packages/frontend/src/pages/SqlRunner.styles.ts
@@ -1,4 +1,4 @@
-import { Callout, H5 } from '@blueprintjs/core';
+import { Callout, Card, H5 } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 
@@ -35,4 +35,34 @@ export const ButtonsWrapper = styled.div`
 
 export const SqlCallout = styled(Callout)`
     margin-top: 20px;
+`;
+
+export const VisualizationCard = styled(Card)`
+    padding: 5px;
+    overflow-y: scroll;
+`;
+
+export const VisualizationCardHeader = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+`;
+export const VisualizationCardTitle = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    h5 {
+        margin: 0;
+        padding: 0;
+    }
+`;
+export const VisualizationCardButtons = styled.div`
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-right: 10px;
+`;
+export const VisualizationCardContentWrapper = styled.div`
+    height: 300px;
 `;

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,14 +1,34 @@
-import { useHotkeys } from '@blueprintjs/core';
+import { Button, Card, Collapse, H5, useHotkeys } from '@blueprintjs/core';
 import { TreeNodeInfo } from '@blueprintjs/core/src/components/tree/treeNode';
-import { TableBase } from '@lightdash/common';
+import {
+    ApiQueryResults,
+    ChartConfig,
+    ChartType,
+    CompiledDimension,
+    DimensionType,
+    Explore,
+    fieldId,
+    FieldId,
+    FieldType,
+    friendlyName,
+    SupportedDbtAdapter,
+    TableBase,
+} from '@lightdash/common';
+import moment from 'moment';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
+import BigNumberConfigPanel from '../components/BigNumberConfig';
+import ChartConfigPanel from '../components/ChartConfigPanel';
+import { ChartDownloadMenu } from '../components/ChartDownload';
 import { CollapsableCard } from '../components/common/CollapsableCard';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
 import SideBarLoadingState from '../components/common/SideBarLoadingState';
 import { Tree } from '../components/common/Tree';
 import RefreshDbtButton from '../components/RefreshDbtButton';
+import VisualizationCardOptions from '../components/Explorer/VisualizationCardOptions';
+import LightdashVisualization from '../components/LightdashVisualization';
+import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
 import RunSqlQueryButton from '../components/SqlRunner/RunSqlQueryButton';
 import SqlRunnerInput from '../components/SqlRunner/SqlRunnerInput';
 import SqlRunnerResultsTable from '../components/SqlRunner/SqlRunnerResultsTable';
@@ -39,7 +59,95 @@ const SqlRunnerPage = () => {
     const { isLoading: isCatalogLoading, data: catalogData } =
         useProjectCatalog();
     const sqlQueryMutation = useSqlQueryMutation();
-    const { isLoading, mutate } = sqlQueryMutation;
+    const { isLoading, mutate, data } = sqlQueryMutation;
+
+    const sqlQueryDimensions: Record<FieldId, CompiledDimension> = useMemo(
+        () =>
+            Object.entries((data?.rows || [])[0] || {}).reduce(
+                (acc, [key, value]) => {
+                    let type = DimensionType.STRING;
+                    if (typeof value === 'number' || !isNaN(value)) {
+                        type = DimensionType.NUMBER;
+                    } else if (typeof value === 'boolean') {
+                        type = DimensionType.BOOLEAN;
+                    } else if (
+                        typeof value === 'string' &&
+                        moment(value).isValid()
+                    ) {
+                        type = DimensionType.TIMESTAMP;
+                    }
+
+                    const dimension: CompiledDimension = {
+                        fieldType: FieldType.DIMENSION,
+                        type,
+                        name: key,
+                        label: friendlyName(key),
+                        table: 'sql_runner',
+                        tableLabel: 'sql_runner',
+                        sql: '',
+                        compiledSql: '',
+                        hidden: false,
+                    };
+                    return { ...acc, [fieldId(dimension)]: dimension };
+                },
+                {},
+            ),
+        [data],
+    );
+
+    const resultsData: ApiQueryResults = useMemo(
+        () => ({
+            metricQuery: {
+                dimensions: Object.keys(sqlQueryDimensions),
+                metrics: [],
+                filters: {},
+                sorts: [],
+                limit: 0,
+                tableCalculations: [],
+            },
+            rows: (data?.rows || []).map((row) =>
+                Object.keys(row).reduce((acc, columnName) => {
+                    const raw = row[columnName];
+                    return {
+                        ...acc,
+                        [`sql_runner_${columnName}`]: {
+                            value: {
+                                raw,
+                                formatted: raw,
+                            },
+                        },
+                    };
+                }, {}),
+            ),
+        }),
+        [data?.rows, sqlQueryDimensions],
+    );
+    const explore: Explore = useMemo(
+        () => ({
+            name: 'sql_runner',
+            label: 'SQL runner',
+            tags: [],
+            baseTable: 'sql_runner',
+            joinedTables: [],
+            tables: {
+                sql_runner: {
+                    name: 'sql_runner',
+                    label: 'sql_runner',
+                    database: 'sql_runner',
+                    schema: 'sql_runner',
+                    sqlTable: 'sql_runner',
+                    dimensions: sqlQueryDimensions,
+                    metrics: {},
+                    lineageGraph: {},
+                },
+            },
+            targetDatabase: SupportedDbtAdapter.POSTGRES,
+        }),
+        [sqlQueryDimensions],
+    );
+    const [vizIsOpen, setVizIsOpen] = useState(false);
+    const [chartConfig, setChartConfig] = useState<ChartConfig['config']>();
+    const [chartType, setChartType] = useState<ChartType>(ChartType.CARTESIAN);
     const onSubmit = useCallback(() => {
         if (sql) {
             mutate(sql);
@@ -112,6 +220,80 @@ const SqlRunnerPage = () => {
                     </ButtonsWrapper>
                 </TrackSection>
                 <CardDivider />
+                <Card style={{ padding: 5, overflowY: 'scroll' }} elevation={1}>
+                    <VisualizationProvider
+                        initialChartConfig={undefined}
+                        chartType={chartType}
+                        initialPivotDimensions={undefined}
+                        resultsData={resultsData}
+                        isLoading={isLoading}
+                        onChartConfigChange={setChartConfig}
+                        onChartTypeChange={setChartType}
+                        onPivotDimensionsChange={() =>
+                            console.log('onPivotDimensionsChange')
+                        }
+                        columnOrder={[]}
+                        explore={explore}
+                    >
+                        <div
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                justifyContent: 'space-between',
+                            }}
+                        >
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'row',
+                                    alignItems: 'center',
+                                }}
+                            >
+                                <Button
+                                    icon={
+                                        vizIsOpen
+                                            ? 'chevron-down'
+                                            : 'chevron-right'
+                                    }
+                                    minimal
+                                    onClick={() =>
+                                        setVizIsOpen((value) => !value)
+                                    }
+                                />
+                                <H5 style={{ margin: 0, padding: 0 }}>
+                                    Charts
+                                </H5>
+                            </div>
+                            {vizIsOpen && (
+                                <div
+                                    style={{
+                                        display: 'inline-flex',
+                                        flexWrap: 'wrap',
+                                        gap: '10px',
+                                        marginRight: '10px',
+                                    }}
+                                >
+                                    <VisualizationCardOptions />
+                                    {chartType === ChartType.BIG_NUMBER ? (
+                                        <BigNumberConfigPanel />
+                                    ) : (
+                                        <ChartConfigPanel />
+                                    )}
+                                    <ChartDownloadMenu />
+                                </div>
+                            )}
+                        </div>
+                        <Collapse isOpen={vizIsOpen}>
+                            <div
+                                style={{ height: '300px' }}
+                                className="cohere-block"
+                            >
+                                <LightdashVisualization />
+                            </div>
+                        </Collapse>
+                    </VisualizationProvider>
+                </Card>
+                <CardDivider />
                 <CollapsableCard title="SQL" isOpenByDefault>
                     <SqlRunnerInput
                         sql={sql}
@@ -131,5 +313,4 @@ const SqlRunnerPage = () => {
         </PageWithSidebar>
     );
 };
-
 export default SqlRunnerPage;

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -52,7 +52,7 @@ const SqlRunnerPage = () => {
         useProjectCatalog();
     const sqlQueryMutation = useSqlQueryMutation();
     const { isLoading, mutate } = sqlQueryMutation;
-    const { explore, chartType, resultsData, setChartType } =
+    const { explore, chartType, resultsData, columnOrder, setChartType } =
         useSqlQueryVisualization({ sqlQueryMutation });
     const [vizIsOpen, setVizIsOpen] = useState(false);
     const onSubmit = useCallback(() => {
@@ -137,7 +137,7 @@ const SqlRunnerPage = () => {
                         onChartConfigChange={() => undefined}
                         onChartTypeChange={setChartType}
                         onPivotDimensionsChange={() => undefined}
-                        columnOrder={[]}
+                        columnOrder={columnOrder}
                         explore={explore}
                     >
                         <VisualizationCardHeader>

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,20 +1,6 @@
-import { Button, Card, Collapse, H5, useHotkeys } from '@blueprintjs/core';
+import { Button, Collapse, H5, useHotkeys } from '@blueprintjs/core';
 import { TreeNodeInfo } from '@blueprintjs/core/src/components/tree/treeNode';
-import {
-    ApiQueryResults,
-    ChartConfig,
-    ChartType,
-    CompiledDimension,
-    DimensionType,
-    Explore,
-    fieldId,
-    FieldId,
-    FieldType,
-    friendlyName,
-    SupportedDbtAdapter,
-    TableBase,
-} from '@lightdash/common';
-import moment from 'moment';
+import { ChartType, TableBase } from '@lightdash/common';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import BigNumberConfigPanel from '../components/BigNumberConfig';
@@ -25,16 +11,17 @@ import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
 import SideBarLoadingState from '../components/common/SideBarLoadingState';
 import { Tree } from '../components/common/Tree';
-import RefreshDbtButton from '../components/RefreshDbtButton';
 import VisualizationCardOptions from '../components/Explorer/VisualizationCardOptions';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
+import RefreshDbtButton from '../components/RefreshDbtButton';
 import RunSqlQueryButton from '../components/SqlRunner/RunSqlQueryButton';
 import SqlRunnerInput from '../components/SqlRunner/SqlRunnerInput';
 import SqlRunnerResultsTable from '../components/SqlRunner/SqlRunnerResultsTable';
 import { useProjectCatalog } from '../hooks/useProjectCatalog';
 import { useProjectCatalogTree } from '../hooks/useProjectCatalogTree';
 import { useSqlQueryMutation } from '../hooks/useSqlQuery';
+import useSqlQueryVisualization from '../hooks/useSqlQueryVisualization';
 import { TrackSection } from '../providers/TrackingProvider';
 import { SectionName } from '../types/Events';
 import {
@@ -44,6 +31,11 @@ import {
     SideBarWrapper,
     SqlCallout,
     Title,
+    VisualizationCard,
+    VisualizationCardButtons,
+    VisualizationCardContentWrapper,
+    VisualizationCardHeader,
+    VisualizationCardTitle,
 } from './SqlRunner.styles';
 
 const CardDivider = styled('div')`
@@ -59,95 +51,10 @@ const SqlRunnerPage = () => {
     const { isLoading: isCatalogLoading, data: catalogData } =
         useProjectCatalog();
     const sqlQueryMutation = useSqlQueryMutation();
-    const { isLoading, mutate, data } = sqlQueryMutation;
-
-    const sqlQueryDimensions: Record<FieldId, CompiledDimension> = useMemo(
-        () =>
-            Object.entries((data?.rows || [])[0] || {}).reduce(
-                (acc, [key, value]) => {
-                    let type = DimensionType.STRING;
-                    if (typeof value === 'number' || !isNaN(value)) {
-                        type = DimensionType.NUMBER;
-                    } else if (typeof value === 'boolean') {
-                        type = DimensionType.BOOLEAN;
-                    } else if (
-                        typeof value === 'string' &&
-                        moment(value).isValid()
-                    ) {
-                        type = DimensionType.TIMESTAMP;
-                    }
-
-                    const dimension: CompiledDimension = {
-                        fieldType: FieldType.DIMENSION,
-                        type,
-                        name: key,
-                        label: friendlyName(key),
-                        table: 'sql_runner',
-                        tableLabel: 'sql_runner',
-                        sql: '',
-                        compiledSql: '',
-                        hidden: false,
-                    };
-                    return { ...acc, [fieldId(dimension)]: dimension };
-                },
-                {},
-            ),
-        [data],
-    );
-
-    const resultsData: ApiQueryResults = useMemo(
-        () => ({
-            metricQuery: {
-                dimensions: Object.keys(sqlQueryDimensions),
-                metrics: [],
-                filters: {},
-                sorts: [],
-                limit: 0,
-                tableCalculations: [],
-            },
-            rows: (data?.rows || []).map((row) =>
-                Object.keys(row).reduce((acc, columnName) => {
-                    const raw = row[columnName];
-                    return {
-                        ...acc,
-                        [`sql_runner_${columnName}`]: {
-                            value: {
-                                raw,
-                                formatted: raw,
-                            },
-                        },
-                    };
-                }, {}),
-            ),
-        }),
-        [data?.rows, sqlQueryDimensions],
-    );
-    const explore: Explore = useMemo(
-        () => ({
-            name: 'sql_runner',
-            label: 'SQL runner',
-            tags: [],
-            baseTable: 'sql_runner',
-            joinedTables: [],
-            tables: {
-                sql_runner: {
-                    name: 'sql_runner',
-                    label: 'sql_runner',
-                    database: 'sql_runner',
-                    schema: 'sql_runner',
-                    sqlTable: 'sql_runner',
-                    dimensions: sqlQueryDimensions,
-                    metrics: {},
-                    lineageGraph: {},
-                },
-            },
-            targetDatabase: SupportedDbtAdapter.POSTGRES,
-        }),
-        [sqlQueryDimensions],
-    );
+    const { isLoading, mutate } = sqlQueryMutation;
+    const { explore, chartType, resultsData, setChartType } =
+        useSqlQueryVisualization({ sqlQueryMutation });
     const [vizIsOpen, setVizIsOpen] = useState(false);
-    const [chartConfig, setChartConfig] = useState<ChartConfig['config']>();
-    const [chartType, setChartType] = useState<ChartType>(ChartType.CARTESIAN);
     const onSubmit = useCallback(() => {
         if (sql) {
             mutate(sql);
@@ -220,35 +127,21 @@ const SqlRunnerPage = () => {
                     </ButtonsWrapper>
                 </TrackSection>
                 <CardDivider />
-                <Card style={{ padding: 5, overflowY: 'scroll' }} elevation={1}>
+                <VisualizationCard elevation={1}>
                     <VisualizationProvider
                         initialChartConfig={undefined}
                         chartType={chartType}
                         initialPivotDimensions={undefined}
                         resultsData={resultsData}
                         isLoading={isLoading}
-                        onChartConfigChange={setChartConfig}
+                        onChartConfigChange={() => undefined}
                         onChartTypeChange={setChartType}
-                        onPivotDimensionsChange={() =>
-                            console.log('onPivotDimensionsChange')
-                        }
+                        onPivotDimensionsChange={() => undefined}
                         columnOrder={[]}
                         explore={explore}
                     >
-                        <div
-                            style={{
-                                display: 'flex',
-                                flexDirection: 'row',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <div
-                                style={{
-                                    display: 'flex',
-                                    flexDirection: 'row',
-                                    alignItems: 'center',
-                                }}
-                            >
+                        <VisualizationCardHeader>
+                            <VisualizationCardTitle>
                                 <Button
                                     icon={
                                         vizIsOpen
@@ -260,19 +153,10 @@ const SqlRunnerPage = () => {
                                         setVizIsOpen((value) => !value)
                                     }
                                 />
-                                <H5 style={{ margin: 0, padding: 0 }}>
-                                    Charts
-                                </H5>
-                            </div>
+                                <H5>Charts</H5>
+                            </VisualizationCardTitle>
                             {vizIsOpen && (
-                                <div
-                                    style={{
-                                        display: 'inline-flex',
-                                        flexWrap: 'wrap',
-                                        gap: '10px',
-                                        marginRight: '10px',
-                                    }}
-                                >
+                                <VisualizationCardButtons>
                                     <VisualizationCardOptions />
                                     {chartType === ChartType.BIG_NUMBER ? (
                                         <BigNumberConfigPanel />
@@ -280,19 +164,16 @@ const SqlRunnerPage = () => {
                                         <ChartConfigPanel />
                                     )}
                                     <ChartDownloadMenu />
-                                </div>
+                                </VisualizationCardButtons>
                             )}
-                        </div>
+                        </VisualizationCardHeader>
                         <Collapse isOpen={vizIsOpen}>
-                            <div
-                                style={{ height: '300px' }}
-                                className="cohere-block"
-                            >
+                            <VisualizationCardContentWrapper className="cohere-block">
                                 <LightdashVisualization />
-                            </div>
+                            </VisualizationCardContentWrapper>
                         </Collapse>
                     </VisualizationProvider>
-                </Card>
+                </VisualizationCard>
                 <CardDivider />
                 <CollapsableCard title="SQL" isOpenByDefault>
                     <SqlRunnerInput

--- a/packages/warehouses/src/types.ts
+++ b/packages/warehouses/src/types.ts
@@ -20,7 +20,10 @@ export interface WarehouseClient {
         }[],
     ) => Promise<WarehouseCatalog>;
 
-    runQuery(sql: string): Promise<Record<string, any>[]>;
+    runQuery(sql: string): Promise<{
+        fields: Record<string, { type: DimensionType }>;
+        rows: Record<string, any>[];
+    }>;
 
     test(): Promise<void>;
 }

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -8,6 +8,7 @@ import {
 } from './BigqueryWarehouseClient.mock';
 import {
     config,
+    expectedFields,
     expectedRow,
     expectedWarehouseSchema,
 } from './WarehouseClient.mock';
@@ -19,9 +20,9 @@ describe('BigqueryWarehouseClient', () => {
         (warehouse.client.createQueryJob as jest.Mock).mockImplementationOnce(
             () => createJobResponse,
         );
-        expect((await warehouse.runQuery('fake sql')).rows[0]).toEqual(
-            expectedRow,
-        );
+        const results = await warehouse.runQuery('fake sql');
+        expect(results.fields).toEqual(expectedFields);
+        expect(results.rows[0]).toEqual(expectedRow);
         expect(
             warehouse.client.createQueryJob as jest.Mock,
         ).toHaveBeenCalledTimes(1);

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,4 +1,5 @@
 import { BigQuery } from '@google-cloud/bigquery';
+import { BigqueryWarehouseClient } from './BigqueryWarehouseClient';
 import {
     createJobResponse,
     credentials,
@@ -10,7 +11,6 @@ import {
     expectedRow,
     expectedWarehouseSchema,
 } from './WarehouseClient.mock';
-import { BigqueryWarehouseClient } from './BigqueryWarehouseClient';
 
 describe('BigqueryWarehouseClient', () => {
     it('expect query rows with mapped values', async () => {
@@ -19,7 +19,9 @@ describe('BigqueryWarehouseClient', () => {
         (warehouse.client.createQueryJob as jest.Mock).mockImplementationOnce(
             () => createJobResponse,
         );
-        expect((await warehouse.runQuery('fake sql'))[0]).toEqual(expectedRow);
+        expect((await warehouse.runQuery('fake sql')).rows[0]).toEqual(
+            expectedRow,
+        );
         expect(
             warehouse.client.createQueryJob as jest.Mock,
         ).toHaveBeenCalledTimes(1);

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -131,7 +131,7 @@ export class BigqueryWarehouseClient implements WarehouseClient {
         }
     }
 
-    async runQuery(query: string): Promise<Record<string, any>[]> {
+    async runQuery(query: string) {
         try {
             const [job] = await this.client.createQueryJob({
                 query,
@@ -146,8 +146,11 @@ export class BigqueryWarehouseClient implements WarehouseClient {
                     this.credentials.timeoutSeconds * 1000,
             });
             // auto paginate - hides full response
-            const [rows] = await job.getQueryResults({ autoPaginate: true });
-            return parseRows(rows);
+            const [rows, ...many] = await job.getQueryResults({
+                autoPaginate: true,
+            });
+            console.log('many', many);
+            return { fields: {}, rows: parseRows(rows) };
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         }

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -107,7 +107,7 @@ export class DatabricksWarehouseClient implements WarehouseClient {
         this.connectionString = `Driver=${DRIVER_PATH};Server=${serverHostName};HOST=${serverHostName};PORT=${port};SparkServerType=3;Schema=default;ThriftTransport=2;SSL=1;AuthMech=3;UID=token;PWD=${personalAccessToken};HTTPPath=${httpPath};UseNativeQuery=1`;
     }
 
-    async runQuery(sql: string): Promise<Record<string, any>[]> {
+    async runQuery(sql: string) {
         let connection: odbc.Connection;
         try {
             connection = await odbc.connect(this.connectionString);
@@ -115,7 +115,9 @@ export class DatabricksWarehouseClient implements WarehouseClient {
             throw new WarehouseConnectionError(e.message);
         }
         try {
-            return await connection.query<Record<string, any>>(sql);
+            const result = await connection.query<Record<string, any>>(sql);
+            console.log('result', result.columns);
+            return { fields: {}, rows: result };
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         } finally {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.mock.ts
@@ -56,3 +56,13 @@ export const columns: Record<string, any>[] = [
         data_type: PostgresTypes.JSON,
     },
 ];
+
+export const queryColumnsMock = [
+    { name: 'myStringColumn', dataTypeID: 1043 },
+    { name: 'myNumberColumn', dataTypeID: 1700 },
+    { name: 'myBooleanColumn', dataTypeID: 16 },
+    { name: 'myDateColumn', dataTypeID: 1082 },
+    { name: 'myTimestampColumn', dataTypeID: 1114 },
+    { name: 'myArrayColumn', dataTypeID: 3802 },
+    { name: 'myObjectColumn', dataTypeID: 3802 },
+];

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -1,10 +1,10 @@
+import { PostgresWarehouseClient } from './PostgresWarehouseClient';
 import { columns, credentials } from './PostgresWarehouseClient.mock';
 import {
     config,
     expectedRow,
     expectedWarehouseSchema,
 } from './WarehouseClient.mock';
-import { PostgresWarehouseClient } from './PostgresWarehouseClient';
 
 jest.mock('pg', () => ({
     ...jest.requireActual('pg'),
@@ -16,7 +16,9 @@ jest.mock('pg', () => ({
 describe('PostgresWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
-        expect((await warehouse.runQuery('fake sql'))[0]).toEqual(expectedRow);
+        expect((await warehouse.runQuery('fake sql')).rows[0]).toEqual(
+            expectedRow,
+        );
     });
     it('expect schema with postgres types mapped to dimension types', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -1,7 +1,12 @@
 import { PostgresWarehouseClient } from './PostgresWarehouseClient';
-import { columns, credentials } from './PostgresWarehouseClient.mock';
+import {
+    columns,
+    credentials,
+    queryColumnsMock,
+} from './PostgresWarehouseClient.mock';
 import {
     config,
+    expectedFields,
     expectedRow,
     expectedWarehouseSchema,
 } from './WarehouseClient.mock';
@@ -9,20 +14,24 @@ import {
 jest.mock('pg', () => ({
     ...jest.requireActual('pg'),
     Pool: jest.fn(() => ({
-        query: jest.fn(() => ({ rows: [expectedRow] })),
+        query: jest.fn(() => ({
+            fields: queryColumnsMock,
+            rows: [expectedRow],
+        })),
     })),
 }));
 
 describe('PostgresWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
-        expect((await warehouse.runQuery('fake sql')).rows[0]).toEqual(
-            expectedRow,
-        );
+        const results = await warehouse.runQuery('fake sql');
+        expect(results.fields).toEqual(expectedFields);
+        expect(results.rows[0]).toEqual(expectedRow);
     });
     it('expect schema with postgres types mapped to dimension types', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         (warehouse.pool.query as jest.Mock).mockImplementationOnce(() => ({
+            fields: queryColumnsMock,
             rows: columns,
         }));
         expect(await warehouse.getCatalog(config)).toEqual(

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
@@ -120,3 +120,32 @@ export const columns: Record<string, any>[] = [
         }),
     },
 ];
+
+class ColumnMock {
+    private readonly name: string;
+
+    private readonly type: string;
+
+    constructor(name: string, type: string) {
+        this.name = name;
+        this.type = type;
+    }
+
+    getName() {
+        return this.name;
+    }
+
+    getType() {
+        return this.type;
+    }
+}
+
+export const queryColumnsMock = [
+    new ColumnMock('myStringColumn', 'string'),
+    new ColumnMock('myNumberColumn', 'number'),
+    new ColumnMock('myBooleanColumn', 'boolean'),
+    new ColumnMock('myDateColumn', 'date'),
+    new ColumnMock('myTimestampColumn', 'timestamp'),
+    new ColumnMock('myArrayColumn', 'array'),
+    new ColumnMock('myObjectColumn', 'object'),
+];

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -25,7 +25,9 @@ jest.mock('snowflake-sdk', () => ({
 describe('SnowflakeWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new SnowflakeWarehouseClient(credentials);
-        expect((await warehouse.runQuery('fake sql'))[0]).toEqual(expectedRow);
+        expect((await warehouse.runQuery('fake sql')).rows[0]).toEqual(
+            expectedRow,
+        );
     });
     it('expect schema with snowflake types mapped to dimension types', async () => {
         (createConnection as jest.Mock).mockImplementationOnce(() => ({

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -101,7 +101,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
         };
     }
 
-    async runQuery(sqlText: string): Promise<Record<string, any>[]> {
+    async runQuery(sqlText: string) {
         let connection: Connection;
         try {
             connection = createConnection(this.connectionOptions);
@@ -111,7 +111,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
         }
 
         try {
-            return await new Promise((resolve, reject) => {
+            const results: any[] = await new Promise((resolve, reject) => {
                 connection.execute({
                     sqlText,
                     complete: (err, stmt, data) => {
@@ -119,6 +119,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
                             reject(err);
                         }
                         if (data) {
+                            console.log('getColumns', stmt.getColumns());
                             resolve(data);
                         } else {
                             reject(
@@ -130,6 +131,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
                     },
                 });
             });
+            return { fields: {}, rows: results };
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         } finally {
@@ -153,7 +155,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
         }[],
     ) {
         const sqlText = 'SHOW COLUMNS IN ACCOUNT';
-        const rows = await this.runQuery(sqlText);
+        const { rows } = await this.runQuery(sqlText);
         return rows.reduce<WarehouseCatalog>((acc, row) => {
             const match = config.find(
                 ({ database, schema, table }) =>

--- a/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
@@ -29,6 +29,16 @@ export const expectedWarehouseSchema: WarehouseCatalog = {
     },
 };
 
+export const expectedFields: Record<string, any> = {
+    myStringColumn: { type: DimensionType.STRING },
+    myNumberColumn: { type: DimensionType.NUMBER },
+    myDateColumn: { type: DimensionType.DATE },
+    myTimestampColumn: { type: DimensionType.TIMESTAMP },
+    myBooleanColumn: { type: DimensionType.BOOLEAN },
+    myArrayColumn: { type: DimensionType.STRING },
+    myObjectColumn: { type: DimensionType.STRING },
+};
+
 export const expectedRow: Record<string, any> = {
     myStringColumn: 'string value',
     myNumberColumn: 100,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #1135<!-- reference the related issue e.g. #150 -->

### Description:

- create a mock explore and metric query based on the sql runner results
- Display chart visualization in sql runner

Out of scope functionality: 
- be able to share the url with the chart configuration

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

![Screenshot 2022-05-19 at 10 40 48](https://user-images.githubusercontent.com/9117144/169263780-79b7d3b9-3fe2-4c57-a81a-ebd08358afd1.png)


### Scope of the changes (select all that apply):
- [x] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
