### PR TITLE
feat: default to string dimensions

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -56,13 +56,8 @@ const convertDimension = (
     source?: Source,
     timeInterval?: string,
 ): Dimension => {
-    let type = column.meta.dimension?.type || column.data_type;
-    if (type === undefined) {
-        throw new MissingCatalogEntryError(
-            `Could not find dimension "${column.name}" for dbt model "${model.name}". Expected at ${model.relation_name}.`,
-            {},
-        );
-    }
+    let type =
+        column.meta.dimension?.type || column.data_type || DimensionType.STRING;
     if (!Object.values(DimensionType).includes(type)) {
         throw new MissingCatalogEntryError(
             `Could not recognise type "${type}" for dimension "${


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #2224  <!-- reference the related issue e.g. #150 -->

### Description:

When a user compiles their project, we automatically determine dimension types by looking for column types in the database (unless the user explicitly provides the `meta.dimension.type` property in their `schema.yml`).

If we can't find the column at the time of compiling we throw an error and it's extremely common that uses hit this error.

This PR changes behaviour to default to a string type dimension, even if we can't find the column in the database. If the column still doesn't exist when the user goes to query the dimension, then they'll get an error that the column doesn't exist.

This is a better flow for two reasons:
* We separate the idea of the database state from the compiled project state (we can never guarantee that any dimension/model is available in the db at all times, so why restrict users during compiling?)
* We delay the error until the user actually tries to use the dimension. Currently, it causes the whole explore to be unavailable if a single dimension cannot be found

**Example**
```yaml
models:
  - name: customers
    description: >-
      This table has basic information about a customer, as well as some derived
      facts based on a customer's orders
    columns:
      - name: not_exists #<<<<<<< this column does not exist! 
      - name: customer_id
        description: This is a unique identifier for a customer
        tests:
          - unique
          - not_null
      - name: first_name
        description: Customer's first name. PII.
```
**Before**
<img width="1212" alt="Screenshot 2022-06-09 at 13 18 19" src="https://user-images.githubusercontent.com/11660098/172848079-6d2afd52-dbb6-4cd7-b80c-85deb1ed42ab.png">


**After**

<img width="477" alt="Screenshot 2022-06-09 at 13 34 12" src="https://user-images.githubusercontent.com/11660098/172848133-adf00136-db96-4d0c-aeee-8e629eb87800.png">
<img width="475" alt="Screenshot 2022-06-09 at 13 34 15" src="https://user-images.githubusercontent.com/11660098/172848137-cfdfe817-5560-4121-85c7-b69b27184cfd.png">

<img width="1528" alt="Screenshot 2022-06-09 at 13 35 25" src="https://user-images.githubusercontent.com/11660098/172848196-d7cd0871-a6af-4e28-801e-81414c530d4a.png">





If a documented column can't be found in the database at the time of compiling, we assume it's a string dimension.

If that dimension is later queried

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
