### PR TITLE
fix: string, date and boolean metric types

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -116,9 +116,9 @@ export enum MetricType {
     MIN = 'min',
     MAX = 'max',
     NUMBER = 'number',
-    STRING = ' string',
-    DATE = ' date',
-    BOOLEAN = ' boolean',
+    STRING = 'string',
+    DATE = 'date',
+    BOOLEAN = 'boolean',
 }
 
 export const parseMetricType = (metricType: string): MetricType => {


### PR DESCRIPTION
Closes: #2903

### Description:
fixes string, date and boolean metric types

before:
<img width="861" alt="CleanShot 2022-08-10 at 11 59 54@2x" src="https://user-images.githubusercontent.com/962095/183854978-f15d233e-474a-4030-8be3-60944555e73c.png">

after:
<img width="774" alt="CleanShot 2022-08-10 at 12 34 34@2x" src="https://user-images.githubusercontent.com/962095/183855061-b734b173-ad29-46e9-907c-f5ae1d6723f3.png">


