### PR TITLE
fix: client_session_keep_alive shouldn't be required in profiles.yml

### DIFF
--- a/packages/cli/src/dbt/targets/snowflake.ts
+++ b/packages/cli/src/dbt/targets/snowflake.ts
@@ -17,7 +17,7 @@ export type SnowflakeUserPasswordTarget = {
     warehouse: string;
     schema: string;
     threads: number;
-    client_session_keep_alive: boolean;
+    client_session_keep_alive?: boolean;
     query_tag?: string;
     connect_retries?: number;
     connect_timeout?: number;
@@ -59,6 +59,7 @@ export const snowflakeUserPasswordSchema: JSONSchemaType<SnowflakeUserPasswordTa
             },
             client_session_keep_alive: {
                 type: 'boolean',
+                nullable: true,
             },
             query_tag: {
                 type: 'string',
@@ -91,7 +92,6 @@ export const snowflakeUserPasswordSchema: JSONSchemaType<SnowflakeUserPasswordTa
             'warehouse',
             'schema',
             'threads',
-            'client_session_keep_alive',
         ],
     };
 
@@ -112,7 +112,7 @@ export const convertSnowflakeSchema = (
             database: target.database,
             schema: target.schema,
             threads: target.threads,
-            clientSessionKeepAlive: target.client_session_keep_alive,
+            clientSessionKeepAlive: !!target.client_session_keep_alive,
             queryTag: target.query_tag,
         };
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2213

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
client_session_keep_alive shouldn't be required in profiles.yml
### Preview:

Before: 
![Screenshot from 2022-05-26 13-44-22](https://user-images.githubusercontent.com/1983672/170481914-8bfb9db8-3b6f-4d44-ae50-084a80c30757.png)

After:
![Screenshot from 2022-05-26 13-44-42](https://user-images.githubusercontent.com/1983672/170481919-a034d3a8-87ca-471e-a00d-4d5adee2c666.png)



<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
- [x] CLI 