### PR TITLE
fix: disable charts options for empty chart

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -2,12 +2,14 @@ import { Button } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import { ChartType } from '@lightdash/common';
 import React from 'react';
+import useEcharts from '../../hooks/echarts/useEcharts';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import ChartConfigTabs from './ChartConfigTabs';
 
 export const ChartConfigPanel: React.FC = () => {
     const { chartType } = useVisualizationContext();
-    const disabled = chartType === ChartType.TABLE;
+    const eChartsOptions = useEcharts();
+    const disabled = chartType === ChartType.TABLE || !eChartsOptions;
 
     return (
         <Popover2

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -13,6 +13,7 @@ import EChartsReact from 'echarts-for-react';
 import JsPDF from 'jspdf';
 import React, { RefObject, useCallback, useState } from 'react';
 import { CSVLink } from 'react-csv';
+import useEcharts from '../hooks/echarts/useEcharts';
 import { useVisualizationContext } from './LightdashVisualization/VisualizationProvider';
 
 const FILE_NAME = 'lightdash_chart';
@@ -214,10 +215,12 @@ export const ChartDownloadMenu: React.FC = () => {
         chartType,
         tableConfig: { rows },
     } = useVisualizationContext();
+    const eChartsOptions = useEcharts();
     const [isOpen, setIsOpen] = useState(false);
     const disabled =
         (chartType === ChartType.TABLE && !rows) ||
-        chartType === ChartType.BIG_NUMBER;
+        chartType === ChartType.BIG_NUMBER ||
+        !eChartsOptions;
 
     return (
         <Popover2

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -6,6 +6,7 @@ import {
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
 import React, { FC, useMemo, useState } from 'react';
+import useEcharts from '../../../hooks/echarts/useEcharts';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import {
     ChartOption,
@@ -22,7 +23,11 @@ const VisualizationCardOptions: FC = () => {
         setPivotDimensions,
         cartesianConfig: { setStacking },
     } = useVisualizationContext();
-    const disabled = isLoading || (resultsData && resultsData.rows.length <= 0);
+    const eChartsOptions = useEcharts();
+    const disabled =
+        isLoading ||
+        (resultsData && resultsData.rows.length <= 0) ||
+        !eChartsOptions;
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/2652

### Description:
- Disable chart options when there is empty chart display

## Screenshot
<img width="1421" alt="Screenshot 2022-08-21 at 5 56 23 PM" src="https://user-images.githubusercontent.com/62111075/185790838-eadf13f0-cdfc-4cbd-94ab-949b6f835c30.png">

