### PR TITLE
chore: bump ubuntu version 20.04

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     concurrency: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
I could have used the latest LTS version `ubuntu-22.04` but we already use `20.04` in someo other workflows, so we better use the same version, and update all flows when needed. 