### PR TITLE
feat: remove chart config fallback values

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -103,6 +103,11 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 <AxisFieldDropdown>
                     <FieldAutoComplete
                         fields={items}
+                        placeholder={
+                            !!dirtyLayout?.xField && !xAxisField
+                                ? `${dirtyLayout?.xField} not available`
+                                : undefined
+                        }
                         activeField={xAxisField}
                         onChange={(item) => {
                             setXField(getItemId(item));
@@ -122,6 +127,11 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                     return (
                         <AxisFieldDropdown key={`${field}-y-axis`}>
                             <FieldAutoComplete
+                                placeholder={
+                                    !!field && !activeField
+                                        ? `${field} not available`
+                                        : undefined
+                                }
                                 fields={
                                     activeField
                                         ? [activeField, ...availableYFields]
@@ -161,7 +171,11 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 <AxisFieldDropdown>
                     <FieldAutoComplete
                         fields={availableDimensions}
-                        placeholder="Select a field to group by"
+                        placeholder={
+                            !!pivotDimension && !groupSelectedField
+                                ? `${pivotDimension} not available`
+                                : 'Select a field to group by'
+                        }
                         activeField={groupSelectedField}
                         onChange={(item) => {
                             setPivotDimensions([getItemId(item)]);

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -103,11 +103,6 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 <AxisFieldDropdown>
                     <FieldAutoComplete
                         fields={items}
-                        placeholder={
-                            !!dirtyLayout?.xField && !xAxisField
-                                ? `${dirtyLayout?.xField} not available`
-                                : undefined
-                        }
                         activeField={xAxisField}
                         onChange={(item) => {
                             setXField(getItemId(item));
@@ -127,11 +122,6 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                     return (
                         <AxisFieldDropdown key={`${field}-y-axis`}>
                             <FieldAutoComplete
-                                placeholder={
-                                    !!field && !activeField
-                                        ? `${field} not available`
-                                        : undefined
-                                }
                                 fields={
                                     activeField
                                         ? [activeField, ...availableYFields]
@@ -171,11 +161,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                 <AxisFieldDropdown>
                     <FieldAutoComplete
                         fields={availableDimensions}
-                        placeholder={
-                            !!pivotDimension && !groupSelectedField
-                                ? `${pivotDimension} not available`
-                                : 'Select a field to group by'
-                        }
+                        placeholder="Select a field to group by"
                         activeField={groupSelectedField}
                         onChange={(item) => {
                             setPivotDimensions([getItemId(item)]);

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -117,6 +117,7 @@ export const VisualizationProvider: FC<Props> = ({
     const { validTableConfig } = tableConfig;
 
     const cartesianConfig = useCartesianChartConfig({
+        chartType,
         initialChartConfig:
             initialChartConfig?.type === ChartType.CARTESIAN
                 ? initialChartConfig.config


### PR DESCRIPTION
Goals:
- only apply chart config default the first time it runs the query
- remove invalid chart config ( eg invalid field in x/y axis )
- allow to have incomplete chart config

Problem:
- the url is only updated with a complete chart config, so when we refresh the page the code assumes it needs defaults.
- the same problem happens when saving a chart with a incomplete config

Do we need to start updating the url and save incomplete chart ? 🤔 
