### PR TITLE
fix: case insensitive behaviour for snowflake

### DIFF
--- a/packages/backend/src/dbt/translator.mock.ts
+++ b/packages/backend/src/dbt/translator.mock.ts
@@ -562,6 +562,16 @@ export const warehouseSchemaWithMissingColumn: WarehouseCatalog = {
     },
 };
 
+export const warehouseSchemaWithUpperCaseColumn: WarehouseCatalog = {
+    [model.database]: {
+        [model.schema]: {
+            [model.name]: {
+                [column.name.toUpperCase()]: DimensionType.STRING,
+            },
+        },
+    },
+};
+
 export const expectedModelWithType: DbtModelNode = {
     ...model,
     columns: {

--- a/packages/backend/src/dbt/translator.test.ts
+++ b/packages/backend/src/dbt/translator.test.ts
@@ -24,6 +24,7 @@ import {
     warehouseSchema,
     warehouseSchemaWithMissingColumn,
     warehouseSchemaWithMissingTable,
+    warehouseSchemaWithUpperCaseColumn,
 } from './translator.mock';
 
 describe('attachTypesToModels', () => {
@@ -67,6 +68,27 @@ describe('attachTypesToModels', () => {
         ).toThrowError(
             'Column "myColumnName" from model "myTable" does not exist.\n "myColumnName.myTable" was not found in your target warehouse at myDatabase.mySchema.myTable. Try rerunning dbt to update your warehouse.',
         );
+    });
+    it('should throw an error when column has wrong case', async () => {
+        expect(() =>
+            attachTypesToModels(
+                [model],
+                warehouseSchemaWithUpperCaseColumn,
+                true,
+            ),
+        ).toThrowError(
+            'Column "myColumnName" from model "myTable" does not exist.\n "myColumnName.myTable" was not found in your target warehouse at myDatabase.mySchema.myTable. Try rerunning dbt to update your warehouse.',
+        );
+    });
+    it('should match uppercase column names when case-sensitive is false', async () => {
+        expect(
+            attachTypesToModels(
+                [model],
+                warehouseSchemaWithUpperCaseColumn,
+                true,
+                false,
+            )[0],
+        ).toEqual(expectedModelWithType);
     });
 });
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -135,6 +135,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 validModels,
                 this.cachedWarehouse.warehouseCatalog,
                 true,
+                adapterType !== 'snowflake',
             );
             Logger.debug('Convert explores');
             const lazyExplores = await convertExplores(
@@ -169,6 +170,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     validModels,
                     warehouseCatalog,
                     false,
+                    adapterType !== 'snowflake',
                 );
                 Logger.debug('Convert explores after missing catalog error');
                 const explores = await convertExplores(

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
@@ -1,4 +1,8 @@
-import { CreateSnowflakeCredentials, WarehouseTypes } from '@lightdash/common';
+import {
+    CreateSnowflakeCredentials,
+    DimensionType,
+    WarehouseTypes,
+} from '@lightdash/common';
 import { SnowflakeTypes } from './SnowflakeWarehouseClient';
 import { config } from './WarehouseClient.mock';
 
@@ -25,7 +29,7 @@ const columnBase = {
 export const columns: Record<string, any>[] = [
     {
         ...columnBase,
-        column_name: 'myStringColumn',
+        column_name: 'MYSTRINGCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.TEXT,
             length: 16777216,
@@ -36,7 +40,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myNumberColumn',
+        column_name: 'MYNUMBERCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.FIXED,
             precision: 18,
@@ -46,7 +50,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myDateColumn',
+        column_name: 'MYDATECOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.DATE,
             nullable: true,
@@ -54,7 +58,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myTimestampColumn',
+        column_name: 'MYTIMESTAMPCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.TIMESTAMP_NTZ,
             precision: 0,
@@ -64,7 +68,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myBooleanColumn',
+        column_name: 'MYBOOLEANCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.BOOLEAN,
             nullable: true,
@@ -72,7 +76,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myArrayColumn',
+        column_name: 'MYARRAYCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.ARRAY,
             nullable: true,
@@ -80,7 +84,7 @@ export const columns: Record<string, any>[] = [
     },
     {
         ...columnBase,
-        column_name: 'myObjectColumn',
+        column_name: 'MYOBJECTCOLUMN',
         data_type: JSON.stringify({
             type: SnowflakeTypes.OBJECT,
             nullable: true,
@@ -91,7 +95,7 @@ export const columns: Record<string, any>[] = [
         database_name: 'databaseNotInModel',
         schema_name: 'schemaNotInModel',
         table_name: 'tableNotInModel',
-        column_name: 'columnNotInModel',
+        column_name: 'COLUMNNOTINMODEL',
         data_type: JSON.stringify({
             type: SnowflakeTypes.BOOLEAN,
             nullable: true,
@@ -102,7 +106,7 @@ export const columns: Record<string, any>[] = [
         database_name: columnBase.database_name,
         schema_name: 'schemaNotInModel',
         table_name: 'tableNotInModel',
-        column_name: 'columnNotInModel',
+        column_name: 'COLUMNNOTINMODEL',
         data_type: JSON.stringify({
             type: SnowflakeTypes.BOOLEAN,
             nullable: true,
@@ -113,7 +117,7 @@ export const columns: Record<string, any>[] = [
         database_name: columnBase.database_name,
         schema_name: columnBase.schema_name,
         table_name: 'tableNotInModel',
-        column_name: 'columnNotInModel',
+        column_name: 'COLUMNNOTINMODEL',
         data_type: JSON.stringify({
             type: SnowflakeTypes.BOOLEAN,
             nullable: true,
@@ -141,11 +145,47 @@ class ColumnMock {
 }
 
 export const queryColumnsMock = [
-    new ColumnMock('myStringColumn', 'string'),
-    new ColumnMock('myNumberColumn', 'number'),
-    new ColumnMock('myBooleanColumn', 'boolean'),
-    new ColumnMock('myDateColumn', 'date'),
-    new ColumnMock('myTimestampColumn', 'timestamp'),
-    new ColumnMock('myArrayColumn', 'array'),
-    new ColumnMock('myObjectColumn', 'object'),
+    new ColumnMock('MYSTRINGCOLUMN', 'string'),
+    new ColumnMock('MYNUMBERCOLUMN', 'number'),
+    new ColumnMock('MYBOOLEANCOLUMN', 'boolean'),
+    new ColumnMock('MYDATECOLUMN', 'date'),
+    new ColumnMock('MYTIMESTAMPCOLUMN', 'timestamp'),
+    new ColumnMock('MYARRAYCOLUMN', 'array'),
+    new ColumnMock('MYOBJECTCOLUMN', 'object'),
 ];
+
+export const expectedWarehouseSchema = {
+    myDatabase: {
+        mySchema: {
+            myTable: {
+                MYSTRINGCOLUMN: DimensionType.STRING,
+                MYNUMBERCOLUMN: DimensionType.NUMBER,
+                MYDATECOLUMN: DimensionType.DATE,
+                MYTIMESTAMPCOLUMN: DimensionType.TIMESTAMP,
+                MYBOOLEANCOLUMN: DimensionType.BOOLEAN,
+                MYARRAYCOLUMN: DimensionType.STRING,
+                MYOBJECTCOLUMN: DimensionType.STRING,
+            },
+        },
+    },
+};
+
+export const expectedFields: Record<string, any> = {
+    MYSTRINGCOLUMN: { type: DimensionType.STRING },
+    MYNUMBERCOLUMN: { type: DimensionType.NUMBER },
+    MYDATECOLUMN: { type: DimensionType.DATE },
+    MYTIMESTAMPCOLUMN: { type: DimensionType.TIMESTAMP },
+    MYBOOLEANCOLUMN: { type: DimensionType.BOOLEAN },
+    MYARRAYCOLUMN: { type: DimensionType.STRING },
+    MYOBJECTCOLUMN: { type: DimensionType.STRING },
+};
+
+export const expectedRow: Record<string, any> = {
+    MYSTRINGCOLUMN: 'string value',
+    MYNUMBERCOLUMN: 100,
+    MYDATECOLUMN: new Date('2021-03-10T00:00:00.000Z'),
+    MYTIMESTAMPCOLUMN: new Date('1990-03-02T08:30:00.010Z'),
+    MYBOOLEANCOLUMN: false,
+    MYARRAYCOLUMN: '1,2,3',
+    MYOBJECTCOLUMN: '[object Object]',
+};

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -7,14 +7,12 @@ import {
 import {
     columns,
     credentials,
-    queryColumnsMock,
-} from './SnowflakeWarehouseClient.mock';
-import {
-    config,
     expectedFields,
     expectedRow,
     expectedWarehouseSchema,
-} from './WarehouseClient.mock';
+    queryColumnsMock,
+} from './SnowflakeWarehouseClient.mock';
+import { config } from './WarehouseClient.mock';
 
 jest.mock('snowflake-sdk', () => ({
     ...jest.requireActual('snowflake-sdk'),

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -176,6 +176,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
                     schema.toLowerCase() === row.schema_name.toLowerCase() &&
                     table.toLowerCase() === row.table_name.toLowerCase(),
             );
+            // Unquoted identifiers will always be
             if (row.kind === 'COLUMN' && !!match) {
                 acc[match.database] = acc[match.database] || {};
                 acc[match.database][match.schema] =
@@ -183,7 +184,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
                 acc[match.database][match.schema][match.table] =
                     acc[match.database][match.schema][match.table] || {};
                 acc[match.database][match.schema][match.table][
-                    row.column_name.toLowerCase()
+                    row.column_name
                 ] = mapFieldType(JSON.parse(row.data_type).type);
             }
             return acc;

--- a/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
@@ -17,13 +17,13 @@ export const expectedWarehouseSchema: WarehouseCatalog = {
     myDatabase: {
         mySchema: {
             myTable: {
-                mystringcolumn: DimensionType.STRING,
-                mynumbercolumn: DimensionType.NUMBER,
-                mydatecolumn: DimensionType.DATE,
-                mytimestampcolumn: DimensionType.TIMESTAMP,
-                mybooleancolumn: DimensionType.BOOLEAN,
-                myarraycolumn: DimensionType.STRING,
-                myobjectcolumn: DimensionType.STRING,
+                myStringColumn: DimensionType.STRING,
+                myNumberColumn: DimensionType.NUMBER,
+                myDateColumn: DimensionType.DATE,
+                myTimestampColumn: DimensionType.TIMESTAMP,
+                myBooleanColumn: DimensionType.BOOLEAN,
+                myArrayColumn: DimensionType.STRING,
+                myObjectColumn: DimensionType.STRING,
             },
         },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

We were implicitly running case-insensitive matches for database/schema/table/column names for the Snowflake adapter (inside the `getCatalog` function).

This makes it explicit during `attachTypesToModels` 

The snowflake schema also returns the raw catalog without changing case for columns, so columns are likely to always be returned upper case.

User experience:
* If I'm on any database except snowflake, the case of the column names in my `schema.yml` file matter!
* If I'm on snowflake, the case of the column names in my `schema.yml` file don't matter


### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
