### PR TITLE
fix: user cascade deletion

### DIFF
--- a/packages/backend/src/database/migrations/20220622093921_remove-user-cascade-deletion.ts
+++ b/packages/backend/src/database/migrations/20220622093921_remove-user-cascade-deletion.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    // Change onDelete from 'CASCADE' to 'SET_NULL'
+    await knex.schema.alterTable('saved_queries_versions', (tableBuilder) => {
+        tableBuilder.dropForeign('updated_by_user_uuid');
+        tableBuilder
+            .foreign('updated_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+
+    await knex.schema.alterTable('dashboard_versions', (tableBuilder) => {
+        tableBuilder.dropForeign('updated_by_user_uuid');
+        tableBuilder
+            .foreign('updated_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+
+    // Delete all invalid saved charts and dashboards
+    await knex('saved_queries')
+        .whereNotExists(
+            knex('saved_queries_versions')
+                .select('*')
+                .whereRaw(
+                    'saved_queries.saved_query_id = saved_queries_versions.saved_query_id',
+                ),
+        )
+        .delete();
+
+    await knex('dashboards')
+        .whereNotExists(
+            knex('dashboard_versions')
+                .select('*')
+                .whereRaw(
+                    'dashboards.dashboard_id = dashboard_versions.dashboard_id',
+                ),
+        )
+        .delete();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export async function down(knex: Knex): Promise<void> {}


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fixing the bug where deleting the user cascades to what the user created/edited. Meaning all the chart and dashboard versions that user created are deleted. 

This changes the behaviour so when the user is deleted we just change the `updated_by_user_uuid` to `null` + deletes all the invalid dashboards and saved charts.
