### PR TITLE
fix: use default utc timezone for snowflake queries

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -120,7 +120,6 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
     }
 
     async runQuery(sqlText: string) {
-        console.time('double');
         let connection: Connection;
         try {
             connection = createConnection(this.connectionOptions);

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -120,6 +120,7 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
     }
 
     async runQuery(sqlText: string) {
+        console.time('double');
         let connection: Connection;
         try {
             connection = createConnection(this.connectionOptions);
@@ -127,50 +128,60 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
         } catch (e) {
             throw new WarehouseConnectionError(`Snowflake error: ${e.message}`);
         }
-
         try {
-            return await new Promise<{
-                fields: Record<string, { type: DimensionType }>;
-                rows: any[];
-            }>((resolve, reject) => {
-                connection.execute({
-                    sqlText,
-                    complete: (err, stmt, data) => {
-                        if (err) {
-                            reject(err);
-                        }
-                        if (data) {
-                            const fields = stmt.getColumns().reduce(
-                                (acc, column) => ({
-                                    ...acc,
-                                    [column.getName()]: {
-                                        type: mapFieldType(
-                                            column.getType().toUpperCase(),
-                                        ),
-                                    },
-                                }),
-                                {},
-                            );
-                            resolve({ fields, rows: parseRows(data) });
-                        } else {
-                            reject(
-                                new WarehouseQueryError(
-                                    'Query result is undefined',
-                                ),
-                            );
-                        }
-                    },
-                });
-            });
+            await this.executeStatement(
+                connection,
+                "ALTER SESSION SET TIMEZONE = 'UTC'",
+            );
+            const result = await this.executeStatement(connection, sqlText);
+            return result;
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         } finally {
+            // todo: does this need to be promisified? uncaught error in callback?
             connection.destroy((err) => {
                 if (err) {
                     throw new WarehouseConnectionError(err.message);
                 }
             });
         }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async executeStatement(connection: Connection, sqlText: string) {
+        return new Promise<{
+            fields: Record<string, { type: DimensionType }>;
+            rows: any[];
+        }>((resolve, reject) => {
+            connection.execute({
+                sqlText,
+                complete: (err, stmt, data) => {
+                    if (err) {
+                        reject(err);
+                    }
+                    if (data) {
+                        const fields = stmt.getColumns().reduce(
+                            (acc, column) => ({
+                                ...acc,
+                                [column.getName()]: {
+                                    type: mapFieldType(
+                                        column.getType().toUpperCase(),
+                                    ),
+                                },
+                            }),
+                            {},
+                        );
+                        resolve({ fields, rows: parseRows(data) });
+                    } else {
+                        reject(
+                            new WarehouseQueryError(
+                                'Query result is undefined',
+                            ),
+                        );
+                    }
+                },
+            });
+        });
     }
 
     async test(): Promise<void> {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2826 





### Description:

We alter the snowflake query session to use UTC as the default, this controls the assumed timezone for `TIMESTAMP_TZ` (timestamps with no time zones).

Ideally we should be able to set this parameter as a connection setting but we're blocked by a feature request on the node sdk for snowflake: https://github.com/snowflakedb/snowflake-connector-nodejs/issues/61

For now we prepend every query with an additional query to set the session timezone. I'm sure we take a performance hit but nothing substantial:

**Without** `ALTER SESSION` pre-query
1. `select 1` - 2.128s
2. `select 1` - 0.682s
3. `show parameters like 'timezone'` - 8.588s
4. `show parameters like 'timezone'` - 0.730s

**With** `ALTER SESSION` pre-query
1. `select 1` - 0.908s
2. `select 1` - 1.091s
3. `show parameters like 'timezone'` - 2.301s
4. `show parameters like 'timezone'` - 0.981s
