### PR TITLE
feat: remove heading icons and add icons to metrics

### DIFF
--- a/packages/frontend/src/components/TableTree.styles.ts
+++ b/packages/frontend/src/components/TableTree.styles.ts
@@ -32,11 +32,19 @@ export const WarningIcon = styled(Icon)`
     color: ${Colors.ORANGE5} !important;
 `;
 
-export const DimensionLabelWrapper = styled.div`
+export const ItemLabelWrapper = styled.div`
     display: flex;
     align-items: center;
+    gap: 5px;
 `;
 
-export const DimensionLabel = styled.p`
+export const ItemIcon = styled(Icon)`
+    margin: 0;
+    path {
+        fill: ${Colors.GRAY2};
+    }
+`;
+
+export const ItemLabel = styled.p`
     margin: 0;
 `;

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -410,6 +410,9 @@ const renderDimensionTreeNode = (
     onOpenSourceDialog: (source: Source) => void,
     hoveredFieldId: string,
 ): TreeNodeInfo<NodeDataProps> => {
+    const itemLabel = dimension?.group
+        ? friendlyName(dimension.name.replace(dimension?.group, ''))
+        : dimension.label;
     const baseNode = {
         id: dimension.name,
         label: (
@@ -419,7 +422,7 @@ const renderDimensionTreeNode = (
                         icon={ItemLabelIconPicker(dimension.type)}
                         className={Classes.TREE_NODE_ICON}
                     />
-                    <ItemLabel>{dimension.label}</ItemLabel>
+                    <ItemLabel>{itemLabel}</ItemLabel>
                 </ItemLabelWrapper>
             </Tooltip2>
         ),

--- a/packages/frontend/src/components/TableTree.tsx
+++ b/packages/frontend/src/components/TableTree.tsx
@@ -4,7 +4,6 @@ import {
     Colors,
     Dialog,
     Icon,
-    Intent,
     Menu,
     MenuItem,
     PopoverPosition,
@@ -36,8 +35,9 @@ import { TrackSection, useTracking } from '../providers/TrackingProvider';
 import { EventName, SectionName } from '../types/Events';
 import DocumentationHelpButton from './DocumentationHelpButton';
 import {
-    DimensionLabel,
-    DimensionLabelWrapper,
+    ItemIcon,
+    ItemLabel,
+    ItemLabelWrapper,
     ItemOptions,
     Placeholder,
     TableTreeGlobalStyle,
@@ -386,20 +386,20 @@ const CustomMetricButtons: FC<{
 
 type DimensionWithSubDimensions = Dimension & { subDimensions?: Dimension[] };
 
-const DimensionIconPicker = (type: DimensionType) => {
+const ItemLabelIconPicker = (type: DimensionType | MetricType) => {
     switch (type) {
-        case DimensionType.STRING:
+        case DimensionType.STRING || MetricType.STRING:
             return 'citation';
-        case DimensionType.NUMBER:
+        case DimensionType.NUMBER || MetricType.NUMBER:
             return 'numerical';
-        case DimensionType.DATE:
+        case DimensionType.DATE || MetricType.DATE:
             return 'calendar';
-        case DimensionType.BOOLEAN:
+        case DimensionType.BOOLEAN || MetricType.BOOLEAN:
             return 'segmented-control';
         case DimensionType.TIMESTAMP:
             return 'time';
         default:
-            return 'citation';
+            return 'numerical';
     }
 };
 
@@ -414,15 +414,13 @@ const renderDimensionTreeNode = (
         id: dimension.name,
         label: (
             <Tooltip2 content={dimension.description}>
-                <DimensionLabelWrapper>
-                    {!dimension.subDimensions && (
-                        <Icon
-                            icon={DimensionIconPicker(dimension.type)}
-                            className={Classes.TREE_NODE_ICON}
-                        />
-                    )}
-                    <DimensionLabel>{dimension.label}</DimensionLabel>
-                </DimensionLabelWrapper>
+                <ItemLabelWrapper>
+                    <ItemIcon
+                        icon={ItemLabelIconPicker(dimension.type)}
+                        className={Classes.TREE_NODE_ICON}
+                    />
+                    <ItemLabel>{dimension.label}</ItemLabel>
+                </ItemLabelWrapper>
             </Tooltip2>
         ),
         secondaryLabel: (
@@ -569,13 +567,6 @@ const TableTree: FC<TableTreeProps> = ({
                 }}
             />
         ) : undefined,
-        icon: (
-            <Icon
-                icon="numerical"
-                intent={Intent.WARNING}
-                className={Classes.TREE_NODE_ICON}
-            />
-        ),
         isExpanded: true,
         hasCaret: false,
         childNodes: hasNoMetrics
@@ -594,7 +585,12 @@ const TableTree: FC<TableTreeProps> = ({
                       id: metric.name,
                       label: (
                           <Tooltip2 content={metric.description}>
-                              {metric.label}
+                              <ItemLabelWrapper>
+                                  <ItemIcon
+                                      icon={ItemLabelIconPicker(metric.type)}
+                                  />
+                                  <ItemLabel>{metric.label}</ItemLabel>
+                              </ItemLabelWrapper>
                           </Tooltip2>
                       ),
                       nodeData: {
@@ -636,13 +632,6 @@ const TableTree: FC<TableTreeProps> = ({
                 <strong>Custom metrics</strong>
             </span>
         ),
-        icon: (
-            <Icon
-                icon="clean"
-                intent={Intent.WARNING}
-                className={Classes.TREE_NODE_ICON}
-            />
-        ),
         hasCaret: false,
         isExpanded: true,
         secondaryLabel: isFirstTable ? (
@@ -679,7 +668,14 @@ const TableTree: FC<TableTreeProps> = ({
                                   key={metric.label}
                                   content={metric.description}
                               >
-                                  {metric.label}
+                                  <ItemLabelWrapper>
+                                      <ItemIcon
+                                          icon={ItemLabelIconPicker(
+                                              metric.type,
+                                          )}
+                                      />
+                                      <ItemLabel>{metric.label}</ItemLabel>
+                                  </ItemLabelWrapper>
                               </Tooltip2>
                           ),
                           nodeData: {
@@ -702,13 +698,6 @@ const TableTree: FC<TableTreeProps> = ({
             <span style={{ color: Colors.BLUE1 }}>
                 <strong>Dimensions</strong>
             </span>
-        ),
-        icon: (
-            <Icon
-                icon="tag"
-                intent={Intent.PRIMARY}
-                className={Classes.TREE_NODE_ICON}
-            />
         ),
         hasCaret: false,
         isExpanded: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2493 

### Description:
This PR updates the icons on the explorer sidebar

- Removes icons from headings (metrics / dimensions / custom metrics)
- Adds icons to metrics / custom metrics
- Updates the icons color
- Adds icons to items with subitems as well so the hierarchy is clear
- removes table names from sub items 

<img width="374" alt="Screenshot 2022-06-23 at 16 50 08" src="https://user-images.githubusercontent.com/31137824/175328991-ff846977-5e26-41a4-a3cd-81c72c3b7d64.png">

