### PR TITLE
chore: remove "last refreshed at" from the dashboard header

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -7,7 +7,6 @@ import {
 } from '@lightdash/common';
 import { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -55,8 +54,6 @@ const DashboardHeader = ({
     onUpdate,
     onCancel,
 }: DashboardHeaderProps) => {
-    const [pageLoadedAt] = useState(new Date());
-    const timeAgo = useTimeAgo(pageLoadedAt);
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
@@ -111,17 +108,15 @@ const DashboardHeader = ({
                 </PageTitleContainer>
 
                 <PageDetailsContainer>
-                    <span>
-                        Last refreshed <b>{timeAgo}</b>
-                    </span>
-                    <SeparatorDot icon="dot" size={6} />
                     <UpdatedInfo
                         updatedAt={dashboardUpdatedAt}
                         user={dashboardUpdatedByUser}
                     />
+
                     {dashboardSpaceName && (
                         <>
                             <SeparatorDot icon="dot" size={6} />
+
                             <IconWithRightMargin
                                 icon="folder-close"
                                 size={10}


### PR DESCRIPTION
Closes: #2932 

### Description:
removed "last refresh at" from the dashboard header
spaces were already added here #2929 

<img width="1440" alt="CleanShot 2022-08-12 at 13 55 42@2x" src="https://user-images.githubusercontent.com/962095/184331050-01304c5a-d9f4-413c-bfc9-bd02f1cdc967.png">