### PR TITLE
feat: handle deleted schema.yml files on cli

### DIFF
--- a/packages/cli/.eslintrc.json
+++ b/packages/cli/.eslintrc.json
@@ -12,6 +12,7 @@
     },
     "rules": {
         "no-console": "off",
-        "import/prefer-default-export": "off"
+        "import/prefer-default-export": "off",
+        "no-restricted-syntax": "off"
     }
 }

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -74,7 +74,6 @@ export const searchForModel = async ({
     modelName,
     filenames,
 }: SearchForModelArgs) => {
-    // eslint-disable-next-line no-restricted-syntax
     for await (const filename of filenames) {
         const results = await findModelInYaml({ filename, modelName });
         if (results) {

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -58,7 +58,6 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     });
 
     console.log(styles.info(`Generated .yml files:`));
-    // eslint-disable-next-line no-restricted-syntax
     for await (const compiledModel of compiledModels) {
         const spinner = ora(
             `  Generating .yml for model ${styles.bold(compiledModel.name)}`,

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -8,9 +8,9 @@ import * as path from 'path';
 import { getDbtContext } from '../dbt/context';
 import { loadManifest } from '../dbt/manifest';
 import {
+    findAndUpdateModelYaml,
     getCompiledModelsFromManifest,
     getWarehouseTableForModel,
-    updateModelYmlFile,
 } from '../dbt/models';
 import {
     loadDbtTarget,
@@ -69,12 +69,14 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                 model: compiledModel,
                 warehouseClient,
             });
-            const { updatedYml, outputFilePath } = await updateModelYmlFile({
-                model: compiledModel,
-                table,
-                docs: manifest.docs,
-                spinner,
-            });
+            const { updatedYml, outputFilePath } = await findAndUpdateModelYaml(
+                {
+                    model: compiledModel,
+                    table,
+                    docs: manifest.docs,
+                    spinner,
+                },
+            );
             try {
                 await fs.writeFile(
                     outputFilePath,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2219 <!-- reference the related issue e.g. #150 -->

### Description:

The CLI should generate new `.yml` files for undocumented models and update `.yml` files for models with existing documentation.

However if the user deletes a `.yml` file **after** running `dbt compile` - then `lightdash generate` will expect a documented model but not find anything.

This PR alters the `lightdash generate` command to fallback to generating a new `.yml` file if it expected but failed to find an existing `.yml` file.


#### Before

Example with jaffle:

```
# existing structure has two `schema` files
$ tree models

models
├── customers.sql
├── docs.md
├── orders.sql
├── overview.md
├── payments.sql
├── schema.yml
└── staging
    ├── schema.yml
    ├── stg_customers.sql
    ├── stg_orders.sql
    └── stg_payments.sql

# Run dbt compile
$ dbt compile

# Run lightdash generate (updates 6 models across 2 yaml files)
$ lightdash generate

Generated .yml files:
✔   payments ➡️  models/schema.yml
✔   customers ➡️  models/schema.yml
✔   orders ➡️  models/schema.yml
✔   stg_customers ➡️  models/staging/schema.yml
✔   stg_payments ➡️  models/staging/schema.yml
✔   stg_orders ➡️  models/staging/schema.yml

# Delete models/schema.yml
$ rm models/schema.yml

# Run generate again (FAILS)
$ lightdash generate

Generated .yml files:
✖   Failed to generate payments.yml
ENOENT: no such file or directory, open '/Users/oliverlaslett/code/jaffle_shop/models/schema.yml'
Error: ENOENT: no such file or directory, open '/Users/oliverlaslett/code/jaffle_shop/models/schema.yml'
```

#### After

CLI reverts to default behaviour as if there was no existing model:
```
# Generate yml (updates existing staging/schema.yml, creates 3 new .yml files)
$ lightdash generate

Generated .yml files:
✔   payments ➡️  models/payments.yml
✔   customers ➡️  models/customers.yml
✔   orders ➡️  models/orders.yml
✔   stg_customers ➡️  models/staging/schema.yml
✔   stg_payments ➡️  models/staging/schema.yml
✔   stg_orders ➡️  models/staging/schema.yml
```