### PR TITLE
fix: database field name in profiles.yml

### DIFF
--- a/packages/cli/src/dbt/targets/postgres.ts
+++ b/packages/cli/src/dbt/targets/postgres.ts
@@ -13,7 +13,8 @@ export type PostgresTarget = {
     host: string;
     user: string;
     port: number;
-    dbname: string;
+    dbname?: string;
+    database?: string;
     schema: string;
     threads: number;
     pass?: string;
@@ -43,6 +44,11 @@ export const postgresSchema: JSONSchemaType<PostgresTarget> = {
         },
         dbname: {
             type: 'string',
+            nullable: true,
+        },
+        database: {
+            type: 'string',
+            nullable: true,
         },
         schema: {
             type: 'string',
@@ -79,7 +85,7 @@ export const postgresSchema: JSONSchemaType<PostgresTarget> = {
             nullable: true,
         },
     },
-    required: ['type', 'host', 'user', 'port', 'dbname', 'schema', 'threads'],
+    required: ['type', 'host', 'user', 'port', 'schema', 'threads'],
 };
 
 export const convertPostgresSchema = (
@@ -89,7 +95,15 @@ export const convertPostgresSchema = (
     if (validate(target)) {
         const password = target.pass || target.password;
         if (!password) {
-            throw new ParseError(`Postgres target requires a password`);
+            throw new ParseError(
+                `Postgres target requires a password: "password"`,
+            );
+        }
+        const dbname = target.dbname || target.database;
+        if (!dbname) {
+            throw new ParseError(
+                `Postgres target requires a database name: "database"`,
+            );
         }
         return {
             type: WarehouseTypes.POSTGRES,
@@ -97,7 +111,7 @@ export const convertPostgresSchema = (
             user: target.user,
             password,
             port: target.port,
-            dbname: target.dbname,
+            dbname,
             schema: target.schema,
             threads: target.threads,
             keepalivesIdle: target.keepalives_idle,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`profiles.yml` for a postgres target supports both `database` and `dbname` interchangeably. Adds support for `database`

**before**
<img width="951" alt="Screenshot 2022-05-26 at 16 28 09" src="https://user-images.githubusercontent.com/11660098/170520922-eb314f0b-b8a5-430f-a093-4675f5c3b202.png">


**after**


<img width="937" alt="Screenshot 2022-05-26 at 16 29 18" src="https://user-images.githubusercontent.com/11660098/170521124-60bf342a-0bc7-47d9-a8ab-30235ccd2ef4.png">


### Pre requirements:
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md#sending-a-pull-request).

### Reference:
Closes: #2228  <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

### Preview:
<!-- Insert your gif/screenshot/loom recording here -->

### Scope of the changes (select all that apply):
- [ ] Frontend  
- [ ] Backend  
- [ ] Common  
- [ ] E2E tests  
- [ ] Docs  
- [ ] CI/CD  
