### PR TITLE
feat: area charts

### DIFF
--- a/packages/common/src/openapi/schemas/SavedChart/ChartConfig/ChartSeries.json
+++ b/packages/common/src/openapi/schemas/SavedChart/ChartConfig/ChartSeries.json
@@ -23,6 +23,9 @@
             "type": "string",
             "enum": ["line", "bar", "scatter"]
         },
+        "areaStyle": {
+            "type": "object"
+        },
         "name": {
             "type": "string"
         },

--- a/packages/common/src/openapi/schemas/SavedChart/CreateSavedChart.json
+++ b/packages/common/src/openapi/schemas/SavedChart/CreateSavedChart.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
         "name": {
             "type": "string"

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1918,7 +1918,7 @@
             },
             "CreateSavedChart": {
                 "type": "object",
-                "additionalProperties": false,
+                "additionalProperties": true,
                 "properties": {
                     "name": {
                         "type": "string"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -31,6 +31,7 @@ export enum CartesianSeriesType {
     LINE = 'line',
     BAR = 'bar',
     SCATTER = 'scatter',
+    AREA = 'area',
 }
 
 type PivotReference = {
@@ -55,6 +56,7 @@ export type Series = {
         position?: 'left' | 'top' | 'right' | 'bottom';
     };
     hidden?: boolean;
+    areaStyle?: {};
 };
 
 export type CompleteEChartsConfig = {

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import {
+    CartesianSeriesType,
     Field,
     getItemId,
     isSeriesWithMixedChartTypes,
@@ -50,8 +51,9 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         );
 
     const canBeStacked =
-        cartesianType !== 'line' &&
-        cartesianType !== 'scatter' &&
+        cartesianType !== CartesianSeriesType.LINE &&
+        cartesianType !== CartesianSeriesType.SCATTER &&
+        cartesianType !== CartesianSeriesType.AREA &&
         isChartTypeTheSameForAllSeries;
 
     // X axis logic

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -46,6 +46,7 @@ const FLIPPED_AXIS_OPTIONS = [
 const CHART_TYPE_OPTIONS = [
     { value: CartesianSeriesType.BAR, label: 'Bar' },
     { value: CartesianSeriesType.LINE, label: 'Line' },
+    { value: CartesianSeriesType.AREA, label: 'Area' },
     { value: CartesianSeriesType.SCATTER, label: 'Scatter' },
 ];
 
@@ -125,6 +126,15 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
 
                 const hasDivider = layout?.yField?.length !== i + 1;
 
+                const chartType =
+                    seriesGroup[0].type === CartesianSeriesType.LINE &&
+                    !!seriesGroup[0].areaStyle
+                        ? CartesianSeriesType.AREA
+                        : seriesGroup[0].type;
+
+                const chartValue = isChartTypeTheSameForAllSeries
+                    ? chartType
+                    : 'mixed';
                 return (
                     <>
                         <GroupSeriesBlock key={fieldKey}>
@@ -135,11 +145,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                 <SeriesExtraInputWrapper label="Chart type">
                                     <SeriesExtraSelect
                                         fill
-                                        value={
-                                            isChartTypeTheSameForAllSeries
-                                                ? seriesGroup[0].type
-                                                : 'mixed'
-                                        }
+                                        value={chartValue}
                                         options={
                                             isChartTypeTheSameForAllSeries
                                                 ? CHART_TYPE_OPTIONS
@@ -152,9 +158,19 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                                   ]
                                         }
                                         onChange={(e) => {
+                                            const value = e.target.value;
+                                            const newType =
+                                                value ===
+                                                CartesianSeriesType.AREA
+                                                    ? CartesianSeriesType.LINE
+                                                    : value;
                                             updateAllGroupedSeries(fieldKey, {
-                                                type: e.target
-                                                    .value as Series['type'],
+                                                type: newType as Series['type'],
+                                                areaStyle:
+                                                    value ===
+                                                    CartesianSeriesType.AREA
+                                                        ? {}
+                                                        : undefined,
                                             });
                                         }}
                                     />

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -40,6 +40,10 @@ const SingleSeriesConfiguration: FC<Props> = ({
     isOpen,
     toggleIsOpen,
 }) => {
+    const type =
+        series.type === CartesianSeriesType.LINE && !!series.areaStyle
+            ? CartesianSeriesType.AREA
+            : series.type;
     return (
         <SeriesWrapper $isSingle={isSingle}>
             <SeriesMainInputs $isGrouped={isGrouped}>
@@ -93,7 +97,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                     <SeriesExtraInputWrapper label={!isGrouped && 'Chart type'}>
                         <SeriesExtraSelect
                             fill
-                            value={series.type}
+                            value={type}
                             options={[
                                 {
                                     value: CartesianSeriesType.BAR,
@@ -104,14 +108,27 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                     label: 'Line',
                                 },
                                 {
+                                    value: CartesianSeriesType.AREA,
+                                    label: 'Area',
+                                },
+                                {
                                     value: CartesianSeriesType.SCATTER,
                                     label: 'Scatter',
                                 },
                             ]}
                             onChange={(e) => {
+                                const value = e.target.value;
+                                const newType =
+                                    value === CartesianSeriesType.AREA
+                                        ? CartesianSeriesType.LINE
+                                        : value;
                                 updateSingleSeries({
                                     ...series,
-                                    type: e.target.value as CartesianSeriesType,
+                                    type: newType as CartesianSeriesType,
+                                    areaStyle:
+                                        value === CartesianSeriesType.AREA
+                                            ? {}
+                                            : undefined,
                                 });
                             }}
                         />

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -42,12 +42,18 @@ const VisualizationCardOptions: FC = () => {
                     };
                 }
                 switch (cartesianType) {
+                    case CartesianSeriesType.AREA:
+                        return {
+                            text: 'Area chart',
+                            icon: 'timeline-area-chart',
+                        };
                     case CartesianSeriesType.LINE:
                         setStacking(false);
                         return {
                             text: 'Line chart',
                             icon: 'timeline-line-chart',
                         };
+
                     case CartesianSeriesType.BAR:
                         return cartesianFlipAxis
                             ? {
@@ -108,6 +114,7 @@ const VisualizationCardOptions: FC = () => {
                             cartesianConfig.setType(
                                 CartesianSeriesType.BAR,
                                 false,
+                                false,
                             );
                             setIsOpen(false);
                         }}
@@ -130,6 +137,7 @@ const VisualizationCardOptions: FC = () => {
                             cartesianConfig.setType(
                                 CartesianSeriesType.BAR,
                                 true,
+                                false,
                             );
                             setIsOpen(false);
                         }}
@@ -151,12 +159,35 @@ const VisualizationCardOptions: FC = () => {
                             cartesianConfig.setType(
                                 CartesianSeriesType.LINE,
                                 false,
+                                false,
                             );
                             setIsOpen(false);
                         }}
                         disabled={disabled}
                         name="Line"
                         text="Line chart"
+                    />
+
+                    <ChartOption
+                        minimal
+                        active={
+                            isChartTypeTheSameForAllSeries &&
+                            chartType === ChartType.CARTESIAN &&
+                            cartesianType === CartesianSeriesType.AREA
+                        }
+                        icon="timeline-area-chart"
+                        onClick={() => {
+                            setChartType(ChartType.CARTESIAN);
+                            cartesianConfig.setType(
+                                CartesianSeriesType.LINE,
+                                false,
+                                true,
+                            );
+                            setIsOpen(false);
+                        }}
+                        disabled={disabled}
+                        name="area"
+                        text="Area chart"
                     />
 
                     <ChartOption
@@ -171,6 +202,7 @@ const VisualizationCardOptions: FC = () => {
                             setChartType(ChartType.CARTESIAN);
                             cartesianConfig.setType(
                                 CartesianSeriesType.SCATTER,
+                                false,
                                 false,
                             );
                             setIsOpen(false);

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -43,6 +43,8 @@ const VisualizationCardOptions: FC = () => {
                 }
                 switch (cartesianType) {
                     case CartesianSeriesType.AREA:
+                        setStacking(true);
+
                         return {
                             text: 'Area chart',
                             icon: 'timeline-area-chart',

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -374,6 +374,8 @@ const useCartesianChartConfig = (
 
     // Generate expected series
     useEffect(() => {
+        const areaStyleConfig = areaStyle ? {} : undefined;
+
         if (isCompleteLayout(dirtyLayout) && resultsData) {
             let expectedSeriesMap: Record<string, Series>;
             if (pivotKey) {
@@ -399,6 +401,7 @@ const useCartesianChartConfig = (
                                     ],
                                 },
                             },
+                            areaStyle: areaStyleConfig,
                         };
                         return {
                             ...acc,
@@ -420,6 +423,7 @@ const useCartesianChartConfig = (
                             },
                         },
                         type: dirtyChartType,
+                        areaStyle: areaStyleConfig,
                     };
                     return { ...sum, [getSeriesId(series)]: series };
                 }, {});
@@ -451,7 +455,7 @@ const useCartesianChartConfig = (
                 };
             });
         }
-    }, [dirtyChartType, dirtyLayout, pivotKey, resultsData]);
+    }, [dirtyChartType, dirtyLayout, pivotKey, resultsData, areaStyle]);
 
     const validCartesianConfig: CartesianChart | undefined = useMemo(
         () =>

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -26,6 +26,10 @@ const useCartesianChartConfig = (
         initialChartConfig?.eChartsConfig?.series?.[0]?.type ||
             CartesianSeriesType.BAR,
     );
+
+    const [areaStyle, setAreaStyle] = useState<boolean>(
+        !!initialChartConfig?.eChartsConfig?.series?.[0]?.areaStyle,
+    );
     const [dirtyLayout, setDirtyLayout] = useState<
         Partial<CartesianChart['layout']> | undefined
     >(initialChartConfig?.layout);
@@ -130,23 +134,28 @@ const useCartesianChartConfig = (
         }));
     }, []);
 
