### PR TITLE
fix: project access permissions

### DIFF
--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -28,17 +28,6 @@ export class JobModel {
         this.database = deps.database;
     }
 
-    async getMostRecentJobByProject(
-        projectUuid: string,
-    ): Promise<Job | undefined> {
-        const [row] = await this.database(JobsTableName)
-            .where('project_uuid', projectUuid)
-            .orderBy('updated_at', 'desc')
-            .limit(1);
-        if (row === undefined) return undefined;
-        return this.convertRowToJob(row);
-    }
-
     async get(jobUuid: string): Promise<Job> {
         const [row] = await this.database(JobsTableName).where(
             'job_uuid',

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -86,6 +86,7 @@ export class DashboardService {
                 'create',
                 subject('Dashboard', {
                     organizationUuid: space.organization_uuid,
+                    projectUuid,
                 }),
             )
         ) {
@@ -200,13 +201,12 @@ export class DashboardService {
     }
 
     async delete(user: SessionUser, dashboardUuid: string): Promise<void> {
-        const { organizationUuid } = await this.dashboardModel.getById(
-            dashboardUuid,
-        );
+        const { organizationUuid, projectUuid } =
+            await this.dashboardModel.getById(dashboardUuid);
         if (
             user.ability.cannot(
                 'delete',
-                subject('Dashboard', { organizationUuid }),
+                subject('Dashboard', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -398,6 +398,17 @@ export class ProjectService {
         projectUuid: string,
         exploreName: string,
     ): Promise<{ query: string; hasExampleMetric: boolean }> {
+        const { organizationUuid } =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         const explore = await this.getExplore(user, projectUuid, exploreName);
         const compiledMetricQuery = compileMetricQuery({
             explore,
@@ -607,12 +618,6 @@ export class ProjectService {
         }
     }
 
-    async getMostRecentJobByProject(
-        projectUuid: string,
-    ): Promise<Job | undefined> {
-        return this.jobModel.getMostRecentJobByProject(projectUuid);
-    }
-
     async getJobStatus(jobUuid: string, user: SessionUser): Promise<Job> {
         const job = await this.jobModel.get(jobUuid);
 
@@ -622,7 +627,10 @@ export class ProjectService {
             if (
                 user.ability.cannot(
                     'view',
-                    subject('Project', { organizationUuid }),
+                    subject('Project', {
+                        organizationUuid,
+                        projectUuid: job.projectUuid,
+                    }),
                 )
             ) {
                 throw new NotFoundError(`Cannot find job`);
@@ -638,7 +646,17 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<{ jobUuid: string }> {
-        if (user.ability.cannot('manage', 'Job')) {
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot('manage', 'Job') ||
+            user.ability.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -751,6 +769,18 @@ export class ProjectService {
         projectUuid: string,
         exploreName: string,
     ): Promise<Explore> {
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         const explores =
             (await this.projectModel.getExploresFromCache(projectUuid)) || [];
         const explore = explores.find((t) => t.name === exploreName);
@@ -818,7 +848,16 @@ export class ProjectService {
         projectUuid: string,
         data: TablesConfiguration,
     ): Promise<TablesConfiguration> {
-        if (user.ability.cannot('update', 'Project')) {
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'update',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         await this.projectModel.updateTablesConfiguration(projectUuid, data);
@@ -874,7 +913,18 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ProjectMemberProfile[]> {
-        // TODO implement permissions
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         return this.projectModel.getProjectAccess(projectUuid);
     }
 
@@ -883,7 +933,18 @@ export class ProjectService {
         projectUuid: string,
         data: CreateProjectMember,
     ): Promise<void> {
-        // TODO implement permissions
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         await this.projectModel.createProjectAccess(
             projectUuid,
@@ -910,7 +971,18 @@ export class ProjectService {
         userUuid: string,
         data: UpdateProjectMember,
     ): Promise<void> {
-        // TODO implement permissions
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         await this.projectModel.updateProjectAccess(
             projectUuid,
@@ -924,7 +996,18 @@ export class ProjectService {
         projectUuid: string,
         userUuid: string,
     ): Promise<void> {
-        // TODO implement permissions
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         await this.projectModel.deleteProjectAccess(projectUuid, userUuid);
     }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -73,14 +73,13 @@ export class SavedChartService {
         savedChartUuid: string,
         data: CreateSavedChartVersion,
     ): Promise<SavedChart> {
-        const { organizationUuid } = await this.savedChartModel.get(
-            savedChartUuid,
-        );
+        const { organizationUuid, projectUuid } =
+            await this.savedChartModel.get(savedChartUuid);
 
         if (
             user.ability.cannot(
                 'update',
-                subject('SavedChart', { organizationUuid }),
+                subject('SavedChart', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -103,14 +102,13 @@ export class SavedChartService {
         savedChartUuid: string,
         data: UpdateSavedChart,
     ): Promise<SavedChart> {
-        const { organizationUuid } = await this.savedChartModel.get(
-            savedChartUuid,
-        );
+        const { organizationUuid, projectUuid } =
+            await this.savedChartModel.get(savedChartUuid);
 
         if (
             user.ability.cannot(
                 'update',
-                subject('SavedChart', { organizationUuid }),
+                subject('SavedChart', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -131,14 +129,13 @@ export class SavedChartService {
     }
 
     async delete(user: SessionUser, savedChartUuid: string): Promise<void> {
-        const { organizationUuid } = await this.savedChartModel.get(
-            savedChartUuid,
-        );
+        const { organizationUuid, projectUuid } =
+            await this.savedChartModel.get(savedChartUuid);
 
         if (
             user.ability.cannot(
                 'delete',
-                subject('SavedChart', { organizationUuid }),
+                subject('SavedChart', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -190,7 +187,7 @@ export class SavedChartService {
         if (
             user.ability.cannot(
                 'create',
-                subject('SavedChart', { organizationUuid }),
+                subject('SavedChart', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -57,7 +57,7 @@ const testCompile = () => {
         .should('not.be.disabled')
         .click();
     cy.url().should('include', '/home', { timeout: 30000 });
-    cy.contains('Welcome, David');
+    cy.findByText('Welcome, David! ⚡'); // wait for page to load and avoid race conditions
 };
 
 const testRunQuery = () => {

--- a/packages/e2e/cypress/e2e/projectPermission.cy.ts
+++ b/packages/e2e/cypress/e2e/projectPermission.cy.ts
@@ -1,10 +1,10 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Login', () => {
+describe('Project Permissions', () => {
     it('Organization admin can see projects', () => {
         cy.login();
 
-        cy.visit('/');
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
         cy.contains('Settings');
         cy.get('.bp4-non-ideal-state').should('not.exist');
     });
@@ -12,7 +12,7 @@ describe('Login', () => {
     it('Organization members without project permission cannot see projects', () => {
         cy.loginWithPermissions('member', []);
 
-        cy.visit('/');
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
         cy.contains('Settings');
         cy.get('.bp4-non-ideal-state').should('exist');
     });
@@ -25,14 +25,14 @@ describe('Login', () => {
             },
         ]);
 
-        cy.visit('/');
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
         cy.contains('Settings');
         cy.get('.bp4-non-ideal-state').should('not.exist');
     });
     it('Organization editors without project permission can still see projects', () => {
         cy.loginWithPermissions('editor', []);
 
-        cy.visit('/');
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
         cy.contains('Settings');
         cy.get('.bp4-non-ideal-state').should('not.exist');
     });
@@ -40,7 +40,7 @@ describe('Login', () => {
     it('Organization admins without project permission can still see projects', () => {
         cy.loginWithPermissions('admin', []);
 
-        cy.visit('/');
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
         cy.contains('Settings');
         cy.get('.bp4-non-ideal-state').should('not.exist');
     });

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -7,10 +7,8 @@ import {
     NonIdealState,
     Spinner,
 } from '@blueprintjs/core';
-import { subject } from '@casl/ability';
 import React, { FC, useMemo, useState } from 'react';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
-import { Can } from '../components/common/Authorization';
 import Content from '../components/common/Page/Content';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
@@ -71,20 +69,12 @@ const ProjectSettings: FC = () => {
                         exact
                         to={`${basePath}/tablesConfiguration`}
                     />
-                    <Can
-                        I="manage"
-                        this={subject('Project', {
-                            organizationUuid: data.organizationUuid,
-                            projectUuid,
-                        })}
-                    >
-                        <MenuDivider />
-                        <RouterMenuItem
-                            text="Project access"
-                            exact
-                            to={`${basePath}/projectAccess`}
-                        />
-                    </Can>
+                    <MenuDivider />
+                    <RouterMenuItem
+                        text="Project access"
+                        exact
+                        to={`${basePath}/projectAccess`}
+                    />
                 </Menu>
             </Sidebar>
 
@@ -127,37 +117,27 @@ const ProjectSettings: FC = () => {
                         </UpdateProjectWrapper>
                     </ProjectConnectionContainer>
                 </Route>
-                <Can
-                    I="manage"
-                    this={subject('Project', {
-                        organizationUuid: data.organizationUuid,
-                        projectUuid,
-                    })}
+                <Route
+                    exact
+                    path="/projects/:projectUuid/settings/projectAccess"
                 >
-                    <Route
-                        exact
-                        path="/projects/:projectUuid/settings/projectAccess"
-                    >
-                        <Content>
-                            <Title>
-                                Project access (only visible to Project Admins)
-                            </Title>
-                            {projectAccessCreate ? (
-                                <ProjectAccessCreation
-                                    onBackClick={() => {
-                                        setProjectAccessCreate(false);
-                                    }}
-                                />
-                            ) : (
-                                <ProjectAccess
-                                    onAddUser={() => {
-                                        setProjectAccessCreate(true);
-                                    }}
-                                />
-                            )}
-                        </Content>
-                    </Route>
-                </Can>
+                    <Content>
+                        <Title>Project access</Title>
+                        {projectAccessCreate ? (
+                            <ProjectAccessCreation
+                                onBackClick={() => {
+                                    setProjectAccessCreate(false);
+                                }}
+                            />
+                        ) : (
+                            <ProjectAccess
+                                onAddUser={() => {
+                                    setProjectAccessCreate(true);
+                                }}
+                            />
+                        )}
+                    </Content>
+                </Route>
                 <Redirect to={basePath} />
             </Switch>
         </PageWithSidebar>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -105,7 +105,7 @@ const Settings: FC = () => {
                         )}
                         {orgData &&
                             !orgData.needsProject &&
-                            user.data?.ability?.can('manage', 'Project') && (
+                            user.data?.ability?.can('view', 'Project') && (
                                 <RouterMenuItem
                                     text="Project management"
                                     exact
@@ -166,7 +166,7 @@ const Settings: FC = () => {
                 )}
                 {orgData &&
                     !orgData.needsProject &&
-                    user.data?.ability?.can('manage', 'Project') && (
+                    user.data?.ability?.can('view', 'Project') && (
                         <Route
                             exact
                             path={`/generalSettings/projectManagement`}


### PR DESCRIPTION
### Description:
- apply permission check to all ProjectService methods
- update permission checks in saved chart and dashboard services
- apply permission check in org appearance form
- apply permission check in all project setting forms
- some other small fixes around permissions


![Screenshot 2022-06-22 at 16 41 20](https://user-images.githubusercontent.com/9117144/175074962-0236c452-3e34-45b3-89c3-a55a9738a95d.png)
![Screenshot 2022-06-22 at 16 41 11](https://user-images.githubusercontent.com/9117144/175074971-9010dd30-c193-48e0-8c9a-e34b9a28a1c3.png)
![Screenshot 2022-06-22 at 16 40 56](https://user-images.githubusercontent.com/9117144/175074976-52a2aa25-8b61-4704-acde-d57ffd98e5e0.png)
![Screenshot 2022-06-22 at 16 38 27](https://user-images.githubusercontent.com/9117144/175074977-fb7cf023-9cd6-4075-bf05-ab365166fd9f.png)
![Screenshot 2022-06-22 at 16 30 44](https://user-images.githubusercontent.com/9117144/175074978-2b4fc202-0610-4350-98da-7ca3c9480859.png)

