### PR TITLE
feat: access project permissions in the UI

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -290,5 +290,5 @@ export const user: SessionUser = {
         { subject: 'Dashboard', action: ['update', 'delete', 'create'] },
     ]),
     isActive: true,
-    projectRoles: [],
+    abilityRules: [],
 };

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -290,4 +290,5 @@ export const user: SessionUser = {
         { subject: 'Dashboard', action: ['update', 'delete', 'create'] },
     ]),
     isActive: true,
+    projectRoles: [],
 };

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -2,11 +2,11 @@ import {
     ActivateUser,
     CreateUserArgs,
     CreateUserWithRole,
-    defineUserAbility,
+    getUserAbilityBuilder,
     isOpenIdUser,
     LightdashMode,
     LightdashUser,
-    LightdashUserWithProjectRoles,
+    LightdashUserWithAbilityRules,
     NotExistsError,
     NotFoundError,
     OpenIdUser,
@@ -342,11 +342,15 @@ export class UserModel {
         }
         const lightdashUser = mapDbUserDetailsToLightdashUser(user);
         const projectRoles = await this.getUserProjectRoles(user.user_id);
+        const abilityBuilder = getUserAbilityBuilder(
+            lightdashUser,
+            projectRoles,
+        );
 
         return {
             userId: user.user_id,
-            projectRoles,
-            ability: defineUserAbility(lightdashUser, projectRoles),
+            abilityRules: abilityBuilder.rules,
+            ability: abilityBuilder.build(),
             ...lightdashUser,
         };
     }
@@ -476,11 +480,15 @@ export class UserModel {
         }
         const lightdashUser = mapDbUserDetailsToLightdashUser(user);
         const projectRoles = await this.getUserProjectRoles(user.user_id);
+        const abilityBuilder = getUserAbilityBuilder(
+            lightdashUser,
+            projectRoles,
+        );
         return {
             ...lightdashUser,
             userId: user.user_id,
-            projectRoles,
-            ability: defineUserAbility(lightdashUser, projectRoles),
+            abilityRules: abilityBuilder.rules,
+            ability: abilityBuilder.build(),
         };
     }
 
@@ -493,17 +501,21 @@ export class UserModel {
         }
         const lightdashUser = mapDbUserDetailsToLightdashUser(user);
         const projectRoles = await this.getUserProjectRoles(user.user_id);
+        const abilityBuilder = getUserAbilityBuilder(
+            lightdashUser,
+            projectRoles,
+        );
         return {
             ...lightdashUser,
-            projectRoles,
-            ability: defineUserAbility(lightdashUser, projectRoles),
+            abilityRules: abilityBuilder.rules,
+            ability: abilityBuilder.build(),
             userId: user.user_id,
         };
     }
 
     static lightdashUserFromSession(
         sessionUser: SessionUser,
-    ): LightdashUserWithProjectRoles {
+    ): LightdashUserWithAbilityRules {
         const { userId, ability, ...lightdashUser } = sessionUser;
         return lightdashUser;
     }

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -30,7 +30,7 @@ export const user: SessionUser = {
         },
     ]),
     isActive: true,
-    projectRoles: [],
+    abilityRules: [],
 };
 
 export const space: SpaceTable['base'] = {

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -30,6 +30,7 @@ export const user: SessionUser = {
         },
     ]),
     isActive: true,
