### PR TITLE
fix: warn about hidden dimensions being used

### DIFF
--- a/packages/frontend/src/components/TableTree.styles.ts
+++ b/packages/frontend/src/components/TableTree.styles.ts
@@ -1,3 +1,4 @@
+import { Colors, Icon } from '@blueprintjs/core';
 import styled, { createGlobalStyle } from 'styled-components';
 
 export const TableTreeGlobalStyle = createGlobalStyle`
@@ -25,4 +26,8 @@ export const ItemOptions = styled.div`
 
 export const Placeholder = styled.div`
     width: 30px;
+`;
+
+export const WarningIcon = styled(Icon)`
+    color: ${Colors.ORANGE5} !important;
 `;

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -284,6 +284,11 @@ const NodeItemButtons: FC<{
     return (
         <ItemOptions>
             {isFiltered && <Icon icon="filter" />}
+            {node.hidden && (
+                <Tooltip2 content="This field has been hidden in the dbt project. It's recommend to remove it from the query">
+                    <Icon icon={'warning-sign'} intent="warning" />
+                </Tooltip2>
+            )}
             {menuItems.length > 0 && (isHovered || isSelected) && (
                 <Popover2
                     content={<Menu>{menuItems}</Menu>}
@@ -461,7 +466,7 @@ const TableTree: FC<TableTreeProps> = ({
         const dimensionsWithSubDimensions = Object.values(allDimensions).reduce<
             Record<string, DimensionWithSubDimensions>
         >((acc, dimension) => {
-            if (dimension.hidden) {
+            if (dimension.hidden && !selectedNodes.has(fieldId(dimension))) {
                 return acc;
             }
             if (dimension.group) {
@@ -480,7 +485,7 @@ const TableTree: FC<TableTreeProps> = ({
         }, {});
 
         return Object.values(dimensionsWithSubDimensions);
-    }, [allDimensions]);
+    }, [allDimensions, selectedNodes]);
 
     const filteredMetrics: Metric[] = useMemo(() => {
         if (search !== '') {

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -40,6 +40,7 @@ import {
     Placeholder,
     TableTreeGlobalStyle,
     TooltipContent,
+    WarningIcon,
 } from './TableTree.styles';
 
 const TreeWrapper = styled.div<{ hasMultipleTables: boolean }>`
@@ -286,7 +287,7 @@ const NodeItemButtons: FC<{
             {isFiltered && <Icon icon="filter" />}
             {node.hidden && (
                 <Tooltip2 content="This field has been hidden in the dbt project. It's recommend to remove it from the query">
-                    <Icon icon={'warning-sign'} intent="warning" />
+                    <WarningIcon icon={'warning-sign'} intent="warning" />
                 </Tooltip2>
             )}
             {menuItems.length > 0 && (isHovered || isSelected) && (


### PR DESCRIPTION

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
When a saved chart is using a dimension that has been hidden in the dbt project ( `hidden: true` ) we used to keep the saved chart working but we wouldn't display the dimension in the sidebar. 

With this fix we now show the dimension in the sidebar as long as being used but with a warning.

<!-- Even better add a screenshot / gif / loom -->
![Screenshot 2022-06-15 at 13 17 52](https://user-images.githubusercontent.com/9117144/173825152-146796a9-77d6-41a8-a0d2-102eff776be1.png)

