### PR TITLE
fix: tooltip to be disabled on click

### DIFF
--- a/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
+++ b/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
@@ -7,7 +7,7 @@ const RunSqlQueryButton: FC<{
     isLoading: boolean;
     onSubmit: () => void;
 }> = ({ onSubmit, isLoading }) => (
-    <Tooltip2 content={<KeyCombo combo="cmd+enter" />}>
+    <Tooltip2 content={<KeyCombo combo="cmd+enter" />} disabled={isLoading}>
         <BigButton
             icon="play"
             intent="primary"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1619 

### Description:
This PR fixes the `Run query` button tooltip from staying active when the button is clicked
