### PR TITLE
fix: explore reset

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -138,7 +138,7 @@ const FiltersCard: FC = () => {
                     <Button
                         icon={filterIsOpen ? 'chevron-down' : 'chevron-right'}
                         minimal
-                        disabled={!isEditMode}
+                        disabled={!isEditMode || !tableName}
                         onClick={() =>
                             toggleExpandedSection(ExplorerSection.FILTERS)
                         }

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -33,16 +33,19 @@ const ResultsCard: FC = () => {
                         onClick={() =>
                             toggleExpandedSection(ExplorerSection.RESULTS)
                         }
+                        disabled={!unsavedChartVersion.tableName}
                     />
                     <H5>Results</H5>
-                    {isEditMode && resultsIsOpen && (
-                        <LimitButton
-                            limit={unsavedChartVersion.metricQuery.limit}
-                            onLimitChange={setRowLimit}
-                        />
-                    )}
+                    {isEditMode &&
+                        resultsIsOpen &&
+                        unsavedChartVersion.tableName && (
+                            <LimitButton
+                                limit={unsavedChartVersion.metricQuery.limit}
+                                onLimitChange={setRowLimit}
+                            />
+                        )}
                 </CardHeaderLeftContent>
-                {resultsIsOpen && (
+                {resultsIsOpen && unsavedChartVersion.tableName && (
                     <CardHeaderRightContent>
                         {isEditMode && <AddColumnButton />}
                         <DownloadCsvButton

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -9,7 +9,7 @@ import { CardHeader, StyledCard } from './SqlCard.styles';
 
 const SqlCard: FC = () => {
     const {
-        state: { expandedSections },
+        state: { expandedSections, unsavedChartVersion },
         actions: { toggleExpandedSection },
     } = useExplorer();
     const sqlIsOpen = expandedSections.includes(ExplorerSection.SQL);
@@ -20,6 +20,7 @@ const SqlCard: FC = () => {
                     icon={sqlIsOpen ? 'chevron-down' : 'chevron-right'}
                     minimal
                     onClick={() => toggleExpandedSection(ExplorerSection.SQL)}
+                    disabled={!unsavedChartVersion.tableName}
                 />
                 <H5>SQL</H5>
             </CardHeader>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.styles.ts
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.styles.ts
@@ -1,10 +1,26 @@
 import { Card } from '@blueprintjs/core';
 import styled from 'styled-components';
 
+export const CardHeaderTitle = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    h5 {
+        margin: 0;
+        padding: 0;
+    }
+`;
 export const CardHeader = styled.div`
     display: flex;
-    flexdirection: row;
-    alignitems: center;
+    flex-direction: row;
+    justify-content: space-between;
+`;
+export const CardHeaderButtons = styled.div`
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-right: 10px;
 `;
 
 export const MainCard = styled(Card)`

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -13,6 +13,9 @@ import LightdashVisualization from '../../LightdashVisualization';
 import VisualizationProvider from '../../LightdashVisualization/VisualizationProvider';
 import VisualizationCardOptions from '../VisualizationCardOptions';
 import {
+    CardHeader,
+    CardHeaderButtons,
+    CardHeaderTitle,
     MainCard,
     VisualizationCardContentWrapper,
 } from './VisualizationCard.styles';
@@ -30,83 +33,72 @@ const VisualizationCard: FC = () => {
     } = useExplorer();
     const { data: explore } = useExplore(unsavedChartVersion.tableName);
     const vizIsOpen = expandedSections.includes(ExplorerSection.VISUALIZATION);
-
-    return (
-        <>
+    console.log('queryResults', queryResults.isLoading, queryResults.data);
+    if (!unsavedChartVersion.tableName) {
+        return (
             <MainCard elevation={1}>
-                <VisualizationProvider
-                    initialChartConfig={unsavedChartVersion.chartConfig}
-                    chartType={unsavedChartVersion.chartConfig.type}
-                    initialPivotDimensions={
-                        unsavedChartVersion.pivotConfig?.columns
-                    }
-                    explore={explore}
-                    resultsData={queryResults.data}
-                    isLoading={queryResults.isLoading}
-                    onChartConfigChange={setChartConfig}
-                    onChartTypeChange={setChartType}
-                    onPivotDimensionsChange={setPivotFields}
-                    columnOrder={unsavedChartVersion.tableConfig.columnOrder}
-                >
-                    <div
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            justifyContent: 'space-between',
-                        }}
-                    >
-                        <div
-                            style={{
-                                display: 'flex',
-                                flexDirection: 'row',
-                                alignItems: 'center',
-                            }}
-                        >
-                            <Button
-                                icon={
-                                    vizIsOpen ? 'chevron-down' : 'chevron-right'
-                                }
-                                minimal
-                                onClick={() =>
-                                    toggleExpandedSection(
-                                        ExplorerSection.VISUALIZATION,
-                                    )
-                                }
-                            />
-                            <H5 style={{ margin: 0, padding: 0 }}>Charts</H5>
-                        </div>
-                        {vizIsOpen && (
-                            <div
-                                style={{
-                                    display: 'inline-flex',
-                                    flexWrap: 'wrap',
-                                    gap: '10px',
-                                    marginRight: '10px',
-                                }}
-                            >
-                                {isEditMode && (
-                                    <>
-                                        <VisualizationCardOptions />
-                                        {unsavedChartVersion.chartConfig
-                                            .type === ChartType.BIG_NUMBER ? (
-                                            <BigNumberConfigPanel />
-                                        ) : (
-                                            <ChartConfigPanel />
-                                        )}
-                                    </>
-                                )}
-                                <ChartDownloadMenu />
-                            </div>
-                        )}
-                    </div>
-                    <Collapse className="explorer-chart" isOpen={vizIsOpen}>
-                        <VisualizationCardContentWrapper className="cohere-block">
-                            <LightdashVisualization />
-                        </VisualizationCardContentWrapper>
-                    </Collapse>
-                </VisualizationProvider>
+                <CardHeader>
+                    <CardHeaderTitle>
+                        <Button icon={'chevron-right'} minimal disabled />
+                        <H5>Charts</H5>
+                    </CardHeaderTitle>
+                </CardHeader>
             </MainCard>
-        </>
+        );
+    }
+    return (
+        <MainCard elevation={1}>
+            <VisualizationProvider
+                initialChartConfig={unsavedChartVersion.chartConfig}
+                chartType={unsavedChartVersion.chartConfig.type}
+                initialPivotDimensions={
+                    unsavedChartVersion.pivotConfig?.columns
+                }
+                explore={explore}
+                resultsData={queryResults.data}
+                isLoading={queryResults.isLoading}
+                onChartConfigChange={setChartConfig}
+                onChartTypeChange={setChartType}
+                onPivotDimensionsChange={setPivotFields}
+                columnOrder={unsavedChartVersion.tableConfig.columnOrder}
+            >
+                <CardHeader>
+                    <CardHeaderTitle>
+                        <Button
+                            icon={vizIsOpen ? 'chevron-down' : 'chevron-right'}
+                            minimal
+                            onClick={() =>
+                                toggleExpandedSection(
+                                    ExplorerSection.VISUALIZATION,
+                                )
+                            }
+                        />
+                        <H5>Charts</H5>
+                    </CardHeaderTitle>
+                    {vizIsOpen && (
+                        <CardHeaderButtons>
+                            {isEditMode && (
+                                <>
+                                    <VisualizationCardOptions />
+                                    {unsavedChartVersion.chartConfig.type ===
+                                    ChartType.BIG_NUMBER ? (
+                                        <BigNumberConfigPanel />
+                                    ) : (
+                                        <ChartConfigPanel />
+                                    )}
+                                </>
+                            )}
+                            <ChartDownloadMenu />
+                        </CardHeaderButtons>
+                    )}
+                </CardHeader>
+                <Collapse className="explorer-chart" isOpen={vizIsOpen}>
+                    <VisualizationCardContentWrapper className="cohere-block">
+                        <LightdashVisualization />
+                    </VisualizationCardContentWrapper>
+                </Collapse>
+            </VisualizationProvider>
+        </MainCard>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -33,7 +33,7 @@ const VisualizationCard: FC = () => {
     } = useExplorer();
     const { data: explore } = useExplore(unsavedChartVersion.tableName);
     const vizIsOpen = expandedSections.includes(ExplorerSection.VISUALIZATION);
-    console.log('queryResults', queryResults.isLoading, queryResults.data);
+
     if (!unsavedChartVersion.tableName) {
         return (
             <MainCard elevation={1}>

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -684,13 +684,6 @@ export const ExplorerProvider: FC<{
         return [fields, fields.size > 0];
     }, [reducerState]);
 
-    const clear = useCallback(() => {
-        dispatch({
-            type: ActionType.RESET,
-            payload: defaultState,
-        });
-    }, []);
-
     const reset = useCallback(() => {
         dispatch({
             type: ActionType.RESET,
@@ -906,7 +899,7 @@ export const ExplorerProvider: FC<{
     const queryResults = useQueryResults(state);
 
     // Fetch query results after state update
-    const { mutate } = queryResults;
+    const { mutate, reset: resetQueryResults } = queryResults;
     useEffect(() => {
         if (state.shouldFetchResults) {
             mutate();
@@ -915,6 +908,14 @@ export const ExplorerProvider: FC<{
             });
         }
     }, [mutate, state]);
+
+    const clear = useCallback(async () => {
+        dispatch({
+            type: ActionType.RESET,
+            payload: defaultState,
+        });
+        resetQueryResults();
+    }, [resetQueryResults]);
 
     const defaultSort = useDefaultSortField(reducerState.unsavedChartVersion);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:[#2607](https://github.com/lightdash/lightdash/issues/2607)<!-- reference the related issue e.g. #150 -->

### Description:

- reset chart config
- reset results data
- disable sections when no table is selected 
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot 2022-07-01 at 16 00 51](https://user-images.githubusercontent.com/9117144/176921508-3b605183-6c00-43fe-8700-81ce9a4d6ad1.png)

