### PR TITLE
fix: table calculation overlapping labels

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -283,24 +283,25 @@ const getPivotSeries = ({
         tooltip: {
             valueFormatter: valueFormatter(series.encode.yRef.field, items),
         },
-        ...(series.label?.show &&
-            formats &&
-            formats[series.encode.yRef.field] && {
-                label: {
-                    ...series.label,
-                    formatter: (val: any) =>
-                        formatValue(
-                            formats[series.encode.yRef.field].format,
-                            formats[series.encode.yRef.field].round,
-                            val?.value?.[yFieldHash],
-                        ),
-                },
-                labelLayout: function (params: any) {
-                    return {
-                        hideOverlap: true,
-                    };
-                },
-            }),
+        ...(series.label?.show && {
+            label: {
+                ...series.label,
+                ...(formats &&
+                    formats[series.encode.yRef.field] && {
+                        formatter: (val: any) =>
+                            formatValue(
+                                formats[series.encode.yRef.field].format,
+                                formats[series.encode.yRef.field].round,
+                                val?.value?.[yFieldHash],
+                            ),
+                    }),
+            },
+            labelLayout: function (params: any) {
+                return {
+                    hideOverlap: true,
+                };
+            },
+        }),
     };
 };
 

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -351,24 +351,25 @@ const getSimpleSeries = ({
         valueFormatter: valueFormatter(yFieldHash, items),
     },
 
-    ...(series.label?.show &&
-        formats &&
-        formats[yFieldHash] && {
-            label: {
-                ...series.label,
-                formatter: (value: any) =>
-                    formatValue(
-                        formats[yFieldHash].format,
-                        formats[yFieldHash].round,
-                        value?.value?.[yFieldHash],
-                    ),
-            },
-            labelLayout: function (params: any) {
-                return {
-                    hideOverlap: true,
-                };
-            },
-        }),
+    ...(series.label?.show && {
+        label: {
+            ...series.label,
+            ...(formats &&
+                formats[yFieldHash] && {
+                    formatter: (value: any) =>
+                        formatValue(
+                            formats[yFieldHash].format,
+                            formats[yFieldHash].round,
+                            value?.value?.[yFieldHash],
+                        ),
+                }),
+        },
+        labelLayout: function (params: any) {
+            return {
+                hideOverlap: true,
+            };
+        },
+    }),
 });
 
 export const getEchartsSeries = (


### PR DESCRIPTION
Closes: #2874 

### Description:
Fixes table calculation line chart label overlap

before:
<img width="1130" alt="CleanShot 2022-08-09 at 19 10 24@2x" src="https://user-images.githubusercontent.com/962095/183687734-ac340e28-7283-4cc3-b047-6e90fbd6c420.png">

after:
<img width="1118" alt="CleanShot 2022-08-09 at 19 08 33@2x" src="https://user-images.githubusercontent.com/962095/183687744-30056cc2-08b6-4b48-bd16-2038421ddbe1.png">

