### PR TITLE
fix: disable visualization buttons

### DIFF
--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -22,6 +22,7 @@ export const BigNumberConfigPanel: React.FC = () => {
         },
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
+    const disabled = !selectedField;
 
     const styleOptions = [
         { value: '', label: 'none' },
@@ -31,6 +32,7 @@ export const BigNumberConfigPanel: React.FC = () => {
     ];
     return (
         <Popover2
+            disabled={disabled}
             content={
                 <>
                     <InputWrapper label="Select field">
@@ -81,7 +83,12 @@ export const BigNumberConfigPanel: React.FC = () => {
             onInteraction={setIsOpen}
             position="bottom"
         >
-            <Button minimal rightIcon="caret-down" text="Configure" />
+            <Button
+                minimal
+                rightIcon="caret-down"
+                text="Configure"
+                disabled={disabled}
+            />
         </Popover2>
     );
 };

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -1,17 +1,12 @@
 import { Button } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { ChartType } from '@lightdash/common';
 import React from 'react';
 import useEcharts from '../../hooks/echarts/useEcharts';
-import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import ChartConfigTabs from './ChartConfigTabs';
 
 export const ChartConfigPanel: React.FC = () => {
-    const { chartType } = useVisualizationContext();
     const eChartsOptions = useEcharts();
-    const disabled =
-        chartType === ChartType.TABLE ||
-        (chartType === ChartType.CARTESIAN && !eChartsOptions);
+    const disabled = !eChartsOptions;
 
     return (
         <Popover2

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -9,7 +9,9 @@ import ChartConfigTabs from './ChartConfigTabs';
 export const ChartConfigPanel: React.FC = () => {
     const { chartType } = useVisualizationContext();
     const eChartsOptions = useEcharts();
-    const disabled = chartType === ChartType.TABLE || !eChartsOptions;
+    const disabled =
+        chartType === ChartType.TABLE ||
+        (chartType === ChartType.CARTESIAN && !eChartsOptions);
 
     return (
         <Popover2

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -220,7 +220,7 @@ export const ChartDownloadMenu: React.FC = memo(() => {
     const disabled =
         (chartType === ChartType.TABLE && !rows) ||
         chartType === ChartType.BIG_NUMBER ||
-        !eChartsOptions;
+        (chartType === ChartType.CARTESIAN && !eChartsOptions);
 
     return (
         <Popover2

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -218,7 +218,7 @@ export const ChartDownloadMenu: React.FC = memo(() => {
     const eChartsOptions = useEcharts();
     const [isOpen, setIsOpen] = useState(false);
     const disabled =
-        (chartType === ChartType.TABLE && !rows) ||
+        (chartType === ChartType.TABLE && rows.length <= 0) ||
         chartType === ChartType.BIG_NUMBER ||
         (chartType === ChartType.CARTESIAN && !eChartsOptions);
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCardHeader.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCardHeader.tsx
@@ -17,16 +17,18 @@ import {
     CardHeaderTitle,
 } from './VisualizationCard.styles';
 
-const ConfigPanel: FC<{ chartType: ChartType }> = memo(({ chartType }) => {
-    switch (chartType) {
-        case ChartType.BIG_NUMBER:
-            return <BigNumberConfigPanel />;
-        case ChartType.TABLE:
-            return <TableConfigPanel />;
-        default:
-            return <ChartConfigPanel />;
-    }
-});
+export const ConfigPanel: FC<{ chartType: ChartType }> = memo(
+    ({ chartType }) => {
+        switch (chartType) {
+            case ChartType.BIG_NUMBER:
+                return <BigNumberConfigPanel />;
+            case ChartType.TABLE:
+                return <TableConfigPanel />;
+            default:
+                return <ChartConfigPanel />;
+        }
+    },
+);
 
 const VisualizationCardHeader = memo(() => {
     const isEditMode = useExplorerContext(

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -5,8 +5,7 @@ import {
     ChartType,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
-import { FC, memo, useMemo, useState } from 'react';
-import useEcharts from '../../../hooks/echarts/useEcharts';
+import { FC, useMemo, useState } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 
 const VisualizationCardOptions: FC = memo(() => {
@@ -19,11 +18,7 @@ const VisualizationCardOptions: FC = memo(() => {
         setPivotDimensions,
         cartesianConfig: { setStacking },
     } = useVisualizationContext();
-    const eChartsOptions = useEcharts();
-    const disabled =
-        isLoading ||
-        (resultsData && resultsData.rows.length <= 0) ||
-        !eChartsOptions;
+    const disabled = isLoading || (resultsData && resultsData.rows.length <= 0);
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -18,7 +18,7 @@ const VisualizationCardOptions: FC = memo(() => {
         setPivotDimensions,
         cartesianConfig: { setStacking },
     } = useVisualizationContext();
-    const disabled = isLoading || (resultsData && resultsData.rows.length <= 0);
+    const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
     const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -5,7 +5,7 @@ import {
     ChartType,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
-import { FC, useMemo, useState } from 'react';
+import { FC, memo, useMemo, useState } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 
 const VisualizationCardOptions: FC = memo(() => {

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -21,11 +21,13 @@ export const TableConfigPanel: React.FC = () => {
             showTableNames,
             setShowTableName,
             setShowColumnCalculation,
+            rows,
         },
         setPivotDimensions,
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
     const pivotDimension = pivotDimensions?.[0];
+    const disabled = rows.length <= 0;
 
     const availableDimensions = explore
         ? getDimensions(explore).filter((field) =>
@@ -40,6 +42,7 @@ export const TableConfigPanel: React.FC = () => {
 
     return (
         <Popover2
+            disabled={disabled}
             content={
                 <ConfigWrapper>
                     <SectionTitle>Group</SectionTitle>
@@ -92,7 +95,12 @@ export const TableConfigPanel: React.FC = () => {
             onInteraction={setIsOpen}
             position="bottom"
         >
-            <Button minimal rightIcon="caret-down" text="Configure" />
+            <Button
+                minimal
+                rightIcon="caret-down"
+                text="Configure"
+                disabled={disabled}
+            />
         </Popover2>
     );
 };

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,17 +1,16 @@
 import { Button, Collapse, H5, useHotkeys } from '@blueprintjs/core';
 import { TreeNodeInfo } from '@blueprintjs/core/src/components/tree/treeNode';
-import { ChartType, TableBase } from '@lightdash/common';
+import { TableBase } from '@lightdash/common';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useMount } from 'react-use';
 import styled from 'styled-components';
-import BigNumberConfigPanel from '../components/BigNumberConfig';
-import ChartConfigPanel from '../components/ChartConfigPanel';
 import { ChartDownloadMenu } from '../components/ChartDownload';
 import { CollapsableCard } from '../components/common/CollapsableCard';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';
 import Sidebar from '../components/common/Page/Sidebar';
 import SideBarLoadingState from '../components/common/SideBarLoadingState';
 import { Tree } from '../components/common/Tree';
+import { ConfigPanel } from '../components/Explorer/VisualizationCard/VisualizationCardHeader';
 import VisualizationCardOptions from '../components/Explorer/VisualizationCardOptions';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import LightdashVisualization from '../components/LightdashVisualization';
@@ -204,11 +203,7 @@ const SqlRunnerPage = () => {
                             {vizIsOpen && (
                                 <VisualizationCardButtons>
                                     <VisualizationCardOptions />
-                                    {chartType === ChartType.BIG_NUMBER ? (
-                                        <BigNumberConfigPanel />
-                                    ) : (
-                                        <ChartConfigPanel />
-                                    )}
+                                    <ConfigPanel chartType={chartType} />
                                     <ChartDownloadMenu />
                                 </VisualizationCardButtons>
                             )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 --> https://github.com/lightdash/lightdash/issues/3122

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

-  Visualisation ( Chart -> table -> Number ) : Free to choose even if there is no data available
- Chart Configure: Disable if it is chart type and no data available
- Chart export: Disable if chart type and no data available  
<!-- Even better add a screenshot / gif / loom -->
