### PR TITLE
feat: hide title toggle on dashboards

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -50,6 +50,7 @@ type DbDashboardTileChart = {
     dashboard_version_id: number;
     dashboard_tile_uuid: string;
     saved_chart_id: number;
+    hide_title?: boolean;
 };
 
 export type DashboardTable = Knex.CompositeTableType<
@@ -80,6 +81,7 @@ type DbDashboardTileLooms = {
     dashboard_tile_uuid: string;
     title: string;
     url: string;
+    hide_title?: boolean;
 };
 
 export type DashboardTileLoomsTable =

--- a/packages/backend/src/database/migrations/20220804115530_tile_hide_title_property.ts
+++ b/packages/backend/src/database/migrations/20220804115530_tile_hide_title_property.ts
@@ -7,10 +7,10 @@ const HideTitleColumn = 'hide_title';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.table(DASHBOARD_TILE_LOOMS_TABLE, (table) => {
-        table.string(HideTitleColumn);
+        table.boolean(HideTitleColumn).notNullable().defaultTo(false);
     });
     await knex.schema.table(DASHBOARD_TILE_CHARTS_TABLE, (table) => {
-        table.string(HideTitleColumn);
+        table.boolean(HideTitleColumn).notNullable().defaultTo(false);
     });
 }
 

--- a/packages/backend/src/database/migrations/20220804115530_tile_hide_title_property.ts
+++ b/packages/backend/src/database/migrations/20220804115530_tile_hide_title_property.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+const DASHBOARD_TILE_LOOMS_TABLE = 'dashboard_tile_looms';
+const DASHBOARD_TILE_CHARTS_TABLE = 'dashboard_tile_charts';
+
+const HideTitleColumn = 'hide_title';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.table(DASHBOARD_TILE_LOOMS_TABLE, (table) => {
+        table.string(HideTitleColumn);
+    });
+    await knex.schema.table(DASHBOARD_TILE_CHARTS_TABLE, (table) => {
+        table.string(HideTitleColumn);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (
+        await knex.schema.hasColumn(DASHBOARD_TILE_LOOMS_TABLE, HideTitleColumn)
+    ) {
+        await knex.schema.table(DASHBOARD_TILE_LOOMS_TABLE, (table) => {
+            table.dropColumns(HideTitleColumn);
+        });
+    }
+    if (
+        await knex.schema.hasColumn(
+            DASHBOARD_TILE_CHARTS_TABLE,
+            HideTitleColumn,
+        )
+    ) {
+        await knex.schema.table(DASHBOARD_TILE_CHARTS_TABLE, (table) => {
+            table.dropColumns(HideTitleColumn);
+        });
+    }
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -134,6 +134,7 @@ export class DashboardModel {
                                     dashboard_tile_uuid:
                                         insertedTile.dashboard_tile_uuid,
                                     saved_chart_id: savedChart.saved_query_id,
+                                    hide_title: tile.properties.hideTitle,
                                 });
                             }
                             break;
