### PR TITLE
fix: remove divider and update markdown tile styling

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -245,7 +245,6 @@ const DashboardChartTile: FC<Props> = (props) => {
 
     return (
         <TileBase
-            isChart
             extraHeaderElement={
                 appliedFilterRules.length > 0 && (
                     <div>

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.styles.ts
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.styles.ts
@@ -1,0 +1,14 @@
+import { Colors } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const MarkdownWrapper = styled.div`
+    flex: 1;
+    overflow: auto;
+
+    .wmde-markdown {
+        font-size: 14px;
+        p {
+            color: ${Colors.GRAY1};
+        }
+    }
+`;

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -1,6 +1,7 @@
 import { DashboardMarkdownTile } from '@lightdash/common';
 import MDEditor from '@uiw/react-md-editor';
 import React, { FC } from 'react';
+import { MarkdownWrapper } from './DashboardMarkdownTile.styles';
 import TileBase from './TileBase/index';
 
 type Props = Pick<
@@ -16,12 +17,9 @@ const MarkdownTile: FC<Props> = (props) => {
     } = props;
     return (
         <TileBase title={title} {...props}>
-            <div
-                style={{ flex: 1, overflow: 'auto' }}
-                className="non-draggable"
-            >
+            <MarkdownWrapper className="non-draggable">
                 <MDEditor.Markdown source={content} linkTarget="_blank" />
-            </div>
+            </MarkdownWrapper>
         </TileBase>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -28,6 +28,7 @@ export const Title = styled(H5)`
 export const HeaderWrapper = styled.div`
     display: flex;
     flex-direction: column;
+    margin-bottom: 15px;
 `;
 
 export const FilterLabel = styled.span`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -1,7 +1,6 @@
 import {
     Button,
     Classes,
-    Divider,
     Menu,
     MenuDivider,
     MenuItem,
@@ -30,7 +29,6 @@ type Props<T> = {
     onDelete: (tile: T) => void;
     onEdit: (tile: T) => void;
     children: ReactNode;
-    isChart?: boolean;
     extraHeaderElement?: React.ReactNode;
 };
 
@@ -44,7 +42,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     onDelete,
     onEdit,
     children,
-    isChart,
     extraHeaderElement,
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
@@ -99,7 +96,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     </Popover2>
                 )}
             </HeaderContainer>
-            {!isChart && <Divider />}
+
             <ChartContainer className="non-draggable cohere-block">
                 {children}
             </ChartContainer>
@@ -118,7 +115,6 @@ TileBase.defaultProps = {
     isLoading: false,
     extraMenuItems: null,
     description: null,
-    isChart: false,
     hasFilters: false,
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2410 

### Description:
This PR updates the markdown tiles styling, and removes the divider from the markdown and the rest of the tiles 

<img width="719" alt="Screenshot 2022-06-15 at 17 53 41" src="https://user-images.githubusercontent.com/31137824/173871634-c6067eb4-1161-4857-a3d9-972746bfcce4.png">


