### PR TITLE
chore: refactor underlying data provider

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -40,7 +40,7 @@ export const ExplorerResults = memo(() => {
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );
-    const activeExplore = useExplore(activeTableName);
+    const activeExplore = useExplore(activeTableName, false);
 
     const cellContextMenu = useCallback(
         (props) => <CellContextMenu isEditMode={isEditMode} {...props} />,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -42,7 +42,7 @@ const VisualizationCard: FC = memo(() => {
     const unsavedChartVersion = useExplorerContext(
         (context) => context.state.unsavedChartVersion,
     );
-    const isEditMode = useExplorerContext(packages/frontend/src/hooks/useColumns.tsx
+    const isEditMode = useExplorerContext(
         (context) => context.state.isEditMode,
     );
     const isLoadingQueryResults = useExplorerContext(

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -42,7 +42,7 @@ const VisualizationCard: FC = memo(() => {
     const unsavedChartVersion = useExplorerContext(
         (context) => context.state.unsavedChartVersion,
     );
-    const isEditMode = useExplorerContext(
+    const isEditMode = useExplorerContext(packages/frontend/src/hooks/useColumns.tsx
         (context) => context.state.isEditMode,
     );
     const isLoadingQueryResults = useExplorerContext(

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataModal.tsx
@@ -1,24 +1,12 @@
-import { AnchorButton, Dialog } from '@blueprintjs/core';
-import { getResultValues } from '@lightdash/common';
+import { Dialog } from '@blueprintjs/core';
 import React, { FC } from 'react';
-import DownloadCsvButton from '../DownloadCsvButton';
-import { HeaderRightContent } from './UnderlyingDataModal.styles';
+import UnderlyingDataModalContent from './UnderlyingDataModalContent';
 import { useUnderlyingDataContext } from './UnderlyingDataProvider';
-import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 
 interface Props {}
 
 const UnderlyingDataModal: FC<Props> = () => {
-    const {
-        resultsData,
-        fieldsMap,
-        closeModal,
-        tableName,
-        exploreFromHereUrl,
-        hasJoins,
-        isModalOpen,
-        isLoading,
-    } = useUnderlyingDataContext();
+    const { isModalOpen, closeModal } = useUnderlyingDataContext();
 
     return (
         <Dialog
@@ -33,26 +21,7 @@ const UnderlyingDataModal: FC<Props> = () => {
                 minWidth: '500px',
             }}
         >
-            <HeaderRightContent>
-                <DownloadCsvButton
-                    fileName={tableName}
-                    rows={resultsData && getResultValues(resultsData.rows)}
-                />
-                <AnchorButton
-                    intent="primary"
-                    href={exploreFromHereUrl}
-                    icon="series-search"
-                    target="_blank"
-                >
-                    Explore from here
-                </AnchorButton>
-            </HeaderRightContent>
-            <UnderlyingDataResultsTable
-                isLoading={isLoading}
-                resultsData={resultsData}
-                fieldsMap={fieldsMap}
-                hasJoins={hasJoins}
-            />
+            <UnderlyingDataModalContent />
         </Dialog>
     );
 };

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataModalContent.tsx
@@ -40,7 +40,7 @@ const UnderlyingDataModalContent: FC<Props> = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { tableName, filters, config } = useUnderlyingDataContext();
 
-    const { data: explore } = useExplore(tableName);
+    const { data: explore } = useExplore(tableName, false);
 
     const allFields = useMemo(
         () => (explore ? getFields(explore) : []),

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataModalContent.tsx
@@ -1,0 +1,229 @@
+import { AnchorButton } from '@blueprintjs/core';
+import {
+    ChartType,
+    CreateSavedChartVersion,
+    Field,
+    FilterOperator,
+    FilterRule,
+    getDimensions,
+    getFields,
+    getResultValues,
+    isDimension,
+    isField,
+    MetricQuery,
+} from '@lightdash/common';
+import { fieldId as getFieldId } from '@lightdash/common/dist/types/field';
+import React, { FC, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { useExplore } from '../../hooks/useExplore';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import { useUnderlyingDataResults } from '../../hooks/useQueryResults';
+import DownloadCsvButton from '../DownloadCsvButton';
+import { HeaderRightContent } from './UnderlyingDataModal.styles';
+import { useUnderlyingDataContext } from './UnderlyingDataProvider';
+import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
+
+interface Props {}
+
+const defaultMetricQuery: MetricQuery = {
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+};
+
+const UnderlyingDataModalContent: FC<Props> = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { tableName, filters, config } = useUnderlyingDataContext();
+
+    const { data: explore } = useExplore(tableName);
+
+    const allFields = useMemo(
+        () => (explore ? getFields(explore) : []),
+        [explore],
+    );
+    const allDimensions = useMemo(
+        () => (explore ? getDimensions(explore) : []),
+        [explore],
+    );
+
+    const hasJoins = useMemo(() => {
+        return (explore?.joinedTables || []).length > 0;
+    }, [explore]);
+
+    const metricQuery = useMemo<MetricQuery>(() => {
+        if (!config) return defaultMetricQuery;
+        const { meta, row, pivot, dimensions, value } = config;
+        if (meta?.item === undefined) return defaultMetricQuery;
+
+        // We include tables from all fields that appear on the SQL query (aka tables from all columns in results)
+        const rowFieldIds = pivot
+            ? [pivot.fieldId, ...Object.keys(row)]
+            : Object.keys(row);
+
+        // On charts, we might want to include the dimensions from SQLquery and not from rowdata, so we include those instead
+        const dimensionFieldIds = dimensions ? dimensions : rowFieldIds;
+        const fieldsInQuery = allFields.filter((field) =>
+            dimensionFieldIds.includes(getFieldId(field)),
+        );
+        const tablesInQuery = new Set([
+            ...fieldsInQuery.map((field) => field.table),
+            tableName,
+        ]);
+
+        // If we are viewing data from a metric or a table calculation, we filter using all existing dimensions in the table
+        const dimensionFilters = !isDimension(meta?.item)
+            ? Object.entries(row).reduce((acc, r) => {
+                  const [
+                      key,
+                      {
+                          value: { raw },
+                      },
+                  ] = r;
+
+                  const dimensionFilter: FilterRule = {
+                      id: uuidv4(),
+                      target: {
+                          fieldId: key,
+                      },
+                      operator:
+                          raw === null
+                              ? FilterOperator.NULL
+                              : FilterOperator.EQUALS,
+                      values: raw === null ? undefined : [raw],
+                  };
+                  const isValidDimension = allDimensions.find(
+                      (dimension) => getFieldId(dimension) === key,
+                  );
+
+                  if (isValidDimension) {
+                      return [...acc, dimensionFilter];
+                  }
+                  return acc;
+              }, [] as FilterRule[])
+            : [
+                  {
+                      id: uuidv4(),
+                      target: {
+                          fieldId: getFieldId(meta?.item),
+                      },
+                      operator:
+                          value.raw === null
+                              ? FilterOperator.NULL
+                              : FilterOperator.EQUALS,
+                      values: value.raw === null ? undefined : [value.raw],
+                  },
+              ];
+
+        const pivotFilter: FilterRule[] = pivot
+            ? [
+                  {
+                      id: uuidv4(),
+                      target: {
+                          fieldId: pivot.fieldId,
+                      },
+                      operator: FilterOperator.EQUALS,
+                      values: [pivot.value],
+                  },
+              ]
+            : [];
+
+        const exploreFilters =
+            filters?.dimensions !== undefined ? [filters?.dimensions] : [];
+        const combinedFilters = [
+            ...exploreFilters,
+            ...dimensionFilters,
+            ...pivotFilter,
+        ];
+
+        const metricFilters = {
+            dimensions: {
+                id: uuidv4(),
+                and: combinedFilters,
+            },
+        };
+
+        const availableDimensions = allDimensions.filter(
+            (dimension) =>
+                tablesInQuery.has(dimension.table) &&
+                !dimension.timeInterval &&
+                !dimension.hidden,
+        );
+        const dimensionFields = availableDimensions.map(getFieldId);
+        return {
+            ...defaultMetricQuery,
+            dimensions: dimensionFields,
+            filters: metricFilters,
+        };
+    }, [config, filters, tableName, allFields, allDimensions]);
+
+    const fieldsMap: Record<string, Field> = useMemo(() => {
+        const selectedDimensions = metricQuery.dimensions;
+        const dimensions = explore ? getDimensions(explore) : [];
+        return dimensions.reduce((acc, dimension) => {
+            const fieldId = isField(dimension) ? getFieldId(dimension) : '';
+            if (selectedDimensions.includes(fieldId))
+                return {
+                    ...acc,
+                    [fieldId]: dimension,
+                };
+            else return acc;
+        }, {});
+    }, [explore, metricQuery]);
+
+    const exploreFromHereUrl = useMemo(() => {
+        const createSavedChartVersion: CreateSavedChartVersion = {
+            tableName,
+            metricQuery,
+            pivotConfig: undefined,
+            tableConfig: {
+                columnOrder: [],
+            },
+            chartConfig: {
+                type: ChartType.CARTESIAN,
+                config: { layout: {}, eChartsConfig: {} },
+            },
+        };
+        const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
+            projectUuid,
+            createSavedChartVersion,
+        );
+        return `${pathname}?${search}`;
+    }, [tableName, metricQuery, projectUuid]);
+
+    const { data: resultsData, isLoading } = useUnderlyingDataResults(
+        tableName,
+        metricQuery,
+    );
+
+    return (
+        <>
+            <HeaderRightContent>
+                <DownloadCsvButton
+                    fileName={tableName}
+                    rows={resultsData && getResultValues(resultsData.rows)}
+                />
+                <AnchorButton
+                    intent="primary"
+                    href={exploreFromHereUrl}
+                    icon="series-search"
+                    target="_blank"
+                >
+                    Explore from here
+                </AnchorButton>
+            </HeaderRightContent>
+            <UnderlyingDataResultsTable
+                isLoading={isLoading}
+                resultsData={resultsData}
+                fieldsMap={fieldsMap}
+                hasJoins={hasJoins}
+            />
+        </>
+    );
+};
+
+export default UnderlyingDataModalContent;

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataResultsTable.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataResultsTable.tsx
@@ -1,6 +1,6 @@
 import { NonIdealState, Spinner } from '@blueprintjs/core';
 import { ApiQueryResults, Field } from '@lightdash/common';
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import useUnderlyingDataColumns from '../../hooks/useUnderlyingDataColumns';
 import { TrackSection } from '../../providers/TrackingProvider';
 import { SectionName } from '../../types/Events';
@@ -19,16 +19,19 @@ const UnderlyingDataResultsTable: FC<{
     isLoading: boolean;
     hasJoins?: boolean;
 }> = ({ fieldsMap, resultsData, isLoading, hasJoins }) => {
-    const columnHeader = (dimension: Field) => (
-        <TableHeaderLabelContainer>
-            {hasJoins === true && (
-                <TableHeaderRegularLabel>
-                    {dimension.tableLabel} -{' '}
-                </TableHeaderRegularLabel>
-            )}
+    const columnHeader = useCallback(
+        (dimension: Field) => (
+            <TableHeaderLabelContainer>
+                {hasJoins === true && (
+                    <TableHeaderRegularLabel>
+                        {dimension.tableLabel} -{' '}
+                    </TableHeaderRegularLabel>
+                )}
 
-            <TableHeaderBoldLabel>{dimension.label}</TableHeaderBoldLabel>
-        </TableHeaderLabelContainer>
+                <TableHeaderBoldLabel>{dimension.label}</TableHeaderBoldLabel>
+            </TableHeaderLabelContainer>
+        ),
+        [hasJoins],
     );
 
     const columns = useUnderlyingDataColumns({

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -57,7 +57,7 @@ export const useColumns = (): TableColumn[] => {
     const resultsData = useExplorerContext(
         (context) => context.queryResults.data,
     );
-    const { data: exploreData } = useExplore(tableName);
+    const { data: exploreData } = useExplore(tableName, false);
 
     const { activeItemsMap, invalidActiveItems } = useMemo<{
         activeItemsMap: Record<string, Field | TableCalculation>;

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -21,5 +21,6 @@ export const useExplore = (activeTableName: string | undefined) => {
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
+        refetchOnMount: false,
     });
 };

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -11,7 +11,10 @@ const getExplore = async (projectUuid: string, exploreId: string) =>
         body: undefined,
     });
 
-export const useExplore = (activeTableName: string | undefined) => {
+export const useExplore = (
+    activeTableName: string | undefined,
+    refetchOnMount?: boolean,
+) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const setErrorResponse = useQueryError();
     const queryKey = ['tables', activeTableName, projectUuid];
@@ -21,6 +24,6 @@ export const useExplore = (activeTableName: string | undefined) => {
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
-        refetchOnMount: false,
+        refetchOnMount,
     });
 };

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -90,7 +90,6 @@ export const useUnderlyingDataResults = (
                 query,
             }),
         retry: false,
-        refetchOnMount: false,
     });
 };
 

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -71,6 +71,29 @@ export const useQueryResults = (
     );
 };
 
+export const useUnderlyingDataResults = (
+    tableId: string,
+    query: MetricQuery,
+) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const queryKey = [
+        'underlyingDataResults',
+        projectUuid,
+        JSON.stringify(query),
+    ];
+    return useQuery<ApiQueryResults, ApiError>({
+        queryKey,
+        queryFn: () =>
+            getQueryResults({
+                projectUuid,
+                tableId,
+                query,
+            }),
+        retry: false,
+        refetchOnMount: false,
+    });
+};
+
 export const useSavedChartResults = (
     projectUuid: string,
     savedChart: SavedChart,


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Related to: #2997

Changes:
- move all the logic in the underlying data provider to the model content component `UnderlyingDataModalContent.tsx`. So it only calculates once the model opens.
- stop using the same hook as the explore page to fetch results. Now, it has a dedicated hook `useUnderlyingDataResults()` with a unique queryKey.
- and stop refetch the explore when component mounts.
Before:

![before](https://user-images.githubusercontent.com/9117144/188196637-645f0202-8c21-455f-bc3c-5c0f92f4179c.gif)

After:

![after](https://user-images.githubusercontent.com/9117144/188196675-550ac7d9-c369-47e5-bc03-da9a707975e2.gif)
