### PR TITLE
chore: cell context menu perf improvement

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,5 +1,5 @@
-import { Menu, Position } from '@blueprintjs/core';
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { Menu } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { isField, isFilterableField, ResultRow } from '@lightdash/common';
 import { FC } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
@@ -9,14 +9,9 @@ import { isUrl } from '../../common/Table/ScrollableTable/RichBodyCell';
 import { CellContextMenuProps, TableColumn } from '../../common/Table/types';
 import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataProvider';
 
-interface CommonProps extends CellContextMenuProps {
-    isEditMode: boolean;
-}
-
-const ContextMenu: FC<Pick<CommonProps, 'cell' | 'isEditMode'>> = ({
-    cell,
-    isEditMode,
-}) => {
+const CellContextMenu: FC<
+    Pick<CellContextMenuProps, 'cell' | 'isEditMode'>
+> = ({ cell, isEditMode }) => {
     const { addFilter } = useFilters();
     const { viewData } = useUnderlyingDataContext();
     const { track } = useTracking();
@@ -66,26 +61,6 @@ const ContextMenu: FC<Pick<CommonProps, 'cell' | 'isEditMode'>> = ({
                 />
             )}
         </Menu>
-    );
-};
-
-const CellContextMenu: FC<CommonProps> = ({
-    isEditMode,
-    cell,
-    renderCell,
-    onOpen,
-    onClose,
-}) => {
-    return (
-        <Popover2
-            minimal
-            position={Position.BOTTOM_RIGHT}
-            defaultIsOpen
-            content={<ContextMenu cell={cell} isEditMode={isEditMode} />}
-            renderTarget={renderCell}
-            onOpening={onOpen}
-            onClosing={onClose}
-        />
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,14 +1,7 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
-import {
-    Field,
-    isField,
-    isFilterableField,
-    ResultRow,
-    TableCalculation,
-} from '@lightdash/common';
-import { Cell } from '@tanstack/react-table';
-import { cloneElement, FC, isValidElement } from 'react';
+import { isField, isFilterableField, ResultRow } from '@lightdash/common';
+import { FC } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -16,22 +9,20 @@ import { isUrl } from '../../common/Table/ScrollableTable/RichBodyCell';
 import { CellContextMenuProps, TableColumn } from '../../common/Table/types';
 import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataProvider';
 
-interface ContextMenuProps {
-    cell: Cell<ResultRow, ResultRow[0]>;
-    item?: Field | TableCalculation;
-    meta: TableColumn['meta'];
+interface CommonProps extends CellContextMenuProps {
     isEditMode: boolean;
 }
 
-const ContextMenu: FC<ContextMenuProps> = ({
-    meta,
-    item,
+const ContextMenu: FC<Pick<CommonProps, 'cell' | 'isEditMode'>> = ({
     cell,
     isEditMode,
 }) => {
     const { addFilter } = useFilters();
     const { viewData } = useUnderlyingDataContext();
     const { track } = useTracking();
+
+    const meta = cell.column.columnDef.meta as TableColumn['meta'];
+    const item = meta?.item;
 
     const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
 
@@ -78,44 +69,21 @@ const ContextMenu: FC<ContextMenuProps> = ({
     );
 };
 
-const CellContextMenu: FC<
-    CellContextMenuProps & {
-        isEditMode: boolean;
-    }
-> = ({ isEditMode, boundaryElement, children, cell, onOpen, onClose }) => {
-    const meta = cell.column.columnDef.meta as TableColumn['meta'];
-    const item = meta?.item;
-
-    if (!item || !boundaryElement) {
-        return <>{children}</>;
-    }
-
+const CellContextMenu: FC<CommonProps> = ({
+    isEditMode,
+    cell,
+    renderCell,
+    onOpen,
+    onClose,
+}) => {
     return (
         <Popover2
             minimal
             lazy
             position={Position.BOTTOM_RIGHT}
-            boundary={boundaryElement}
-            content={
-                <ContextMenu
-                    cell={cell}
-                    item={item}
-                    meta={meta}
-                    isEditMode={isEditMode}
-                />
-            }
-            renderTarget={({ ref, ...targetProps }) => {
-                if (isValidElement(children)) {
-                    return cloneElement(children, {
-                        ref,
-                        ...targetProps,
-                    });
-                } else {
-                    throw new Error(
-                        'CellContextMenu children must be a valid React element',
-                    );
-                }
-            }}
+            defaultIsOpen
+            content={<ContextMenu cell={cell} isEditMode={isEditMode} />}
+            renderTarget={renderCell}
             onOpening={onOpen}
             onClosing={onClose}
         />

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -79,7 +79,6 @@ const CellContextMenu: FC<CommonProps> = ({
     return (
         <Popover2
             minimal
-            lazy
             position={Position.BOTTOM_RIGHT}
             defaultIsOpen
             content={<ContextMenu cell={cell} isEditMode={isEditMode} />}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,11 +1,11 @@
-import { Menu, Position } from '@blueprintjs/core';
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { Menu } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { ResultRow } from '@lightdash/common';
 import { FC } from 'react';
 import { CellContextMenuProps, TableColumn } from '../common/Table/types';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
-const ContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
+const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const { viewData } = useUnderlyingDataContext();
 
     const meta = cell.column.columnDef.meta as TableColumn['meta'];
@@ -34,25 +34,6 @@ const ContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                 }}
             />
         </Menu>
-    );
-};
-
-const CellContextMenu: FC<CellContextMenuProps> = ({
-    cell,
-    renderCell,
-    onOpen,
-    onClose,
-}) => {
-    return (
-        <Popover2
-            minimal
-            defaultIsOpen
-            position={Position.BOTTOM_RIGHT}
-            content={<ContextMenu cell={cell} />}
-            renderTarget={renderCell}
-            onOpening={onOpen}
-            onClosing={onClose}
-        />
     );
 };
 

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -46,7 +46,6 @@ const CellContextMenu: FC<CellContextMenuProps> = ({
     return (
         <Popover2
             minimal
-            lazy
             defaultIsOpen
             position={Position.BOTTOM_RIGHT}
             content={<ContextMenu cell={cell} />}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,18 +1,14 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { ResultRow } from '@lightdash/common';
-import { Cell } from '@tanstack/react-table';
-import { cloneElement, FC, isValidElement } from 'react';
+import { FC } from 'react';
 import { CellContextMenuProps, TableColumn } from '../common/Table/types';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
-interface ContextMenuProps {
-    cell: Cell<ResultRow, ResultRow[0]>;
-    meta: TableColumn['meta'];
-}
-
-const ContextMenu: FC<ContextMenuProps> = ({ meta, cell }) => {
+const ContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const { viewData } = useUnderlyingDataContext();
+
+    const meta = cell.column.columnDef.meta as TableColumn['meta'];
 
     const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
     const pivot = meta?.pivotReference?.pivotValues?.[0]
@@ -42,38 +38,19 @@ const ContextMenu: FC<ContextMenuProps> = ({ meta, cell }) => {
 };
 
 const CellContextMenu: FC<CellContextMenuProps> = ({
-    boundaryElement,
-    children,
     cell,
+    renderCell,
     onOpen,
     onClose,
 }) => {
-    const meta = cell.column.columnDef.meta as TableColumn['meta'];
-    const item = meta?.item;
-
-    if (!item || !boundaryElement) {
-        return <>{children}</>;
-    }
-
     return (
         <Popover2
             minimal
             lazy
+            defaultIsOpen
             position={Position.BOTTOM_RIGHT}
-            boundary={boundaryElement}
-            content={<ContextMenu cell={cell} meta={meta} />}
-            renderTarget={({ ref, ...targetProps }) => {
-                if (isValidElement(children)) {
-                    return cloneElement(children, {
-                        ref,
-                        ...targetProps,
-                    });
-                } else {
-                    throw new Error(
-                        'CellContextMenu children must be a valid React element',
-                    );
-                }
-            }}
+            content={<ContextMenu cell={cell} />}
+            renderTarget={renderCell}
             onOpening={onOpen}
             onClosing={onClose}
         />

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -1,8 +1,11 @@
+import { Position } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
 import { ResultRow } from '@lightdash/common';
 import { Cell } from '@tanstack/react-table';
 import React, { FC, useCallback, useState } from 'react';
 import RichBodyCell from './ScrollableTable/RichBodyCell';
 import { Td } from './Table.styles';
+import { useTableContext } from './TableProvider';
 import { CellContextMenuProps } from './types';
 
 interface CommonBodyCellProps {
@@ -52,6 +55,8 @@ const BodyCell = React.forwardRef<HTMLTableCellElement, BodyCellProps>(
 );
 
 const BodyCellWrapper: FC<CommonBodyCellProps> = ({ onSelect, ...props }) => {
+    const { scrollableWrapperRef } = useTableContext();
+
     const CellContextMenu = props.cellContextMenu;
 
     const [isCellSelected, setIsCellSelected] = useState<boolean>(false);
@@ -67,12 +72,17 @@ const BodyCellWrapper: FC<CommonBodyCellProps> = ({ onSelect, ...props }) => {
     const canHaveContextMenu = !!CellContextMenu && props.hasData;
 
     return canHaveContextMenu && isCellSelected ? (
-        <CellContextMenu
-            key={props.cell.id}
-            cell={props.cell as Cell<ResultRow, ResultRow[0]>}
-            onOpen={() => handleCellSelect(props.cell.id)}
-            onClose={() => handleCellSelect(undefined)}
-            renderCell={({ ref }) => (
+        <Popover2
+            minimal
+            position={Position.BOTTOM_RIGHT}
+            defaultIsOpen
+            portalContainer={scrollableWrapperRef.current}
+            content={
+                <CellContextMenu
+                    cell={props.cell as Cell<ResultRow, ResultRow[0]>}
+                />
+            }
+            renderTarget={({ ref }) => (
                 <BodyCell
                     {...props}
                     hasContextMenu
@@ -81,6 +91,8 @@ const BodyCellWrapper: FC<CommonBodyCellProps> = ({ onSelect, ...props }) => {
                     ref={ref}
                 />
             )}
+            onOpening={() => handleCellSelect(props.cell.id)}
+            onClosing={() => handleCellSelect(undefined)}
         />
     ) : (
         <BodyCell

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -1,0 +1,74 @@
+import { ResultRow } from '@lightdash/common';
+import { Cell } from '@tanstack/react-table';
+import React, { FC } from 'react';
+import RichBodyCell from './ScrollableTable/RichBodyCell';
+import { Td } from './Table.styles';
+import { CellContextMenuProps } from './types';
+
+interface CommonBodyCellProps {
+    cell: Cell<ResultRow, unknown>;
+    rowIndex: number;
+    isNumericItem: boolean;
+    isSelected: boolean;
+    hasData: boolean;
+    hasContextMenu: boolean;
+    cellContextMenu?: FC<CellContextMenuProps>;
+}
+
+interface BodyCellProps extends CommonBodyCellProps {
+    onClick?: (e: React.MouseEvent<HTMLTableCellElement>) => void;
+}
+
+const BodyCell = React.forwardRef<HTMLTableCellElement, BodyCellProps>(
+    (
+        {
+            rowIndex,
+            cell,
+            hasContextMenu,
+            hasData,
+            isNumericItem,
+            isSelected,
+            children,
+            onClick,
+        },
+        ref,
+    ) => {
+        return (
+            <Td
+                ref={ref}
+                $rowIndex={rowIndex}
+                $isSelected={isSelected}
+                $isInteractive={hasContextMenu}
+                $hasData={hasData}
+                $isNaN={!hasData || !isNumericItem}
+                onClick={onClick}
+            >
+                <RichBodyCell cell={cell as Cell<ResultRow, ResultRow[0]>}>
+                    {children}
+                </RichBodyCell>
+            </Td>
+        );
+    },
+);
+
+interface BodyCellWrapperProps extends CommonBodyCellProps {
+    onSelect: (cellId: string | undefined) => void;
+}
+
+const BodyCellWrapper: FC<BodyCellWrapperProps> = (props) => {
+    const CellContextMenu = props.cellContextMenu;
+
+    return CellContextMenu && props.isSelected ? (
+        <CellContextMenu
+            key={props.cell.id}
+            cell={props.cell as Cell<ResultRow, ResultRow[0]>}
+            onOpen={() => props.onSelect(props.cell.id)}
+            onClose={() => props.onSelect(undefined)}
+            renderCell={({ ref }) => <BodyCell ref={ref} {...props} />}
+        />
+    ) : (
+        <BodyCell {...props} onClick={() => props.onSelect(props.cell.id)} />
+    );
+};
+
+export default BodyCellWrapper;

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,19 +1,12 @@
 import { isNumericItem } from '@lightdash/common';
 import { flexRender } from '@tanstack/react-table';
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
 import BodyCell from '../BodyCell';
 import { useTableContext } from '../TableProvider';
 import { TableColumn } from '../types';
 
 const TableBody: FC = () => {
-    const { table, cellContextMenu, setIsScrollable } = useTableContext();
-
-    const handleCellSelect = useCallback(
-        (cellId: string | undefined) => {
-            setIsScrollable(!cellId);
-        },
-        [setIsScrollable],
-    );
+    const { table, cellContextMenu } = useTableContext();
 
     return (
         <tbody>
@@ -31,7 +24,6 @@ const TableBody: FC = () => {
                                 isNumericItem={isNumericItem(meta?.item)}
                                 hasData={!!meta?.item}
                                 cellContextMenu={cellContextMenu}
-                                onSelect={handleCellSelect}
                             >
                                 {flexRender(
                                     cell.column.columnDef.cell,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,18 +1,19 @@
 import { isNumericItem } from '@lightdash/common';
 import { flexRender } from '@tanstack/react-table';
-import { FC, useState } from 'react';
+import { FC, useCallback } from 'react';
 import BodyCell from '../BodyCell';
 import { useTableContext } from '../TableProvider';
 import { TableColumn } from '../types';
 
 const TableBody: FC = () => {
     const { table, cellContextMenu, setIsScrollable } = useTableContext();
-    const [selectedCell, setSelectedCell] = useState<string>();
 
-    const handleCellSelect = (cellId: string | undefined) => {
-        setIsScrollable(!cellId);
-        setSelectedCell(cellId);
-    };
+    const handleCellSelect = useCallback(
+        (cellId: string | undefined) => {
+            setIsScrollable(!cellId);
+        },
+        [setIsScrollable],
+    );
 
     return (
         <tbody>
@@ -27,7 +28,6 @@ const TableBody: FC = () => {
                                 key={cell.id}
                                 rowIndex={rowIndex}
                                 cell={cell}
-                                isSelected={cell.id === selectedCell}
                                 isNumericItem={isNumericItem(meta?.item)}
                                 hasContextMenu={!!cellContextMenu}
                                 hasData={!!meta?.item}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -29,7 +29,6 @@ const TableBody: FC = () => {
                                 rowIndex={rowIndex}
                                 cell={cell}
                                 isNumericItem={isNumericItem(meta?.item)}
-                                hasContextMenu={!!cellContextMenu}
                                 hasData={!!meta?.item}
                                 cellContextMenu={cellContextMenu}
                                 onSelect={handleCellSelect}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,15 +1,12 @@
-import { isNumericItem, ResultRow } from '@lightdash/common';
-import { Cell, flexRender } from '@tanstack/react-table';
-import React, { FC, Fragment, useState } from 'react';
-import { BodyCell } from '../Table.styles';
+import { isNumericItem } from '@lightdash/common';
+import { flexRender } from '@tanstack/react-table';
+import { FC, useState } from 'react';
+import BodyCell from '../BodyCell';
 import { useTableContext } from '../TableProvider';
 import { TableColumn } from '../types';
-import RichBodyCell from './RichBodyCell';
 
 const TableBody: FC = () => {
-    const { table, cellContextMenu, tableWrapperRef, setIsScrollable } =
-        useTableContext();
-    const CellContextMenu = cellContextMenu || Fragment;
+    const { table, cellContextMenu, setIsScrollable } = useTableContext();
     const [selectedCell, setSelectedCell] = useState<string>();
 
     const handleCellSelect = (cellId: string | undefined) => {
@@ -26,37 +23,22 @@ const TableBody: FC = () => {
                             .meta as TableColumn['meta'];
 
                         return (
-                            <CellContextMenu
+                            <BodyCell
                                 key={cell.id}
-                                cell={cell as Cell<ResultRow, ResultRow[0]>}
-                                boundaryElement={tableWrapperRef.current}
-                                onOpen={() => handleCellSelect(cell.id)}
-                                onClose={() => handleCellSelect(undefined)}
+                                rowIndex={rowIndex}
+                                cell={cell}
+                                isSelected={cell.id === selectedCell}
+                                isNumericItem={isNumericItem(meta?.item)}
+                                hasContextMenu={!!cellContextMenu}
+                                hasData={!!meta?.item}
+                                cellContextMenu={cellContextMenu}
+                                onSelect={handleCellSelect}
                             >
-                                <BodyCell
-                                    $rowIndex={rowIndex}
-                                    $isSelected={cell.id === selectedCell}
-                                    $isInteractive={!!cellContextMenu}
-                                    $hasData={!!meta?.item}
-                                    $isNaN={
-                                        !meta?.item || !isNumericItem(meta.item)
-                                    }
-                                >
-                                    <RichBodyCell
-                                        cell={
-                                            cell as Cell<
-                                                ResultRow,
-                                                ResultRow[0]
-                                            >
-                                        }
-                                    >
-                                        {flexRender(
-                                            cell.column.columnDef.cell,
-                                            cell.getContext(),
-                                        )}
-                                    </RichBodyCell>
-                                </BodyCell>
-                            </CellContextMenu>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )}
+                            </BodyCell>
                         );
                     })}
                 </tr>

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -5,13 +5,10 @@ import TableFooter from './TableFooter';
 import TableHeader from './TableHeader';
 
 const ScrollableTable = () => {
-    const { footer, setTableWrapperRef, isScrollable } = useTableContext();
+    const { footer, isScrollable } = useTableContext();
 
     return (
-        <TableScrollableWrapper
-            ref={setTableWrapperRef}
-            $isScrollable={isScrollable}
-        >
+        <TableScrollableWrapper $isScrollable={isScrollable}>
             <Table bordered condensed showFooter={!!footer?.show}>
                 <TableHeader />
                 <TableBody />

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -5,10 +5,12 @@ import TableFooter from './TableFooter';
 import TableHeader from './TableHeader';
 
 const ScrollableTable = () => {
-    const { footer, isScrollable } = useTableContext();
+    const { footer, scrollableWrapperRef } = useTableContext();
 
     return (
-        <TableScrollableWrapper $isScrollable={isScrollable}>
+        <TableScrollableWrapper
+            ref={(ref) => (scrollableWrapperRef.current = ref || undefined)}
+        >
             <Table bordered condensed showFooter={!!footer?.show}>
                 <TableHeader />
                 <TableBody />

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -9,12 +9,9 @@ export const TableContainer = styled.div`
     flex-direction: column;
 `;
 
-interface TableScrollableProps {
-    $isScrollable: boolean;
-}
-
-export const TableScrollableWrapper = styled.div<TableScrollableProps>`
-    overflow: ${({ $isScrollable }) => ($isScrollable ? 'auto' : 'hidden')};
+export const TableScrollableWrapper = styled.div`
+    position: relative;
+    overflow: auto;
     min-height: 90px;
 `;
 
@@ -29,6 +26,7 @@ export const Table = styled(HTMLTable)<{ showFooter: boolean }>`
     thead {
         position: sticky;
         top: 0;
+        z-index: 21; // blueprint's popover menu + 1
         inset-block-start: 0; /* "top" */
         background: ${Colors.GRAY5};
 
@@ -93,6 +91,8 @@ export const Td = styled.td<{
     $hasData: boolean;
 }>`
     ${CellStyles}
+    position: relative;
+    z-index: 2;
 
     ${({ $isInteractive, $hasData }) =>
         $isInteractive && $hasData

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -91,8 +91,6 @@ export const Td = styled.td<{
     $hasData: boolean;
 }>`
     ${CellStyles}
-    position: relative;
-    z-index: 2;
 
     ${({ $isInteractive, $hasData }) =>
         $isInteractive && $hasData

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -85,7 +85,7 @@ const CellStyles = css<{ $isNaN: boolean }>`
     text-align: ${({ $isNaN }) => ($isNaN ? 'left' : 'right')} !important;
 `;
 
-export const BodyCell = styled.td<{
+export const Td = styled.td<{
     $isNaN: boolean;
     $rowIndex: number;
     $isSelected: boolean;

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -11,7 +11,6 @@ import React, {
     FC,
     useContext,
     useEffect,
-    useRef,
     useState,
 } from 'react';
 import {
@@ -42,8 +41,6 @@ type Props = {
 };
 
 type TableContext = Props & {
-    tableWrapperRef: React.MutableRefObject<HTMLDivElement | null>;
-    setTableWrapperRef: (instance: HTMLDivElement | null) => void;
     isScrollable: boolean;
     setIsScrollable: React.Dispatch<React.SetStateAction<boolean>>;
     table: Table<ResultRow>;
@@ -65,7 +62,6 @@ export const TableProvider: FC<Props> = ({ children, ...rest }) => {
     const { data, columns, columnOrder, pagination } = rest;
     const [columnVisibility, setColumnVisibility] = useState({});
     const [isScrollable, setIsScrollable] = useState(true);
-    const tableWrapperRef = useRef<HTMLDivElement | null>(null);
     const [tempColumnOrder, setTempColumnOrder] = useState<ColumnOrderState>([
         ROW_NUMBER_COLUMN_ID,
         ...(columnOrder || []),
@@ -99,16 +95,10 @@ export const TableProvider: FC<Props> = ({ children, ...rest }) => {
         }
     }, [pagination, setPageSize]);
 
-    const setTableWrapperRef = (instance: HTMLDivElement | null) => {
-        tableWrapperRef.current = instance;
-    };
-
     return (
         <Context.Provider
             value={{
                 table,
-                tableWrapperRef,
-                setTableWrapperRef,
                 isScrollable,
                 setIsScrollable,
                 ...rest,

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -11,6 +11,7 @@ import React, {
     FC,
     useContext,
     useEffect,
+    useRef,
     useState,
 } from 'react';
 import {
@@ -41,9 +42,8 @@ type Props = {
 };
 
 type TableContext = Props & {
-    isScrollable: boolean;
-    setIsScrollable: React.Dispatch<React.SetStateAction<boolean>>;
     table: Table<ResultRow>;
+    scrollableWrapperRef: React.MutableRefObject<HTMLDivElement | undefined>;
 };
 
 const Context = createContext<TableContext | undefined>(undefined);
@@ -61,7 +61,7 @@ const rowColumn: TableColumn = {
 export const TableProvider: FC<Props> = ({ children, ...rest }) => {
     const { data, columns, columnOrder, pagination } = rest;
     const [columnVisibility, setColumnVisibility] = useState({});
-    const [isScrollable, setIsScrollable] = useState(true);
+    const scrollableWrapperRef = useRef<HTMLDivElement>();
     const [tempColumnOrder, setTempColumnOrder] = useState<ColumnOrderState>([
         ROW_NUMBER_COLUMN_ID,
         ...(columnOrder || []),
@@ -99,8 +99,7 @@ export const TableProvider: FC<Props> = ({ children, ...rest }) => {
         <Context.Provider
             value={{
                 table,
-                isScrollable,
-                setIsScrollable,
+                scrollableWrapperRef,
                 ...rest,
             }}
         >

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -1,4 +1,3 @@
-import { Popover2Props } from '@blueprintjs/popover2';
 import {
     Field,
     PivotReference,
@@ -17,9 +16,7 @@ import { MouseEventHandler } from 'react';
 export type HeaderProps = { header: Header<ResultRow, any> };
 export type CellContextMenuProps = {
     cell: Cell<ResultRow, ResultRow[0]>;
-    renderCell: Popover2Props['renderTarget'];
-    onOpen: () => void;
-    onClose: () => void;
+    isEditMode?: boolean;
 };
 
 export type Sort = {

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -1,3 +1,4 @@
+import { Popover2Props } from '@blueprintjs/popover2';
 import {
     Field,
     PivotReference,
@@ -16,9 +17,9 @@ import { MouseEventHandler } from 'react';
 export type HeaderProps = { header: Header<ResultRow, any> };
 export type CellContextMenuProps = {
     cell: Cell<ResultRow, ResultRow[0]>;
+    renderCell: Popover2Props['renderTarget'];
     onOpen: () => void;
     onClose: () => void;
-    boundaryElement: HTMLDivElement | null;
 };
 
 export type Sort = {


### PR DESCRIPTION
related to #2997 

### Description:
- makes rendering tables fast by wrapping cell with popover menu only after the click.
- keeps the existing UX untouched
- cleans up `TableBody` to be relatively simple by extracting `BodyCell`
- simplifies `CellContextMenu`
- removes blocking scroll when the context menu is open