### PR TITLE
chore: add missing keys / migrate MenuItem deprecations / menu appearance

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/FilterSearch.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/FilterSearch.styles.tsx
@@ -1,4 +1,5 @@
-import { Colors, MenuItem } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 
 export const FilterModalContainer = styled.div``;
@@ -18,7 +19,7 @@ export const FilterFooter = styled.p`
     margin: 2.5em 0 0;
 `;
 
-export const DimensionLabel = styled(MenuItem)`
+export const DimensionLabel = styled(MenuItem2)`
     margin: 0;
     width: 100%;
     border-radius: 0;

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,13 +1,7 @@
-import {
-    Button,
-    Menu,
-    MenuDivider,
-    MenuItem,
-    PopoverPosition,
-} from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
+import { Button, Menu, MenuDivider, PopoverPosition } from '@blueprintjs/core';
+import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
-import React, { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import AddChartTilesModal from './TileForms/AddChartTilesModal';
 import { AddTileModal } from './TileForms/TileModal';
 
@@ -31,21 +25,25 @@ const AddTileButton: FC<Props> = ({ onAddTiles }) => {
                 className="non-draggable"
                 content={
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             icon="chart"
                             text="Saved chart"
                             onClick={() => setIsAddChartTilesModalOpen(true)}
                         />
+
                         <MenuDivider />
-                        <MenuItem
+
+                        <MenuItem2
                             icon="new-text-box"
                             text="Markdown"
                             onClick={() =>
                                 setAddTileType(DashboardTileTypes.MARKDOWN)
                             }
                         />
+
                         <MenuDivider />
-                        <MenuItem
+
+                        <MenuItem2
                             icon="mobile-video"
                             text="Loom video"
                             onClick={() =>

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1,5 +1,10 @@
-import { Icon, Menu, MenuItem, NonIdealState, Portal } from '@blueprintjs/core';
-import { Popover2, Popover2TargetProps, Tooltip2 } from '@blueprintjs/popover2';
+import { Icon, Menu, NonIdealState, Portal } from '@blueprintjs/core';
+import {
+    MenuItem2,
+    Popover2,
+    Popover2TargetProps,
+    Tooltip2,
+} from '@blueprintjs/popover2';
 import {
     ChartType,
     DashboardChartTile as IDashboardChartTile,
@@ -100,7 +105,7 @@ const DownloadCSV: FC<{
 
     const rows = resultData?.rows;
     if (!rows || rows.length <= 0) {
-        return <MenuItem icon="download" text=".csv" disabled />;
+        return <MenuItem2 icon="download" text=".csv" disabled />;
     }
 
     return (
@@ -371,13 +376,13 @@ const DashboardChartTile: FC<Props> = (props) => {
                 savedChartUuid !== null && (
                     <>
                         {user.data?.ability?.can('manage', 'SavedChart') && (
-                            <MenuItem
+                            <MenuItem2
                                 icon="document-open"
                                 text="Edit chart"
                                 href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit`}
                             />
                         )}
-                        <MenuItem
+                        <MenuItem2
                             icon="series-search"
                             text="Explore from here"
                             href={exploreFromHereUrl}
@@ -402,7 +407,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                             content={
                                 <div onContextMenu={cancelContextMenu}>
                                     <Menu>
-                                        <MenuItem
+                                        <MenuItem2
                                             text={`View underlying data`}
                                             icon={'layers'}
                                             onClick={(e) => {
@@ -428,13 +433,13 @@ const DashboardChartTile: FC<Props> = (props) => {
                                             }}
                                         />
 
-                                        <MenuItem
+                                        <MenuItem2
                                             icon="filter"
                                             text="Filter dashboard to..."
                                         >
                                             {dashboardTileFilterOptions.map(
                                                 (filter) => (
-                                                    <MenuItem
+                                                    <MenuItem2
                                                         key={filter.id}
                                                         text={`${friendlyName(
                                                             filter.target
@@ -490,7 +495,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                                                     />
                                                 ),
                                             )}
-                                        </MenuItem>
+                                        </MenuItem2>
                                     </Menu>
                                 </div>
                             }

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -3,10 +3,9 @@ import {
     Classes,
     Menu,
     MenuDivider,
-    MenuItem,
     PopoverPosition,
 } from '@blueprintjs/core';
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
+import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import React, { ReactNode, useState } from 'react';
 import { TileModal } from '../TileForms/TileModal';
@@ -80,14 +79,14 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                 )}
                                 {isEditMode && (
                                     <>
-                                        <MenuItem
+                                        <MenuItem2
                                             icon="edit"
                                             text="Edit tile"
                                             onClick={() => setIsEditing(true)}
                                         />
                                         {tile.type !==
                                             DashboardTileTypes.MARKDOWN && (
-                                            <MenuItem
+                                            <MenuItem2
                                                 icon={
                                                     hideTitle
                                                         ? 'eye-open'
@@ -108,8 +107,10 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                 }
                                             />
                                         )}
+
                                         <MenuDivider />
-                                        <MenuItem
+
+                                        <MenuItem2
                                             icon="delete"
                                             intent="danger"
                                             text="Remove tile"

--- a/packages/frontend/src/components/ExploreMenuItem.tsx
+++ b/packages/frontend/src/components/ExploreMenuItem.tsx
@@ -1,5 +1,5 @@
-import { Colors, Icon, Intent, MenuItem } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
+import { Colors, Icon, Intent } from '@blueprintjs/core';
+import { MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
 import { InlineErrorType, SummaryExplore } from '@lightdash/common';
 import React from 'react';
 
@@ -33,7 +33,7 @@ export const ExploreMenuItem: React.FC<ExploreMenuItemProps> = ({
             .join('\n');
         return (
             <Tooltip2 content={errorMessage} targetTagName="div">
-                <MenuItem
+                <MenuItem2
                     icon="th"
                     text={explore.label}
                     disabled
@@ -48,5 +48,5 @@ export const ExploreMenuItem: React.FC<ExploreMenuItemProps> = ({
             </Tooltip2>
         );
     }
-    return <MenuItem icon="th" text={explore.label} onClick={onClick} />;
+    return <MenuItem2 icon="th" text={explore.label} onClick={onClick} />;
 };

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Collapse, MenuDivider, MenuItem } from '@blueprintjs/core';
-import { Breadcrumbs2, Tooltip2 } from '@blueprintjs/popover2';
+import { Button, Collapse, MenuDivider } from '@blueprintjs/core';
+import { Breadcrumbs2, MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
 import {
     AdditionalMetric,
     CompiledTable,
@@ -44,7 +44,7 @@ const SideBarLoadingState = () => (
     <LoadingStateWrapper large>
         {[0, 1, 2, 3, 4].map((idx) => (
             <React.Fragment key={idx}>
-                <MenuItem className="bp4-skeleton" />
+                <MenuItem2 className="bp4-skeleton" />
                 <MenuDivider />
             </React.Fragment>
         ))}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -3,10 +3,9 @@ import {
     InputGroup,
     Menu,
     MenuDivider,
-    MenuItem,
     NonIdealState,
 } from '@blueprintjs/core';
-import { Breadcrumbs2 } from '@blueprintjs/popover2';
+import { Breadcrumbs2, MenuItem2 } from '@blueprintjs/popover2';
 import Fuse from 'fuse.js';
 import React, { useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
@@ -31,7 +30,7 @@ const SideBarLoadingState = () => (
     <Menu large style={{ flex: 1 }}>
         {[0, 1, 2, 3, 4].map((idx) => (
             <React.Fragment key={idx}>
-                <MenuItem className="bp4-skeleton" />
+                <MenuItem2 className="bp4-skeleton" />
                 <MenuDivider />
             </React.Fragment>
         ))}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,5 +1,5 @@
-import { Menu, MenuItem } from '@blueprintjs/core';
-import { ContextMenu2 } from '@blueprintjs/popover2';
+import { Menu } from '@blueprintjs/core';
+import { ContextMenu2, MenuItem2 } from '@blueprintjs/popover2';
 import { fieldId, isField, isFilterableField } from '@lightdash/common';
 import React from 'react';
 import { useFilters } from '../../../hooks/useFilters';
@@ -24,7 +24,7 @@ const ColumnHeaderContextMenu: React.FC<HeaderProps> = ({
             <ContextMenu2
                 content={
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             text={`Filter by ${item.label}`}
                             icon={'filter'}
                             onClick={(e) => {
@@ -36,7 +36,7 @@ const ColumnHeaderContextMenu: React.FC<HeaderProps> = ({
                             }}
                         />
 
-                        <MenuItem
+                        <MenuItem2
                             text={`Remove`}
                             icon={'cross'}
                             onClick={(e) => {
@@ -55,7 +55,7 @@ const ColumnHeaderContextMenu: React.FC<HeaderProps> = ({
             <ContextMenu2
                 content={
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             text={`Remove`}
                             icon={'cross'}
                             onClick={(e) => {

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -5,9 +5,8 @@ import {
     Divider,
     Intent,
     Menu,
-    MenuItem,
 } from '@blueprintjs/core';
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
+import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { FC, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import useMoveToSpace from '../../../hooks/useMoveToSpace';
@@ -230,7 +229,7 @@ const SavedChartsHeader: FC = () => {
                             disabled={!unsavedChartVersion.tableName}
                             content={
                                 <Menu>
-                                    <MenuItem
+                                    <MenuItem2
                                         icon={
                                             hasUnsavedChanges
                                                 ? 'add'
@@ -252,14 +251,14 @@ const SavedChartsHeader: FC = () => {
                                             }
                                         }}
                                     />
-                                    <MenuItem
+                                    <MenuItem2
                                         icon="control"
                                         text="Add to dashboard"
                                         onClick={() =>
                                             setIsAddToDashboardModalOpen(true)
                                         }
                                     />
-                                    <MenuItem
+                                    <MenuItem2
                                         icon="folder-close"
                                         text="Move to space"
                                         onClick={(e) => {
@@ -272,7 +271,8 @@ const SavedChartsHeader: FC = () => {
                                                 savedChart?.spaceUuid ===
                                                 spaceToMove.uuid;
                                             return (
-                                                <MenuItem
+                                                <MenuItem2
+                                                    key={spaceToMove.uuid}
                                                     text={spaceToMove.name}
                                                     icon={
                                                         isDisabled
@@ -302,11 +302,11 @@ const SavedChartsHeader: FC = () => {
                                                 />
                                             );
                                         })}
-                                    </MenuItem>
+                                    </MenuItem2>
 
                                     <Divider />
 
-                                    <MenuItem
+                                    <MenuItem2
                                         icon="trash"
                                         text="Delete"
                                         intent="danger"

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -15,6 +15,7 @@ export const SpaceBrowserMenu: React.FC<Props> = ({
     return (
         <>
             <Popover2
+                minimal
                 captureDismiss
                 content={
                     <Menu>

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -45,53 +45,51 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             >
                 <SpaceListWrapper>
                     {spaces?.map(({ uuid, name, dashboards, queries }) => (
-                        <>
-                            <SpaceLinkButton
-                                key={uuid}
-                                minimal
-                                outlined
-                                href={`/projects/${projectUuid}/spaces/${uuid}`}
-                            >
-                                <SpaceHeader>
-                                    <Icon
-                                        icon="folder-close"
-                                        size={20}
-                                        color={Colors.BLUE5}
-                                    ></Icon>
-                                    <div
-                                        onClick={(e) => {
-                                            // prevent clicks in menu to trigger redirect
-                                            e.stopPropagation();
-                                            e.preventDefault();
-                                        }}
+                        <SpaceLinkButton
+                            key={uuid}
+                            minimal
+                            outlined
+                            href={`/projects/${projectUuid}/spaces/${uuid}`}
+                        >
+                            <SpaceHeader>
+                                <Icon
+                                    icon="folder-close"
+                                    size={20}
+                                    color={Colors.BLUE5}
+                                ></Icon>
+                                <div
+                                    onClick={(e) => {
+                                        // prevent clicks in menu to trigger redirect
+                                        e.stopPropagation();
+                                        e.preventDefault();
+                                    }}
+                                >
+                                    <SpaceBrowserMenu
+                                        onRename={() =>
+                                            setUpdateSpaceUuid(uuid)
+                                        }
+                                        onDelete={() =>
+                                            setDeleteSpaceUuid(uuid)
+                                        }
                                     >
-                                        <SpaceBrowserMenu
-                                            onRename={() =>
-                                                setUpdateSpaceUuid(uuid)
-                                            }
-                                            onDelete={() =>
-                                                setDeleteSpaceUuid(uuid)
-                                            }
-                                        >
-                                            <Tooltip2 content="View options">
-                                                <Button minimal icon="more" />
-                                            </Tooltip2>
-                                        </SpaceBrowserMenu>
-                                    </div>
-                                </SpaceHeader>
-                                <SpaceTitle ellipsize>{name}</SpaceTitle>
-                                <SpaceFooter>
-                                    <SpaceItemCount
-                                        icon="control"
-                                        value={dashboards.length}
-                                    />
-                                    <SpaceItemCount
-                                        icon="timeline-bar-chart"
-                                        value={queries.length}
-                                    />
-                                </SpaceFooter>
-                            </SpaceLinkButton>
-                        </>
+                                        <Tooltip2 content="View options">
+                                            <Button minimal icon="more" />
+                                        </Tooltip2>
+                                    </SpaceBrowserMenu>
+                                </div>
+                            </SpaceHeader>
+                            <SpaceTitle ellipsize>{name}</SpaceTitle>
+                            <SpaceFooter>
+                                <SpaceItemCount
+                                    icon="control"
+                                    value={dashboards.length}
+                                />
+                                <SpaceItemCount
+                                    icon="timeline-bar-chart"
+                                    value={queries.length}
+                                />
+                            </SpaceFooter>
+                        </SpaceLinkButton>
                     ))}
                 </SpaceListWrapper>
             </LatestCard>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -1,5 +1,9 @@
-import { Menu, MenuItem, Portal } from '@blueprintjs/core';
-import { Popover2, Popover2TargetProps } from '@blueprintjs/popover2';
+import { Menu, Portal } from '@blueprintjs/core';
+import {
+    MenuItem2,
+    Popover2,
+    Popover2TargetProps,
+} from '@blueprintjs/popover2';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
@@ -81,7 +85,7 @@ export const SeriesContextMenu: FC<{
             content={
                 <div onContextMenu={cancelContextMenu}>
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             text={`View underlying data`}
                             icon={'layers'}
                             onClick={(e) => {

--- a/packages/frontend/src/components/NavBar/BrowseMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu/index.tsx
@@ -1,13 +1,12 @@
 import {
     Button,
     MenuDivider,
-    MenuItem,
     PopoverInteractionKind,
     Position,
     Spinner,
 } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
-import React, { FC } from 'react';
+import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { FC } from 'react';
 import { useSpaces } from '../../../hooks/useSpaces';
 import NavLink from '../../NavLink';
 import { FirstItem, MenuWrapper, SpinnerWrapper } from '../NavBar.styles';
@@ -21,6 +20,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
     return (
         <>
             <Popover2
+                minimal
                 interactionKind={PopoverInteractionKind.CLICK}
                 content={
                     !projectUuid || isLoading ? (
@@ -37,17 +37,20 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                                 />
                             </NavLink>
                             <NavLink to={`/projects/${projectUuid}/saved`}>
-                                <MenuItem
+                                <MenuItem2
                                     icon="chart"
                                     text="All saved charts"
                                 />
                             </NavLink>
+
                             <MenuDivider />
+
                             {spaces?.map((space) => (
                                 <NavLink
+                                    key={space.uuid}
                                     to={`/projects/${projectUuid}/spaces/${space.uuid}`}
                                 >
-                                    <MenuItem
+                                    <MenuItem2
                                         icon="folder-close"
                                         text={space.name}
                                     />

--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -1,11 +1,10 @@
 import {
     Button,
-    MenuItem,
     PopoverInteractionKind,
     Position,
     Spinner,
 } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
+import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import React, { FC } from 'react';
 import { useApp } from '../../../providers/AppProvider';
@@ -23,6 +22,7 @@ const ExploreMenu: FC<Props> = ({ projectUuid }) => {
     return (
         <>
             <Popover2
+                minimal
                 interactionKind={PopoverInteractionKind.CLICK}
                 content={
                     !projectUuid ? (
@@ -49,7 +49,7 @@ const ExploreMenu: FC<Props> = ({ projectUuid }) => {
                                 <NavLink
                                     to={`/projects/${projectUuid}/sqlRunner`}
                                 >
-                                    <MenuItem
+                                    <MenuItem2
                                         role="button"
                                         icon="console"
                                         text="SQL Runner"

--- a/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
@@ -1,11 +1,5 @@
-import {
-    Button,
-    Classes,
-    KeyCombo,
-    MenuItem,
-    Spinner,
-    Tag,
-} from '@blueprintjs/core';
+import { Button, Classes, KeyCombo, Spinner, Tag } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemPredicate, ItemRenderer } from '@blueprintjs/select';
 import { getSearchResultId } from '@lightdash/common';
 import React, { FC, useState } from 'react';
@@ -37,7 +31,7 @@ const renderItem: ItemRenderer<SearchItem> = (
         return null;
     }
     return (
-        <MenuItem
+        <MenuItem2
             key={getSearchResultId(field.meta)}
             selected={modifiers.active}
             disabled={modifiers.disabled}
@@ -132,7 +126,7 @@ const GlobalSearch: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     getSearchResultId(a.meta) === getSearchResultId(b.meta)
                 }
                 initialContent={
-                    <MenuItem
+                    <MenuItem2
                         disabled={true}
                         text={`${
                             !query ? 'Start' : 'Keep'
@@ -140,7 +134,7 @@ const GlobalSearch: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     />
                 }
                 noResults={
-                    <MenuItem
+                    <MenuItem2
                         disabled={true}
                         text={
                             !query || query.length < 3

--- a/packages/frontend/src/components/NavBar/NavBar.styles.tsx
+++ b/packages/frontend/src/components/NavBar/NavBar.styles.tsx
@@ -2,10 +2,10 @@ import {
     Colors,
     HTMLSelect,
     Menu,
-    MenuItem,
     Navbar,
     NavbarDivider,
 } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 import { ReactComponent as Logo } from '../../svgs/logo-icon.svg';
 
@@ -45,7 +45,7 @@ export const MenuWrapper = styled(Menu)`
     }
 `;
 
-export const FirstItem = styled(MenuItem)`
+export const FirstItem = styled(MenuItem2)`
     margin-bottom: 0.357em;
 `;
 

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -3,14 +3,12 @@ import {
     Button,
     Classes,
     Menu,
-    MenuItem,
     NavbarGroup,
     PopoverInteractionKind,
     Position,
 } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
+import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { ProjectType } from '@lightdash/common';
-import React from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
 import { lightdashApi } from '../../api';
@@ -139,13 +137,13 @@ const NavBar = () => {
                                     'create',
                                     'InviteLink',
                                 ) ? (
-                                    <MenuItem
+                                    <MenuItem2
                                         href={`/generalSettings/userManagement?to=invite`}
                                         icon="new-person"
                                         text="Invite user"
                                     />
                                 ) : null}
-                                <MenuItem
+                                <MenuItem2
                                     icon="log-out"
                                     text="Logout"
                                     onClick={() => mutate()}

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, InputGroup, Intent, MenuItem } from '@blueprintjs/core';
+import { Button, Card, InputGroup, Intent } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemRenderer, Suggest2 } from '@blueprintjs/select';
 import {
     CreateProjectMember,
@@ -34,7 +35,7 @@ const renderItem: ItemRenderer<string> = (item, { modifiers, handleClick }) => {
         return null;
     }
     return (
-        <MenuItem
+        <MenuItem2
             active={modifiers.active}
             key={item}
             text={item}
@@ -190,7 +191,7 @@ const ProjectAccessCreation: FC<{
                             createNewItemRenderer={(email: string) => {
                                 if (validateEmail(email)) {
                                     return (
-                                        <MenuItem
+                                        <MenuItem2
                                             icon="add"
                                             key={email}
                                             text={`Invite ${email} as new member of this organisation`}

--- a/packages/frontend/src/components/ReactHookForm/MultiSelect.tsx
+++ b/packages/frontend/src/components/ReactHookForm/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     ItemRenderer,
     MultiSelect as BlueprintMultiSelect,
@@ -95,7 +95,7 @@ const ControlledMultiSelect: FC<{
                 label
             );
         return (
-            <MenuItem
+            <MenuItem2
                 active={modifiers.active}
                 icon={isSelected ? 'tick' : 'blank'}
                 key={valueId}
@@ -124,7 +124,7 @@ const ControlledMultiSelect: FC<{
             items={items}
             {...props}
             {...field}
-            noResults={<MenuItem disabled text="No results." />}
+            noResults={<MenuItem2 disabled text="No results." />}
             itemsEqual={isItemMatch}
             selectedItems={field.value}
             itemRenderer={renderItem}

--- a/packages/frontend/src/components/SavedQueries/SavedQueriesMenu.tsx
+++ b/packages/frontend/src/components/SavedQueries/SavedQueriesMenu.tsx
@@ -1,12 +1,5 @@
-import {
-    Card,
-    Divider,
-    H3,
-    Menu,
-    MenuDivider,
-    MenuItem,
-    Text,
-} from '@blueprintjs/core';
+import { Card, Divider, H3, Menu, MenuDivider, Text } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { Space } from '@lightdash/common';
 import React, { Dispatch, SetStateAction } from 'react';
 
@@ -53,11 +46,12 @@ const SavedQueriesMenu = (props: SavedQueriesMenuProps) => {
             >
                 {(data || []).map((saved) => (
                     <React.Fragment key={saved.uuid}>
-                        <MenuItem
+                        <MenuItem2
                             active={saved.uuid === selectedMenu}
                             text={saved.name}
                             onClick={() => setSelectedMenu(saved.uuid)}
                         />
+
                         <MenuDivider />
                     </React.Fragment>
                 ))}

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,5 +1,9 @@
-import { Menu, MenuItem, Portal } from '@blueprintjs/core';
-import { Popover2, Popover2TargetProps } from '@blueprintjs/popover2';
+import { Menu, Portal } from '@blueprintjs/core';
+import {
+    MenuItem2,
+    Popover2,
+    Popover2TargetProps,
+} from '@blueprintjs/popover2';
 import { fieldId, getFields, ResultRow } from '@lightdash/common';
 import { FC, useCallback } from 'react';
 import { useExplore } from '../../hooks/useExplore';
@@ -55,7 +59,7 @@ export const BigNumberContextMenu: FC<{
             content={
                 <div onContextMenu={cancelContextMenu}>
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             text={`View underlying data`}
                             icon={'layers'}
                             onClick={() => {

--- a/packages/frontend/src/components/TableCalculationHeaderButton.tsx
+++ b/packages/frontend/src/components/TableCalculationHeaderButton.tsx
@@ -1,13 +1,7 @@
-import {
-    Button,
-    Icon,
-    Menu,
-    MenuItem,
-    PopoverPosition,
-} from '@blueprintjs/core';
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
+import { Button, Icon, Menu, PopoverPosition } from '@blueprintjs/core';
+import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { TableCalculation } from '@lightdash/common';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
 import {
@@ -30,7 +24,7 @@ const TableCalculationHeaderButton: FC<{
                 onInteraction={setIsOpen}
                 content={
                     <Menu>
-                        <MenuItem
+                        <MenuItem2
                             icon={<Icon icon="edit" />}
                             text="Edit"
                             onClick={(e) => {
@@ -42,7 +36,7 @@ const TableCalculationHeaderButton: FC<{
                                 });
                             }}
                         />
-                        <MenuItem
+                        <MenuItem2
                             icon={<Icon icon="delete" />}
                             text="Delete"
                             onClick={(e) => {

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataModal.tsx
@@ -8,7 +8,7 @@ import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 
 interface Props {}
 
-const UnderlyingDataModal: FC<Props> = ({}) => {
+const UnderlyingDataModal: FC<Props> = () => {
     const {
         resultsData,
         fieldsMap,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/StringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/StringAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemRenderer, MultiSelect } from '@blueprintjs/select';
 import React, { FC, useCallback } from 'react';
 
@@ -39,7 +39,7 @@ const StringMultiSelect: FC<Props> = ({ values, suggestions, onChange }) => {
                 return null;
             }
             return (
-                <MenuItem
+                <MenuItem2
                     active={modifiers.active}
                     icon={values.includes(name) ? 'tick' : 'blank'}
                     key={name}
@@ -57,7 +57,7 @@ const StringMultiSelect: FC<Props> = ({ values, suggestions, onChange }) => {
             active: boolean,
             handleClick: React.MouseEventHandler<HTMLElement>,
         ) => (
-            <MenuItem
+            <MenuItem2
                 icon="add"
                 text={`Add "${query}"`}
                 active={active}
@@ -83,7 +83,7 @@ const StringMultiSelect: FC<Props> = ({ values, suggestions, onChange }) => {
         <MultiSelect
             fill
             items={Array.from(new Set([...suggestions, ...values]))}
-            noResults={<MenuItem disabled text="No suggestions." />}
+            noResults={<MenuItem2 disabled text="No suggestions." />}
             itemsEqual={(value, other) =>
                 value.toLowerCase() === other.toLowerCase()
             }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/UnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/UnitOfTimeAutoComplete.tsx
@@ -1,7 +1,8 @@
-import { Button, MenuItem } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { UnitOfTime } from '@lightdash/common';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 type UnitOfTimeOption = {
@@ -46,7 +47,7 @@ const renderItem: ItemRenderer<UnitOfTimeOption> = (
         return null;
     }
     return (
-        <MenuItem
+        <MenuItem2
             active={modifiers.active}
             key={`${field.completed}_${field.unitOfTime}`}
             text={field.label}
@@ -89,7 +90,7 @@ const UnitOfTimeAutoComplete: FC<Props> = ({
                 unitOfTime,
                 completed,
             }}
-            noResults={<MenuItem disabled text="No results." />}
+            noResults={<MenuItem2 disabled text="No results." />}
             onItemSelect={onChange}
             itemPredicate={(
                 query: string,

--- a/packages/frontend/src/components/common/RouterMenuItem.tsx
+++ b/packages/frontend/src/components/common/RouterMenuItem.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import React, { FC } from 'react';
 import { Route, useHistory } from 'react-router-dom';
 
@@ -7,7 +7,7 @@ interface Props {
     exact?: boolean;
 }
 
-const RouterMenuItem: FC<Props & React.ComponentProps<typeof MenuItem>> = ({
+const RouterMenuItem: FC<Props & React.ComponentProps<typeof MenuItem2>> = ({
     to,
     exact,
     ...rest
@@ -19,7 +19,7 @@ const RouterMenuItem: FC<Props & React.ComponentProps<typeof MenuItem>> = ({
             exact={exact}
             /* eslint-disable-next-line react/no-children-prop */
             children={({ match }) => (
-                <MenuItem
+                <MenuItem2
                     active={!!match}
                     {...rest}
                     onClick={() => history.push(to)}

--- a/packages/frontend/src/components/common/SideBarLoadingState.tsx
+++ b/packages/frontend/src/components/common/SideBarLoadingState.tsx
@@ -1,11 +1,12 @@
-import { Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
+import { Menu, MenuDivider } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import React from 'react';
 
 const SideBarLoadingState = () => (
     <Menu large style={{ flex: 1 }}>
         {[0, 1, 2, 3, 4].map((idx) => (
             <React.Fragment key={idx}>
-                <MenuItem className="bp4-skeleton" />
+                <MenuItem2 className="bp4-skeleton" />
                 <MenuDivider />
             </React.Fragment>
         ))}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -35,6 +35,7 @@ const TableHeader = () => {
                                     .meta as TableColumn['meta'];
                                 return (
                                     <th
+                                        key={header.id}
                                         colSpan={header.colSpan}
                                         style={{
                                             width: meta?.width,
@@ -47,7 +48,6 @@ const TableHeader = () => {
                                         onClick={meta?.onHeaderClick}
                                     >
                                         <Draggable
-                                            key={header.id}
                                             draggableId={header.id}
                                             index={header.index}
                                             isDragDisabled={!meta?.draggable}

--- a/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
+++ b/packages/frontend/src/components/common/modal/ModalActionButtons.tsx
@@ -1,6 +1,6 @@
-import { Button, Divider, Menu, MenuItem } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Button, Divider, Menu } from '@blueprintjs/core';
+import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDuplicateDashboardMutation } from '../../../hooks/dashboard/useDashboard';
 import { useDuplicateMutation } from '../../../hooks/useSavedQuery';
@@ -53,7 +53,7 @@ const ModalActionButtons = ({
             }}
             content={
                 <Menu>
-                    <MenuItem
+                    <MenuItem2
                         role="button"
                         icon="edit"
                         text="Rename"
@@ -67,7 +67,7 @@ const ModalActionButtons = ({
                             });
                         }}
                     />
-                    <MenuItem
+                    <MenuItem2
                         role="button"
                         icon="duplicate"
                         text="Duplicate"
@@ -84,7 +84,7 @@ const ModalActionButtons = ({
                         }}
                     />
                     {!isDashboardPage && (
-                        <MenuItem
+                        <MenuItem2
                             icon="insert"
                             text="Add to Dashboard"
                             onClick={(e) => {
@@ -100,7 +100,7 @@ const ModalActionButtons = ({
                         />
                     )}
 
-                    <MenuItem
+                    <MenuItem2
                         icon="folder-close"
                         text="Move to Space"
                         onClick={(e) => {
@@ -111,7 +111,8 @@ const ModalActionButtons = ({
                         {spaces?.map((space) => {
                             const isDisabled = data.spaceUuid === space.uuid;
                             return (
-                                <MenuItem
+                                <MenuItem2
+                                    key={space.uuid}
                                     text={space.name}
                                     icon={isDisabled ? 'small-tick' : undefined}
                                     className={isDisabled ? 'bp4-disabled' : ''}
@@ -134,7 +135,7 @@ const ModalActionButtons = ({
                         })}
 
                         <Divider />
-                        <MenuItem
+                        <MenuItem2
                             text="+ Create new"
                             onClick={(e) => {
                                 e.preventDefault();
@@ -145,9 +146,11 @@ const ModalActionButtons = ({
                                 });
                             }}
                         />
-                    </MenuItem>
+                    </MenuItem2>
+
                     <Divider />
-                    <MenuItem
+
+                    <MenuItem2
                         role="button"
                         icon="trash"
                         text="Delete"


### PR DESCRIPTION
### Description:
- [x] add missing key props to random places
- [x] migrates deprecated MenuItem to MenuItem2
- [x] gives navigation menus minimal appearance instead of popups

<img width="449" alt="CleanShot 2022-08-25 at 13 08 53@2x" src="https://user-images.githubusercontent.com/962095/186624414-978c4d51-6f3b-45de-be13-4c7bf93a0496.png">
