### PR TITLE
test: fix flaky table tests

### DIFF
--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -159,6 +159,9 @@ describe('Explore', () => {
                     // open chart
                     cy.findByText('Charts').prev('button').click();
 
+                    // wait for the chart to finish loading
+                    cy.findByText('Loading chart').should('not.exist');
+
                     // open chart menu and change chart type to Table
                     cy.get('button').contains('Bar chart').click();
                     cy.get('[role="menuitem"]').contains('Table').click();
@@ -197,6 +200,9 @@ describe('Explore', () => {
 
                     // open chart
                     cy.findByText('Charts').prev('button').click();
+
+                    // wait for the chart to finish loading
+                    cy.findByText('Loading chart').should('not.exist');
 
                     // open chart menu and change chart type to Table
                     cy.get('button').contains('Bar chart').click();


### PR DESCRIPTION
### Description:

Fixes flaky tests that I've added recently.

Tests were not waiting for the chart to load. Because of that Chart Type menu button was disabled and caused timeouts sometime