### PR TITLE
chore: no refetch on mount

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import { PageName } from './types/Events';
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
+            refetchOnMount: false,
             refetchOnWindowFocus: false,
             onError: async (result) => {
                 // @ts-ignore


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #2997

### Description:
Read more about [react-query important defaults](https://react-query-v3.tanstack.com/guides/important-defaults#_top
)

> refetchOnMount: boolean | "always" | ((query: Query) => boolean | "always")
> Optional
> Defaults to true
> If set to true, the query will refetch on mount if the data is stale.
> If set to false, the query will not refetch on mount.
> If set to "always", the query will always refetch on mount.
> If set to a function, the function will be executed with the query to compute the value

Before:
![before](https://user-images.githubusercontent.com/9117144/188198980-f7fc7c62-9d48-42e4-960f-e943bb9bfa20.gif)

After:

![after](https://user-images.githubusercontent.com/9117144/188198999-99d6f455-dd6b-4285-975e-65574480a36d.gif)
