### PR TITLE
fix: renaming and removing spaces always renamed/removed the last item

### DIFF
--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Colors, Icon } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { useSpaces } from '../../../hooks/useSpaces';
 import LatestCard from '../../Home/LatestCard';
 import { CreateSpaceModal } from './CreateSpaceModal';
@@ -19,8 +19,8 @@ import {
 import { SpaceBrowserMenu } from './SpaceBrowserMenu';
 
 const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
-    const [updateSpace, setUpdateSpace] = useState<boolean>(false);
-    const [deleteSpace, setDeleteSpace] = useState<boolean>(false);
+    const [updateSpaceUuid, setUpdateSpaceUuid] = useState<string>();
+    const [deleteSpaceUuid, setDeleteSpaceUuid] = useState<string>();
     const { data: spaces, isLoading } = useSpaces(projectUuid);
 
     const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
@@ -44,83 +44,82 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 }
             >
                 <SpaceListWrapper>
-                    {spaces &&
-                        spaces.map(({ uuid, name, dashboards, queries }) => (
-                            <>
-                                <SpaceLinkButton
-                                    key={uuid}
-                                    minimal
-                                    outlined
-                                    href={`/projects/${projectUuid}/spaces/${uuid}`}
-                                >
-                                    <SpaceHeader>
-                                        <Icon
-                                            icon="folder-close"
-                                            size={20}
-                                            color={Colors.BLUE5}
-                                        ></Icon>
-                                        <div
-                                            onClick={(e) => {
-                                                // prevent clicks in menu to trigger redirect
-                                                e.stopPropagation();
-                                                e.preventDefault();
-                                            }}
+                    {spaces?.map(({ uuid, name, dashboards, queries }) => (
+                        <>
+                            <SpaceLinkButton
+                                key={uuid}
+                                minimal
+                                outlined
+                                href={`/projects/${projectUuid}/spaces/${uuid}`}
+                            >
+                                <SpaceHeader>
+                                    <Icon
+                                        icon="folder-close"
+                                        size={20}
+                                        color={Colors.BLUE5}
+                                    ></Icon>
+                                    <div
+                                        onClick={(e) => {
+                                            // prevent clicks in menu to trigger redirect
+                                            e.stopPropagation();
+                                            e.preventDefault();
+                                        }}
+                                    >
+                                        <SpaceBrowserMenu
+                                            onRename={() =>
+                                                setUpdateSpaceUuid(uuid)
+                                            }
+                                            onDelete={() =>
+                                                setDeleteSpaceUuid(uuid)
+                                            }
                                         >
-                                            <SpaceBrowserMenu
-                                                onRename={() =>
-                                                    setUpdateSpace(true)
-                                                }
-                                                onDelete={() =>
-                                                    setDeleteSpace(true)
-                                                }
-                                            >
-                                                <Tooltip2 content="View options">
-                                                    <Button
-                                                        minimal
-                                                        icon="more"
-                                                    />
-                                                </Tooltip2>
-                                            </SpaceBrowserMenu>
-                                        </div>
-                                    </SpaceHeader>
-                                    <SpaceTitle ellipsize>{name}</SpaceTitle>
-                                    <SpaceFooter>
-                                        <SpaceItemCount
-                                            icon="control"
-                                            value={dashboards.length}
-                                        />
-                                        <SpaceItemCount
-                                            icon="timeline-bar-chart"
-                                            value={queries.length}
-                                        />
-                                    </SpaceFooter>
-                                </SpaceLinkButton>
-                                {updateSpace && (
-                                    <EditSpaceModal
-                                        spaceUuid={uuid}
-                                        onClose={() => {
-                                            setUpdateSpace(false);
-                                        }}
-                                    ></EditSpaceModal>
-                                )}
-                                {deleteSpace && (
-                                    <DeleteSpaceModal
-                                        spaceUuid={uuid}
-                                        onClose={() => {
-                                            setDeleteSpace(false);
-                                        }}
-                                    ></DeleteSpaceModal>
-                                )}
-                            </>
-                        ))}
+                                            <Tooltip2 content="View options">
+                                                <Button minimal icon="more" />
+                                            </Tooltip2>
+                                        </SpaceBrowserMenu>
+                                    </div>
+                                </SpaceHeader>
+                                <SpaceTitle ellipsize>{name}</SpaceTitle>
+                                <SpaceFooter>
+                                    <SpaceItemCount
+                                        icon="control"
+                                        value={dashboards.length}
+                                    />
+                                    <SpaceItemCount
+                                        icon="timeline-bar-chart"
+                                        value={queries.length}
+                                    />
+                                </SpaceFooter>
+                            </SpaceLinkButton>
+                        </>
+                    ))}
                 </SpaceListWrapper>
             </LatestCard>
+
             <CreateSpaceModal
                 isOpen={isCreateModalOpen}
                 onClose={() => {
                     setIsCreateModalOpen(false);
                 }}
-            ></CreateSpaceModal>
+            />
+
+            {updateSpaceUuid && (
+                <EditSpaceModal
+                    spaceUuid={updateSpaceUuid}
+                    onClose={() => {
+                        setUpdateSpaceUuid(undefined);
+                    }}
+                />
+            )}
+
+            {deleteSpaceUuid && (
+                <DeleteSpaceModal
+                    spaceUuid={deleteSpaceUuid}
+                    onClose={() => {
+                        setDeleteSpaceUuid(undefined);
+                    }}
+                />
+            )}
         </SpaceBrowserWrapper>
     );
 };


### PR DESCRIPTION
Closes: #2936 

### Description:
renaming or removing spaces always renamed/removed the last item because all edit/delete modals popped at once (last always on top)

https://user-images.githubusercontent.com/962095/184309043-7df52ab7-1f2e-4be9-bfd3-595d4f5c392c.mp4