-    const setType = useCallback((type: Series['type'], flipAxes: boolean) => {
-        setChartType(type);
-        setDirtyLayout((prev) => ({
-            ...prev,
-            flipAxes,
-        }));
-        setDirtyEchartsConfig(
-            (prevState) =>
-                prevState && {
-                    ...prevState,
-                    series: prevState?.series?.map((series) => ({
-                        ...series,
-                        type,
-                    })),
-                },
-        );
-    }, []);
+    const setType = useCallback(
+        (type: Series['type'], flipAxes: boolean, hasAreaStyle: boolean) => {
+            setChartType(type);
+            setAreaStyle(hasAreaStyle);
+            setDirtyLayout((prev) => ({
+                ...prev,
+                flipAxes,
+            }));
+            setDirtyEchartsConfig(
+                (prevState) =>
+                    prevState && {
+                        ...prevState,
+                        series: prevState?.series?.map((series) => ({
+                            ...series,
+                            type,
+                            areaStyle: hasAreaStyle ? {} : undefined,
+                        })),
+                    },
+            );
+        },
+        [],
+    );
 
     const setFlipAxis = useCallback((flipAxes: boolean) => {
         setDirtyLayout((prev) => ({
@@ -455,9 +464,14 @@ const useCartesianChartConfig = (
                 : undefined,
         [dirtyLayout, dirtyEchartsConfig],
     );
+
+    const chartType =
+        dirtyChartType === CartesianSeriesType.LINE && areaStyle
+            ? CartesianSeriesType.AREA
+            : dirtyChartType;
     return {
         validCartesianConfig,
-        dirtyChartType,
+        dirtyChartType: chartType,
         dirtyLayout,
         dirtyEchartsConfig,
         setXField,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2284

### Description:

Add area charts as new chart. Unlike other charts, this is not a type, but an AreaStyle property (empty for now) on the series

![Peek 2022-06-13 10-18](https://user-images.githubusercontent.com/1983672/173310471-f474e48e-ab8e-4fa0-9516-a91cfad7075b.gif)

![Peek 2022-06-13 09-382](https://user-images.githubusercontent.com/1983672/173310511-0b8b2ae9-0b9c-4e35-a828-72c59959ab36.gif)

Stacking is enabled for area charts, but the result looks weird... 

![Peek 2022-06-13 09-44](https://user-images.githubusercontent.com/1983672/173312453-014f7bc2-0752-4c5e-b111-4ecd221a1626.gif)

