### PR TITLE
fix: duplicated tooltip when grouping

### DIFF
--- a/packages/frontend/src/hooks/usePlottedData.ts
+++ b/packages/frontend/src/hooks/usePlottedData.ts
@@ -30,11 +30,7 @@ export const getPivotedData = (
     }, {});
 
     const rowUniqueKeys = [...new Set(rows.map((r) => r[xAxis]))];
-    console.log('rowUniqueKeys', rowUniqueKeys);
-
     const sortedPivoted = rowUniqueKeys.flatMap((rowKey) => pivoted[rowKey]);
-    console.log('sortedPivoted', sortedPivoted);
-    console.log('pivoted', Object.values(pivoted));
 
     return Object.values(sortedPivoted);
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2350
### Description:

When generating `sortedPivoted` some of the keys were duplicated,  to fix this I get first a unique list of xAxis items 

![image](https://user-images.githubusercontent.com/1983672/172636815-59a923ed-e1d8-417e-a3cb-ce45248dbd11.png)
