### PR TITLE
fix: format table viz totals

### DIFF
--- a/packages/frontend/src/hooks/useTableConfig.ts
+++ b/packages/frontend/src/hooks/useTableConfig.ts
@@ -3,6 +3,7 @@ import {
     ColumnProperties,
     Explore,
     Field,
+    formatItemValue,
     getItemId,
     getItemLabel,
     getItemMap,
@@ -90,7 +91,10 @@ const useTableConfig = (
                 header: getHeader(itemId) || getDefaultColumnLabel(itemId),
                 accessorKey: itemId,
                 cell: (info) => info.getValue()?.value.formatted || '-',
-                footer: () => (totals[itemId] ? totals[itemId] : null),
+                footer: () =>
+                    totals[itemId]
+                        ? formatItemValue(item, totals[itemId])
+                        : null,
                 meta: {
                     item,
                 },


### PR DESCRIPTION
Totals in the table viz weren't formatted like the values in the column.

Closes: #2695

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot 2022-07-13 at 11 01 28](https://user-images.githubusercontent.com/9117144/178707774-52a36fff-505a-4061-9712-6234057b4654.png)

