### PR TITLE
chore: fail check based on yarn audit result

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,4 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies audit
+      id: audit
       run: yarn audit --groups dependencies --level high
+    - name: Check for high vulnerabilities
+      if: job.steps.audit.status > 90
+      run: exit 1


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

The `--level high` option only filters what is printed in the console. The check would fail even if there are issues bellow `high` level. 
