### PR TITLE
chore: refactor app provider

### DIFF
--- a/packages/frontend/src/components/ErrorLogsDrawer.tsx
+++ b/packages/frontend/src/components/ErrorLogsDrawer.tsx
@@ -9,8 +9,7 @@ import {
 } from '@blueprintjs/core';
 import MDEditor from '@uiw/react-md-editor';
 import React from 'react';
-import { ErrorLogEntry } from '../hooks/useErrorLogs';
-import { useApp } from '../providers/AppProvider';
+import { ErrorLogEntry, useErrorLogs } from '../providers/ErrorLogsProvider';
 
 const ErrorCard: React.FC<ErrorLogEntry & { onDismiss: () => void }> = ({
     title,
@@ -59,7 +58,7 @@ const ErrorCard: React.FC<ErrorLogEntry & { onDismiss: () => void }> = ({
 );
 
 export const ErrorLogsDrawer = () => {
-    const { errorLogs } = useApp();
+    const errorLogs = useErrorLogs();
     return (
         <Drawer
             autoFocus

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -11,7 +11,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
 import { useExplores } from '../../../hooks/useExplores';
-import { useApp } from '../../../providers/AppProvider';
+import { useErrorLogs } from '../../../providers/ErrorLogsProvider';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -40,7 +40,7 @@ const SideBarLoadingState = () => (
 const BasePanel = () => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { errorLogs } = useApp();
+    const errorLogs = useErrorLogs();
     const [search, setSearch] = useState<string>('');
     const [filterExplores, toggleFilterExplores] = useToggle(true);
     const exploresResult = useExplores(filterExplores);

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -12,7 +12,7 @@ import {
     jobStepStatusLabel,
     runningStepsInfo,
 } from '../../hooks/useRefreshServer';
-import { useApp } from '../../providers/AppProvider';
+import { useActiveJob } from '../../providers/ActiveJobProvider';
 import {
     ErrorMessageWrapper,
     RefreshStepsHeadingWrapper,
@@ -94,7 +94,7 @@ const StepIcon: FC<StepIconProps> = ({ step }: StepIconProps) => {
 };
 
 const JobDetailsDrawer: FC = () => {
-    const { isJobsDrawerOpen, setIsJobsDrawerOpen, activeJob } = useApp();
+    const { isJobsDrawerOpen, setIsJobsDrawerOpen, activeJob } = useActiveJob();
 
     if (!activeJob) {
         return null;

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
 import { lightdashApi } from '../../api';
+import useToaster from '../../hooks/toaster/useToaster';
 import {
     getLastProject,
     setLastProject,
@@ -20,6 +21,7 @@ import {
     useProjects,
 } from '../../hooks/useProjects';
 import { useApp } from '../../providers/AppProvider';
+import { useErrorLogs } from '../../providers/ErrorLogsProvider';
 import { UserAvatar } from '../Avatar';
 import { ErrorLogsDrawer } from '../ErrorLogsDrawer';
 import NavLink from '../NavLink';
@@ -43,11 +45,9 @@ const logoutQuery = async () =>
     });
 
 const NavBar = memo(() => {
-    const {
-        user,
-        errorLogs: { errorLogs, setErrorLogsVisible },
-        showToastSuccess,
-    } = useApp();
+    const { user } = useApp();
+    const { errorLogs, setErrorLogsVisible } = useErrorLogs();
+    const { showToastSuccess } = useToaster();
     const defaultProject = useDefaultProject();
     const { isLoading, data } = useProjects();
     const params = useParams<{ projectUuid: string | undefined }>();

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
@@ -13,10 +13,10 @@ import React, { FC, useEffect, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useCreateProjectAccessMutation } from '../../../hooks/useProjectAccess';
-import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import {
@@ -51,7 +51,7 @@ const ProjectAccessCreation: FC<{
     const { track } = useTracking();
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
-    const { showToastSuccess } = useApp();
+    const { showToastSuccess } = useToaster();
     const {
         mutate: createMutation,
         isError,

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -12,12 +12,14 @@ import React, { FC, useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 import { SubmitErrorHandler } from 'react-hook-form/dist/types/form';
 import { useHistory } from 'react-router-dom';
+import useToaster from '../../hooks/toaster/useToaster';
 import {
     useCreateMutation,
     useProject,
     useUpdateMutation,
 } from '../../hooks/useProject';
 import { SelectedWarehouse } from '../../pages/CreateProject';
+import { useActiveJob } from '../../providers/ActiveJobProvider';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
@@ -181,7 +183,7 @@ const ProjectForm: FC<Props> = ({
 };
 
 const useOnProjectError = (): SubmitErrorHandler<ProjectConnectionForm> => {
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     return async (errors: FieldErrors<ProjectConnectionForm>) => {
         if (!errors) {
             showToastError({
@@ -334,7 +336,8 @@ export const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     selectedWarehouse,
 }) => {
     const history = useHistory();
-    const { user, health, activeJobIsRunning, activeJob } = useApp();
+    const { user, health } = useApp();
+    const { activeJobIsRunning, activeJob } = useActiveJob();
     const onError = useOnProjectError();
     const createMutation = useCreateMutation();
     const { isLoading: isSaving, mutateAsync } = createMutation;

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -4,6 +4,7 @@ import React, { ComponentProps, FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { useProject } from '../../hooks/useProject';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
+import { useActiveJob } from '../../providers/ActiveJobProvider';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
@@ -17,7 +18,7 @@ import {
 const RefreshDbtButton: FC<ComponentProps<typeof BigButton>> = (props) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data } = useProject(projectUuid);
-    const { activeJob } = useApp();
+    const { activeJob } = useActiveJob();
     const { mutate } = useRefreshServer();
     const isLoading = activeJob && activeJob?.jobStatus === 'RUNNING';
 

--- a/packages/frontend/src/components/ShareLinkButton/index.tsx
+++ b/packages/frontend/src/components/ShareLinkButton/index.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import { useApp } from '../../providers/AppProvider';
+import useToaster from '../../hooks/toaster/useToaster';
 import { ShareLink } from './ShareLinkButton.styles';
 
 const ShareLinkButton: FC<{ url: string }> = ({ url }) => {
-    const { showToastSuccess } = useApp();
+    const { showToastSuccess } = useToaster();
     return (
         <CopyToClipboard
             text={url}

--- a/packages/frontend/src/components/ShowErrorsButton.tsx
+++ b/packages/frontend/src/components/ShowErrorsButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@blueprintjs/core';
 import React from 'react';
 import styled from 'styled-components';
-import { ErrorLogs } from '../hooks/useErrorLogs';
+import { ErrorLogs } from '../providers/ErrorLogsProvider';
 
 const ErrorsButton = styled(Button)`
     margin-right: 20px;

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -7,9 +7,9 @@ import {
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import useToaster from '../../hooks/toaster/useToaster';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerAceEditorCompleter } from '../../hooks/useExplorerAceEditorCompleter';
-import { useApp } from '../../providers/AppProvider';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
 import Input from '../ReactHookForm/Input';
 import SqlInput from '../ReactHookForm/SqlInput';
@@ -47,7 +47,7 @@ const TableCalculationModal: FC<Props> = ({
     onClose,
 }) => {
     const [isFullscreen, toggleFullscreen] = useToggle(false);
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     const tableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );

--- a/packages/frontend/src/components/UserSettings/CreateTokenPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/CreateTokenPanel/index.tsx
@@ -3,8 +3,8 @@ import { CreatePersonalAccessToken, formatTimestamp } from '@lightdash/common';
 import React, { FC, useEffect, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useForm } from 'react-hook-form';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useCreateAccessToken } from '../../../hooks/useAccessToken';
-import { useApp } from '../../../providers/AppProvider';
 import {
     AccessTokenForm,
     BackButton,
@@ -20,7 +20,7 @@ import {
 const CreateTokenPanel: FC<{
     onBackClick: () => void;
 }> = ({ onBackClick }) => {
-    const { showToastSuccess } = useApp();
+    const { showToastSuccess } = useToaster();
     const { data, mutate, isError, isLoading, isSuccess } =
         useCreateAccessToken();
 

--- a/packages/frontend/src/components/UserSettings/InvitesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/InvitesPanel/index.tsx
@@ -7,6 +7,7 @@ import {
 import React, { FC, useEffect } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useForm } from 'react-hook-form';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
@@ -28,7 +29,8 @@ const InvitePanel: FC<{
     onBackClick: () => void;
 }> = ({ onBackClick }) => {
     const { track } = useTracking();
-    const { showToastSuccess, health, user } = useApp();
+    const { health, user } = useApp();
+    const { showToastSuccess } = useToaster();
     const { data, mutate, isError, isLoading, isSuccess } =
         useCreateInviteLinkMutation();
     const methods = useForm<Omit<CreateInviteLink, 'expiresAt'>>({

--- a/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
@@ -3,7 +3,8 @@ import { ApiError } from '@lightdash/common';
 import React, { FC, useEffect, useState } from 'react';
 import { useMutation } from 'react-query';
 import { lightdashApi } from '../../../api';
-import { useApp } from '../../../providers/AppProvider';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useErrorLogs } from '../../../providers/ErrorLogsProvider';
 import PasswordInput from '../../PasswordInput';
 
 const updateUserPasswordQuery = async (data: {
@@ -17,10 +18,8 @@ const updateUserPasswordQuery = async (data: {
     });
 
 const PasswordPanel: FC = () => {
-    const {
-        errorLogs: { showError },
-        showToastError,
-    } = useApp();
+    const { showToastError } = useToaster();
+    const { showError } = useErrorLogs();
     const [password, setPassword] = useState<string>();
     const [newPassword, setNewPassword] = useState<string>();
 

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -8,7 +8,9 @@ import {
 import React, { FC, useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useApp } from '../../../providers/AppProvider';
+import { useErrorLogs } from '../../../providers/ErrorLogsProvider';
 
 const updateUserQuery = async (data: Partial<UpdateUserArgs>) =>
     lightdashApi<LightdashUser>({
@@ -19,12 +21,9 @@ const updateUserQuery = async (data: Partial<UpdateUserArgs>) =>
 
 const ProfilePanel: FC = () => {
     const queryClient = useQueryClient();
-    const {
-        showToastError,
-        errorLogs: { showError },
-        showToastSuccess,
-        user,
-    } = useApp();
+    const { user } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
+    const { showError } = useErrorLogs();
     const [firstName, setFirstName] = useState<string | undefined>(
         user.data?.firstName,
     );

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -16,6 +16,7 @@ import {
 import React, { FC, useEffect, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useLocation } from 'react-router-dom';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import {
     useDeleteUserMutation,
@@ -70,7 +71,8 @@ const UserListItem: FC<{
     const { mutate, isLoading: isDeleting } = useDeleteUserMutation();
     const inviteLink = useCreateInviteLinkMutation();
     const { track } = useTracking();
-    const { user, showToastSuccess, health } = useApp();
+    const { user, health } = useApp();
+    const { showToastSuccess } = useToaster();
     const updateUser = useUpdateUserMutation(userUuid);
     const handleDelete = () => mutate(userUuid);
 

--- a/packages/frontend/src/components/common/GoogleLoginButton/index.tsx
+++ b/packages/frontend/src/components/common/GoogleLoginButton/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import { useApp } from '../../../providers/AppProvider';
 import {
@@ -10,7 +11,8 @@ import {
 export const GoogleLoginButton: React.FC<{ inviteCode?: string }> = ({
     inviteCode,
 }) => {
-    const { health, showToastError } = useApp();
+    const { health } = useApp();
+    const { showToastError } = useToaster();
     const flashMessages = useFlashMessages();
 
     if (!health.data?.auth.google.oauth2ClientId) {
@@ -48,7 +50,8 @@ export const GoogleLoginButton: React.FC<{ inviteCode?: string }> = ({
 export const OktaLoginButton: React.FC<{ inviteCode?: string }> = ({
     inviteCode,
 }) => {
-    const { health, showToastError } = useApp();
+    const { health } = useApp();
+    const { showToastError } = useToaster();
     const flashMessages = useFlashMessages();
 
     if (!health.data?.auth.okta.enabled) {

--- a/packages/frontend/src/components/common/modal/ActionModal.tsx
+++ b/packages/frontend/src/components/common/modal/ActionModal.tsx
@@ -2,7 +2,7 @@ import { Button, IconName, Intent } from '@blueprintjs/core';
 import React, { Dispatch, SetStateAction, useCallback, useEffect } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import styled from 'styled-components';
-import { useApp } from '../../../providers/AppProvider';
+import useToaster from '../../../hooks/toaster/useToaster';
 import BaseModal from './BaseModal';
 
 export const ErrorMessage = styled.div`
@@ -58,7 +58,7 @@ const ActionModal = <T extends object>(props: ActionModalProps<T>) => {
         ModalContent,
         errorMessage,
     } = props;
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
 
     const methods = useForm<any>({
         mode: 'onSubmit',

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -13,7 +13,7 @@ import { UseQueryResult } from 'react-query/types/react/types';
 import { useHistory, useParams } from 'react-router-dom';
 import { useDeepCompareEffect } from 'react-use';
 import { lightdashApi } from '../../api';
-import { useApp } from '../../providers/AppProvider';
+import useToaster from '../toaster/useToaster';
 import useQueryError from '../useQueryError';
 
 const getDashboard = async (id: string) =>
@@ -131,7 +131,7 @@ export const useUpdateDashboard = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<Dashboard, ApiError, UpdateDashboard>(
         (data) => updateDashboard(id, data),
         {
@@ -180,7 +180,7 @@ export const useMoveDashboard = (uuid: string | undefined) => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<
         Dashboard,
         ApiError,
@@ -240,7 +240,7 @@ export const useCreateMutation = (
     showRedirectButton: boolean = false,
 ) => {
     const history = useHistory();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const queryClient = useQueryClient();
     return useMutation<Dashboard, ApiError, CreateDashboard>(
         (data) => createDashboard(projectUuid, data),
@@ -282,7 +282,7 @@ export const useDuplicateDashboardMutation = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<Dashboard, ApiError, string>(
         () => duplicateDashboard(projectUuid, dashboardUuid),
         {
@@ -319,7 +319,7 @@ export const useDuplicateDashboardMutation = (
 
 export const useDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteDashboard, {
         onSuccess: async () => {
             await queryClient.invalidateQueries('dashboards');

--- a/packages/frontend/src/hooks/dashboard/useDashboards.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboards.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../../api';
-import { useApp } from '../../providers/AppProvider';
+import useToaster from '../toaster/useToaster';
 import useQueryError from '../useQueryError';
 
 const getDashboards = async (projectUuid: string) =>
@@ -59,7 +59,7 @@ const updateMultipleDashboard = async (
 
 export const useUpdateMultipleDashboard = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, UpdateMultipleDashboards[]>(
         (data) => updateMultipleDashboard(projectUuid, data),
         {

--- a/packages/frontend/src/hooks/health/useHealth.tsx
+++ b/packages/frontend/src/hooks/health/useHealth.tsx
@@ -1,0 +1,43 @@
+import { ApiError, ApiHealthResults, HealthState } from '@lightdash/common';
+import React, { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { lightdashApi } from '../../api';
+import { AppToaster } from '../../components/AppToaster';
+
+const getHealthState = async () =>
+    lightdashApi<ApiHealthResults>({
+        url: `/health`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const useHealth = () => {
+    const health = useQuery<HealthState, ApiError>({
+        queryKey: 'health',
+        queryFn: getHealthState,
+    });
+
+    useEffect(() => {
+        if (health.error) {
+            const [first, ...rest] = health.error.error.message.split('\n');
+            AppToaster.show(
+                {
+                    intent: 'danger',
+                    message: (
+                        <div>
+                            <b>{first}</b>
+                            <p>{rest.join('\n')}</p>
+                        </div>
+                    ),
+                    timeout: 0,
+                    icon: 'error',
+                },
+                first,
+            );
+        }
+    }, [health]);
+
+    return health;
+};
+
+export default useHealth;

--- a/packages/frontend/src/hooks/organisation/useOrganisationUpdateMutation.ts
+++ b/packages/frontend/src/hooks/organisation/useOrganisationUpdateMutation.ts
@@ -1,7 +1,7 @@
 import { ApiError, Organisation } from '@lightdash/common';
 import { useMutation, useQueryClient } from 'react-query';
 import { lightdashApi } from '../../api';
-import { useApp } from '../../providers/AppProvider';
+import useToaster from '../toaster/useToaster';
 
 const updateOrgQuery = async (data: Organisation) =>
     lightdashApi<undefined>({
@@ -12,7 +12,7 @@ const updateOrgQuery = async (data: Organisation) =>
 
 export const useOrganisationUpdateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<undefined, ApiError, Organisation>(updateOrgQuery, {
         mutationKey: ['organisation_update'],
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/thirdPartyServices/useCohere.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useCohere.ts
@@ -1,0 +1,25 @@
+import { HealthState, LightdashUser } from '@lightdash/common';
+import Cohere from 'cohere-js';
+import { useEffect, useState } from 'react';
+
+const useCohere = (
+    cohereConfig: HealthState['cohere'] | undefined,
+    user: LightdashUser | undefined,
+) => {
+    const [isCohereLoaded, setIsCohereLoaded] = useState(false);
+
+    useEffect(() => {
+        if (!isCohereLoaded && cohereConfig && cohereConfig.token.length > 0) {
+            Cohere.init(cohereConfig.token);
+            setIsCohereLoaded(true);
+        }
+        if (user) {
+            Cohere.identify(user.userUuid, {
+                displayName: `${user.firstName} ${user.lastName}`,
+                email: user.email,
+            });
+        }
+    }, [cohereConfig, isCohereLoaded, user]);
+};
+
+export default useCohere;

--- a/packages/frontend/src/hooks/thirdPartyServices/useHeadway.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useHeadway.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useHeadway = () => {
+    const [isHeadwayLoaded, setIsHeadwayLoaded] = useState(false);
+
+    useEffect(() => {
+        if (!isHeadwayLoaded) {
+            const script = document.createElement('script');
+            script.async = false;
+            script.src = 'https://cdn.headwayapp.co/widget.js';
+            document.head.appendChild(script);
+            setIsHeadwayLoaded(true);
+        }
+    }, [isHeadwayLoaded]);
+};
+
+export default useHeadway;

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -1,0 +1,23 @@
+import { HealthState } from '@lightdash/common';
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+import { useEffect, useState } from 'react';
+
+const useSentry = (sentryConfig: HealthState['sentry'] | undefined) => {
+    const [isSentryLoaded, setIsSentryLoaded] = useState(false);
+
+    useEffect(() => {
+        if (sentryConfig && !isSentryLoaded && sentryConfig.dsn) {
+            Sentry.init({
+                dsn: sentryConfig.dsn,
+                release: sentryConfig.release,
+                environment: sentryConfig.environment,
+                integrations: [new Integrations.BrowserTracing()],
+                tracesSampleRate: 1.0,
+            });
+            setIsSentryLoaded(true);
+        }
+    }, [isSentryLoaded, setIsSentryLoaded, sentryConfig]);
+};
+
+export default useSentry;

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,0 +1,67 @@
+import { Intent } from '@blueprintjs/core';
+import { IToastProps } from '@blueprintjs/core/src/components/toast/toast';
+import MDEditor from '@uiw/react-md-editor';
+import React, { useCallback } from 'react';
+import { AppToaster } from '../../components/AppToaster';
+
+interface Message extends Omit<IToastProps, 'message'> {
+    title: string;
+    subtitle?: string;
+    key?: string;
+}
+
+const useToaster = () => {
+    const showToastSuccess = useCallback(
+        ({ title, subtitle, key, ...rest }: Message) => {
+            AppToaster.show(
+                {
+                    intent: Intent.SUCCESS,
+                    icon: 'tick-circle',
+                    timeout: 5000,
+                    message: (
+                        <div>
+                            <p style={{ fontWeight: 'bold', marginBottom: 0 }}>
+                                {title}
+                            </p>
+                            {subtitle && (
+                                <MDEditor.Markdown
+                                    source={subtitle}
+                                    linkTarget="_blank"
+                                />
+                            )}
+                        </div>
+                    ),
+                    ...rest,
+                },
+                key || title,
+            );
+        },
+        [],
+    );
+
+    const showToastError = useCallback(
+        (props: Message) => {
+            showToastSuccess({
+                intent: Intent.DANGER,
+                icon: 'error',
+                ...props,
+            });
+        },
+        [showToastSuccess],
+    );
+
+    const showToastInfo = useCallback(
+        (props: Message) => {
+            showToastSuccess({
+                intent: Intent.NONE,
+                icon: 'info-sign',
+                ...props,
+            });
+        },
+        [showToastSuccess],
+    );
+
+    return { showToastSuccess, showToastError, showToastInfo };
+};
+
+export default useToaster;

--- a/packages/frontend/src/hooks/useAccessToken.ts
+++ b/packages/frontend/src/hooks/useAccessToken.ts
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
 // gets users access tokens
@@ -42,7 +42,7 @@ export const useAccessToken = () => {
 
 export const useCreateAccessToken = () => {
     const queryClient = useQueryClient();
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     return useMutation<
         ApiCreateUserTokenResults,
         ApiError,
@@ -64,7 +64,7 @@ export const useCreateAccessToken = () => {
 
 export const useDeleteAccessToken = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteAccessToken, {
         mutationKey: ['personal_access_tokens'],
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -1,12 +1,12 @@
 import { ChartType, CreateSavedChartVersion } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { useApp } from '../providers/AppProvider';
 import {
     ExplorerReduceState,
     ExplorerSection,
     useExplorerContext,
 } from '../providers/ExplorerProvider';
+import useToaster from './toaster/useToaster';
 
 export const getExplorerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
@@ -82,7 +82,7 @@ export const useExplorerRoute = () => {
 };
 
 export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     const { search } = useLocation();
     const pathParams = useParams<{
         projectUuid: string;

--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const createInviteQuery = async (
     data: CreateInviteLink,
@@ -55,7 +55,7 @@ export const useInviteLink = (inviteCode: string) =>
 
 export const useCreateInviteLinkMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<
         InviteLink,
         ApiError,
@@ -81,7 +81,7 @@ export const useCreateInviteLinkMutation = () => {
 };
 
 export const useRevokeInvitesMutation = () => {
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError>(revokeInvitesQuery, {
         mutationKey: ['invite_link_revoke'],
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
 const getOrganizationUsersQuery = async () =>
@@ -43,7 +44,7 @@ export const useOrganizationUsers = () => {
 
 export const useDeleteUserMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteUserQuery, {
         mutationKey: ['saved_query_create'],
         onSuccess: async () => {
@@ -63,7 +64,8 @@ export const useDeleteUserMutation = () => {
 
 export const useUpdateUserMutation = (userUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError, user } = useApp();
+    const { user } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, OrganizationMemberProfileUpdate>(
         (data) => {
             if (userUuid) {

--- a/packages/frontend/src/hooks/usePasswordReset.ts
+++ b/packages/frontend/src/hooks/usePasswordReset.ts
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const getPasswordResetLinkQuery = async (code: string): Promise<undefined> =>
     lightdashApi<undefined>({
@@ -37,7 +37,7 @@ export const usePasswordResetLink = (code: string) =>
     });
 
 export const usePasswordResetLinkMutation = () => {
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<undefined, ApiError, CreatePasswordResetLink>(
         sendPasswordResetLinkQuery,
         {
@@ -58,7 +58,7 @@ export const usePasswordResetLinkMutation = () => {
 };
 
 export const usePasswordResetMutation = () => {
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<undefined, ApiError, PasswordReset>(resetPasswordQuery, {
         mutationKey: ['reset_password'],
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -7,7 +7,8 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import { useActiveJob } from '../providers/ActiveJobProvider';
+import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
@@ -44,7 +45,8 @@ export const useProject = (id: string | undefined) => {
 
 export const useUpdateMutation = (id: string) => {
     const queryClient = useQueryClient();
-    const { setActiveJobId, showToastError } = useApp();
+    const { setActiveJobId } = useActiveJob();
+    const { showToastError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, UpdateProject>(
         (data) => updateProject(id, data),
         {
@@ -69,7 +71,8 @@ export const useUpdateMutation = (id: string) => {
 };
 
 export const useCreateMutation = () => {
-    const { setActiveJobId, showToastError } = useApp();
+    const { setActiveJobId } = useActiveJob();
+    const { showToastError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, CreateProject>(
         (data) => createProject(data),
         {

--- a/packages/frontend/src/hooks/useProjectAccess.tsx
+++ b/packages/frontend/src/hooks/useProjectAccess.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
 const getProjectAccessQuery = async (projectUuid: string) =>
@@ -37,7 +37,7 @@ const removeProjectAccessQuery = async (
 
 export const useRevokeProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(
         (data) => removeProjectAccessQuery(projectUuid, data),
         {
@@ -70,7 +70,7 @@ const createProjectAccessQuery = async (
 
 export const useCreateProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<undefined, ApiError, CreateProjectMember>(
         (data) => createProjectAccessQuery(projectUuid, data),
         {
@@ -105,7 +105,7 @@ const updateProjectAccessQuery = async (
 
 export const useUpdateProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useApp();
+    const { showToastError, showToastSuccess } = useToaster();
     return useMutation<
         undefined,
         ApiError,

--- a/packages/frontend/src/hooks/useProjectTablesConfiguration.ts
+++ b/packages/frontend/src/hooks/useProjectTablesConfiguration.ts
@@ -1,7 +1,7 @@
 import { ApiError, TablesConfiguration } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
 const getProjectTablesConfigurationQuery = async (projectUuid: string) =>
@@ -31,7 +31,7 @@ export const useProjectTablesConfiguration = (projectUuid: string) => {
 };
 
 export const useUpdateProjectTablesConfiguration = (projectUuid: string) => {
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const queryClient = useQueryClient();
     return useMutation<TablesConfiguration, ApiError, TablesConfiguration>(
         (data) => updateProjectTablesConfigurationQuery(projectUuid, data),

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -1,7 +1,7 @@
 import { ApiError, OrganizationProject } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const getProjectsQuery = async () =>
     lightdashApi<OrganizationProject[]>({
@@ -50,7 +50,7 @@ const deleteProjectQuery = async (id: string) =>
 
 export const useDeleteProjectMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteProjectQuery, {
         mutationKey: ['organization_project_delete'],
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -1,14 +1,12 @@
 import { ApiError } from '@lightdash/common';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
-import { useApp } from '../providers/AppProvider';
+import { useErrorLogs } from '../providers/ErrorLogsProvider';
 
 const useQueryError = (): Dispatch<SetStateAction<ApiError | undefined>> => {
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<ApiError | undefined>();
-    const {
-        errorLogs: { showError },
-    } = useApp();
+    const { showError } = useErrorLogs();
     useEffect(() => {
         (async function doIfError() {
             const { error } = errorResponse || {};

--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -10,7 +10,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import { useActiveJob } from '../providers/ActiveJobProvider';
+import useToaster from './toaster/useToaster';
 
 export const jobStepStatusLabel = (
     status: JobStepStatusType,
@@ -114,7 +115,8 @@ export const useJob = (
 export const useRefreshServer = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { setActiveJobId, showToastError } = useApp();
+    const { setActiveJobId } = useActiveJob();
+    const { showToastError } = useToaster();
     return useMutation<ApiRefreshResults, ApiError>({
         mutationKey: ['refresh', projectUuid],
         mutationFn: () => refresh(projectUuid),

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -9,7 +9,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const createSavedQuery = async (
     projectUuid: string,
@@ -87,7 +87,7 @@ export const useSavedQuery = ({ id }: Args = {}) =>
 
 export const useDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteSavedQuery, {
         mutationKey: ['saved_query_create'],
         onSuccess: async () => {
@@ -120,7 +120,7 @@ const updateMultipleSavedQuery = async (
 
 export const useUpdateMultipleMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
 
     return useMutation<SavedChart[], ApiError, UpdateMultipleSavedChart[]>(
         (data) => {
@@ -153,7 +153,7 @@ export const useUpdateMultipleMutation = (projectUuid: string) => {
 
 export const useUpdateMutation = (savedQueryUuid?: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
     return useMutation<SavedChart, ApiError, UpdateSavedChart>(
@@ -188,7 +188,7 @@ export const useMoveMutation = (savedQueryUuid?: string) => {
     const history = useHistory();
     const queryClient = useQueryClient();
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
 
     return useMutation<
         SavedChart,
@@ -234,7 +234,7 @@ export const useCreateMutation = () => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<SavedChart, ApiError, CreateSavedChart>(
         (data) => createSavedQuery(projectUuid, data),
         {
@@ -265,7 +265,7 @@ export const useDuplicateMutation = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<SavedChart, ApiError, string>(
         () => duplicateSavedQuery(projectUuid, chartUuid),
         {
@@ -307,7 +307,7 @@ export const useDuplicateMutation = (
 export const useAddVersionMutation = () => {
     const history = useHistory();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<
         SavedChart,
         ApiError,

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -2,7 +2,7 @@ import { ApiError, CreateSpace, Space, UpdateSpace } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const getSpaces = async (projectUuid: string) =>
     lightdashApi<Space[]>({
@@ -46,7 +46,7 @@ const deleteQuery = async (projectUuid: string, spaceUuid: string) =>
 
 export const useDeleteMutation = (projectUuid: string) => {
     const history = useHistory();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<undefined, ApiError, string>(
@@ -84,7 +84,7 @@ const updateSpace = async (
     });
 
 export const useUpdateMutation = (projectUuid: string, spaceUuid: string) => {
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<Space, ApiError, UpdateSpace>(
@@ -125,7 +125,7 @@ export const useCreateMutation = (
         onSuccess?: (space: Space) => void;
     },
 ) => {
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<Space, ApiError, CreateSpace>(

--- a/packages/frontend/src/hooks/useSqlQuery.ts
+++ b/packages/frontend/src/hooks/useSqlQuery.ts
@@ -2,7 +2,7 @@ import { ApiError, ApiSqlQueryResults } from '@lightdash/common';
 import { useMutation } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 
 const runSqlQuery = async (projectUuid: string, sql: string) =>
     lightdashApi<ApiSqlQueryResults>({
@@ -13,7 +13,7 @@ const runSqlQuery = async (projectUuid: string, sql: string) =>
 
 export const useSqlQueryMutation = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     return useMutation<ApiSqlQueryResults, ApiError, string>(
         (sql) => runSqlQuery(projectUuid, sql),
         {

--- a/packages/frontend/src/hooks/useSqlRunnerRoute.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerRoute.ts
@@ -1,7 +1,7 @@
 import { CreateSavedChartVersion } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { useApp } from '../providers/AppProvider';
+import useToaster from './toaster/useToaster';
 import { parseExplorerSearchParams } from './useExplorerRoute';
 
 export type SqlRunnerState = {
@@ -48,7 +48,7 @@ export const useSqlRunnerRoute = (sqlRunnerState: SqlRunnerState) => {
 };
 
 export const useSqlRunnerUrlState = (): SqlRunnerState | undefined => {
-    const { showToastError } = useApp();
+    const { showToastError } = useToaster();
     const { search } = useLocation();
 
     return useMemo(() => {

--- a/packages/frontend/src/hooks/user/useDeleteOpenIdentityMutation.ts
+++ b/packages/frontend/src/hooks/user/useDeleteOpenIdentityMutation.ts
@@ -1,7 +1,7 @@
 import { ApiError, DeleteOpenIdentity } from '@lightdash/common';
 import { useMutation, useQueryClient } from 'react-query';
 import { lightdashApi } from '../../api';
-import { useApp } from '../../providers/AppProvider';
+import useToaster from '../toaster/useToaster';
 
 const deleteOpenIdentity = async (data: DeleteOpenIdentity) =>
     lightdashApi<undefined>({
@@ -12,7 +12,7 @@ const deleteOpenIdentity = async (data: DeleteOpenIdentity) =>
 
 export const useDeleteOpenIdentityMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useApp();
+    const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, DeleteOpenIdentity>(
         deleteOpenIdentity,
         {

--- a/packages/frontend/src/hooks/user/useUser.ts
+++ b/packages/frontend/src/hooks/user/useUser.ts
@@ -1,0 +1,31 @@
+import { Ability } from '@casl/ability';
+import { ApiError, LightdashUserWithAbilityRules } from '@lightdash/common';
+import { useQuery } from 'react-query';
+import { lightdashApi } from '../../api';
+
+export type UserWithAbility = LightdashUserWithAbilityRules & {
+    ability: Ability;
+};
+const getUserState = async (): Promise<UserWithAbility> => {
+    const user = await lightdashApi<LightdashUserWithAbilityRules>({
+        url: `/user`,
+        method: 'GET',
+        body: undefined,
+    });
+
+    return {
+        ...user,
+        ability: new Ability(user.abilityRules),
+    };
+};
+
+const useUser = (isAuthenticated: boolean) => {
+    return useQuery<UserWithAbility, ApiError>({
+        queryKey: 'user',
+        queryFn: getUserState,
+        enabled: isAuthenticated,
+        retry: false,
+    });
+};
+
+export default useUser;

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -19,6 +19,7 @@ import {
 import Page from '../components/common/Page/Page';
 import PageSpinner from '../components/PageSpinner';
 import Form from '../components/ReactHookForm/Form';
+import useToaster from '../hooks/toaster/useToaster';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
@@ -47,7 +48,8 @@ const loginQuery = async (data: LoginParams) =>
 
 const Login: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
-    const { health, showToastError } = useApp();
+    const { health } = useApp();
+    const { showToastError } = useToaster();
     const methods = useForm<LoginParams>({
         mode: 'onSubmit',
     });

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -10,6 +10,7 @@ import {
 import Page from '../components/common/Page/Page';
 import CreateUserForm from '../components/CreateUserForm';
 import PageSpinner from '../components/PageSpinner';
+import useToaster from '../hooks/toaster/useToaster';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
@@ -34,7 +35,8 @@ const registerQuery = async (data: CreateUserArgs) =>
 
 const Register: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
-    const { health, showToastError } = useApp();
+    const { health } = useApp();
+    const { showToastError } = useToaster();
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
     const { identify } = useTracking();

--- a/packages/frontend/src/pages/Signup.tsx
+++ b/packages/frontend/src/pages/Signup.tsx
@@ -17,6 +17,7 @@ import Page from '../components/common/Page/Page';
 import CreateUserForm from '../components/CreateUserForm';
 import PageSpinner from '../components/PageSpinner';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
+import useToaster from '../hooks/toaster/useToaster';
 import { useInviteLink } from '../hooks/useInviteLink';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
@@ -93,7 +94,8 @@ const createUserQuery = async (data: CreateOrganizationUser) =>
 
 const Signup: FC = () => {
     const { inviteCode } = useParams<{ inviteCode: string }>();
-    const { health, showToastError } = useApp();
+    const { health } = useApp();
+    const { showToastError } = useToaster();
     const { search } = useLocation();
     const { identify } = useTracking();
     const [isLinkFromEmail, setIsLinkFromEmail] = useState<boolean>(false);

--- a/packages/frontend/src/providers/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJobProvider.tsx
@@ -1,0 +1,140 @@
+import { SpinnerSize } from '@blueprintjs/core';
+import { ApiError, Job, JobStatusType, JobType } from '@lightdash/common';
+import React, {
+    createContext,
+    Dispatch,
+    FC,
+    SetStateAction,
+    useCallback,
+    useContext,
+    useEffect,
+    useState,
+} from 'react';
+import { useQueryClient } from 'react-query';
+import { AppToaster } from '../components/AppToaster';
+import { ToastSpinner } from '../components/ToastSpinner';
+import useToaster from '../hooks/toaster/useToaster';
+import {
+    jobStatusLabel,
+    runningStepsInfo,
+    TOAST_KEY_FOR_REFRESH_JOB,
+    useJob,
+} from '../hooks/useRefreshServer';
+
+interface ContextType {
+    isJobsDrawerOpen: boolean;
+    setIsJobsDrawerOpen: Dispatch<SetStateAction<boolean>>;
+    activeJobId: string | undefined;
+    setActiveJobId: Dispatch<SetStateAction<any>>;
+    activeJob: Job | undefined;
+    activeJobIsRunning: boolean | undefined;
+}
+
+const Context = createContext<ContextType>(undefined as any);
+
+export const ActiveJobProvider: FC = ({ children }) => {
+    const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
+    const [activeJobId, setActiveJobId] = useState();
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastError, showToastInfo } = useToaster();
+
+    const toastJobStatus = useCallback(
+        (job: Job | undefined) => {
+            if (job && !isJobsDrawerOpen) {
+                const toastTitle = `${jobStatusLabel(job?.jobStatus).label}`;
+                switch (job.jobStatus) {
+                    case 'DONE':
+                        if (job.jobType === JobType.CREATE_PROJECT) {
+                            queryClient.invalidateQueries(['projects']);
+                            queryClient.invalidateQueries([
+                                'projects',
+                                'defaultProject',
+                            ]);
+                        }
+                        showToastSuccess({
+                            key: TOAST_KEY_FOR_REFRESH_JOB,
+                            title: toastTitle,
+                        });
+                        break;
+                    case 'RUNNING':
+                        showToastInfo({
+                            key: TOAST_KEY_FOR_REFRESH_JOB,
+                            title: toastTitle,
+                            subtitle: job?.steps
+                                ? runningStepsInfo(job?.steps)
+                                      .runningStepMessage
+                                : '',
+                            icon: <ToastSpinner size={SpinnerSize.SMALL} />,
+                            timeout: 0,
+                            action: {
+                                text: 'View log',
+                                icon: 'arrow-right',
+                                onClick: () => setIsJobsDrawerOpen(true),
+                            },
+                            className: 'toast-with-no-close-button',
+                        });
+                        break;
+                    case 'ERROR':
+                        AppToaster.dismiss(TOAST_KEY_FOR_REFRESH_JOB);
+                        setIsJobsDrawerOpen(true);
+                }
+            }
+        },
+        [showToastInfo, showToastSuccess, queryClient, isJobsDrawerOpen],
+    );
+    const toastJobError = (error: ApiError) => {
+        showToastError({
+            key: TOAST_KEY_FOR_REFRESH_JOB,
+            title: 'Failed to refresh server',
+            subtitle: error.error.message,
+        });
+    };
+    const { data: activeJob } = useJob(
+        activeJobId,
+        toastJobStatus,
+        toastJobError,
+    );
+
+    // Always display either a toast or job bar when job is running
+    useEffect(() => {
+        if (activeJobId && activeJob && activeJob.jobStatus === 'RUNNING') {
+            if (isJobsDrawerOpen) {
+                AppToaster.dismiss(TOAST_KEY_FOR_REFRESH_JOB);
+            } else {
+                toastJobStatus(activeJob);
+            }
+        }
+        if (
+            activeJobId &&
+            activeJob &&
+            activeJob.jobStatus === JobStatusType.DONE
+        ) {
+            queryClient.refetchQueries('user'); // a new project level permission might be added to the user
+        }
+    }, [activeJob, activeJobId, toastJobStatus, isJobsDrawerOpen, queryClient]);
+
+    const activeJobIsRunning = activeJob && activeJob?.jobStatus === 'RUNNING';
+
+    return (
+        <Context.Provider
+            value={{
+                isJobsDrawerOpen,
+                setIsJobsDrawerOpen,
+                activeJobId,
+                setActiveJobId,
+                activeJob,
+                activeJobIsRunning,
+            }}
+        >
+            {children}
+        </Context.Provider>
+    );
+};
+
+export function useActiveJob(): ContextType {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useActiveJob must be used within a ActiveJobProvider');
+    }
+    return context;
+}

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -1,84 +1,20 @@
-import { Intent, SpinnerSize } from '@blueprintjs/core';
-import { IToastProps } from '@blueprintjs/core/src/components/toast/toast';
 import { Ability } from '@casl/ability';
-import {
-    ApiError,
-    ApiHealthResults,
-    HealthState,
-    Job,
-    JobStatusType,
-    JobType,
-    LightdashUserWithAbilityRules,
-} from '@lightdash/common';
-import * as Sentry from '@sentry/react';
-import { Integrations } from '@sentry/tracing';
-import MDEditor from '@uiw/react-md-editor';
-import Cohere from 'cohere-js';
-import React, {
-    createContext,
-    Dispatch,
-    FC,
-    SetStateAction,
-    useCallback,
-    useContext,
-    useEffect,
-    useState,
-} from 'react';
-import { useQuery, useQueryClient } from 'react-query';
+import { ApiError, HealthState } from '@lightdash/common';
+import React, { createContext, FC, useContext } from 'react';
 import { UseQueryResult } from 'react-query/types/react/types';
 import { IntercomProvider } from 'react-use-intercom';
-import { lightdashApi } from '../api';
-import { AppToaster } from '../components/AppToaster';
 import { AbilityContext } from '../components/common/Authorization';
-import { ToastSpinner } from '../components/ToastSpinner';
-import { ErrorLogs, useErrorLogs } from '../hooks/useErrorLogs';
-import {
-    jobStatusLabel,
-    runningStepsInfo,
-    TOAST_KEY_FOR_REFRESH_JOB,
-    useJob,
-} from '../hooks/useRefreshServer';
-
-const getHealthState = async () =>
-    lightdashApi<ApiHealthResults>({
-        url: `/health`,
-        method: 'GET',
-        body: undefined,
-    });
-
-type User = LightdashUserWithAbilityRules & { ability: Ability };
-const getUserState = async (): Promise<User> => {
-    const user = await lightdashApi<LightdashUserWithAbilityRules>({
-        url: `/user`,
-        method: 'GET',
-        body: undefined,
-    });
-
-    return {
-        ...user,
-        ability: new Ability(user.abilityRules),
-    };
-};
-
-interface Message extends Omit<IToastProps, 'message'> {
-    title: string;
-    subtitle?: string;
-    key?: string;
-}
+import useHealth from '../hooks/health/useHealth';
+import useCohere from '../hooks/thirdPartyServices/useCohere';
+import useHeadway from '../hooks/thirdPartyServices/useHeadway';
+import useSentry from '../hooks/thirdPartyServices/useSentry';
+import useUser, { UserWithAbility } from '../hooks/user/useUser';
+import { ActiveJobProvider } from './ActiveJobProvider';
+import { ErrorLogsProvider } from './ErrorLogsProvider';
 
 interface AppContext {
     health: UseQueryResult<HealthState, ApiError>;
-    user: UseQueryResult<User, ApiError>;
-    isJobsDrawerOpen: boolean;
-    setIsJobsDrawerOpen: Dispatch<SetStateAction<boolean>>;
-    activeJobId: string | undefined;
-    setActiveJobId: Dispatch<SetStateAction<any>>;
-    activeJob: Job | undefined;
-    activeJobIsRunning: boolean | undefined;
-    showToastSuccess: (props: Message) => void;
-    showToastError: (props: Message) => void;
-    showToastInfo: (props: Message) => void;
-    errorLogs: ErrorLogs;
+    user: UseQueryResult<UserWithAbility, ApiError>;
 }
 
 const Context = createContext<AppContext>(undefined as any);
@@ -86,227 +22,17 @@ const Context = createContext<AppContext>(undefined as any);
 const defaultAbility = new Ability();
 
 export const AppProvider: FC = ({ children }) => {
-    const [isSentryLoaded, setIsSentryLoaded] = useState(false);
-    const [isCohereLoaded, setIsCohereLoaded] = useState(false);
-    const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
-    const [activeJobId, setActiveJobId] = useState();
-    const queryClient = useQueryClient();
+    const health = useHealth();
+    const user = useUser(!!health?.data?.isAuthenticated);
 
-    const health = useQuery<HealthState, ApiError>({
-        queryKey: 'health',
-        queryFn: getHealthState,
-    });
-    const user = useQuery<User, ApiError>({
-        queryKey: 'user',
-        queryFn: getUserState,
-        enabled: !!health.data?.isAuthenticated,
-        retry: false,
-    });
-
-    const [isHeadwayLoaded, setIsHeadwayLoaded] = useState(false);
-
-    useEffect(() => {
-        if (health.data && !isSentryLoaded && health.data.sentry.dsn) {
-            Sentry.init({
-                dsn: health.data.sentry.dsn,
-                release: health.data.sentry.release,
-                environment: health.data.sentry.environment,
-                integrations: [new Integrations.BrowserTracing()],
-                tracesSampleRate: 1.0,
-            });
-            setIsSentryLoaded(true);
-        }
-    }, [isSentryLoaded, setIsSentryLoaded, health]);
-
-    useEffect(() => {
-        if (
-            !isCohereLoaded &&
-            health.data &&
-            health.data.cohere.token.length > 0
-        ) {
-            Cohere.init(health.data.cohere.token);
-            setIsCohereLoaded(true);
-        }
-        if (user.data) {
-            Cohere.identify(user.data.userUuid, {
-                displayName: `${user.data.firstName} ${user.data.lastName}`,
-                email: user.data.email,
-            });
-        }
-    }, [health, isCohereLoaded, user]);
-
-    useEffect(() => {
-        if (!isHeadwayLoaded) {
-            const script = document.createElement('script');
-            script.async = false;
-            script.src = 'https://cdn.headwayapp.co/widget.js';
-            document.head.appendChild(script);
-            setIsHeadwayLoaded(true);
-        }
-    }, [isHeadwayLoaded, health]);
-
-    const showToastSuccess = useCallback<AppContext['showToastSuccess']>(
-        ({ title, subtitle, key, ...rest }) => {
-            AppToaster.show(
-                {
-                    intent: Intent.SUCCESS,
-                    icon: 'tick-circle',
-                    timeout: 5000,
-                    message: (
-                        <div>
-                            <p style={{ fontWeight: 'bold', marginBottom: 0 }}>
-                                {title}
-                            </p>
-                            {subtitle && (
-                                <MDEditor.Markdown
-                                    source={subtitle}
-                                    linkTarget="_blank"
-                                />
-                            )}
-                        </div>
-                    ),
-                    ...rest,
-                },
-                key || title,
-            );
-        },
-        [],
-    );
-
-    const showToastError = useCallback<AppContext['showToastError']>(
-        (props) => {
-            showToastSuccess({
-                intent: Intent.DANGER,
-                icon: 'error',
-                ...props,
-            });
-        },
-        [showToastSuccess],
-    );
-
-    const showToastInfo = useCallback<AppContext['showToastInfo']>(
-        (props) => {
-            showToastSuccess({
-                intent: Intent.NONE,
-                icon: 'info-sign',
-                ...props,
-            });
-        },
-        [showToastSuccess],
-    );
-
-    const toastJobStatus = useCallback(
-        (job: Job | undefined) => {
-            if (job && !isJobsDrawerOpen) {
-                const toastTitle = `${jobStatusLabel(job?.jobStatus).label}`;
-                switch (job.jobStatus) {
-                    case 'DONE':
-                        if (job.jobType === JobType.CREATE_PROJECT) {
-                            queryClient.invalidateQueries(['projects']);
-                            queryClient.invalidateQueries([
-                                'projects',
-                                'defaultProject',
-                            ]);
-                        }
-                        showToastSuccess({
-                            key: TOAST_KEY_FOR_REFRESH_JOB,
-                            title: toastTitle,
-                        });
-                        break;
-                    case 'RUNNING':
-                        showToastInfo({
-                            key: TOAST_KEY_FOR_REFRESH_JOB,
-                            title: toastTitle,
-                            subtitle: job?.steps
-                                ? runningStepsInfo(job?.steps)
-                                      .runningStepMessage
-                                : '',
-                            icon: <ToastSpinner size={SpinnerSize.SMALL} />,
-                            timeout: 0,
-                            action: {
-                                text: 'View log',
-                                icon: 'arrow-right',
-                                onClick: () => setIsJobsDrawerOpen(true),
-                            },
-                            className: 'toast-with-no-close-button',
-                        });
-                        break;
-                    case 'ERROR':
-                        AppToaster.dismiss(TOAST_KEY_FOR_REFRESH_JOB);
-                        setIsJobsDrawerOpen(true);
-                }
-            }
-        },
-        [showToastInfo, showToastSuccess, queryClient, isJobsDrawerOpen],
-    );
-    const toastJobError = (error: ApiError) => {
-        showToastError({
-            key: TOAST_KEY_FOR_REFRESH_JOB,
-            title: 'Failed to refresh server',
-            subtitle: error.error.message,
-        });
-    };
-    const { data: activeJob } = useJob(
-        activeJobId,
-        toastJobStatus,
-        toastJobError,
-    );
-
-    // Always display either a toast or job bar when job is running
-    useEffect(() => {
-        if (activeJobId && activeJob && activeJob.jobStatus === 'RUNNING') {
-            if (isJobsDrawerOpen) {
-                AppToaster.dismiss(TOAST_KEY_FOR_REFRESH_JOB);
-            } else {
-                toastJobStatus(activeJob);
-            }
-        }
-        if (
-            activeJobId &&
-            activeJob &&
-            activeJob.jobStatus === JobStatusType.DONE
-        ) {
-            queryClient.refetchQueries('user'); // a new project level permission might be added to the user
-        }
-    }, [activeJob, activeJobId, toastJobStatus, isJobsDrawerOpen, queryClient]);
-
-    const activeJobIsRunning = activeJob && activeJob?.jobStatus === 'RUNNING';
-    const errorLogs = useErrorLogs();
+    useSentry(health?.data?.sentry);
+    useCohere(health?.data?.cohere, user.data);
+    useHeadway();
 
     const value = {
         health,
         user,
-        showToastSuccess,
-        showToastError,
-        showToastInfo,
-        isJobsDrawerOpen,
-        setIsJobsDrawerOpen,
-        activeJobId,
-        setActiveJobId,
-        activeJob,
-        activeJobIsRunning,
-        errorLogs,
     };
-
-    useEffect(() => {
-        if (health.error) {
-            const [first, ...rest] = health.error.error.message.split('\n');
-            AppToaster.show(
-                {
-                    intent: 'danger',
-                    message: (
-                        <div>
-                            <b>{first}</b>
-                            <p>{rest.join('\n')}</p>
-                        </div>
-                    ),
-                    timeout: 0,
-                    icon: 'error',
-                },
-                first,
-            );
-        }
-    }, [health]);
 
     return (
         <Context.Provider value={value}>
@@ -317,7 +43,9 @@ export const AppProvider: FC = ({ children }) => {
                 autoBoot
             >
                 <AbilityContext.Provider value={defaultAbility}>
-                    {children}
+                    <ActiveJobProvider>
+                        <ErrorLogsProvider>{children}</ErrorLogsProvider>
+                    </ActiveJobProvider>
                 </AbilityContext.Provider>
             </IntercomProvider>
         </Context.Provider>

--- a/packages/frontend/src/providers/ErrorLogsProvider.tsx
+++ b/packages/frontend/src/providers/ErrorLogsProvider.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useState } from 'react';
+import React, {
+    createContext,
+    FC,
+    useCallback,
+    useContext,
+    useState,
+} from 'react';
 
 const MAX_LOG_ENTRIES = 50;
 
@@ -18,7 +24,9 @@ export interface ErrorLogs {
     deleteErrorLogEntry: (idx: number) => void;
 }
 
-export const useErrorLogs = (): ErrorLogs => {
+const Context = createContext<ErrorLogs>(undefined as any);
+
+export const ErrorLogsProvider: FC = ({ children }) => {
     const [errorLogs, setErrorLogs] = useState<ErrorLogEntry[]>([]);
     const [errorLogsVisible, setErrorLogsVisible] = useState<boolean>(false);
 
@@ -67,7 +75,7 @@ export const useErrorLogs = (): ErrorLogs => {
         },
         [setErrorLogsVisible, appendErrorLogEntry],
     );
-    return {
+    const value = {
         errorLogs,
         errorLogsVisible,
         setErrorLogsVisible,
@@ -75,4 +83,16 @@ export const useErrorLogs = (): ErrorLogs => {
         setAllLogsRead,
         deleteErrorLogEntry,
     };
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
 };
+
+export function useErrorLogs(): ErrorLogs {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error(
+            'useErrorLogsContext must be used within a ErrorLogsProvider',
+        );
+    }
+    return context;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #2997

### Description:
Refactor:
- split provider in 3:
  -  **AppProvider**: packages/frontend/src/providers/AppProvider.tsx
  -  **ActiveJobProvider**: packages/frontend/src/providers/ActiveJobProvider.tsx
  -  **ErrorLogsProvider**: packages/frontend/src/providers/ErrorLogsProvider.tsx
- move all third-party logic to separate hooks: 
  - **useCohere**: packages/frontend/src/hooks/thirdPartyServices/useCohere.ts
  - **useSentry**: packages/frontend/src/hooks/thirdPartyServices/useHeadway.ts
  - **useHeadway**: packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
- move request logic to separate hooks:
  - **useHealth**: packages/frontend/src/hooks/health/useHealth.tsx
  - **useUser**: packages/frontend/src/hooks/user/useUser.ts
- move toast message callbacks to separate hook:
  - **useToaster**: packages/frontend/src/hooks/toaster/useToaster.tsx

Note that I haven't changed any of the logic, just moved it to different files.
This should help with tech debt and performance since the providers are smaller there is a lower change of trigger undesired re-renders. 

Note that this PR doesn't introduce the context selector approach since we were able to break down the provider. If this isn't enough we can open a separate PR to introduce that approach.