### PR TITLE
feat: analytics permission updated

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -5,6 +5,7 @@ import {
     DbtProjectType,
     LightdashInstallType,
     LightdashUser,
+    OrganizationMemberRole,
     TableSelectionType,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -324,6 +325,21 @@ type SavedChartUpdateMultiple = BaseTrack & {
         projectId: string;
     };
 };
+
+type PermissionsUpdated = BaseTrack & {
+    event: 'permission.updated';
+    userId?: string;
+    anonymousId?: string;
+    properties: {
+        userId: string;
+        userIdUpdated: string;
+        organizationPermissions: OrganizationMemberRole;
+        projectPermissions: any;
+        newUser: boolean;
+        generatedInvite: boolean;
+    };
+};
+
 type Track =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -351,7 +367,8 @@ type Track =
     | SpaceUpdated
     | SpaceDeleted
     | DashboardUpdateMultiple
-    | SavedChartUpdateMultiple;
+    | SavedChartUpdateMultiple
+    | PermissionsUpdated;
 
 export class LightdashAnalytics extends Analytics {
     static lightdashContext = {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -180,6 +180,27 @@ export class OrganizationService {
                 'Organization must have at least one admin',
             );
         }
+        if (data.role !== undefined) {
+            const organization = await this.organizationModel.get(
+                organizationUuid,
+            );
+            analytics.track({
+                userId: authenticatedUser.userUuid,
+                event: 'permission.updated',
+                properties: {
+                    userId: authenticatedUser.userUuid,
+                    userIdUpdated: memberUserUuid,
+                    organizationPermissions: data.role,
+                    projectPermissions: {
+                        name: organization.name,
+                        role: data.role,
+                    },
+                    newUser: false,
+                    generatedInvite: false,
+                },
+            });
+        }
+
         return this.organizationMemberProfileModel.updateOrganizationMember(
             organizationUuid,
             memberUserUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2980

### Description:

I added 2 extra args: 

- newUser : it is true if the invitation is created for a new user
- generatedInvite: false if only the role was updated, true if a new invitation is created (for a new or existing user) 

I added some info to org properties that was easily accessible (org name) , the rest requires a bit of refactoring

![Screenshot from 2022-08-24 11-09-37](https://user-images.githubusercontent.com/1983672/186384276-ad4d9363-f446-4ea7-b466-8f132c2b9952.png)

