### PR TITLE
fix: fix empty chart sqlrunner 1+ metrics 1 dimension

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -88,7 +88,6 @@ const useCartesianChartConfig = ({
         !!initialChartConfig &&
         isCompleteLayout(initialChartConfig.layout) &&
         isCompleteEchartsConfig(initialChartConfig.eChartsConfig);
-
     const [dirtyLayout, setDirtyLayout] = useState<
         Partial<CartesianChart['layout']> | undefined
     >(initialChartConfig?.layout);
@@ -421,13 +420,14 @@ const useCartesianChartConfig = ({
                     newPivotFields = [availableDimensions[1]];
                 }
 
-                // two metrics, one dimension
+                // 1+ metrics, one dimension
                 else if (
-                    availableMetrics.length === 2 &&
+                    availableMetrics.length > 1 &&
                     availableDimensions.length === 1
                 ) {
+                    //Max 4 metrics in Y-axis
                     newXField = availableDimensions[0];
-                    newYFields = availableMetrics;
+                    newYFields = availableMetrics.slice(0, 4);
                 }
 
                 // 2+ dimensions and 1+ metrics


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3070

### Description:
We were missing an initial chart config combination: (3 metrics, 1 dimension)

![Screenshot from 2022-08-30 10-50-01](https://user-images.githubusercontent.com/1983672/187394796-30dc461c-1b44-4f81-85b1-0b47ffb33095.png)
