### PR TITLE
fix: in the last filter

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -90,7 +90,7 @@
         "build": "tsc --build tsconfig.json",
         "postbuild": "copyfiles --error --up 1 src/**/*.html dist",
         "start": "node dist/index.js",
-        "test": "jest",
+        "test": "TZ=UTC jest",
         "lint": "eslint ./src",
         "format": "prettier --check --ignore-unknown ./src",
         "create-migration": "knex migrate:make --knexfile src/database/knexfile.ts",

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -637,7 +637,7 @@ export const InTheLast1DayFilter = {
     },
 };
 
-export const InTheLast1DayFilterSQL = `(customers.created) >= ('2020-04-03')`;
+export const InTheLast1DayFilterSQL = `((customers.created) >= ('2020-04-03') AND (customers.created) < ('2020-04-04 01:12:00'))`;
 
 export const InTheLast1WeekFilter = {
     ...InTheLast1DayFilter,
@@ -647,7 +647,7 @@ export const InTheLast1WeekFilter = {
     },
 };
 
-export const InTheLast1WeekFilterSQL = `(customers.created) >= ('2020-03-28')`;
+export const InTheLast1WeekFilterSQL = `((customers.created) >= ('2020-03-28') AND (customers.created) < ('2020-04-04 01:12:00'))`;
 
 export const InTheLast1MonthFilter = {
     ...InTheLast1WeekFilter,
@@ -657,7 +657,7 @@ export const InTheLast1MonthFilter = {
     },
 };
 
-export const InTheLast1MonthFilterSQL = `(customers.created) >= ('2020-03-04')`;
+export const InTheLast1MonthFilterSQL = `((customers.created) >= ('2020-03-04') AND (customers.created) < ('2020-04-04 01:12:00'))`;
 
 export const InTheLast1YearFilter = {
     ...InTheLast1WeekFilter,
@@ -667,7 +667,7 @@ export const InTheLast1YearFilter = {
     },
 };
 
-export const InTheLast1YearFilterSQL = `(customers.created) >= ('2019-04-04')`;
+export const InTheLast1YearFilterSQL = `((customers.created) >= ('2019-04-04') AND (customers.created) < ('2020-04-04 01:12:00'))`;
 
 export const InTheLast1CompletedYearFilter = {
     ...InTheLast1WeekFilter,

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -637,7 +637,7 @@ export const InTheLast1DayFilter = {
     },
 };
 
-export const InTheLast1DayFilterSQL = `((customers.created) >= ('2020-04-03') AND (customers.created) < ('2020-04-04 01:12:00'))`;
+export const InTheLast1DayFilterSQL = `((customers.created) >= ('2020-04-03') AND (customers.created) < ('2020-04-04 00:12:00'))`;
 
 export const InTheLast1WeekFilter = {
     ...InTheLast1DayFilter,
@@ -647,7 +647,7 @@ export const InTheLast1WeekFilter = {
     },
 };
 
-export const InTheLast1WeekFilterSQL = `((customers.created) >= ('2020-03-28') AND (customers.created) < ('2020-04-04 01:12:00'))`;
+export const InTheLast1WeekFilterSQL = `((customers.created) >= ('2020-03-28') AND (customers.created) < ('2020-04-04 00:12:00'))`;
 
 export const InTheLast1MonthFilter = {
     ...InTheLast1WeekFilter,
@@ -657,7 +657,7 @@ export const InTheLast1MonthFilter = {
     },
 };
 
-export const InTheLast1MonthFilterSQL = `((customers.created) >= ('2020-03-04') AND (customers.created) < ('2020-04-04 01:12:00'))`;
+export const InTheLast1MonthFilterSQL = `((customers.created) >= ('2020-03-04') AND (customers.created) < ('2020-04-04 00:12:00'))`;
 
 export const InTheLast1YearFilter = {
     ...InTheLast1WeekFilter,
@@ -667,7 +667,7 @@ export const InTheLast1YearFilter = {
     },
 };
 
-export const InTheLast1YearFilterSQL = `((customers.created) >= ('2019-04-04') AND (customers.created) < ('2020-04-04 01:12:00'))`;
+export const InTheLast1YearFilterSQL = `((customers.created) >= ('2019-04-04') AND (customers.created) < ('2020-04-04 00:12:00'))`;
 
 export const InTheLast1CompletedYearFilter = {
     ...InTheLast1WeekFilter,

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -144,9 +144,11 @@ export const renderDateFilterSql = (
                     completedDate,
                 )}'))`;
             }
-            return `(${dimensionSql}) >= ('${dateFormatter(
+            return `((${dimensionSql}) >= ('${dateFormatter(
                 moment().subtract(filter.values?.[0], unitOfTime).toDate(),
-            )}')`;
+            )}') AND (${dimensionSql}) < ('${formatTimestamp(
+                moment().toDate(),
+            )}'))`;
         default:
             throw Error(
                 `No function implemented to render sql for filter type ${filterType} on dimension of date type`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 2793 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
@owlas @TuringLovesDeathMetal  In the ticket I mentioned the end of the current day but that would still include future values so I used the current time.

eg: In the last 1 day filter 
`((customers.created) >= ('2020-04-03') AND (customers.created) < ('2020-04-04 01:12:00'))`