### PR TITLE
fix: stack area chart when not grouping

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -19,6 +19,7 @@ const VisualizationCardOptions: FC = () => {
         isLoading,
         plotData,
         cartesianConfig,
+        pivotDimensions,
         setPivotDimensions,
         cartesianConfig: { setStacking },
     } = useVisualizationContext();
@@ -57,6 +58,9 @@ const VisualizationCardOptions: FC = () => {
                         };
 
                     case CartesianSeriesType.BAR:
+                        if (!pivotDimensions || pivotDimensions.length === 0) {
+                            setStacking(false);
+                        }
                         return cartesianFlipAxis
                             ? {
                                   text: 'Horizontal bar chart',
@@ -96,6 +100,7 @@ const VisualizationCardOptions: FC = () => {
         cartesianType,
         chartType,
         setStacking,
+        pivotDimensions,
     ]);
 
     return (

--- a/packages/frontend/src/hooks/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/useCartesianChartConfig.ts
@@ -207,11 +207,15 @@ const useCartesianChartConfig = ({
             const yFields = dirtyLayout?.yField || [];
             yFields.forEach((yField) => {
                 updateAllGroupedSeries(yField, {
-                    stack: stack ? yField : undefined,
+                    stack: stack
+                        ? pivotKey
+                            ? yField
+                            : 'stack-all-series'
+                        : undefined,
                 });
             });
         },
-        [updateAllGroupedSeries, dirtyLayout],
+        [dirtyLayout?.yField, updateAllGroupedSeries, pivotKey],
     );
 
     const [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2526 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Area chart when stacking 2 y axis with no grouping:
![Screenshot 2022-06-24 at 12 38 33](https://user-images.githubusercontent.com/9117144/175527461-ef7137cc-fdcf-4c91-bedb-cbf32eb20853.png)

Area chart when stacking 2 y axis with grouping:
![Screenshot 2022-06-24 at 12 41 09](https://user-images.githubusercontent.com/9117144/175527552-627aa3ee-b179-455d-850f-5d4275ff1b37.png)


Note that we have in place some restrictions on what is possible to do with stacked charts. There is a [separate ticket to improve stacking configuration](https://github.com/lightdash/lightdash/issues/2524).