### PR TITLE
fix: performance when ordering columns

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/HeaderDnD.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/HeaderDnD.tsx
@@ -3,6 +3,7 @@ import { flexRender, HeaderGroup } from '@tanstack/react-table';
 import React, { FC, MutableRefObject } from 'react';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import { useTableContext } from '../TableProvider';
+import { ROW_NUMBER_COLUMN_ID } from '../types';
 
 type HeaderDndContextProps = {
     colOrderRef: MutableRefObject<string[]>;
@@ -12,7 +13,7 @@ export const HeaderDndContext: FC<HeaderDndContextProps> = ({
     colOrderRef,
     children,
 }) => {
-    const { table } = useTableContext();
+    const { table, onColumnOrderChange } = useTableContext();
     return (
         <DragDropContext
             onDragStart={() => {
@@ -28,10 +29,18 @@ export const HeaderDndContext: FC<HeaderDndContextProps> = ({
                 if (typeof dIndex === 'number') {
                     colOrder.splice(sIndex, 1);
                     colOrder.splice(dIndex, 0, dragUpdateObj.draggableId);
-                    table.setColumnOrder(colOrder);
+                    table.setColumnOrder([ROW_NUMBER_COLUMN_ID, ...colOrder]);
                 }
             }}
-            onDragEnd={() => undefined}
+            onDragEnd={() => {
+                onColumnOrderChange?.(
+                    table
+                        .getState()
+                        .columnOrder.filter(
+                            (value) => value !== ROW_NUMBER_COLUMN_ID,
+                        ),
+                );
+            }}
         >
             {children}
         </DragDropContext>

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -49,28 +49,22 @@ const rowColumn: TableColumn = {
 };
 
 export const TableProvider: FC<Props> = ({ children, ...rest }) => {
-    const { data, columns, columnOrder, pagination, onColumnOrderChange } =
-        rest;
+    const { data, columns, columnOrder, pagination } = rest;
     const [columnVisibility, setColumnVisibility] = React.useState({});
-    const allColumnIds = columns.reduce<string[]>(
-        (acc, col) => (col.id ? [...acc, col.id] : acc),
-        [],
-    );
-    const reactTableColumnOrder = [
-        ...new Set([
+    const [tempColumnOrder, setTempColumnOrder] =
+        React.useState<ColumnOrderState>([
             ROW_NUMBER_COLUMN_ID,
             ...(columnOrder || []),
-            ...allColumnIds,
-        ]),
-    ];
-    const [tempColumnOrder, setTempColumnOrder] =
-        React.useState<ColumnOrderState>(reactTableColumnOrder);
+        ]);
+    useEffect(() => {
+        setTempColumnOrder([ROW_NUMBER_COLUMN_ID, ...(columnOrder || [])]);
+    }, [columnOrder]);
     const table = useReactTable({
         data,
         columns: [rowColumn, ...columns],
         state: {
             columnVisibility,
-            columnOrder: reactTableColumnOrder,
+            columnOrder: tempColumnOrder,
         },
         onColumnVisibilityChange: setColumnVisibility,
         onColumnOrderChange: setTempColumnOrder,
@@ -81,11 +75,6 @@ export const TableProvider: FC<Props> = ({ children, ...rest }) => {
     useEffect(() => {
         setPageSize(pagination?.show ? DEFAULT_PAGE_SIZE : MAX_PAGE_SIZE);
     }, [pagination, setPageSize]);
-    useEffect(() => {
-        onColumnOrderChange?.(
-            tempColumnOrder.filter((value) => value !== ROW_NUMBER_COLUMN_ID),
-        );
-    }, [tempColumnOrder, onColumnOrderChange]);
     return (
         <Context.Provider
             value={{

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -549,6 +549,13 @@ function reducer(
                             (sort) => sort.fieldId !== action.payload,
                         ),
                     },
+                    tableConfig: {
+                        ...state.unsavedChartVersion.tableConfig,
+                        columnOrder:
+                            state.unsavedChartVersion.tableConfig.columnOrder.filter(
+                                (fieldId) => fieldId !== action.payload,
+                            ),
+                    },
                 },
             };
         }


### PR DESCRIPTION
The explore components are constantly re-rendering when ordering the columns. Causing the app to be less responsive. 

This is really noticeable in the open PR #2942 where it's constantly recalculating the pivot data.

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Now we only re-render the explore when the ordering finishes. 

<!-- Even better add a screenshot / gif / loom -->
Before:
![before](https://user-images.githubusercontent.com/9117144/184853499-9d6c01c3-5894-4964-93d2-d2ff1bb1268a.gif)

After:
![after](https://user-images.githubusercontent.com/9117144/184853511-950fdc9a-28e7-46b5-9adf-34edae4b9b27.gif)

