### PR TITLE
wip: convert truncated timestamps to UTC

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -31,12 +31,20 @@ const getDataTruncSql = (
     switch (adapterType) {
         case SupportedDbtAdapter.BIGQUERY:
             if (type === DimensionType.TIMESTAMP) {
-                return `DATETIME_TRUNC(${field}, ${timeInterval.toUpperCase()})`;
+                return `DATETIME(DATETIME_TRUNC(${field}, ${timeInterval.toUpperCase()}), 'UTC')`;
             }
             return `DATE_TRUNC(${field}, ${timeInterval.toUpperCase()})`;
+        case SupportedDbtAdapter.SNOWFLAKE:
+            if (type === DimensionType.TIMESTAMP) {
+                return `CONVERT_TIMEZONE('UTC', DATE_TRUNC('${timeInterval.toUpperCase()}', ${field}))`;
+            }
+            return `DATE_TRUNC('${timeInterval.toUpperCase()}', ${field})`;
         case SupportedDbtAdapter.REDSHIFT:
         case SupportedDbtAdapter.POSTGRES:
-        case SupportedDbtAdapter.SNOWFLAKE:
+            if (type === DimensionType.TIMESTAMP) {
+                return `DATE_TRUNC('${timeInterval.toUpperCase()}', ${field}) AT TIME ZONE 'UTC'`;
+            }
+            return `DATE_TRUNC('${timeInterval.toUpperCase()}', ${field})`;
         case SupportedDbtAdapter.DATABRICKS:
             return `DATE_TRUNC('${timeInterval.toUpperCase()}', ${field})`;
         default:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2445 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- [DATETIME bigquery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime)
- [CONVERT_TIMEZONE  snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone.html)
- [AT TIME ZONE Postgres docs](https://www.postgresql.org/docs/current/datatype-datetime.html)

> For timestamp with time zone, the internally stored value is always in UTC (Universal Coordinated Time, traditionally known as Greenwich Mean Time, GMT). An input value that has an explicit time zone specified is converted to UTC using the appropriate offset for that time zone. If no time zone is stated in the input string, then it is assumed to be in the time zone indicated by the system's [TimeZone](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TIMEZONE) parameter, and is converted to UTC using the offset for the timezone zone.

> When a timestamp with time zone value is output, it is always converted from UTC to the current timezone zone, and displayed as local time in that zone. To see the time in another time zone, either change timezone or use the AT TIME ZONE construct (see [Section 9.9.4](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT)).

I'm not sure if we actually need to change the sql for postgres&redshift.

<!-- Even better add a screenshot / gif / loom -->
