### PR TITLE
feat: default string dimensions on cli

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -42,7 +42,7 @@ export const compile = async (options: GenerateHandlerOptions) => {
         getSchemaStructureFromDbtModels(models),
     );
 
-    const typedModels = attachTypesToModels(models, catalog, true);
+    const typedModels = attachTypesToModels(models, catalog, false);
     if (!isSupportedDbtAdapter(manifest.metadata)) {
         throw new ParseError(
             `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2552 
Closes: #2538 <!-- reference the related issue e.g. #150 -->

### Description:

Changes the compile process on the CLI to behave similarly to compiling in the UI
* Compiling Lightdash does not require all referenced tables/columns to exist (we can never guarantee that)
* If the user doesn't specify a dimension type, we'll still try and find the type in the warehouse, if we can't we default to string

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
