### PR TITLE
feat: add dimension type icons to the explorer sidebar

### DIFF
--- a/packages/frontend/src/components/TableTree.styles.ts
+++ b/packages/frontend/src/components/TableTree.styles.ts
@@ -31,3 +31,12 @@ export const Placeholder = styled.div`
 export const WarningIcon = styled(Icon)`
     color: ${Colors.ORANGE5} !important;
 `;
+
+export const DimensionLabelWrapper = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const DimensionLabel = styled.p`
+    margin: 0;
+`;

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -36,6 +36,8 @@ import { TrackSection, useTracking } from '../providers/TrackingProvider';
 import { EventName, SectionName } from '../types/Events';
 import DocumentationHelpButton from './DocumentationHelpButton';
 import {
+    DimensionLabel,
+    DimensionLabelWrapper,
     ItemOptions,
     Placeholder,
     TableTreeGlobalStyle,
@@ -384,6 +386,23 @@ const CustomMetricButtons: FC<{
 
 type DimensionWithSubDimensions = Dimension & { subDimensions?: Dimension[] };
 
+const DimensionIconPicker = (type: DimensionType) => {
+    switch (type) {
+        case DimensionType.STRING:
+            return 'citation';
+        case DimensionType.NUMBER:
+            return 'numerical';
+        case DimensionType.DATE:
+            return 'calendar';
+        case DimensionType.BOOLEAN:
+            return 'segmented-control';
+        case DimensionType.TIMESTAMP:
+            return 'time';
+        default:
+            return 'citation';
+    }
+};
+
 const renderDimensionTreeNode = (
     dimension: DimensionWithSubDimensions,
     expandedNodes: Array<string | number>,
@@ -395,7 +414,15 @@ const renderDimensionTreeNode = (
         id: dimension.name,
         label: (
             <Tooltip2 content={dimension.description}>
-                {dimension.label}
+                <DimensionLabelWrapper>
+                    {!dimension.subDimensions && (
+                        <Icon
+                            icon={DimensionIconPicker(dimension.type)}
+                            className={Classes.TREE_NODE_ICON}
+                        />
+                    )}
+                    <DimensionLabel>{dimension.label}</DimensionLabel>
+                </DimensionLabelWrapper>
             </Tooltip2>
         ),
         secondaryLabel: (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2493 

### Description:
This PR adds icons to the dimension types in the explorer sidebar

<img width="313" alt="Screenshot 2022-06-22 at 17 00 22" src="https://user-images.githubusercontent.com/31137824/175063996-197d7d32-2906-46dd-adf0-a1d44ad9c67b.png">
<img width="241" alt="Screenshot 2022-06-22 at 17 00 07" src="https://user-images.githubusercontent.com/31137824/175064007-db05c30e-5d7c-40cd-b07d-ad12da379d38.png">



