### PR TITLE
fix: option to remove invalid fields

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,11 +1,6 @@
 import { Menu, MenuItem } from '@blueprintjs/core';
 import { ContextMenu2 } from '@blueprintjs/popover2';
-import {
-    fieldId,
-    isDimension,
-    isField,
-    isFilterableField,
-} from '@lightdash/common';
+import { fieldId, isField, isFilterableField } from '@lightdash/common';
 import React from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useExplorer } from '../../../providers/ExplorerProvider';
@@ -22,7 +17,7 @@ const ColumnHeaderContextMenu: React.FC<HeaderProps> = ({
     const item = meta?.item;
     const { track } = useTracking();
     const {
-        actions: { toggleActiveField },
+        actions: { removeActiveField },
     } = useExplorer();
     if (item && isField(item) && isFilterableField(item)) {
         return (
@@ -45,10 +40,26 @@ const ColumnHeaderContextMenu: React.FC<HeaderProps> = ({
                             icon={'cross'}
                             onClick={(e) => {
                                 e.stopPropagation();
-                                toggleActiveField(
-                                    fieldId(item),
-                                    isDimension(item),
-                                );
+                                removeActiveField(fieldId(item));
+                            }}
+                        />
+                    </Menu>
+                }
+            >
+                {children}
+            </ContextMenu2>
+        );
+    } else if (meta?.isInvalidItem) {
+        return (
+            <ContextMenu2
+                content={
+                    <Menu>
+                        <MenuItem
+                            text={`Remove`}
+                            icon={'cross'}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                removeActiveField(header.column.id);
                             }}
                         />
                     </Menu>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,4 +1,5 @@
-import { Colors } from '@blueprintjs/core';
+import { Button, Colors } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { isField } from '@lightdash/common';
 import React, { FC, ReactNode } from 'react';
 import { useColumns } from '../../../hooks/useColumns';
@@ -20,10 +21,31 @@ import {
 import { TableContainer } from './ResultsCard.styles';
 
 const HeaderButton: React.FC<HeaderProps> = ({ header }) => {
+    const {
+        actions: { removeActiveField },
+    } = useExplorer();
     const meta = header.column.columnDef.meta as TableColumn['meta'];
     const item = meta?.item;
     if (item && !isField(item)) {
         return <TableCalculationHeaderButton tableCalculation={item} />;
+    } else if (meta?.isInvalidItem) {
+        return (
+            <Tooltip2 content="Remove">
+                <Button
+                    minimal
+                    small
+                    icon={'cross'}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        removeActiveField(header.column.id);
+                    }}
+                    style={{
+                        minHeight: 'auto',
+                        minWidth: 'auto',
+                    }}
+                />
+            </Tooltip2>
+        );
     }
     return null;
 };

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -19,6 +19,7 @@ export type Sort = {
 
 export type TableColumn = ColumnDef<ResultRow> & {
     meta?: {
+        isInvalidItem?: boolean;
         width?: number;
         draggable?: boolean;
         item?: Field | TableCalculation;

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -38,6 +38,7 @@ export enum ExplorerSection {
 export enum ActionType {
     RESET,
     SET_TABLE_NAME,
+    REMOVE_FIELD,
     TOGGLE_DIMENSION,
     TOGGLE_METRIC,
     TOGGLE_SORT_FIELD,
@@ -65,6 +66,7 @@ type Action =
     | { type: ActionType.TOGGLE_EXPANDED_SECTION; payload: ExplorerSection }
     | {
           type:
+              | ActionType.REMOVE_FIELD
               | ActionType.TOGGLE_DIMENSION
               | ActionType.TOGGLE_METRIC
               | ActionType.TOGGLE_SORT_FIELD;
@@ -144,6 +146,7 @@ interface ExplorerContext {
         clear: () => void;
         reset: () => void;
         setTableName: (tableName: string) => void;
+        removeActiveField: (fieldId: FieldId) => void;
         toggleActiveField: (fieldId: FieldId, isDimension: boolean) => void;
         toggleSortField: (fieldId: FieldId) => void;
         setSortFields: (sortFields: SortField[]) => void;
@@ -285,6 +288,37 @@ function reducer(
                     state.expandedSections,
                     action.payload,
                 ),
+            };
+        }
+        case ActionType.REMOVE_FIELD: {
+            const dimensions =
+                state.unsavedChartVersion.metricQuery.dimensions.filter(
+                    (fieldId) => fieldId !== action.payload,
+                );
+            const metrics =
+                state.unsavedChartVersion.metricQuery.metrics.filter(
+                    (fieldId) => fieldId !== action.payload,
+                );
+            return {
+                ...state,
+                unsavedChartVersion: {
+                    ...state.unsavedChartVersion,
+                    metricQuery: {
+                        ...state.unsavedChartVersion.metricQuery,
+                        dimensions,
+                        metrics,
+                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
+                            (s) => s.fieldId !== action.payload,
+                        ),
+                    },
+                    tableConfig: {
+                        ...state.unsavedChartVersion.tableConfig,
+                        columnOrder:
+                            state.unsavedChartVersion.tableConfig.columnOrder.filter(
+                                (fieldId) => fieldId !== action.payload,
+                            ),
+                    },
+                },
             };
         }
         case ActionType.TOGGLE_DIMENSION: {
@@ -737,6 +771,12 @@ export const ExplorerProvider: FC<{
         },
         [],
     );
+    const removeActiveField = useCallback((fieldId: FieldId) => {
+        dispatch({
+            type: ActionType.REMOVE_FIELD,
+            payload: fieldId,
+        });
+    }, []);
     const toggleSortField = useCallback((fieldId: FieldId) => {
         dispatch({
             type: ActionType.TOGGLE_SORT_FIELD,
@@ -964,6 +1004,7 @@ export const ExplorerProvider: FC<{
                 clear,
                 reset,
                 setTableName,
+                removeActiveField,
                 toggleActiveField,
                 toggleSortField,
                 setSortFields,
@@ -986,6 +1027,7 @@ export const ExplorerProvider: FC<{
                 clear,
                 reset,
                 setTableName,
+                removeActiveField,
                 toggleActiveField,
                 toggleSortField,
                 setSortFields,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2924 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We need to show in the results table all fields that are active but can't be found in the table fields.

Since I don't know if the field is a dimension or metrics I had to introduce an agnostic function to remove any active field from the metric query.

<img width="1234" alt="Screenshot 2022-08-10 at 15 09 21" src="https://user-images.githubusercontent.com/9117144/183925079-b00f9bfc-9797-4d35-8867-adb1931195e7.png">


<img width="526" alt="Screenshot 2022-08-10 at 15 21 01" src="https://user-images.githubusercontent.com/9117144/183925377-4f5fe8a3-e1b0-463f-a4c5-6119e18e6882.png">