@@ -155,6 +156,7 @@ export class DashboardModel {
                                     insertedTile.dashboard_tile_uuid,
                                 title: tile.properties.title,
                                 url: tile.properties.url,
+                                hide_title: tile.properties.hideTitle,
                             });
                             break;
                         default: {
@@ -350,6 +352,8 @@ export class DashboardModel {
                     url: string | null;
                     markdownTitle: string | null;
                     content: string | null;
+                    loomHideTitle: boolean | false;
+                    chartHideTitle: boolean | false;
                 }[]
             >([
                 `${DashboardTilesTableName}.x_offset`,
@@ -363,6 +367,9 @@ export class DashboardModel {
                 `${DashboardTileLoomsTableName}.url`,
                 `${DashboardTileMarkdownsTableName}.title as markdownTitle`,
                 `${DashboardTileMarkdownsTableName}.content`,
+
+                `${DashboardTileLoomsTableName}.hide_title as loomHideTitle`,
+                `${DashboardTileChartTableName}.hide_title as chartHideTitle`,
             ])
             .leftJoin(DashboardTileChartTableName, function chartsJoin() {
                 this.on(
@@ -430,6 +437,8 @@ export class DashboardModel {
                     url,
                     markdownTitle,
                     content,
+                    loomHideTitle,
+                    chartHideTitle,
                 }) => {
                     const base: Omit<
                         Dashboard['tiles'][number],
@@ -449,6 +458,7 @@ export class DashboardModel {
                                 type: DashboardTileTypes.SAVED_CHART,
                                 properties: {
                                     savedChartUuid: saved_query_uuid,
+                                    hideTitle: chartHideTitle,
                                 },
                             };
                         case DashboardTileTypes.MARKDOWN:
@@ -467,6 +477,7 @@ export class DashboardModel {
                                 properties: {
                                     title: loomTitle || '',
                                     url: url || '',
+                                    hideTitle: loomHideTitle,
                                 },
                             };
                         default: {

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -32,6 +32,7 @@ export type DashboardLoomTileProperties = {
     properties: {
         title: string;
         url: string;
+        hideTitle?: boolean;
     };
 };
 
@@ -39,6 +40,7 @@ export type DashboardChartTileProperties = {
     type: DashboardTileTypes.SAVED_CHART;
     properties: {
         savedChartUuid: string | null;
+        hideTitle?: boolean;
     };
 };
 

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -7,7 +7,7 @@ import {
     PopoverPosition,
 } from '@blueprintjs/core';
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
-import { Dashboard } from '@lightdash/common';
+import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import React, { ReactNode, useState } from 'react';
 import { TileModal } from '../TileForms/TileModal';
 import {
@@ -46,18 +46,27 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
 
+    const hideTitle =
+        tile.type !== DashboardTileTypes.MARKDOWN
+            ? tile.properties.hideTitle
+            : false;
     return (
         <TileBaseWrapper className={isLoading ? Classes.SKELETON : undefined}>
             <HeaderContainer>
                 <HeaderWrapper>
-                    <TitleWrapper>
-                        <Title className="non-draggable">{title}</Title>
-                        {description && (
-                            <Tooltip2 content={description} position="bottom">
-                                <Button icon="info-sign" minimal />
-                            </Tooltip2>
-                        )}
-                    </TitleWrapper>
+                    {!hideTitle && (
+                        <TitleWrapper>
+                            <Title className="non-draggable">{title}</Title>
+                            {description && (
+                                <Tooltip2
+                                    content={description}
+                                    position="bottom"
+                                >
+                                    <Button icon="info-sign" minimal />
+                                </Tooltip2>
+                            )}
+                        </TitleWrapper>
+                    )}
                     {extraHeaderElement}
                 </HeaderWrapper>
                 {(isEditMode || (!isEditMode && extraMenuItems)) && (
@@ -76,6 +85,29 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                             text="Edit tile"
                                             onClick={() => setIsEditing(true)}
                                         />
+                                        {tile.type !==
+                                            DashboardTileTypes.MARKDOWN && (
+                                            <MenuItem
+                                                icon={
+                                                    hideTitle
+                                                        ? 'eye-open'
+                                                        : 'eye-off'
+                                                }
+                                                text={`${
+                                                    hideTitle ? 'Show' : 'Hide'
+                                                } title`}
+                                                onClick={() =>
+                                                    onEdit({
+                                                        ...tile,
+                                                        properties: {
+                                                            ...tile.properties,
+                                                            hideTitle:
+                                                                !hideTitle,
+                                                        },
+                                                    })
+                                                }
+                                            />
+                                        )}
                                         <MenuDivider />
                                         <MenuItem
                                             icon="delete"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1848

### Description:

Only applies to Charts and Looms, we should move title from markdowns into their content , see more https://github.com/lightdash/lightdash/issues/1848#issuecomment-1109737276

But that requires a new spec, what happens to everyone’s Markdown tiles that already have titles? do we just make them into H1?


![Peek 2022-08-04 15-22](https://user-images.githubusercontent.com/1983672/182859069-45aad74f-97fd-454e-a26f-380cab5d6d3c.gif)


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
