### PR TITLE
docs: add vital steps to deprecate onboarding email

### DIFF
--- a/docs/docs/get-started/setup-lightdash/connect-project.mdx
+++ b/docs/docs/get-started/setup-lightdash/connect-project.mdx
@@ -26,6 +26,12 @@ If you're looking to create a new project in an organization with an existing pr
 
 We always recommend giving read-only permissions to Lightdash, that way you ensure than no data can be manipulated. See each section below for warehouse specific details.
 
+:::info
+
+If you need to add our IP address to your database's allow-list, you should use `35.245.81.252`
+
+:::
+
 ### Bigquery
 
 #### Project

--- a/docs/docs/get-started/setup-lightdash/lightdash-cli.mdx
+++ b/docs/docs/get-started/setup-lightdash/lightdash-cli.mdx
@@ -10,6 +10,13 @@ This doc is for someone who's just getting started with Lightdash and **has an e
 
 :::
 
+
+:::caution
+
+Make sure your dbt project is compatible with dbt version 1.0.0 - if you're not sure about this, we're happy to help upgrade if you [contact us](https://docs.lightdash.com/help-and-contact/contact/contact_info/), or reach out via the #help channel in [our Slack community](https://join.slack.com/t/lightdash-community/shared_invite/zt-1bfmfnyfq-nSeTVj0cT7i2ekAHYbBVdQ)!
+
+:::
+
 In Lightdash, everything you need for BI is written as code in your dbt project. You use dbt to transform all of the data from your data warehouse, then you use Lightdash to explore it.
 
 But, before you hook up your dbt project to Lightdash, we want to make sure it's ready for exploring. We'll walk you through the steps of installing + using the Lightdash CLI and generating the .yml you need for your dbt project.


### PR DESCRIPTION
We're looking to simplify onboarding. Previously, we had some vital steps only available in the onboarding email.



> 1. Open up our [getting started guide](https://docs.lightdash.com/get-started/setup-lightdash/intro/).
> 2. Make sure your dbt project is compatible with dbt version 1.0.0 - we can help upgrade if you have issues).
> 2. If you need to add our IP address to your database’s allow-list, you should use: 35.245.81.252
> 3. Ensure you have access to a dbt project on github/gitlab/bitbucket/etc along with the credentials for your data warehouse.
> 4. One person from your org should [sign up here using your work email](https://app.lightdash.cloud/register). You will be provisioned with a cloud instance.
> 5. Once you’re in, you can go into the Settings menu to invite the rest of your team to your organisation in Lightdash.

Some were redundant since they're already covered in the docs. The others have been moved into relevant places in the documentation within this PR.