+    projectRoles: [],
 };
 
 export const space: SpaceTable['base'] = {

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -1,7 +1,4 @@
-import {
-    defineAbilityForOrganizationMember,
-    ForbiddenError,
-} from '@lightdash/common';
+import { defineUserAbility, ForbiddenError } from '@lightdash/common';
 import { analytics } from '../../analytics/client';
 import { dashboardModel } from '../../models/models';
 import { DashboardService } from './DashboardService';
@@ -224,10 +221,13 @@ describe('DashboardService', () => {
     test('should not see dashboard from other organizations', async () => {
         const anotherUser = {
             ...user,
-            ability: defineAbilityForOrganizationMember({
-                ...user,
-                organizationUuid: 'another-org-uuid',
-            }),
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [],
+            ),
         };
         await expect(
             service.getById(anotherUser, dashboard.uuid),
@@ -236,10 +236,13 @@ describe('DashboardService', () => {
     test('should not see empty list if getting all dashboard by project uuid from another organization', async () => {
         const anotherUser = {
             ...user,
-            ability: defineAbilityForOrganizationMember({
-                ...user,
-                organizationUuid: 'another-org-uuid',
-            }),
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [],
+            ),
         };
         const result = await service.getAllByProject(
             anotherUser,

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -23,6 +23,7 @@ export const user: SessionUser = {
         { subject: 'Dashboard', action: ['update', 'delete', 'create'] },
     ]),
     isActive: true,
+    projectRoles: [],
 };
 
 export const organisation: Organisation = {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -23,7 +23,7 @@ export const user: SessionUser = {
         { subject: 'Dashboard', action: ['update', 'delete', 'create'] },
     ]),
     isActive: true,
-    projectRoles: [],
+    abilityRules: [],
 };
 
 export const organisation: Organisation = {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -42,6 +42,7 @@ export const user: SessionUser = {
         { subject: 'Job', action: ['view'] },
     ]),
     isActive: true,
+    projectRoles: [],
 };
 
 export const expectedTablesConfiguration: TablesConfiguration = {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -42,7 +42,7 @@ export const user: SessionUser = {
         { subject: 'Job', action: ['view'] },
     ]),
     isActive: true,
-    projectRoles: [],
+    abilityRules: [],
 };
 
 export const expectedTablesConfiguration: TablesConfiguration = {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,5 +1,5 @@
 import {
-    defineAbilityForOrganizationMember,
+    defineUserAbility,
     NotFoundError,
     OrganizationMemberRole,
     SessionUser,
@@ -167,11 +167,14 @@ describe('ProjectService', () => {
                 userUuid: 'another-user-uuid',
                 role: OrganizationMemberRole.VIEWER,
 
-                ability: defineAbilityForOrganizationMember({
-                    ...user,
-                    role: OrganizationMemberRole.VIEWER,
-                    userUuid: 'another-user-uuid',
-                }),
+                ability: defineUserAbility(
+                    {
+                        ...user,
+                        role: OrganizationMemberRole.VIEWER,
+                        userUuid: 'another-user-uuid',
+                    },
+                    [],
+                ),
             };
             await expect(
                 projectService.getJobStatus('jobUuid', anotherUser),

--- a/packages/common/src/authorization/index.mock.ts
+++ b/packages/common/src/authorization/index.mock.ts
@@ -1,9 +1,11 @@
 import {
     OrganizationMemberProfile,
     OrganizationMemberRole,
+} from '../types/organizationMemberProfile';
+import {
     ProjectMemberProfile,
     ProjectMemberRole,
-} from '@lightdash/common';
+} from '../types/projectMemberProfile';
 
 export const orgProfile: OrganizationMemberProfile = {
     userUuid: 'user-uuid-1234',

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -371,12 +371,25 @@ describe('Lightdash member permissions', () => {
         });
 
         it('can view project', async () => {
+            expect(ability.rules).toContainEqual({
+                action: 'manage',
+                subject: 'Project',
+                conditions: {
+                    organizationUuid: {
+                        $eq: adminOrgProfile.organizationUuid,
+                        $exists: true,
+                    },
+                },
+            });
+            const rule = ability.relevantRuleFor('manage', 'Project');
+
+            console.log('rule', rule);
             expect(ability.can('manage', 'Project')).toEqual(true);
             expect(
                 ability.can(
                     'manage',
                     subject('Project', {
-                        organizationUuid: orgProfile.organizationUuid,
+                        organizationUuid: adminOrgProfile.organizationUuid,
                     }),
                 ),
             ).toEqual(true);
@@ -387,12 +400,12 @@ describe('Lightdash member permissions', () => {
                         projectUuid: projectProfile.projectUuid,
                     }),
                 ),
-            ).toEqual(true);
+            ).toEqual(false);
             expect(
                 ability.can(
                     'manage',
                     subject('Project', {
-                        organizationUuid: orgProfile.organizationUuid,
+                        organizationUuid: adminOrgProfile.organizationUuid,
                         projectUuid: projectProfile.projectUuid,
                     }),
                 ),

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -1,21 +1,19 @@
 import { subject } from '@casl/ability';
-import { UserModel } from './UserModel';
+import { defineUserAbility } from './index';
 import {
     adminOrgProfile,
     adminProjectProfile,
     conditions as defaultConditions,
     orgProfile,
     projectProfile,
-} from './UserModel.mock';
+} from './index.mock';
 
-describe('Project member permissions', () => {
-    let ability = UserModel.mergeUserAbilities(orgProfile, [projectProfile]);
+describe('Lightdash member permissions', () => {
+    let ability = defineUserAbility(orgProfile, [projectProfile]);
     let conditions = defaultConditions;
     describe('when user is an org viewer and project viewer', () => {
         beforeEach(() => {
-            ability = UserModel.mergeUserAbilities(orgProfile, [
-                projectProfile,
-            ]);
+            ability = defineUserAbility(orgProfile, [projectProfile]);
         });
 
         it('can view org and project', async () => {
@@ -94,9 +92,7 @@ describe('Project member permissions', () => {
         // org admins and editors have `manage` permissions over all projects
         // within the org
         beforeEach(() => {
-            ability = UserModel.mergeUserAbilities(adminOrgProfile, [
-                projectProfile,
-            ]);
+            ability = defineUserAbility(adminOrgProfile, [projectProfile]);
             conditions = {
                 organizationUuid: adminOrgProfile.organizationUuid,
                 projectUuid: projectProfile.projectUuid,
@@ -145,9 +141,7 @@ describe('Project member permissions', () => {
 
     describe('when user is an org viewer and project admin', () => {
         beforeEach(() => {
-            ability = UserModel.mergeUserAbilities(orgProfile, [
-                adminProjectProfile,
-            ]);
+            ability = defineUserAbility(orgProfile, [adminProjectProfile]);
             conditions = {
                 organizationUuid: orgProfile.organizationUuid,
                 projectUuid: adminProjectProfile.projectUuid,
@@ -240,7 +234,7 @@ describe('Project member permissions', () => {
 
     describe('when user is viewer in one project but admin in another', () => {
         beforeEach(() => {
-            ability = UserModel.mergeUserAbilities(orgProfile, [
+            ability = defineUserAbility(orgProfile, [
                 projectProfile,
                 adminProjectProfile,
             ]);
@@ -364,6 +358,35 @@ describe('Project member permissions', () => {
                 ability.can(
                     'manage',
                     subject('Project', { ...conditionsProjectAdmin }),
+                ),
+            ).toEqual(true);
+        });
+    });
+
+    describe('when user is an org admin and has no project roles', () => {
+        // org admins and editors have `manage` permissions over all projects
+        // within the org
+        beforeEach(() => {
+            ability = defineUserAbility(adminOrgProfile, []);
+        });
+
+        it('can view project', async () => {
+            expect(ability.can('manage', 'Project')).toEqual(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Project', {
+                        projectUuid: projectProfile.projectUuid,
+                    }),
+                ),
+            ).toEqual(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Project', {
+                        organizationUuid: orgProfile.organizationUuid,
+                        projectUuid: projectProfile.projectUuid,
+                    }),
                 ),
             ).toEqual(true);
         });

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -381,9 +381,6 @@ describe('Lightdash member permissions', () => {
                     },
                 },
             });
-            const rule = ability.relevantRuleFor('manage', 'Project');
-
-            console.log('rule', rule);
             expect(ability.can('manage', 'Project')).toEqual(true);
             expect(
                 ability.can(

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -375,10 +375,7 @@ describe('Lightdash member permissions', () => {
                 action: 'manage',
                 subject: 'Project',
                 conditions: {
-                    organizationUuid: {
-                        $eq: adminOrgProfile.organizationUuid,
-                        $exists: true,
-                    },
+                    organizationUuid: adminOrgProfile.organizationUuid,
                 },
             });
             expect(ability.can('manage', 'Project')).toEqual(true);

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -376,6 +376,14 @@ describe('Lightdash member permissions', () => {
                 ability.can(
                     'manage',
                     subject('Project', {
+                        organizationUuid: orgProfile.organizationUuid,
+                    }),
+                ),
+            ).toEqual(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Project', {
                         projectUuid: projectProfile.projectUuid,
                     }),
                 ),

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -1,0 +1,28 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import { OrganizationMemberProfile } from '../types/organizationMemberProfile';
+import { ProjectMemberProfile } from '../types/projectMemberProfile';
+import { organizationMemberAbilities } from './organizationMemberAbility';
+import { projectMemberAbilities } from './projectMemberAbility';
+import { MemberAbility } from './types';
+
+// eslint-disable-next-line import/prefer-default-export
+export const defineUserAbility = (
+    organizationProfile: Pick<
+        OrganizationMemberProfile,
+        'role' | 'organizationUuid' | 'userUuid'
+    >,
+    projectProfiles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[],
+): MemberAbility => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    if (organizationProfile) {
+        organizationMemberAbilities[organizationProfile.role](
+            organizationProfile,
+            builder,
+        );
+    }
+    projectProfiles.forEach((projectProfile) => {
+        projectMemberAbilities[projectProfile.role](projectProfile, builder);
+    });
+
+    return builder.build();
+};

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -5,14 +5,13 @@ import { organizationMemberAbilities } from './organizationMemberAbility';
 import { projectMemberAbilities } from './projectMemberAbility';
 import { MemberAbility } from './types';
 
-// eslint-disable-next-line import/prefer-default-export
-export const defineUserAbility = (
+export const getUserAbilityBuilder = (
     organizationProfile: Pick<
         OrganizationMemberProfile,
         'role' | 'organizationUuid' | 'userUuid'
     >,
     projectProfiles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[],
-): MemberAbility => {
+) => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     if (organizationProfile) {
         organizationMemberAbilities[organizationProfile.role](
@@ -23,6 +22,16 @@ export const defineUserAbility = (
     projectProfiles.forEach((projectProfile) => {
         projectMemberAbilities[projectProfile.role](projectProfile, builder);
     });
+    return builder;
+};
 
+export const defineUserAbility = (
+    organizationProfile: Pick<
+        OrganizationMemberProfile,
+        'role' | 'organizationUuid' | 'userUuid'
+    >,
+    projectProfiles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[],
+): MemberAbility => {
+    const builder = getUserAbilityBuilder(organizationProfile, projectProfiles);
     return builder.build();
 };

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -1,12 +1,29 @@
-import { subject } from '@casl/ability';
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
 import { Organization } from '../types/organization';
-import { defineAbilityForOrganizationMember } from './organizationMemberAbility';
+import { OrganizationMemberProfile } from '../types/organizationMemberProfile';
+import { organizationMemberAbilities } from './organizationMemberAbility';
 import {
     ORGANIZATION_ADMIN,
     ORGANIZATION_EDITOR,
     ORGANIZATION_MEMBER,
     ORGANIZATION_VIEWER,
 } from './organizationMemberAbility.mock';
+import { MemberAbility } from './types';
+
+const defineAbilityForOrganizationMember = (
+    member:
+        | Pick<
+              OrganizationMemberProfile,
+              'role' | 'organizationUuid' | 'userUuid'
+          >
+        | undefined,
+): MemberAbility => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    if (member) {
+        organizationMemberAbilities[member.role](member, builder);
+    }
+    return builder.build();
+};
 
 describe('Organization member permissions', () => {
     let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -33,7 +33,12 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('view', 'Project', {
-            organizationUuid: member.organizationUuid,
+            organizationUuid: {
+                organizationUuid: {
+                    $eq: member.organizationUuid,
+                    $exists: true,
+                },
+            },
         });
         can('view', 'Organization', {
             organizationUuid: member.organizationUuid,
@@ -43,7 +48,7 @@ export const organizationMemberAbilities: Record<
     editor(member, { can }) {
         organizationMemberAbilities.viewer(member, { can });
         can('manage', 'Project', {
-            organizationUuid: member.organizationUuid,
+            organizationUuid: { $eq: member.organizationUuid, $exists: true },
         });
         can('manage', 'Dashboard', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -34,10 +34,7 @@ export const organizationMemberAbilities: Record<
         });
         can('view', 'Project', {
             organizationUuid: {
-                organizationUuid: {
-                    $eq: member.organizationUuid,
-                    $exists: true,
-                },
+                organizationUuid: member.organizationUuid,
             },
         });
         can('view', 'Organization', {
@@ -48,7 +45,7 @@ export const organizationMemberAbilities: Record<
     editor(member, { can }) {
         organizationMemberAbilities.viewer(member, { can });
         can('manage', 'Project', {
-            organizationUuid: { $eq: member.organizationUuid, $exists: true },
+            organizationUuid: member.organizationUuid,
         });
         can('manage', 'Dashboard', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -33,9 +33,7 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('view', 'Project', {
-            organizationUuid: {
-                organizationUuid: member.organizationUuid,
-            },
+            organizationUuid: member.organizationUuid,
         });
         can('view', 'Organization', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -1,39 +1,19 @@
-import { Ability, AbilityBuilder, ForcedSubject } from '@casl/ability';
-import { Organization } from '../types/organization';
+import { AbilityBuilder } from '@casl/ability';
 import {
     OrganizationMemberProfile,
     OrganizationMemberRole,
 } from '../types/organizationMemberProfile';
+import { MemberAbility } from './types';
 
-type Action = 'manage' | 'update' | 'view' | 'create' | 'delete';
-
-type Subject =
-    | Organization
-    | OrganizationMemberProfile
-    | 'Organization'
-    | 'OrganizationMemberProfile'
-    | 'Dashboard'
-    | 'SavedChart'
-    | 'Project'
-    | 'InviteLink'
-    | 'Job'
-    | 'all';
-
-type PossibleAbilities = [
-    Action,
-    Subject | ForcedSubject<Exclude<Subject, 'all'>>,
-];
-
-export type OrganizationMemberAbility = Ability<PossibleAbilities>;
-
-const organizationMemberAbilities: Record<
+// eslint-disable-next-line import/prefer-default-export
+export const organizationMemberAbilities: Record<
     OrganizationMemberRole,
     (
         member: Pick<
             OrganizationMemberProfile,
             'role' | 'organizationUuid' | 'userUuid'
         >,
-        builder: Pick<AbilityBuilder<OrganizationMemberAbility>, 'can'>,
+        builder: Pick<AbilityBuilder<MemberAbility>, 'can'>,
     ) => void
 > = {
     member(member, { can }) {
@@ -86,19 +66,4 @@ const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
     },
-};
-
-export const defineAbilityForOrganizationMember = (
-    member:
-        | Pick<
-              OrganizationMemberProfile,
-              'role' | 'organizationUuid' | 'userUuid'
-          >
-        | undefined,
-): OrganizationMemberAbility => {
-    const builder = new AbilityBuilder<OrganizationMemberAbility>(Ability);
-    if (member) {
-        organizationMemberAbilities[member.role](member, builder);
-    }
-    return builder.build();
 };

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -1,12 +1,24 @@
-import { subject } from '@casl/ability';
-import { defineAbilityForProjectMember } from './projectMemberAbility';
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
+import { ProjectMemberProfile } from '../types/projectMemberProfile';
+import { projectMemberAbilities } from './projectMemberAbility';
 import {
     PROJECT_ADMIN,
     PROJECT_EDITOR,
     PROJECT_VIEWER,
 } from './projectMemberAbility.mock';
+import { MemberAbility } from './types';
 
 const { projectUuid } = PROJECT_VIEWER;
+
+const defineAbilityForProjectMember = (
+    member: Pick<ProjectMemberProfile, 'role' | 'projectUuid'> | undefined,
+): MemberAbility => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    if (member) {
+        projectMemberAbilities[member.role](member, builder);
+    }
+    return builder.build();
+};
 
 describe('Project member permissions', () => {
     let ability = defineAbilityForProjectMember(PROJECT_ADMIN);

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -1,29 +1,16 @@
-import { Ability, AbilityBuilder, ForcedSubject } from '@casl/ability';
+import { AbilityBuilder } from '@casl/ability';
 import {
     ProjectMemberProfile,
     ProjectMemberRole,
 } from '../types/projectMemberProfile';
+import { MemberAbility } from './types';
 
-type Action = 'manage' | 'update' | 'view' | 'create' | 'delete';
-
-interface Project {
-    projectUuid: string;
-}
-
-type Subject = Project | 'Dashboard' | 'SavedChart' | 'Project' | 'Job' | 'all';
-
-type PossibleAbilities = [
-    Action,
-    Subject | ForcedSubject<Exclude<Subject, 'all'>>,
-];
-
-export type ProjectMemberAbility = Ability<PossibleAbilities>;
-
-const projectMemberAbilities: Record<
+// eslint-disable-next-line import/prefer-default-export
+export const projectMemberAbilities: Record<
     ProjectMemberRole,
     (
         member: Pick<ProjectMemberProfile, 'role' | 'projectUuid'>,
-        builder: Pick<AbilityBuilder<ProjectMemberAbility>, 'can'>,
+        builder: Pick<AbilityBuilder<MemberAbility>, 'can'>,
     ) => void
 > = {
     viewer(member, { can }) {
@@ -54,14 +41,4 @@ const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
     },
-};
-
-export const defineAbilityForProjectMember = (
-    member: Pick<ProjectMemberProfile, 'role' | 'projectUuid'> | undefined,
-): ProjectMemberAbility => {
-    const builder = new AbilityBuilder<ProjectMemberAbility>(Ability);
-    if (member) {
-        projectMemberAbilities[member.role](member, builder);
-    }
-    return builder.build();
 };

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -1,0 +1,30 @@
+import { Ability, ForcedSubject } from '@casl/ability';
+import { Organization } from '../types/organization';
+import { OrganizationMemberProfile } from '../types/organizationMemberProfile';
+
+type Action = 'manage' | 'update' | 'view' | 'create' | 'delete';
+
+interface Project {
+    organizationUuid: string;
+    projectUuid: string;
+}
+
+type Subject =
+    | Project
+    | Organization
+    | OrganizationMemberProfile
+    | 'Project'
+    | 'Organization'
+    | 'OrganizationMemberProfile'
+    | 'Dashboard'
+    | 'SavedChart'
+    | 'InviteLink'
+    | 'Job'
+    | 'all';
+
+type PossibleAbilities = [
+    Action,
+    Subject | ForcedSubject<Exclude<Subject, 'all'>>,
+];
+
+export type MemberAbility = Ability<PossibleAbilities>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -51,8 +51,8 @@ import { TableBase } from './types/table';
 import { LightdashUser } from './types/user';
 import { formatItemValue } from './utils/formatting';
 
-export * from './authorization/organizationMemberAbility';
-export * from './authorization/projectMemberAbility';
+export * from './authorization/index';
+export * from './authorization/types';
 export * from './compiler/exploreCompiler';
 export * from './compiler/translator';
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';

--- a/packages/common/src/openapi/schemas/LightdashUser.json
+++ b/packages/common/src/openapi/schemas/LightdashUser.json
@@ -32,19 +32,11 @@
         "role": {
             "type": "string"
         },
-        "projectRoles": {
+        "abilityRules": {
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "role": {
-                        "type": "string"
-                    }
-                }
+                "additionalProperties": true
             }
         }
     },

--- a/packages/common/src/openapi/schemas/LightdashUser.json
+++ b/packages/common/src/openapi/schemas/LightdashUser.json
@@ -31,6 +31,21 @@
         },
         "role": {
             "type": "string"
+        },
+        "projectRoles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "required": [

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1531,19 +1531,11 @@
                     "role": {
                         "type": "string"
                     },
-                    "projectRoles": {
+                    "abilityRules": {
                         "type": "array",
                         "items": {
                             "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "projectUuid": {
-                                    "type": "string"
-                                },
-                                "role": {
-                                    "type": "string"
-                                }
-                            }
+                            "additionalProperties": true
                         }
                     }
                 },

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1530,6 +1530,21 @@
                     },
                     "role": {
                         "type": "string"
+                    },
+                    "projectRoles": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "projectUuid": {
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 },
                 "required": [

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -1,6 +1,6 @@
+import { AbilityBuilder } from '@casl/ability';
 import { MemberAbility } from '../authorization/types';
 import { OrganizationMemberRole } from './organizationMemberProfile';
-import { ProjectMemberProfile } from './projectMemberProfile';
 
 export interface LightdashUser {
     userUuid: string;
@@ -16,11 +16,11 @@ export interface LightdashUser {
     isActive: boolean;
 }
 
-export interface LightdashUserWithProjectRoles extends LightdashUser {
-    projectRoles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[];
+export interface LightdashUserWithAbilityRules extends LightdashUser {
+    abilityRules: AbilityBuilder<MemberAbility>['rules'];
 }
 
-export interface SessionUser extends LightdashUserWithProjectRoles {
+export interface SessionUser extends LightdashUserWithAbilityRules {
     userId: number;
     ability: MemberAbility;
 }

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -1,5 +1,6 @@
-import { Ability } from '@casl/ability';
+import { MemberAbility } from '../authorization/types';
 import { OrganizationMemberRole } from './organizationMemberProfile';
+import { ProjectMemberProfile } from './projectMemberProfile';
 
 export interface LightdashUser {
     userUuid: string;
@@ -15,9 +16,13 @@ export interface LightdashUser {
     isActive: boolean;
 }
 
-export interface SessionUser extends LightdashUser {
+export interface LightdashUserWithProjectRoles extends LightdashUser {
+    projectRoles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[];
+}
+
+export interface SessionUser extends LightdashUserWithProjectRoles {
     userId: number;
-    ability: Ability;
+    ability: MemberAbility;
 }
 
 export interface UpdatedByUser {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,6 +9,8 @@
         "@blueprintjs/popover2": "^1.4.1",
         "@blueprintjs/select": "^4.4.1",
         "@blueprintjs/table": "^4.3.1",
+        "@casl/ability": "^5.4.4",
+        "@casl/react": "^3.0.0",
         "@hookform/error-message": "^2.0.0",
         "@sentry/react": "^6.17.6",
         "@sentry/tracing": "^6.17.6",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import JobDetailsDrawer from './components/JobDetailsDrawer';
 import MobileView from './components/Mobile';
 import NavBar from './components/NavBar';
 import PrivateRoute from './components/PrivateRoute';
+import ProjectRoute from './components/ProjectRoute';
 import UserCompletionModal from './components/UserCompletionModal';
 import CreateProject from './pages/CreateProject';
 import CreateProjectSettings from './pages/CreateProjectSettings';
@@ -144,103 +145,118 @@ const App = () => (
                                                         <ForbiddenPanel />
                                                     </TrackPage>
                                                 </Route>
+                                                <Route path="/no-project-access">
+                                                    <NavBar />
+                                                    <TrackPage
+                                                        name={
+                                                            PageName.NO_PROJECT_ACCESS
+                                                        }
+                                                    >
+                                                        <ForbiddenPanel subject="project" />
+                                                    </TrackPage>
+                                                </Route>
                                                 <AppRoute path="/">
                                                     <Switch>
-                                                        <Route path="/projects/:projectUuid/settings/:tab?">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.PROJECT_SETTINGS
-                                                                }
-                                                            >
-                                                                <ProjectSettings />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/saved/:savedQueryUuid/:mode?">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.SAVED_QUERY_EXPLORER
-                                                                }
-                                                            >
-                                                                <SavedExplorer />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/saved">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.SAVED_QUERIES
-                                                                }
-                                                            >
-                                                                <SavedQueries />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/dashboards/:dashboardUuid/:mode?">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.DASHBOARD
-                                                                }
-                                                            >
-                                                                <DashboardProvider>
-                                                                    <Dashboard />
-                                                                </DashboardProvider>
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/dashboards">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.SAVED_DASHBOARDS
-                                                                }
-                                                            >
-                                                                <SavedDashboards />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/sqlRunner">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.SQL_RUNNER
-                                                                }
-                                                            >
-                                                                <SqlRunner />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/tables/:tableId">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.EXPLORER
-                                                                }
-                                                            >
-                                                                <Explorer />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route path="/projects/:projectUuid/tables">
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.EXPLORE_TABLES
-                                                                }
-                                                            >
-                                                                <Explorer />
-                                                            </TrackPage>
-                                                        </Route>
-                                                        <Route
-                                                            path="/projects/:projectUuid/home"
-                                                            exact
-                                                        >
-                                                            <NavBar />
-                                                            <TrackPage
-                                                                name={
-                                                                    PageName.HOME
-                                                                }
-                                                            >
-                                                                <Home />
-                                                            </TrackPage>
-                                                        </Route>
+                                                        <ProjectRoute path="/projects/:projectUuid">
+                                                            <Switch>
+                                                                <Route path="/projects/:projectUuid/settings/:tab?">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.PROJECT_SETTINGS
+                                                                        }
+                                                                    >
+                                                                        <ProjectSettings />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/saved/:savedQueryUuid/:mode?">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.SAVED_QUERY_EXPLORER
+                                                                        }
+                                                                    >
+                                                                        <SavedExplorer />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/saved">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.SAVED_QUERIES
+                                                                        }
+                                                                    >
+                                                                        <SavedQueries />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/dashboards/:dashboardUuid/:mode?">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.DASHBOARD
+                                                                        }
+                                                                    >
+                                                                        <DashboardProvider>
+                                                                            <Dashboard />
+                                                                        </DashboardProvider>
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/dashboards">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.SAVED_DASHBOARDS
+                                                                        }
+                                                                    >
+                                                                        <SavedDashboards />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/sqlRunner">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.SQL_RUNNER
+                                                                        }
+                                                                    >
+                                                                        <SqlRunner />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/tables/:tableId">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.EXPLORER
+                                                                        }
+                                                                    >
+                                                                        <Explorer />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route path="/projects/:projectUuid/tables">
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.EXPLORE_TABLES
+                                                                        }
+                                                                    >
+                                                                        <Explorer />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Route
+                                                                    path="/projects/:projectUuid/home"
+                                                                    exact
+                                                                >
+                                                                    <NavBar />
+                                                                    <TrackPage
+                                                                        name={
+                                                                            PageName.HOME
+                                                                        }
+                                                                    >
+                                                                        <Home />
+                                                                    </TrackPage>
+                                                                </Route>
+                                                                <Redirect to="/projects" />
+                                                            </Switch>
+                                                        </ProjectRoute>
                                                         <Route
                                                             path="/projects/:projectUuid?"
                                                             exact

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -2,36 +2,27 @@ import { NonIdealState } from '@blueprintjs/core';
 import React, { ComponentProps, FC } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
-import { useProjects } from '../hooks/useProjects';
 import { useApp } from '../providers/AppProvider';
 import PageSpinner from './PageSpinner';
 
 const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
     const { health } = useApp();
     const orgRequest = useOrganisation();
-    const projectsRequest = useProjects();
 
     return (
         <Route
             {...rest}
             render={({ location }) => {
-                if (
-                    health.isLoading ||
-                    orgRequest.isLoading ||
-                    projectsRequest.isLoading
-                ) {
+                if (health.isLoading || orgRequest.isLoading) {
                     return <PageSpinner />;
                 }
 
-                if (orgRequest.error || projectsRequest.error || health.error) {
+                if (orgRequest.error || health.error) {
                     return (
                         <div style={{ marginTop: '20px' }}>
                             <NonIdealState
                                 title="Unexpected error"
-                                description={
-                                    (orgRequest.error || projectsRequest.error)
-                                        ?.error.message
-                                }
+                                description={orgRequest.error?.error.message}
                             />
                         </div>
                     );
@@ -46,13 +37,6 @@ const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
                             }}
                         />
                     );
-                }
-
-                if (
-                    !projectsRequest.data ||
-                    projectsRequest.data?.length <= 0
-                ) {
-                    return <Redirect to={`/no-access`} />;
                 }
 
                 return children;

--- a/packages/frontend/src/components/ForbiddenPanel.tsx
+++ b/packages/frontend/src/components/ForbiddenPanel.tsx
@@ -6,10 +6,12 @@ const ForbiddenPanelWrapper = styled.div`
     margin-top: 30vh;
 `;
 
-const ForbiddenPanel: FC = () => (
+const ForbiddenPanel: FC<{ subject?: string }> = ({ subject }) => (
     <ForbiddenPanelWrapper>
         <NonIdealState
-            title="You don't have access"
+            title={`You don't have access${
+                subject ? ` to this ${subject}` : ''
+            }`}
             description="Please contact the admin to request access."
             icon="lock"
         />

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -13,7 +13,6 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
 
     useEffect(() => {
         if (user.data) {
-            console.log('user.data', user.data.abilityRules);
             ability.update(user.data.abilityRules);
         }
     }, [ability, user]);

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -1,8 +1,7 @@
-import { getUserAbilityBuilder } from '@lightdash/common';
-import React, { ComponentProps, FC, useContext, useEffect } from 'react';
+import React, { ComponentProps, FC, useEffect } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useApp } from '../providers/AppProvider';
-import { AbilityContext } from './common/Authorization';
+import { useAbilityContext } from './common/Authorization';
 import PageSpinner from './PageSpinner';
 
 const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
@@ -10,15 +9,12 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
     ...rest
 }) => {
     const { health, user } = useApp();
-    const ability = useContext(AbilityContext);
+    const ability = useAbilityContext();
 
     useEffect(() => {
         if (user.data) {
-            const builder = getUserAbilityBuilder(
-                user.data,
-                user.data.projectRoles,
-            );
-            ability.update(builder.rules);
+            console.log('user.data', user.data.abilityRules);
+            ability.update(user.data.abilityRules);
         }
     }, [ability, user]);
 

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -41,6 +41,10 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
                     );
                 }
 
+                if (user.isLoading) {
+                    return <PageSpinner />;
+                }
+
                 return children;
             }}
         />

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -8,14 +8,17 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
     children,
     ...rest
 }) => {
-    const { health, user } = useApp();
+    const {
+        health,
+        user: { data, isLoading },
+    } = useApp();
     const ability = useAbilityContext();
 
     useEffect(() => {
-        if (user.data) {
-            ability.update(user.data.abilityRules);
+        if (data) {
+            ability.update(data.abilityRules);
         }
-    }, [ability, user]);
+    }, [ability, data]);
 
     return (
         <Route
@@ -36,7 +39,7 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
                     );
                 }
 
-                if (user.isLoading) {
+                if (isLoading) {
                     return <PageSpinner />;
                 }
 

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -1,13 +1,26 @@
-import React, { ComponentProps, FC } from 'react';
+import { getUserAbilityBuilder } from '@lightdash/common';
+import React, { ComponentProps, FC, useContext, useEffect } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useApp } from '../providers/AppProvider';
+import { AbilityContext } from './common/Authorization';
 import PageSpinner from './PageSpinner';
 
 const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
     children,
     ...rest
 }) => {
-    const { health } = useApp();
+    const { health, user } = useApp();
+    const ability = useContext(AbilityContext);
+
+    useEffect(() => {
+        if (user.data) {
+            const builder = getUserAbilityBuilder(
+                user.data,
+                user.data.projectRoles,
+            );
+            ability.update(builder.rules);
+        }
+    }, [ability, user]);
 
     return (
         <Route

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -53,10 +53,6 @@ const ProjectRoute: FC<ComponentProps<typeof Route>> = ({
                         passThrough
                     >
                         {(isAllowed) => {
-                            console.log('isAllowed', isAllowed, {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid: params.projectUuid,
-                            });
                             return isAllowed ? (
                                 children
                             ) : (

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -1,7 +1,7 @@
 import { NonIdealState } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import React, { ComponentProps, FC } from 'react';
-import { Redirect, Route, useParams } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 import { useProjects } from '../hooks/useProjects';
 import { useApp } from '../providers/AppProvider';
 import { Can } from './common/Authorization';
@@ -11,14 +11,13 @@ const ProjectRoute: FC<ComponentProps<typeof Route>> = ({
     children,
     ...rest
 }) => {
-    const params = useParams<{ projectUuid: string | undefined }>();
     const { user } = useApp();
     const projectsRequest = useProjects();
 
     return (
         <Route
             {...rest}
-            render={() => {
+            render={(location) => {
                 if (projectsRequest.isLoading) {
                     return <PageSpinner />;
                 }
@@ -48,7 +47,7 @@ const ProjectRoute: FC<ComponentProps<typeof Route>> = ({
                         I="view"
                         this={subject('Project', {
                             organizationUuid: user.data?.organizationUuid,
-                            projectUuid: params.projectUuid,
+                            projectUuid: location.match.params.projectUuid,
                         })}
                         passThrough
                     >

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -1,0 +1,73 @@
+import { NonIdealState } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
+import React, { ComponentProps, FC } from 'react';
+import { Redirect, Route, useParams } from 'react-router-dom';
+import { useProjects } from '../hooks/useProjects';
+import { useApp } from '../providers/AppProvider';
+import { Can } from './common/Authorization';
+import PageSpinner from './PageSpinner';
+
+const ProjectRoute: FC<ComponentProps<typeof Route>> = ({
+    children,
+    ...rest
+}) => {
+    const params = useParams<{ projectUuid: string | undefined }>();
+    const { user } = useApp();
+    const projectsRequest = useProjects();
+
+    return (
+        <Route
+            {...rest}
+            render={() => {
+                if (projectsRequest.isLoading) {
+                    return <PageSpinner />;
+                }
+
+                if (projectsRequest.error) {
+                    return (
+                        <div style={{ marginTop: '20px' }}>
+                            <NonIdealState
+                                title="Unexpected error"
+                                description={
+                                    projectsRequest.error.error.message
+                                }
+                            />
+                        </div>
+                    );
+                }
+
+                if (
+                    !projectsRequest.data ||
+                    projectsRequest.data?.length <= 0
+                ) {
+                    return <Redirect to={`/no-access`} />;
+                }
+
+                return (
+                    <Can
+                        I="view"
+                        this={subject('Project', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid: params.projectUuid,
+                        })}
+                        passThrough
+                    >
+                        {(isAllowed) => {
+                            console.log('isAllowed', isAllowed, {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid: params.projectUuid,
+                            });
+                            return isAllowed ? (
+                                children
+                            ) : (
+                                <Redirect to={`/no-project-access`} />
+                            );
+                        }}
+                    </Can>
+                );
+            }}
+        />
+    );
+};
+
+export default ProjectRoute;

--- a/packages/frontend/src/components/common/Authorization/index.tsx
+++ b/packages/frontend/src/components/common/Authorization/index.tsx
@@ -1,6 +1,16 @@
-import {Ability} from '@casl/ability';
-import {createContextualCan} from '@casl/react';
-import {createContext} from 'react';
+import { Ability } from '@casl/ability';
+import { createContextualCan } from '@casl/react';
+import { createContext, useContext } from 'react';
 
 export const AbilityContext = createContext(new Ability());
 export const Can = createContextualCan(AbilityContext.Consumer);
+
+export function useAbilityContext() {
+    const context = useContext(AbilityContext);
+    if (context === undefined) {
+        throw new Error(
+            'useAbilityContext must be used within a AbilityContext.Provider',
+        );
+    }
+    return context;
+}

--- a/packages/frontend/src/components/common/Authorization/index.tsx
+++ b/packages/frontend/src/components/common/Authorization/index.tsx
@@ -1,0 +1,6 @@
+import {Ability} from '@casl/ability';
+import {createContextualCan} from '@casl/react';
+import {createContext} from 'react';
+
+export const AbilityContext = createContext(new Ability());
+export const Can = createContextualCan(AbilityContext.Consumer);

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -71,7 +71,13 @@ const ProjectSettings: FC = () => {
                         exact
                         to={`${basePath}/tablesConfiguration`}
                     />
-                    <Can I="manage" this={subject('Project', { projectUuid })}>
+                    <Can
+                        I="manage"
+                        this={subject('Project', {
+                            organizationUuid: data.organizationUuid,
+                            projectUuid,
+                        })}
+                    >
                         <MenuDivider />
                         <RouterMenuItem
                             text="Project access"
@@ -121,7 +127,13 @@ const ProjectSettings: FC = () => {
                         </UpdateProjectWrapper>
                     </ProjectConnectionContainer>
                 </Route>
-                <Can I="manage" this={subject('Project', { projectUuid })}>
+                <Can
+                    I="manage"
+                    this={subject('Project', {
+                        organizationUuid: data.organizationUuid,
+                        projectUuid,
+                    })}
+                >
                     <Route
                         exact
                         path="/projects/:projectUuid/settings/projectAccess"

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -7,8 +7,10 @@ import {
     NonIdealState,
     Spinner,
 } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
 import React, { FC, useMemo, useState } from 'react';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
+import { Can } from '../components/common/Authorization';
 import Content from '../components/common/Page/Content';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
@@ -18,7 +20,6 @@ import ProjectAccessCreation from '../components/ProjectAccess/ProjectAccessCrea
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectTablesConfiguration from '../components/ProjectTablesConfiguration/ProjectTablesConfiguration';
 import { useProject } from '../hooks/useProject';
-import { useApp } from '../providers/AppProvider';
 import {
     ProjectConnectionContainer,
     Title,
@@ -29,7 +30,6 @@ import {
 const ProjectSettings: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isLoading, data, error } = useProject(projectUuid);
-    const { user } = useApp();
 
     const [projectAccessCreate, setProjectAccessCreate] =
         useState<boolean>(false);
@@ -38,10 +38,6 @@ const ProjectSettings: FC = () => {
         [projectUuid],
     );
 
-    const isOrgAdmin = user.data?.ability.can(
-        'manage',
-        'OrganizationMemberProfile',
-    );
     if (error) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -75,14 +71,14 @@ const ProjectSettings: FC = () => {
                         exact
                         to={`${basePath}/tablesConfiguration`}
                     />
-                    {isOrgAdmin && <MenuDivider />}
-                    {isOrgAdmin && (
+                    <Can I="manage" this={subject('Project', { projectUuid })}>
+                        <MenuDivider />
                         <RouterMenuItem
                             text="Project access"
                             exact
                             to={`${basePath}/projectAccess`}
                         />
-                    )}
+                    </Can>
                 </Menu>
             </Sidebar>
 
@@ -125,7 +121,7 @@ const ProjectSettings: FC = () => {
                         </UpdateProjectWrapper>
                     </ProjectConnectionContainer>
                 </Route>
-                {isOrgAdmin && (
+                <Can I="manage" this={subject('Project', { projectUuid })}>
                     <Route
                         exact
                         path="/projects/:projectUuid/settings/projectAccess"
@@ -149,7 +145,7 @@ const ProjectSettings: FC = () => {
                             )}
                         </Content>
                     </Route>
-                )}
+                </Can>
                 <Redirect to={basePath} />
             </Switch>
         </PageWithSidebar>

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -4,12 +4,10 @@ import { Ability } from '@casl/ability';
 import {
     ApiError,
     ApiHealthResults,
-    defineUserAbility,
     HealthState,
     Job,
     JobType,
-    LightdashUserWithProjectRoles,
-    MemberAbility,
+    LightdashUserWithAbilityRules,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
@@ -47,16 +45,17 @@ const getHealthState = async () =>
         body: undefined,
     });
 
-type User = LightdashUserWithProjectRoles & { ability: MemberAbility };
+type User = LightdashUserWithAbilityRules & { ability: Ability };
 const getUserState = async (): Promise<User> => {
-    const user = await lightdashApi<LightdashUserWithProjectRoles>({
+    const user = await lightdashApi<LightdashUserWithAbilityRules>({
         url: `/user`,
         method: 'GET',
         body: undefined,
     });
+
     return {
         ...user,
-        ability: defineUserAbility(user, user.projectRoles),
+        ability: new Ability(user.abilityRules),
     };
 };
 

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -307,9 +307,7 @@ export const AppProvider: FC = ({ children }) => {
                 apiBase={health.data?.intercom.apiBase || ''}
                 autoBoot
             >
-                <AbilityContext.Provider
-                    value={(user.data?.ability as any) || new Ability()}
-                >
+                <AbilityContext.Provider value={new Ability()}>
                     {children}
                 </AbilityContext.Provider>
             </IntercomProvider>

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -82,6 +82,8 @@ interface AppContext {
 
 const Context = createContext<AppContext>(undefined as any);
 
+const defaultAbility = new Ability();
+
 export const AppProvider: FC = ({ children }) => {
     const [isSentryLoaded, setIsSentryLoaded] = useState(false);
     const [isCohereLoaded, setIsCohereLoaded] = useState(false);
@@ -306,7 +308,7 @@ export const AppProvider: FC = ({ children }) => {
                 apiBase={health.data?.intercom.apiBase || ''}
                 autoBoot
             >
-                <AbilityContext.Provider value={new Ability()}>
+                <AbilityContext.Provider value={defaultAbility}>
                     {children}
                 </AbilityContext.Provider>
             </IntercomProvider>

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -32,6 +32,7 @@ export enum PageName {
     APPEARANCE = 'appearance_settings',
     ACCESS_TOKENS = 'access_tokens',
     NO_ACCESS = 'no_access',
+    NO_PROJECT_ACCESS = 'no_project_access',
 }
 
 export enum CategoryName {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,18 @@
   dependencies:
     "@ucast/mongo2js" "^1.3.0"
 
+"@casl/ability@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@casl/ability/-/ability-5.4.4.tgz#fbe54340c156248e73804942eed350903b27b9f3"
+  integrity sha512-7+GOnMUq6q4fqtDDesymBXTS9LSDVezYhFiSJ8Rn3f0aQLeRm7qHn66KWbej4niCOvm0XzNj9jzpkK0yz6hUww==
+  dependencies:
+    "@ucast/mongo2js" "^1.3.0"
+
+"@casl/react@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@casl/react/-/react-3.0.0.tgz#5fe0e809c97d095cad8055e71d0439c38edf6abb"
+  integrity sha512-1/+mHe9MmYVHzy4YrRqS/eZfSMCZdClgcbfohpMui0n4l4x6Ab4Q+Tok6ZGqzqG05vtBVT+pgb77YyZhzSEboQ==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- [x] move `mergeUserAbilities` from UserModel to common package
- [x] support `<Can />` component and ability context
- [x] hide project access settings based on project permissions
- [x] redirect user to /no-access page when they don't have access to any project
- [x] redirect user to /no-project-access page when they don't have access to a specific project they're trying to access ( introduce <ProjectRoute>, similar to <AppRoute> )