### PR TITLE
fix: show different error reset password for social login

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -222,6 +222,13 @@ export class UserModel {
         return mapDbUserDetailsToLightdashUser(user);
     }
 
+    async hasPassword(userUuid: string): Promise<boolean> {
+        const [user] = await this.database('password_logins')
+            .leftJoin('users', 'users.user_id', 'password_logins.user_id')
+            .where('users.user_uuid', userUuid);
+        return user !== undefined;
+    }
+
     async getUserByUuidAndPassword(
         userUuid: string,
         password: string,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -499,7 +499,13 @@ export class UserService {
             );
         } catch (e) {
             if (e instanceof NotFoundError) {
-                throw new AuthorizationError('Password not recognized.');
+                const hasPassword = await this.userModel.hasPassword(userUuid);
+                if (hasPassword)
+                    throw new AuthorizationError('Password not recognized.');
+                else
+                    throw new AuthorizationError(
+                        `There is no password set on this social login account`,
+                    );
             }
             throw e;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2846

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
We don't expose if the user has a password or not , so we can't simply hide the menu if the user has no password (or even if he has social login) 

Instead we change the error message

See full thread https://lightdash.slack.com/archives/C02NPFHF4F6/p1661410782856119
<!-- Even better add a screenshot / gif / loom -->
![image](https://user-images.githubusercontent.com/1983672/186616595-5203ab5f-5edc-4571-8f08-e7e3354f29aa.png)
