### PR TITLE
chore: refactor ExplorerProvider to use context selector

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -47,8 +47,10 @@
         "react-use": "^17.3.2",
         "react-use-intercom": "^1.5.1",
         "rudder-sdk-js": "^2.8.0",
+        "scheduler": "^0.23.0",
         "styled-components": "^5.3.3",
         "typescript": "^4.5.5",
+        "use-context-selector": "^1.4.1",
         "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
     },

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useContextSelector } from 'use-context-selector';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { ExploreFromHerePrimary } from './ExploreFromHere.styles';
 
 const ExploreFromHereButton = () => {
     const history = useHistory();
-    const savedChart = useContextSelector(
-        Context,
-        (context) => context!.state.savedChart,
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
     );
     const exploreFromHereUrl = useMemo(() => {
         if (savedChart) {

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -1,14 +1,16 @@
 import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useContextSelector } from 'use-context-selector';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { Context } from '../../providers/ExplorerProvider';
 import { ExploreFromHerePrimary } from './ExploreFromHere.styles';
 
 const ExploreFromHereButton = () => {
     const history = useHistory();
-    const {
-        state: { savedChart },
-    } = useExplorer();
+    const savedChart = useContextSelector(
+        Context,
+        (context) => context!.state.savedChart,
+    );
     const exploreFromHereUrl = useMemo(() => {
         if (savedChart) {
             const { pathname, search } =

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,10 +6,11 @@ import {
     extractEntityNameFromIdColumn,
     MetricType,
 } from '@lightdash/common';
-import React, { FC, useEffect } from 'react';
+import React, { FC, memo, useEffect } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
-import { useExplorer } from '../../../providers/ExplorerProvider';
 import { StyledBreadcrumb } from '../ExploreSideBar/ExploreSideBar.styles';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../../providers/ExplorerProvider';
 import ExploreTree from '../ExploreTree';
 import { LoadingStateWrapper, TableDivider } from './ExplorePanel.styles';
 
@@ -47,17 +48,29 @@ interface ExplorePanelProps {
     onBack?: () => void;
 }
 
-export const ExplorePanel: FC<ExplorePanelProps> = ({ onBack }) => {
-    const {
-        state: {
-            activeFields,
-            unsavedChartVersion: {
-                tableName: activeTableName,
-                metricQuery: { additionalMetrics },
-            },
-        },
-        actions: { toggleActiveField, setMagicMetrics },
-    } = useExplorer();
+const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
+    const activeTableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const additionalMetrics = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
+    const activeFields = useContextSelector(
+        Context,
+        (context) => context!.state.activeFields,
+    );
+    const toggleActiveField = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleActiveField,
+    );
+    const setMagicMetrics = useContextSelector(
+        Context,
+        (context) => context!.actions.setMagicMetrics,
+    );
+
     const { data, status } = useExplore(activeTableName);
 
     useEffect(() => {
@@ -127,6 +140,6 @@ export const ExplorePanel: FC<ExplorePanelProps> = ({ onBack }) => {
     }
 
     return <span>Cannot load explore</span>;
-};
+});
 
 export default ExplorePanel;

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -9,8 +9,7 @@ import {
 import React, { FC, memo, useEffect } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
 import { StyledBreadcrumb } from '../ExploreSideBar/ExploreSideBar.styles';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import ExploreTree from '../ExploreTree';
 import { LoadingStateWrapper, TableDivider } from './ExplorePanel.styles';
 
@@ -49,26 +48,21 @@ interface ExplorePanelProps {
 }
 
 const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
-    const activeTableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const activeTableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const additionalMetrics = useContextSelector(
-        Context,
+    const additionalMetrics = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
-    const activeFields = useContextSelector(
-        Context,
-        (context) => context!.state.activeFields,
+    const activeFields = useExplorerContext(
+        (context) => context.state.activeFields,
     );
-    const toggleActiveField = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleActiveField,
+    const toggleActiveField = useExplorerContext(
+        (context) => context.actions.toggleActiveField,
     );
-    const setMagicMetrics = useContextSelector(
-        Context,
-        (context) => context!.actions.setMagicMetrics,
+    const setMagicMetrics = useExplorerContext(
+        (context) => context.actions.setMagicMetrics,
     );
 
     const { data, status } = useExplore(activeTableName);

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -7,12 +7,13 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import Fuse from 'fuse.js';
-import React, { useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
+import { useContextSelector } from 'use-context-selector';
 import { useExplores } from '../../../hooks/useExplores';
 import { useApp } from '../../../providers/AppProvider';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import { ExploreMenuItem } from '../../ExploreMenuItem';
@@ -139,20 +140,22 @@ const BasePanel = () => {
     );
 };
 
-const ExploreSideBar = () => {
+const ExploreSideBar = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const {
-        state: {
-            unsavedChartVersion: { tableName },
-        },
-        actions: { clear },
-    } = useExplorer();
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const clear = useContextSelector(
+        Context,
+        (context) => context!.actions.clear,
+    );
     const history = useHistory();
 
-    const onBack = () => {
+    const onBack = useCallback(() => {
         clear();
         history.push(`/projects/${projectUuid}/tables`);
-    };
+    }, [clear, history, projectUuid]);
 
     return (
         <TrackSection name={SectionName.SIDEBAR}>
@@ -161,6 +164,6 @@ const ExploreSideBar = () => {
             </FooterWrapper>
         </TrackSection>
     );
-};
+});
 
 export default ExploreSideBar;

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -10,10 +10,9 @@ import Fuse from 'fuse.js';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
-import { useContextSelector } from 'use-context-selector';
 import { useExplores } from '../../../hooks/useExplores';
 import { useApp } from '../../../providers/AppProvider';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import { ExploreMenuItem } from '../../ExploreMenuItem';
@@ -142,14 +141,10 @@ const BasePanel = () => {
 
 const ExploreSideBar = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const clear = useContextSelector(
-        Context,
-        (context) => context!.actions.clear,
-    );
+    const clear = useExplorerContext((context) => context.actions.clear);
     const history = useHistory();
 
     const onBack = useCallback(() => {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/CustomMetricButtons.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/CustomMetricButtons.tsx
@@ -2,8 +2,7 @@ import { Button, Menu, PopoverPosition } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { AdditionalMetric, fieldId } from '@lightdash/common';
 import React, { FC, ReactNode, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../../../providers/ExplorerProvider';
 import { useTracking } from '../../../../../providers/TrackingProvider';
 import { EventName } from '../../../../../types/Events';
 import { ItemOptions } from '../TableTree.styles';
@@ -14,9 +13,8 @@ const CustomMetricButtons: FC<{
     isSelected: boolean;
 }> = ({ node, isHovered, isSelected }) => {
     const { track } = useTracking();
-    const removeAdditionalMetric = useContextSelector(
-        Context,
-        (context) => context!.actions.removeAdditionalMetric,
+    const removeAdditionalMetric = useExplorerContext(
+        (context) => context.actions.removeAdditionalMetric,
     );
 
     const menuItems = useMemo<ReactNode[]>(() => {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/CustomMetricButtons.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/CustomMetricButtons.tsx
@@ -2,7 +2,8 @@ import { Button, Menu, PopoverPosition } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { AdditionalMetric, fieldId } from '@lightdash/common';
 import React, { FC, ReactNode, useMemo } from 'react';
-import { useExplorer } from '../../../../../providers/ExplorerProvider';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../../../../providers/ExplorerProvider';
 import { useTracking } from '../../../../../providers/TrackingProvider';
 import { EventName } from '../../../../../types/Events';
 import { ItemOptions } from '../TableTree.styles';
@@ -13,10 +14,10 @@ const CustomMetricButtons: FC<{
     isSelected: boolean;
 }> = ({ node, isHovered, isSelected }) => {
     const { track } = useTracking();
-
-    const {
-        actions: { removeAdditionalMetric },
-    } = useExplorer();
+    const removeAdditionalMetric = useContextSelector(
+        Context,
+        (context) => context!.actions.removeAdditionalMetric,
+    );
 
     const menuItems = useMemo<ReactNode[]>(() => {
         return [

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/FieldButtons.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/FieldButtons.tsx
@@ -10,9 +10,8 @@ import {
     Source,
 } from '@lightdash/common';
 import React, { FC, ReactNode, useCallback, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { useFilters } from '../../../../../hooks/useFilters';
-import { Context } from '../../../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../../../providers/ExplorerProvider';
 import { useTracking } from '../../../../../providers/TrackingProvider';
 import { EventName } from '../../../../../types/Events';
 import { ItemOptions, Placeholder, WarningIcon } from '../TableTree.styles';
@@ -54,9 +53,8 @@ const FieldButtons: FC<{
     const { isFilteredField, addFilter } = useFilters();
     const isFiltered = isFilteredField(node);
     const { track } = useTracking();
-    const addAdditionalMetric = useContextSelector(
-        Context,
-        (context) => context!.actions.addAdditionalMetric,
+    const addAdditionalMetric = useExplorerContext(
+        (context) => context.actions.addAdditionalMetric,
     );
 
     const createCustomMetric = useCallback(

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/FieldButtons.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/FieldButtons.tsx
@@ -10,8 +10,9 @@ import {
     Source,
 } from '@lightdash/common';
 import React, { FC, ReactNode, useCallback, useMemo } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { useFilters } from '../../../../../hooks/useFilters';
-import { useExplorer } from '../../../../../providers/ExplorerProvider';
+import { Context } from '../../../../../providers/ExplorerProvider';
 import { useTracking } from '../../../../../providers/TrackingProvider';
 import { EventName } from '../../../../../types/Events';
 import { ItemOptions, Placeholder, WarningIcon } from '../TableTree.styles';
@@ -53,10 +54,10 @@ const FieldButtons: FC<{
     const { isFilteredField, addFilter } = useFilters();
     const isFiltered = isFilteredField(node);
     const { track } = useTracking();
-
-    const {
-        actions: { addAdditionalMetric },
-    } = useExplorer();
+    const addAdditionalMetric = useContextSelector(
+        Context,
+        (context) => context!.actions.addAdditionalMetric,
+    );
 
     const createCustomMetric = useCallback(
         (dimension: Dimension, type: MetricType) => {

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,7 +1,6 @@
 import React, { FC, memo } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { useApp } from '../../../providers/AppProvider';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
@@ -9,13 +8,11 @@ import SaveChartButton from '../SaveChartButton';
 import { Wrapper } from './ExplorerHeader.styles';
 
 const ExplorerHeader: FC = memo(() => {
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const savedChart = useContextSelector(
-        Context,
-        (context) => context!.state.savedChart,
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
     );
 
     const { user } = useApp();

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,16 +1,22 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { useApp } from '../../../providers/AppProvider';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import SaveChartButton from '../SaveChartButton';
 import { Wrapper } from './ExplorerHeader.styles';
 
-const ExplorerHeader: FC = () => {
-    const {
-        state: { isEditMode, savedChart },
-    } = useExplorer();
+const ExplorerHeader: FC = memo(() => {
+    const isEditMode = useContextSelector(
+        Context,
+        (context) => context!.state.isEditMode,
+    );
+    const savedChart = useContextSelector(
+        Context,
+        (context) => context!.state.savedChart,
+    );
 
     const { user } = useApp();
 
@@ -32,6 +38,6 @@ const ExplorerHeader: FC = () => {
             )}
         </Wrapper>
     );
-};
+});
 
 export default ExplorerHeader;

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -159,23 +159,6 @@ const FiltersCard: FC = memo(() => {
         },
         [data],
     );
-    useEffect(
-        () => console.log('expandedSections', expandedSections),
-        [expandedSections],
-    );
-    useEffect(() => console.log('isEditMode', isEditMode), [isEditMode]);
-    useEffect(() => console.log('tableName', tableName), [tableName]);
-    useEffect(() => console.log('filters', filters), [filters]);
-    useEffect(
-        () => console.log('additionalMetrics', additionalMetrics),
-        [additionalMetrics],
-    );
-    useEffect(() => console.log('queryResults', queryResults), [queryResults]);
-    useEffect(() => console.log('setFilters', setFilters), [setFilters]);
-    useEffect(
-        () => console.log('toggleExpandedSection', toggleExpandedSection),
-        [toggleExpandedSection],
-    );
     return (
         <Card style={{ padding: 5 }} elevation={1}>
             <CardHeader>

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -21,9 +21,11 @@ import React, {
     useMemo,
     useState,
 } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { useExplore } from '../../../hooks/useExplore';
-import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorerContext,
+} from '../../../providers/ExplorerProvider';
 import FiltersForm from '../../common/Filters';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import {
@@ -33,38 +35,30 @@ import {
 import { CardHeader, FilterValues, Tooltip } from './FiltersCard.styles';
 
 const FiltersCard: FC = memo(() => {
-    const expandedSections = useContextSelector(
-        Context,
-        (context) => context!.state.expandedSections,
+    const expandedSections = useExplorerContext(
+        (context) => context.state.expandedSections,
     );
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const filters = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    const filters = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.filters,
     );
-    const additionalMetrics = useContextSelector(
-        Context,
+    const additionalMetrics = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
-    const queryResults = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const queryResults = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const setFilters = useContextSelector(
-        Context,
-        (context) => context!.actions.setFilters,
+    const setFilters = useExplorerContext(
+        (context) => context.actions.setFilters,
     );
-    const toggleExpandedSection = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleExpandedSection,
+    const toggleExpandedSection = useExplorerContext(
+        (context) => context.actions.toggleExpandedSection,
     );
     const { data } = useExplore(tableName);
     const filterIsOpen = useMemo(

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -13,12 +13,10 @@ import {
     isFilterableField,
     Metric,
 } from '@lightdash/common';
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { useExplore } from '../../../hooks/useExplore';
-import {
-    ExplorerSection,
-    useExplorer,
-} from '../../../providers/ExplorerProvider';
+import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
 import FiltersForm from '../../common/Filters';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import {
@@ -27,19 +25,40 @@ import {
 } from '../../common/Filters/FiltersProvider';
 import { CardHeader, FilterValues, Tooltip } from './FiltersCard.styles';
 
-const FiltersCard: FC = () => {
-    const {
-        state: {
-            isEditMode,
-            expandedSections,
-            unsavedChartVersion: {
-                tableName,
-                metricQuery: { filters, additionalMetrics },
-            },
-        },
-        queryResults,
-        actions: { setFilters, toggleExpandedSection },
-    } = useExplorer();
+const FiltersCard: FC = memo(() => {
+    const expandedSections = useContextSelector(
+        Context,
+        (context) => context!.state.expandedSections,
+    );
+    const isEditMode = useContextSelector(
+        Context,
+        (context) => context!.state.isEditMode,
+    );
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const filters = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    );
+    const additionalMetrics = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
+    const queryResults = useContextSelector(
+        Context,
+        (context) => context!.queryResults,
+    );
+    const setFilters = useContextSelector(
+        Context,
+        (context) => context!.actions.setFilters,
+    );
+    const toggleExpandedSection = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleExpandedSection,
+    );
     const explore = useExplore(tableName);
     const filterIsOpen = expandedSections.includes(ExplorerSection.FILTERS);
     const totalActiveFilters: number = countTotalFilterRules(filters);
@@ -162,6 +181,6 @@ const FiltersCard: FC = () => {
             </Collapse>
         </Card>
     );
-};
+});
 
 export default FiltersCard;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { FC, useState } from 'react';
 import styled from 'styled-components';
 import { useFilters } from '../../../hooks/useFilters';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { HeaderProps, TableColumn } from '../../common/Table/types';
@@ -17,7 +17,6 @@ import {
     DeleteTableCalculationModal,
     UpdateTableCalculationModal,
 } from '../../TableCalculationModels';
-import { useContextSelector } from 'use-context-selector';
 
 const FlatButton = styled(Button)`
     min-height: 16px !important;
@@ -39,9 +38,8 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const meta = header.column.columnDef.meta as TableColumn['meta'];
     const item = meta?.item;
 
-    const removeActiveField = useContextSelector(
-        Context,
-        (context) => context!.actions.removeActiveField,
+    const removeActiveField = useExplorerContext(
+        (context) => context.actions.removeActiveField,
     );
 
     if (item && isField(item) && isFilterableField(item)) {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { FC, useState } from 'react';
 import styled from 'styled-components';
 import { useFilters } from '../../../hooks/useFilters';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { HeaderProps, TableColumn } from '../../common/Table/types';
@@ -17,6 +17,7 @@ import {
     DeleteTableCalculationModal,
     UpdateTableCalculationModal,
 } from '../../TableCalculationModels';
+import { useContextSelector } from 'use-context-selector';
 
 const FlatButton = styled(Button)`
     min-height: 16px !important;
@@ -32,14 +33,16 @@ const ContextMenu: FC<ContextMenuProps> = ({
     onToggleCalculationEditModal,
     onToggleCalculationDeleteModal,
 }) => {
-    const {
-        actions: { removeActiveField },
-    } = useExplorer();
     const { addFilter } = useFilters();
     const { track } = useTracking();
 
     const meta = header.column.columnDef.meta as TableColumn['meta'];
     const item = meta?.item;
+
+    const removeActiveField = useContextSelector(
+        Context,
+        (context) => context!.actions.removeActiveField,
+    );
 
     if (item && isField(item) && isFilterableField(item)) {
         return (

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,9 +1,8 @@
 import { Colors } from '@blueprintjs/core';
 import React, { FC, ReactNode } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import Table from '../../common/Table';
@@ -19,37 +18,27 @@ import { TableContainer } from './ResultsCard.styles';
 
 export const ExplorerResults = () => {
     const columns = useColumns();
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const activeTableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const activeTableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const dimensions = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.dimensions,
+    const dimensions = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.dimensions,
     );
-    const metrics = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.metrics,
+    const metrics = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.metrics,
     );
-    const explorerColumnOrder = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableConfig.columnOrder,
+    const explorerColumnOrder = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
     );
-    const resultsData = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const resultsData = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const status = useContextSelector(
-        Context,
-        (context) => context!.queryResults.status,
-    );
-    const setColumnOrder = useContextSelector(
-        Context,
-        (context) => context!.actions.setColumnOrder,
+    const status = useExplorerContext((context) => context.queryResults.status);
+    const setColumnOrder = useExplorerContext(
+        (context) => context.actions.setColumnOrder,
     );
     const activeExplore = useExplore(activeTableName);
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,8 +1,9 @@
 import { Colors } from '@blueprintjs/core';
 import React, { FC, ReactNode } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import Table from '../../common/Table';
@@ -18,18 +19,38 @@ import { TableContainer } from './ResultsCard.styles';
 
 export const ExplorerResults = () => {
     const columns = useColumns();
-    const {
-        state: {
-            isEditMode,
-            unsavedChartVersion: {
-                tableName: activeTableName,
-                metricQuery: { dimensions, metrics },
-                tableConfig: { columnOrder: explorerColumnOrder },
-            },
-        },
-        queryResults: { data: resultsData, status },
-        actions: { setColumnOrder },
-    } = useExplorer();
+    const isEditMode = useContextSelector(
+        Context,
+        (context) => context!.state.isEditMode,
+    );
+    const activeTableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const dimensions = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.dimensions,
+    );
+    const metrics = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.metrics,
+    );
+    const explorerColumnOrder = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableConfig.columnOrder,
+    );
+    const resultsData = useContextSelector(
+        Context,
+        (context) => context!.queryResults.data,
+    );
+    const status = useContextSelector(
+        Context,
+        (context) => context!.queryResults.status,
+    );
+    const setColumnOrder = useContextSelector(
+        Context,
+        (context) => context!.actions.setColumnOrder,
+    );
     const activeExplore = useExplore(activeTableName);
 
     if (!activeTableName) return <NoTableSelected />;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,8 +1,10 @@
 import { Button, Card, Collapse, H5 } from '@blueprintjs/core';
 import { getResultValues } from '@lightdash/common';
 import { FC, memo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorerContext,
+} from '../../../providers/ExplorerProvider';
 import AddColumnButton from '../../AddColumnButton';
 import DownloadCsvButton from '../../DownloadCsvButton';
 import LimitButton from '../../LimitButton';
@@ -16,37 +18,29 @@ import {
 } from './ResultsCard.styles';
 
 const ResultsCard: FC = memo(() => {
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const expandedSections = useContextSelector(
-        Context,
-        (context) => context!.state.expandedSections,
+    const expandedSections = useExplorerContext(
+        (context) => context.state.expandedSections,
     );
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const filters = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    const filters = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.filters,
     );
-    const limit = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.limit,
+    const limit = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.limit,
     );
-    const queryResults = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const queryResults = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const setRowLimit = useContextSelector(
-        Context,
-        (context) => context!.actions.setRowLimit,
+    const setRowLimit = useExplorerContext(
+        (context) => context.actions.setRowLimit,
     );
-    const toggleExpandedSection = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleExpandedSection,
+    const toggleExpandedSection = useExplorerContext(
+        (context) => context.actions.toggleExpandedSection,
     );
     const resultsIsOpen = expandedSections.includes(ExplorerSection.RESULTS);
     return (

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -38,7 +38,7 @@ const ResultsCard: FC = memo(() => {
     );
     const queryResults = useContextSelector(
         Context,
-        (context) => context!.queryResults,
+        (context) => context!.queryResults.data,
     );
     const setRowLimit = useContextSelector(
         Context,
@@ -75,8 +75,8 @@ const ResultsCard: FC = memo(() => {
                         <DownloadCsvButton
                             fileName={tableName}
                             rows={
-                                queryResults.data &&
-                                getResultValues(queryResults.data.rows)
+                                queryResults &&
+                                getResultValues(queryResults.rows)
                             }
                         />
                     </CardHeaderRightContent>

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,22 +1,18 @@
 import React, { FC, useState } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import CreateSavedQueryModal from '../../SavedQueries/CreateSavedQueryModal';
 import { SaveButton } from './SaveChartButton.styles';
 
 const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
-    const unsavedChartVersion = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion,
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
     );
-    const hasUnsavedChanges = useContextSelector(
-        Context,
-        (context) => context!.state.hasUnsavedChanges,
+    const hasUnsavedChanges = useExplorerContext(
+        (context) => context.state.hasUnsavedChanges,
     );
-    const savedChart = useContextSelector(
-        Context,
-        (context) => context!.state.savedChart,
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
     );
 
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,13 +1,23 @@
 import React, { FC, useState } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import CreateSavedQueryModal from '../../SavedQueries/CreateSavedQueryModal';
 import { SaveButton } from './SaveChartButton.styles';
 
 const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
-    const {
-        state: { unsavedChartVersion, hasUnsavedChanges, savedChart },
-    } = useExplorer();
+    const unsavedChartVersion = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion,
+    );
+    const hasUnsavedChanges = useContextSelector(
+        Context,
+        (context) => context!.state.hasUnsavedChanges,
+    );
+    const savedChart = useContextSelector(
+        Context,
+        (context) => context!.state.savedChart,
+    );
 
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
 

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -9,7 +9,6 @@ import {
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { FC, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import { useContextSelector } from 'use-context-selector';
 import useMoveToSpace from '../../../hooks/useMoveToSpace';
 import {
     useDuplicateMutation,
@@ -17,7 +16,7 @@ import {
 } from '../../../hooks/useSavedQuery';
 import { useSpaces } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import { UpdatedInfo } from '../../common/ActionCard';
@@ -42,26 +41,19 @@ import SaveChartButton from '../SaveChartButton';
 const SavedChartsHeader: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const history = useHistory();
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const unsavedChartVersion = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion,
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
     );
-    const hasUnsavedChanges = useContextSelector(
-        Context,
-        (context) => context!.state.hasUnsavedChanges,
+    const hasUnsavedChanges = useExplorerContext(
+        (context) => context.state.hasUnsavedChanges,
     );
-    const savedChart = useContextSelector(
-        Context,
-        (context) => context!.state.savedChart,
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
     );
-    const reset = useContextSelector(
-        Context,
-        (context) => context!.actions.reset,
-    );
+    const reset = useExplorerContext((context) => context.actions.reset);
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
     const [isSaveWarningModalOpen, setIsSaveWarningModalOpen] =

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -9,6 +9,7 @@ import {
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { FC, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { useContextSelector } from 'use-context-selector';
 import useMoveToSpace from '../../../hooks/useMoveToSpace';
 import {
     useDuplicateMutation,
@@ -16,7 +17,7 @@ import {
 } from '../../../hooks/useSavedQuery';
 import { useSpaces } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import { UpdatedInfo } from '../../common/ActionCard';
@@ -41,15 +42,26 @@ import SaveChartButton from '../SaveChartButton';
 const SavedChartsHeader: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const history = useHistory();
-    const {
-        state: {
-            isEditMode,
-            unsavedChartVersion,
-            hasUnsavedChanges,
-            savedChart,
-        },
-        actions: { reset },
-    } = useExplorer();
+    const isEditMode = useContextSelector(
+        Context,
+        (context) => context!.state.isEditMode,
+    );
+    const unsavedChartVersion = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion,
+    );
+    const hasUnsavedChanges = useContextSelector(
+        Context,
+        (context) => context!.state.hasUnsavedChanges,
+    );
+    const savedChart = useContextSelector(
+        Context,
+        (context) => context!.state.savedChart,
+    );
+    const reset = useContextSelector(
+        Context,
+        (context) => context!.actions.reset,
+    );
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
     const [isSaveWarningModalOpen, setIsSaveWarningModalOpen] =

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,17 +1,23 @@
 import { Button, Collapse, H5 } from '@blueprintjs/core';
-import { FC } from 'react';
-import {
-    ExplorerSection,
-    useExplorer,
-} from '../../../providers/ExplorerProvider';
+import { FC, memo } from 'react';
+import { useContextSelector } from 'use-context-selector';
+import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
 import { RenderedSql } from '../../RenderedSql';
 import { CardHeader, StyledCard } from './SqlCard.styles';
 
-const SqlCard: FC = () => {
-    const {
-        state: { expandedSections, unsavedChartVersion },
-        actions: { toggleExpandedSection },
-    } = useExplorer();
+const SqlCard: FC = memo(() => {
+    const expandedSections = useContextSelector(
+        Context,
+        (context) => context!.state.expandedSections,
+    );
+    const unsavedChartVersionTableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const toggleExpandedSection = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleExpandedSection,
+    );
     const sqlIsOpen = expandedSections.includes(ExplorerSection.SQL);
     return (
         <StyledCard isOpen={sqlIsOpen} elevation={1}>
@@ -20,7 +26,7 @@ const SqlCard: FC = () => {
                     icon={sqlIsOpen ? 'chevron-down' : 'chevron-right'}
                     minimal
                     onClick={() => toggleExpandedSection(ExplorerSection.SQL)}
-                    disabled={!unsavedChartVersion.tableName}
+                    disabled={!unsavedChartVersionTableName}
                 />
                 <H5>SQL</H5>
             </CardHeader>
@@ -29,6 +35,6 @@ const SqlCard: FC = () => {
             </Collapse>
         </StyledCard>
     );
-};
+});
 
 export default SqlCard;

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,22 +1,21 @@
 import { Button, Collapse, H5 } from '@blueprintjs/core';
 import { FC, memo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorerContext,
+} from '../../../providers/ExplorerProvider';
 import { RenderedSql } from '../../RenderedSql';
 import { CardHeader, StyledCard } from './SqlCard.styles';
 
 const SqlCard: FC = memo(() => {
-    const expandedSections = useContextSelector(
-        Context,
-        (context) => context!.state.expandedSections,
+    const expandedSections = useExplorerContext(
+        (context) => context.state.expandedSections,
     );
-    const unsavedChartVersionTableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const unsavedChartVersionTableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const toggleExpandedSection = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleExpandedSection,
+    const toggleExpandedSection = useExplorerContext(
+        (context) => context.actions.toggleExpandedSection,
     );
     const sqlIsOpen = expandedSections.includes(ExplorerSection.SQL);
     return (

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -5,9 +5,10 @@ import {
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
 import { FC, useCallback, useEffect, useState } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
-import { useExplorer } from '../../../providers/ExplorerProvider';
+import { Context } from '../../../providers/ExplorerProvider';
 import { EchartSeriesClickEvent } from '../../SimpleChart';
 import {
     getDataFromChartClick,
@@ -20,10 +21,11 @@ export const SeriesContextMenu: FC<{
     pivot: string | undefined;
     series: EChartSeries[];
 }> = ({ echartSeriesClickEvent, dimensions, pivot, series }) => {
-    const {
-        state: { unsavedChartVersion },
-    } = useExplorer();
-    const { data: explore } = useExplore(unsavedChartVersion.tableName);
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const { data: explore } = useExplore(tableName);
 
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const { viewData } = useUnderlyingDataContext();

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -5,10 +5,9 @@ import {
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
 import { FC, useCallback, useEffect, useState } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
-import { Context } from '../../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { EchartSeriesClickEvent } from '../../SimpleChart';
 import {
     getDataFromChartClick,
@@ -21,9 +20,8 @@ export const SeriesContextMenu: FC<{
     pivot: string | undefined;
     series: EChartSeries[];
 }> = ({ echartSeriesClickEvent, dimensions, pivot, series }) => {
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
     const { data: explore } = useExplore(tableName);
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,10 +1,12 @@
 import { Button, Collapse, H5 } from '@blueprintjs/core';
 import { ChartType } from '@lightdash/common';
 import { FC, memo, useCallback, useState } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
-import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorerContext,
+} from '../../../providers/ExplorerProvider';
 import BigNumberConfigPanel from '../../BigNumberConfig';
 import ChartConfigPanel from '../../ChartConfigPanel';
 import { ChartDownloadMenu } from '../../ChartDownload';
@@ -34,41 +36,32 @@ const ConfigPanel: FC<{ chartType: ChartType }> = ({ chartType }) => {
     }
 };
 const VisualizationCard: FC = memo(() => {
-    const expandedSections = useContextSelector(
-        Context,
-        (context) => context!.state.expandedSections,
+    const expandedSections = useExplorerContext(
+        (context) => context.state.expandedSections,
     );
-    const unsavedChartVersion = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion,
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
     );
-    const isEditMode = useContextSelector(
-        Context,
-        (context) => context!.state.isEditMode,
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
     );
-    const isLoadingQueryResults = useContextSelector(
-        Context,
-        (context) => context!.queryResults.isLoading,
+    const isLoadingQueryResults = useExplorerContext(
+        (context) => context.queryResults.isLoading,
     );
-    const queryResults = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const queryResults = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const setPivotFields = useContextSelector(
-        Context,
-        (context) => context!.actions.setPivotFields,
+    const setPivotFields = useExplorerContext(
+        (context) => context.actions.setPivotFields,
     );
-    const setChartType = useContextSelector(
-        Context,
-        (context) => context!.actions.setChartType,
+    const setChartType = useExplorerContext(
+        (context) => context.actions.setChartType,
     );
-    const setChartConfig = useContextSelector(
-        Context,
-        (context) => context!.actions.setChartConfig,
+    const setChartConfig = useExplorerContext(
+        (context) => context.actions.setChartConfig,
     );
-    const toggleExpandedSection = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleExpandedSection,
+    const toggleExpandedSection = useExplorerContext(
+        (context) => context.actions.toggleExpandedSection,
     );
 
     const { data: explore } = useExplore(unsavedChartVersion.tableName);

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,12 +1,10 @@
 import { Button, Collapse, H5 } from '@blueprintjs/core';
 import { ChartType } from '@lightdash/common';
-import { FC, useCallback, useState } from 'react';
+import { FC, memo, useCallback, useState } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
-import {
-    ExplorerSection,
-    useExplorer,
-} from '../../../providers/ExplorerProvider';
+import { Context, ExplorerSection } from '../../../providers/ExplorerProvider';
 import BigNumberConfigPanel from '../../BigNumberConfig';
 import ChartConfigPanel from '../../ChartConfigPanel';
 import { ChartDownloadMenu } from '../../ChartDownload';
@@ -35,17 +33,40 @@ const ConfigPanel: FC<{ chartType: ChartType }> = ({ chartType }) => {
             return <ChartConfigPanel />;
     }
 };
-const VisualizationCard: FC = () => {
-    const {
-        state: { isEditMode, unsavedChartVersion, expandedSections },
-        queryResults,
-        actions: {
-            setPivotFields,
-            setChartType,
-            setChartConfig,
-            toggleExpandedSection,
-        },
-    } = useExplorer();
+const VisualizationCard: FC = memo(() => {
+    const expandedSections = useContextSelector(
+        Context,
+        (context) => context!.state.expandedSections,
+    );
+    const unsavedChartVersion = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion,
+    );
+    const isEditMode = useContextSelector(
+        Context,
+        (context) => context!.state.isEditMode,
+    );
+    const queryResults = useContextSelector(
+        Context,
+        (context) => context!.queryResults,
+    );
+    const setPivotFields = useContextSelector(
+        Context,
+        (context) => context!.actions.setPivotFields,
+    );
+    const setChartType = useContextSelector(
+        Context,
+        (context) => context!.actions.setChartType,
+    );
+    const setChartConfig = useContextSelector(
+        Context,
+        (context) => context!.actions.setChartConfig,
+    );
+    const toggleExpandedSection = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleExpandedSection,
+    );
+
     const { data: explore } = useExplore(unsavedChartVersion.tableName);
     const vizIsOpen = expandedSections.includes(ExplorerSection.VISUALIZATION);
 
@@ -147,6 +168,6 @@ const VisualizationCard: FC = () => {
             </VisualizationProvider>
         </MainCard>
     );
-};
+});
 
 export default VisualizationCard;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -46,9 +46,13 @@ const VisualizationCard: FC = memo(() => {
         Context,
         (context) => context!.state.isEditMode,
     );
+    const isLoadingQueryResults = useContextSelector(
+        Context,
+        (context) => context!.queryResults.isLoading,
+    );
     const queryResults = useContextSelector(
         Context,
-        (context) => context!.queryResults,
+        (context) => context!.queryResults.data,
     );
     const setPivotFields = useContextSelector(
         Context,
@@ -113,8 +117,8 @@ const VisualizationCard: FC = memo(() => {
                     unsavedChartVersion.pivotConfig?.columns
                 }
                 explore={explore}
-                resultsData={queryResults.data}
-                isLoading={queryResults.isLoading}
+                resultsData={queryResults}
+                isLoading={isLoadingQueryResults}
                 onChartConfigChange={setChartConfig}
                 onChartTypeChange={setChartType}
                 onPivotDimensionsChange={setPivotFields}

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,6 +1,5 @@
 import { FC, memo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import UnderlyingDataModal from '../UnderlyingData/UnderlyingDataModal';
 import UnderlyingDataProvider from '../UnderlyingData/UnderlyingDataProvider';
 import { ExplorerWrapper } from './Explorer.styles';
@@ -11,13 +10,11 @@ import SqlCard from './SqlCard/SqlCard';
 import VisualizationCard from './VisualizationCard/VisualizationCard';
 
 const Explorer: FC = memo(() => {
-    const unsavedChartVersionTableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const unsavedChartVersionTableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const unsavedChartVersionFilters = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    const unsavedChartVersionFilters = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.filters,
     );
     return (
         <ExplorerWrapper>

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,5 +1,6 @@
-import { FC } from 'react';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { FC, memo } from 'react';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../providers/ExplorerProvider';
 import UnderlyingDataModal from '../UnderlyingData/UnderlyingDataModal';
 import UnderlyingDataProvider from '../UnderlyingData/UnderlyingDataProvider';
 import { ExplorerWrapper } from './Explorer.styles';
@@ -9,26 +10,30 @@ import ResultsCard from './ResultsCard/ResultsCard';
 import SqlCard from './SqlCard/SqlCard';
 import VisualizationCard from './VisualizationCard/VisualizationCard';
 
-const Explorer: FC = () => {
-    const {
-        state: { unsavedChartVersion },
-    } = useExplorer();
+const Explorer: FC = memo(() => {
+    const unsavedChartVersionTableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const unsavedChartVersionFilters = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    );
     return (
         <ExplorerWrapper>
             <ExplorerHeader />
             <FiltersCard />
             <UnderlyingDataProvider
-                filters={unsavedChartVersion.metricQuery.filters}
-                tableName={unsavedChartVersion.tableName}
+                filters={unsavedChartVersionFilters}
+                tableName={unsavedChartVersionTableName}
             >
                 <VisualizationCard />
                 <UnderlyingDataModal />
             </UnderlyingDataProvider>
-
             <ResultsCard />
             <SqlCard />
         </ExplorerWrapper>
     );
-};
+});
 
 export default Explorer;

--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
 import NavLink from '../../NavLink';
@@ -17,7 +17,7 @@ interface Props {
     projectUuid: string;
 }
 
-const ExploreMenu: FC<Props> = ({ projectUuid }) => {
+const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
     const { user } = useApp();
 
     return (
@@ -65,5 +65,5 @@ const ExploreMenu: FC<Props> = ({ projectUuid }) => {
             </Popover2>
         </>
     );
-};
+});
 export default ExploreMenu;

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { ProjectType } from '@lightdash/common';
+import { memo } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
 import { lightdashApi } from '../../api';
@@ -41,7 +42,7 @@ const logoutQuery = async () =>
         body: undefined,
     });
 
-const NavBar = () => {
+const NavBar = memo(() => {
     const {
         user,
         errorLogs: { errorLogs, setErrorLogsVisible },
@@ -159,6 +160,6 @@ const NavBar = () => {
             <ErrorLogsDrawer />
         </>
     );
-};
+});
 
 export default NavBar;

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,17 +1,25 @@
 import { KeyCombo, useHotkeys } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import React, { useCallback, useMemo } from 'react';
-import { useExplorer } from '../providers/ExplorerProvider';
+import React, { memo, useCallback, useMemo } from 'react';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
 import { BigButton } from './common/BigButton';
 
-export const RefreshButton = () => {
-    const {
-        state: { isValidQuery },
-        queryResults: { isLoading: isLoadingResults },
-        actions: { fetchResults },
-    } = useExplorer();
+export const RefreshButton = memo(() => {
+    const isValidQuery = useContextSelector(
+        Context,
+        (context) => context!.state.isValidQuery,
+    );
+    const isLoadingResults = useContextSelector(
+        Context,
+        (context) => context!.queryResults.isLoading,
+    );
+    const fetchResults = useContextSelector(
+        Context,
+        (context) => context!.actions.fetchResults,
+    );
     const { track } = useTracking();
     const isDisabled = !isValidQuery;
     const onClick = useCallback(async () => {
@@ -58,4 +66,4 @@ export const RefreshButton = () => {
             </BigButton>
         </Tooltip2>
     );
-};
+});

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,24 +1,20 @@
 import { KeyCombo, useHotkeys } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import React, { memo, useCallback, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../providers/ExplorerProvider';
+import { useExplorerContext } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
 import { BigButton } from './common/BigButton';
 
 export const RefreshButton = memo(() => {
-    const isValidQuery = useContextSelector(
-        Context,
-        (context) => context!.state.isValidQuery,
+    const isValidQuery = useExplorerContext(
+        (context) => context.state.isValidQuery,
     );
-    const isLoadingResults = useContextSelector(
-        Context,
-        (context) => context!.queryResults.isLoading,
+    const isLoadingResults = useExplorerContext(
+        (context) => context.queryResults.isLoading,
     );
-    const fetchResults = useContextSelector(
-        Context,
-        (context) => context!.actions.fetchResults,
+    const fetchResults = useExplorerContext(
+        (context) => context.actions.fetchResults,
     );
     const { track } = useTracking();
     const isDisabled = !isValidQuery;

--- a/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
@@ -1,7 +1,6 @@
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import TableCalculationModal from './TableCalculationModal';
@@ -15,9 +14,8 @@ const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> = ({
     isOpen,
     onClose,
 }) => {
-    const addTableCalculation = useContextSelector(
-        Context,
-        (context) => context!.actions.addTableCalculation,
+    const addTableCalculation = useExplorerContext(
+        (context) => context.actions.addTableCalculation,
     );
     const { track } = useTracking();
     const onCreate = (value: TableCalculation) => {

--- a/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/CreateTableCalculationModal.tsx
@@ -1,6 +1,7 @@
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import TableCalculationModal from './TableCalculationModal';
@@ -14,9 +15,10 @@ const CreateTableCalculationModal: FC<CreateTableCalculationModalProps> = ({
     isOpen,
     onClose,
 }) => {
-    const {
-        actions: { addTableCalculation },
-    } = useExplorer();
+    const addTableCalculation = useContextSelector(
+        Context,
+        (context) => context!.actions.addTableCalculation,
+    );
     const { track } = useTracking();
     const onCreate = (value: TableCalculation) => {
         addTableCalculation(value);

--- a/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
@@ -1,7 +1,8 @@
 import { Button, Classes, Dialog } from '@blueprintjs/core';
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 
@@ -16,9 +17,10 @@ const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> = ({
     tableCalculation,
     onClose,
 }) => {
-    const {
-        actions: { deleteTableCalculation },
-    } = useExplorer();
+    const deleteTableCalculation = useContextSelector(
+        Context,
+        (context) => context!.actions.deleteTableCalculation,
+    );
     const { track } = useTracking();
 
     const onConfirm = () => {

--- a/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
@@ -1,8 +1,7 @@
 import { Button, Classes, Dialog } from '@blueprintjs/core';
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 
@@ -17,9 +16,8 @@ const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> = ({
     tableCalculation,
     onClose,
 }) => {
-    const deleteTableCalculation = useContextSelector(
-        Context,
-        (context) => context!.actions.deleteTableCalculation,
+    const deleteTableCalculation = useExplorerContext(
+        (context) => context.actions.deleteTableCalculation,
     );
     const { track } = useTracking();
 

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -7,11 +7,10 @@ import {
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useToggle } from 'react-use';
-import { useContextSelector } from 'use-context-selector';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerAceEditorCompleter } from '../../hooks/useExplorerAceEditorCompleter';
 import { useApp } from '../../providers/AppProvider';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import Input from '../ReactHookForm/Input';
 import SqlInput from '../ReactHookForm/SqlInput';
 import {
@@ -49,22 +48,18 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const [isFullscreen, toggleFullscreen] = useToggle(false);
     const { showToastError } = useApp();
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const dimensions = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.dimensions,
+    const dimensions = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.dimensions,
     );
-    const metrics = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.metrics,
+    const metrics = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.metrics,
     );
-    const tableCalculations = useContextSelector(
-        Context,
+    const tableCalculations = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.tableCalculations,
+            context.state.unsavedChartVersion.metricQuery.tableCalculations,
     );
     const { setAceEditor } = useExplorerAceEditorCompleter();
     const { data: { targetDatabase } = {} } = useExplore(tableName);

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -7,10 +7,11 @@ import {
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import { useContextSelector } from 'use-context-selector';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerAceEditorCompleter } from '../../hooks/useExplorerAceEditorCompleter';
 import { useApp } from '../../providers/AppProvider';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { Context } from '../../providers/ExplorerProvider';
 import Input from '../ReactHookForm/Input';
 import SqlInput from '../ReactHookForm/SqlInput';
 import {
@@ -48,14 +49,23 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const [isFullscreen, toggleFullscreen] = useToggle(false);
     const { showToastError } = useApp();
-    const {
-        state: {
-            unsavedChartVersion: {
-                tableName,
-                metricQuery: { dimensions, metrics, tableCalculations },
-            },
-        },
-    } = useExplorer();
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const dimensions = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.dimensions,
+    );
+    const metrics = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.metrics,
+    );
+    const tableCalculations = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.tableCalculations,
+    );
     const { setAceEditor } = useExplorerAceEditorCompleter();
     const { data: { targetDatabase } = {} } = useExplore(tableName);
     const methods = useForm<TableCalculationFormInputs>({

--- a/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
@@ -1,7 +1,6 @@
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context } from '../../providers/ExplorerProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import TableCalculationModal from './TableCalculationModal';
@@ -17,9 +16,8 @@ const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> = ({
     tableCalculation,
     onClose,
 }) => {
-    const updateTableCalculation = useContextSelector(
-        Context,
-        (context) => context!.actions.updateTableCalculation,
+    const updateTableCalculation = useExplorerContext(
+        (context) => context.actions.updateTableCalculation,
     );
     const { track } = useTracking();
     const onUpdate = (value: TableCalculation) => {

--- a/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/UpdateTableCalculationModal.tsx
@@ -1,6 +1,7 @@
 import { TableCalculation } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useExplorer } from '../../providers/ExplorerProvider';
+import { useContextSelector } from 'use-context-selector';
+import { Context } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import TableCalculationModal from './TableCalculationModal';
@@ -16,9 +17,10 @@ const UpdateTableCalculationModal: FC<UpdateTableCalculationModalProps> = ({
     tableCalculation,
     onClose,
 }) => {
-    const {
-        actions: { updateTableCalculation },
-    } = useExplorer();
+    const updateTableCalculation = useContextSelector(
+        Context,
+        (context) => context!.actions.updateTableCalculation,
+    );
     const { track } = useTracking();
     const onUpdate = (value: TableCalculation) => {
         updateTableCalculation(tableCalculation.name, value);

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -13,13 +13,14 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { useMemo } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import {
     TableHeaderBoldLabel,
     TableHeaderLabelContainer,
     TableHeaderRegularLabel,
 } from '../components/common/Table/Table.styles';
 import { TableColumn } from '../components/common/Table/types';
-import { useExplorer } from '../providers/ExplorerProvider';
+import { Context } from '../providers/ExplorerProvider';
 import useColumnTotals from './useColumnTotals';
 import { useExplore } from './useExplore';
 
@@ -37,17 +38,40 @@ export const getItemBgColor = (
 };
 
 export const useColumns = (): TableColumn[] => {
-    const {
-        state: {
-            activeFields,
-            unsavedChartVersion: {
-                tableName,
-                metricQuery: { tableCalculations, additionalMetrics, sorts },
-            },
-        },
-        queryResults: { data: resultsData },
-        actions: { toggleSortField, setSortFields },
-    } = useExplorer();
+    const activeFields = useContextSelector(
+        Context,
+        (context) => context!.state.activeFields,
+    );
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const tableCalculations = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.tableCalculations,
+    );
+    const additionalMetrics = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
+    const sorts = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.sorts,
+    );
+    const resultsData = useContextSelector(
+        Context,
+        (context) => context!.queryResults.data,
+    );
+    const toggleSortField = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleSortField,
+    );
+    const setSortFields = useContextSelector(
+        Context,
+        (context) => context!.actions.setSortFields,
+    );
     const { data: exploreData } = useExplore(tableName);
 
     const { activeItemsMap, invalidActiveItems } = useMemo<{

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -13,14 +13,13 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import {
     TableHeaderBoldLabel,
     TableHeaderLabelContainer,
     TableHeaderRegularLabel,
 } from '../components/common/Table/Table.styles';
 import { TableColumn } from '../components/common/Table/types';
-import { Context } from '../providers/ExplorerProvider';
+import { useExplorerContext } from '../providers/ExplorerProvider';
 import useColumnTotals from './useColumnTotals';
 import { useExplore } from './useExplore';
 
@@ -38,39 +37,31 @@ export const getItemBgColor = (
 };
 
 export const useColumns = (): TableColumn[] => {
-    const activeFields = useContextSelector(
-        Context,
-        (context) => context!.state.activeFields,
+    const activeFields = useExplorerContext(
+        (context) => context.state.activeFields,
     );
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const tableCalculations = useContextSelector(
-        Context,
+    const tableCalculations = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.tableCalculations,
+            context.state.unsavedChartVersion.metricQuery.tableCalculations,
     );
-    const additionalMetrics = useContextSelector(
-        Context,
+    const additionalMetrics = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
-    const sorts = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.sorts,
+    const sorts = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.sorts,
     );
-    const resultsData = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const resultsData = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const toggleSortField = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleSortField,
+    const toggleSortField = useExplorerContext(
+        (context) => context.actions.toggleSortField,
     );
-    const setSortFields = useContextSelector(
-        Context,
-        (context) => context!.actions.setSortFields,
+    const setSortFields = useExplorerContext(
+        (context) => context.actions.setSortFields,
     );
     const { data: exploreData } = useExplore(tableName);
 

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -5,8 +5,9 @@ import {
 } from '@lightdash/common';
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
+import { useContextSelector } from 'use-context-selector';
 import { lightdashApi } from '../api';
-import { useExplorer } from '../providers/ExplorerProvider';
+import { Context } from '../providers/ExplorerProvider';
 import useQueryError from './useQueryError';
 
 const getCompiledQuery = async (
@@ -22,22 +23,23 @@ const getCompiledQuery = async (
 
 export const useCompliedSql = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const tableId = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
     const {
-        state: {
-            unsavedChartVersion: {
-                tableName: tableId,
-                metricQuery: {
-                    dimensions,
-                    metrics,
-                    sorts,
-                    filters,
-                    limit,
-                    tableCalculations,
-                    additionalMetrics,
-                },
-            },
-        },
-    } = useExplorer();
+        dimensions,
+        metrics,
+        sorts,
+        filters,
+        limit,
+        tableCalculations,
+        additionalMetrics,
+    } = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery,
+    );
+
     const setErrorResponse = useQueryError();
     const metricQuery: MetricQuery = {
         dimensions: Array.from(dimensions),

--- a/packages/frontend/src/hooks/useCompiledSql.tsx
+++ b/packages/frontend/src/hooks/useCompiledSql.tsx
@@ -5,9 +5,8 @@ import {
 } from '@lightdash/common';
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
-import { useContextSelector } from 'use-context-selector';
 import { lightdashApi } from '../api';
-import { Context } from '../providers/ExplorerProvider';
+import { useExplorerContext } from '../providers/ExplorerProvider';
 import useQueryError from './useQueryError';
 
 const getCompiledQuery = async (
@@ -23,9 +22,8 @@ const getCompiledQuery = async (
 
 export const useCompliedSql = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const tableId = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableId = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
     const {
         dimensions,
@@ -35,9 +33,8 @@ export const useCompliedSql = () => {
         limit,
         tableCalculations,
         additionalMetrics,
-    } = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery,
+    } = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery,
     );
 
     const setErrorResponse = useQueryError();

--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
@@ -10,8 +10,9 @@ import {
     Metric,
 } from '@lightdash/common';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { useExplorer } from '../providers/ExplorerProvider';
+import { Context } from '../providers/ExplorerProvider';
 import { useExplore } from './useExplore';
+import { useContextSelector } from 'use-context-selector';
 
 const createCompleter: (fields: Ace.Completion[]) => Ace.Completer = (
     fields,
@@ -46,15 +47,19 @@ const mapActiveFieldsToCompletions = (
 export const useExplorerAceEditorCompleter = (): {
     setAceEditor: Dispatch<SetStateAction<Ace.Editor | undefined>>;
 } => {
-    const {
-        state: {
-            activeFields,
-            unsavedChartVersion: {
-                tableName,
-                metricQuery: { additionalMetrics },
-            },
-        },
-    } = useExplorer();
+    const activeFields = useContextSelector(
+        Context,
+        (context) => context!.state.activeFields,
+    );
+    const tableName = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.tableName,
+    );
+    const additionalMetrics = useContextSelector(
+        Context,
+        (context) =>
+            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
     const explore = useExplore(tableName);
     const [aceEditor, setAceEditor] = useState<Ace.Editor>();
 

--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.tsx
@@ -10,9 +10,8 @@ import {
     Metric,
 } from '@lightdash/common';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Context } from '../providers/ExplorerProvider';
+import { useExplorerContext } from '../providers/ExplorerProvider';
 import { useExplore } from './useExplore';
-import { useContextSelector } from 'use-context-selector';
 
 const createCompleter: (fields: Ace.Completion[]) => Ace.Completer = (
     fields,
@@ -47,18 +46,15 @@ const mapActiveFieldsToCompletions = (
 export const useExplorerAceEditorCompleter = (): {
     setAceEditor: Dispatch<SetStateAction<Ace.Editor | undefined>>;
 } => {
-    const activeFields = useContextSelector(
-        Context,
-        (context) => context!.state.activeFields,
+    const activeFields = useExplorerContext(
+        (context) => context.state.activeFields,
     );
-    const tableName = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.tableName,
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
     );
-    const additionalMetrics = useContextSelector(
-        Context,
+    const additionalMetrics = useExplorerContext(
         (context) =>
-            context!.state.unsavedChartVersion.metricQuery.additionalMetrics,
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
     const explore = useExplore(tableName);
     const [aceEditor, setAceEditor] = useState<Ace.Editor>();

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -1,11 +1,12 @@
 import { ChartType, CreateSavedChartVersion } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useContextSelector } from 'use-context-selector';
 import { useApp } from '../providers/AppProvider';
 import {
+    Context,
     ExplorerReduceState,
     ExplorerSection,
-    useExplorer,
 } from '../providers/ExplorerProvider';
 
 export const getExplorerUrlFromCreateSavedChartVersion = (
@@ -41,11 +42,22 @@ export const useExplorerRoute = () => {
         projectUuid: string;
         tableId: string | undefined;
     }>();
-    const {
-        state: { unsavedChartVersion },
-        queryResults: { data: queryResultsData },
-        actions: { clear, setTableName },
-    } = useExplorer();
+    const unsavedChartVersion = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion,
+    );
+    const queryResultsData = useContextSelector(
+        Context,
+        (context) => context!.queryResults.data,
+    );
+    const clear = useContextSelector(
+        Context,
+        (context) => context!.actions.clear,
+    );
+    const setTableName = useContextSelector(
+        Context,
+        (context) => context!.actions.setTableName,
+    );
 
     // Update url params based on pristine state
     useEffect(() => {

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -1,12 +1,11 @@
 import { ChartType, CreateSavedChartVersion } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { useContextSelector } from 'use-context-selector';
 import { useApp } from '../providers/AppProvider';
 import {
-    Context,
     ExplorerReduceState,
     ExplorerSection,
+    useExplorerContext,
 } from '../providers/ExplorerProvider';
 
 export const getExplorerUrlFromCreateSavedChartVersion = (
@@ -42,21 +41,15 @@ export const useExplorerRoute = () => {
         projectUuid: string;
         tableId: string | undefined;
     }>();
-    const unsavedChartVersion = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion,
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
     );
-    const queryResultsData = useContextSelector(
-        Context,
-        (context) => context!.queryResults.data,
+    const queryResultsData = useExplorerContext(
+        (context) => context.queryResults.data,
     );
-    const clear = useContextSelector(
-        Context,
-        (context) => context!.actions.clear,
-    );
-    const setTableName = useContextSelector(
-        Context,
-        (context) => context!.actions.setTableName,
+    const clear = useExplorerContext((context) => context.actions.clear);
+    const setTableName = useExplorerContext(
+        (context) => context.actions.setTableName,
     );
 
     // Update url params based on pristine state

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -6,25 +6,23 @@ import {
     getTotalFilterRules,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { Context, ExplorerSection } from '../providers/ExplorerProvider';
+import {
+    ExplorerSection,
+    useExplorerContext,
+} from '../providers/ExplorerProvider';
 
 export const useFilters = () => {
-    const expandedSections = useContextSelector(
-        Context,
-        (context) => context!.state.expandedSections,
+    const expandedSections = useExplorerContext(
+        (context) => context.state.expandedSections,
     );
-    const filters = useContextSelector(
-        Context,
-        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    const filters = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.filters,
     );
-    const setFilters = useContextSelector(
-        Context,
-        (context) => context!.actions.setFilters,
+    const setFilters = useExplorerContext(
+        (context) => context.actions.setFilters,
     );
-    const toggleExpandedSection = useContextSelector(
-        Context,
-        (context) => context!.actions.toggleExpandedSection,
+    const toggleExpandedSection = useExplorerContext(
+        (context) => context.actions.toggleExpandedSection,
     );
     const filterIsOpen = expandedSections.includes(ExplorerSection.FILTERS);
 

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -6,18 +6,26 @@ import {
     getTotalFilterRules,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
-import { ExplorerSection, useExplorer } from '../providers/ExplorerProvider';
+import { useContextSelector } from 'use-context-selector';
+import { Context, ExplorerSection } from '../providers/ExplorerProvider';
 
 export const useFilters = () => {
-    const {
-        state: {
-            expandedSections,
-            unsavedChartVersion: {
-                metricQuery: { filters },
-            },
-        },
-        actions: { setFilters, toggleExpandedSection },
-    } = useExplorer();
+    const expandedSections = useContextSelector(
+        Context,
+        (context) => context!.state.expandedSections,
+    );
+    const filters = useContextSelector(
+        Context,
+        (context) => context!.state.unsavedChartVersion.metricQuery.filters,
+    );
+    const setFilters = useContextSelector(
+        Context,
+        (context) => context!.actions.setFilters,
+    );
+    const toggleExpandedSection = useContextSelector(
+        Context,
+        (context) => context!.actions.toggleExpandedSection,
+    );
     const filterIsOpen = expandedSections.includes(ExplorerSection.FILTERS);
 
     const allFilterRules = useMemo(

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import Explorer from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
 import ForbiddenPanel from '../components/ForbiddenPanel';
@@ -17,12 +17,12 @@ import {
     SideBarCard,
 } from './Explorer.styles';
 
-const ExplorerWithUrlParams = () => {
+const ExplorerWithUrlParams = memo(() => {
     useExplorerRoute();
     return <Explorer />;
-};
+});
 
-const ExplorerPage = () => {
+const ExplorerPage = memo(() => {
     const explorerUrlState = useExplorerUrlState();
     const { sidebarRef, sidebarWidth, isResizing, startResizing } =
         useSidebarResize({
@@ -57,6 +57,6 @@ const ExplorerPage = () => {
             </PageContainer>
         </ExplorerProvider>
     );
-};
+});
 
 export default ExplorerPage;

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -16,15 +16,8 @@ import {
     TableCalculation,
     toggleArrayValue,
 } from '@lightdash/common';
-import React, {
-    createContext,
-    FC,
-    useCallback,
-    useContext,
-    useEffect,
-    useMemo,
-    useReducer,
-} from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useReducer } from 'react';
+import { createContext } from 'use-context-selector';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
 
@@ -175,7 +168,7 @@ interface ExplorerContext {
     };
 }
 
-const Context = createContext<ExplorerContext | undefined>(undefined);
+export const Context = createContext<ExplorerContext | undefined>(undefined);
 
 const defaultState: ExplorerReduceState = {
     shouldFetchResults: false,
@@ -1057,11 +1050,3 @@ export const ExplorerProvider: FC<{
     };
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };
-
-export function useExplorer(): ExplorerContext {
-    const context = useContext(Context);
-    if (context === undefined) {
-        throw new Error('useExplorer must be used within a ExplorerProvider');
-    }
-    return context;
-}

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -17,7 +17,11 @@ import {
     toggleArrayValue,
 } from '@lightdash/common';
 import React, { FC, useCallback, useEffect, useMemo, useReducer } from 'react';
-import { createContext } from 'use-context-selector';
+import {
+    createContext,
+    useContext,
+    useContextSelector,
+} from 'use-context-selector';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
 
@@ -168,7 +172,7 @@ interface ExplorerContext {
     };
 }
 
-export const Context = createContext<ExplorerContext | undefined>(undefined);
+const Context = createContext<ExplorerContext | undefined>(undefined);
 
 const defaultState: ExplorerReduceState = {
     shouldFetchResults: false,
@@ -1050,3 +1054,27 @@ export const ExplorerProvider: FC<{
     };
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };
+
+/**
+ * @deprecated The method should not be used. Should be replaced with useExplorerContext hook
+ */
+export function useExplorer(): ExplorerContext {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useExplorer must be used within a ExplorerProvider');
+    }
+    return context;
+}
+
+export function useExplorerContext<Selected>(
+    selector: (value: ExplorerContext) => Selected,
+) {
+    return useContextSelector(Context, (context) => {
+        if (context === undefined) {
+            throw new Error(
+                'useExplorer must be used within a ExplorerProvider',
+            );
+        }
+        return selector(context);
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17726,6 +17726,13 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
+
 schema-utils@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
@@ -19795,6 +19802,11 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-context-selector@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-1.4.1.tgz#eb96279965846b72915d7f899b8e6ef1d768b0ae"
+  integrity sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==
 
 use-memo-one@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Main problem:
**useContext** doesn't let you subscribe to a part of the context value (or some memoized selector) without fully re-rendering. 
Issue being tracked here: https://github.com/facebook/react/issues/14110
There is a proposal under development/review https://github.com/reactjs/rfcs/pull/119
So in this PR I'm using a library that polyfills the proposal so once it's introduced in react we can easily migrate.
Library: https://github.com/dai-shi/use-context-selector

Before:
```
    const {
        state: { isEditMode, savedChart },
    } = useExplorer();
```

After:
```
    const isEditMode = useContextSelector(
        Context,
        (context) => context!.state.isEditMode,
    );
    const savedChart = useContextSelector(
        Context,
        (context) => context!.state.savedChart,
    );
```

Top 3 providers that need to be changed:
- AppProvider
- ExplorerProvider
- VisualizationProvider

I can make a PR for each one since it implies changes in lots of files and avoid merge conflicts. I can also make it backwards compatible so any existing PR merged would still be compatible ( it would still have bad performance )


**This PR only refactors `ExplorerProvider`.** 