### PR TITLE
docs: amend broken "developing in lightdash" link in docs

### DIFF
--- a/docs/docs/get-started/intro.mdx
+++ b/docs/docs/get-started/intro.mdx
@@ -23,7 +23,7 @@ If you:
 ✅ want to add or change some dimensions, metrics, or tables in your project
 ✅ want to add formatting or descriptions to existing metrics, dimensions or tables in your project
 
-then this tutorial is for you! [👩‍💻 Developing in Lightdash](get-started/develop-in-lightdash/intro)
+then this tutorial is for you! [👩‍💻 Developing in Lightdash](/get-started/develop-in-lightdash/intro)
 
 ## 🔭 Learning to explore data in Lightdash
 


### PR DESCRIPTION
1 character change to fix a broken [link](https://docs.lightdash.com/get-started/intro/get-started/develop-in-lightdash/intro) in the docs.
