### PR TITLE
feat: proper sort indicators based on field type

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -165,8 +165,8 @@ const NonAggregateMetricTypes = [
     MetricType.BOOLEAN,
 ];
 
-export const isMetric = (field: Field): field is Metric =>
-    field.fieldType === FieldType.METRIC;
+export const isMetric = (field: Field | undefined): field is Metric =>
+    field ? field.fieldType === FieldType.METRIC : false;
 
 export const isNonAggregateMetric = (field: Field): boolean =>
     isMetric(field) && NonAggregateMetricTypes.includes(field.type);

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -182,7 +182,7 @@ describe('Explore', () => {
                 .find('button')
                 .click();
             // sort `Unique order count` by ascending
-            cy.findByRole('option', { name: 'Sort A-Z' }).click();
+            cy.findByRole('option', { name: 'Sort First-Last' }).click();
 
             cy.get('span').contains('Sorted by 1 field').should('exist');
 

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -30,7 +30,7 @@ describe('Explore', () => {
             .find('button')
             .click();
 
-        // sort `Unique order count` by ascending
+        // sort `Customers - First-Name` by ascending
         cy.findByRole('option', { name: 'Sort A-Z' }).click();
 
         // wait for query to finish
@@ -181,8 +181,8 @@ describe('Explore', () => {
                 .closest('th')
                 .find('button')
                 .click();
-            // sort `Unique order count` by ascending
-            cy.findByRole('option', { name: 'Sort First-Last' }).click();
+            // sort `Orders - Unique order count` by ascending
+            cy.findByRole('option', { name: 'Sort 1-9' }).click();
 
             cy.get('span').contains('Sorted by 1 field').should('exist');
 
@@ -191,7 +191,7 @@ describe('Explore', () => {
                 .closest('th')
                 .find('button')
                 .click();
-            // sort `Unique order count` by ascending
+            // sort `Customers - First name` by ascending
             cy.findByRole('option', { name: 'Sort Z-A' }).click();
 
             cy.get('span').contains('Sorted by 2 fields').should('exist');

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -19,6 +19,10 @@ import {
     UpdateTableCalculationModal,
 } from '../../TableCalculationModels';
 
+const BolderLabel = styled.span`
+    font-weight: 600;
+`;
+
 const FlatButton = styled(Button)`
     min-height: 16px !important;
 `;
@@ -59,7 +63,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
         return (
             <Menu>
                 <MenuItem2
-                    text={`Filter by ${item.label}`}
+                    text={
+                        <>
+                            Filter by <BolderLabel>{item.label}</BolderLabel>
+                        </>
+                    }
                     icon="filter"
                     onClick={() => {
                         track({ name: EventName.ADD_FILTER_CLICKED });
@@ -72,7 +80,14 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <MenuItem2
                     roleStructure="listoption"
                     selected={hasSort && isAscending}
-                    text={`Sort ${getSortLabel(item, SortDirection.ASC)}`}
+                    text={
+                        <>
+                            Sort{' '}
+                            <BolderLabel>
+                                {getSortLabel(item, SortDirection.ASC)}
+                            </BolderLabel>
+                        </>
+                    }
                     onClick={() =>
                         hasSort && isAscending
                             ? removeSortField(itemFieldId)
@@ -83,7 +98,14 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <MenuItem2
                     roleStructure="listoption"
                     selected={hasSort && isDescending}
-                    text={`Sort ${getSortLabel(item, SortDirection.DESC)}`}
+                    text={
+                        <>
+                            Sort{' '}
+                            <BolderLabel>
+                                {getSortLabel(item, SortDirection.DESC)}
+                            </BolderLabel>
+                        </>
+                    }
                     onClick={() =>
                         hasSort && isDescending
                             ? removeSortField(itemFieldId)

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -12,6 +12,7 @@ import { useFilters } from '../../../hooks/useFilters';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
+import { getSortLabel, SortDirection } from '../../../utils/sortUtils';
 import { HeaderProps, TableColumn } from '../../common/Table/types';
 import {
     DeleteTableCalculationModal,
@@ -71,7 +72,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <MenuItem2
                     roleStructure="listoption"
                     selected={hasSort && isAscending}
-                    text="Sort A-Z"
+                    text={`Sort ${getSortLabel(item, SortDirection.ASC)}`}
                     onClick={() =>
                         hasSort && isAscending
                             ? removeSortField(itemFieldId)
@@ -82,7 +83,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <MenuItem2
                     roleStructure="listoption"
                     selected={hasSort && isDescending}
-                    text="Sort Z-A"
+                    text={`Sort ${getSortLabel(item, SortDirection.DESC)}`}
                     onClick={() =>
                         hasSort && isDescending
                             ? removeSortField(itemFieldId)

--- a/packages/frontend/src/components/SortButton/SortButton.styles.ts
+++ b/packages/frontend/src/components/SortButton/SortButton.styles.ts
@@ -1,11 +1,18 @@
-import { Colors } from '@blueprintjs/core';
+import { ButtonGroup, Colors } from '@blueprintjs/core';
 import styled, { createGlobalStyle } from 'styled-components';
 
 export const PopoverGlobalStyles = createGlobalStyle`
     .bp4-popover-portal-results-table-sort-fields .bp4-popover2-content {
-        width: 400px;
-        max-width: 400px !important;
+        width: 430px;
+        max-width: 430px !important;
         padding: 0 !important;
+    }
+`;
+
+export const StyledButtonGroup = styled(ButtonGroup)`
+    button {
+        min-width: 70px !important;
+        font-size: 12px;
     }
 `;
 
@@ -39,7 +46,7 @@ export const SortItemContainer = styled.div<SortItemContainerProps>`
 `;
 
 export const LabelWrapper = styled.div`
-    flex: 0 0 60px;
+    flex: 0 0 55px;
 `;
 
 export const ColumnNameWrapper = styled.div`

--- a/packages/frontend/src/components/SortButton/SortButton.styles.ts
+++ b/packages/frontend/src/components/SortButton/SortButton.styles.ts
@@ -48,6 +48,7 @@ export const ColumnNameWrapper = styled.div`
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 150px;
+    font-weight: bold;
 `;
 
 export const StretchSpacer = styled.div`

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Icon } from '@blueprintjs/core';
+import { Button, Icon } from '@blueprintjs/core';
 import { isField, SortField } from '@lightdash/common';
 import { forwardRef } from 'react';
 import {
@@ -14,6 +14,7 @@ import {
     SortItemContainer,
     Spacer,
     StretchSpacer,
+    StyledButtonGroup,
 } from './SortButton.styles';
 
 interface SortItemProps {
@@ -78,7 +79,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
 
                 <StretchSpacer />
 
-                <ButtonGroup>
+                <StyledButtonGroup>
                     <Button
                         small
                         intent={isAscending ? 'primary' : 'none'}
@@ -102,7 +103,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                     >
                         {getSortLabel(item, SortDirection.DESC)}
                     </Button>
-                </ButtonGroup>
+                </StyledButtonGroup>
 
                 <Spacer $width={6} />
 

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -51,6 +51,10 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
 
         const item = column?.meta?.item;
 
+        if (!isField(item)) {
+            return null;
+        }
+
         return (
             <SortItemContainer
                 ref={ref}
@@ -74,7 +78,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                 </LabelWrapper>
 
                 <ColumnNameWrapper>
-                    {isField(item) ? item.label : item?.name || sort.fieldId}
+                    {item.label || sort.fieldId}
                 </ColumnNameWrapper>
 
                 <StretchSpacer />

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -1,11 +1,12 @@
 import { Button, ButtonGroup, Icon } from '@blueprintjs/core';
-import { SortField } from '@lightdash/common';
+import { isField, SortField } from '@lightdash/common';
 import { forwardRef } from 'react';
 import {
     DraggableProvidedDraggableProps,
     DraggableProvidedDragHandleProps,
 } from 'react-beautiful-dnd';
 import { ExplorerContext } from '../../providers/ExplorerProvider';
+import { getSortLabel, SortDirection } from '../../utils/sortUtils';
 import { TableColumn } from '../common/Table/types';
 import {
     ColumnNameWrapper,
@@ -47,6 +48,8 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
         const isDescending = !!sort.descending;
         const isAscending = !isDescending;
 
+        const item = column?.meta?.item;
+
         return (
             <SortItemContainer
                 ref={ref}
@@ -70,7 +73,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                 </LabelWrapper>
 
                 <ColumnNameWrapper>
-                    <b>{column?.columnLabel || sort.fieldId}</b>
+                    {isField(item) ? item.label : item?.name || sort.fieldId}
                 </ColumnNameWrapper>
 
                 <StretchSpacer />
@@ -85,7 +88,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                                 : onAddSortField({ descending: false })
                         }
                     >
-                        A-Z
+                        {getSortLabel(item, SortDirection.ASC)}
                     </Button>
 
                     <Button
@@ -97,7 +100,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                                 : onAddSortField({ descending: true })
                         }
                     >
-                        Z-A
+                        {getSortLabel(item, SortDirection.DESC)}
                     </Button>
                 </ButtonGroup>
 

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -1,4 +1,4 @@
-import { FilterableField } from '@lightdash/common';
+import { Field, isField, TableCalculation } from '@lightdash/common';
 
 export enum SortDirection {
     ASC = 'ASC',
@@ -6,17 +6,21 @@ export enum SortDirection {
 }
 
 export const getSortLabel = (
-    item: FilterableField,
+    item: Field | TableCalculation | undefined,
     direction: SortDirection,
 ) => {
-    switch (item.type) {
-        case 'number':
-            return direction === SortDirection.ASC ? '1-9' : '9-1';
-        case 'string':
-            return direction === SortDirection.ASC ? 'A-Z' : 'Z-A';
-        default:
-            return direction === SortDirection.ASC
-                ? 'First-Last'
-                : 'Last-First';
+    if (isField(item)) {
+        switch (item.type) {
+            case 'number':
+                return direction === SortDirection.ASC ? '1-9' : '9-1';
+            case 'string':
+                return direction === SortDirection.ASC ? 'A-Z' : 'Z-A';
+            default:
+                return direction === SortDirection.ASC
+                    ? 'First-Last'
+                    : 'Last-First';
+        }
+    } else {
+        return direction === SortDirection.ASC ? 'Low-High' : 'Last-First';
     }
 };

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -1,0 +1,22 @@
+import { FilterableField } from '@lightdash/common';
+
+export enum SortDirection {
+    ASC = 'ASC',
+    DESC = 'DESC',
+}
+
+export const getSortLabel = (
+    item: FilterableField,
+    direction: SortDirection,
+) => {
+    switch (item.type) {
+        case 'number':
+            return direction === SortDirection.ASC ? '1-9' : '9-1';
+        case 'string':
+            return direction === SortDirection.ASC ? 'A-Z' : 'Z-A';
+        default:
+            return direction === SortDirection.ASC
+                ? 'First-Last'
+                : 'Last-First';
+    }
+};

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -1,24 +1,92 @@
-import { Field, isField, TableCalculation } from '@lightdash/common';
+import {
+    DimensionType,
+    Field,
+    isDimension,
+    isMetric,
+    MetricType,
+} from '@lightdash/common';
 
 export enum SortDirection {
     ASC = 'ASC',
     DESC = 'DESC',
 }
 
+enum NumericSortLabels {
+    ASC = '1-9',
+    DESC = '9-1',
+}
+
+enum StringSortLabels {
+    ASC = 'A-Z',
+    DESC = 'Z-A',
+}
+
+enum DateSortLabels {
+    ASC = 'Old-New',
+    DESC = 'New-Old',
+}
+
+enum DefaultSortLabels {
+    ASC = 'First-Last',
+    DESC = 'Last-First',
+}
+
+const assertUnreachable = (_x: never): never => {
+    throw new Error("Didn't expect to get here");
+};
+
 export const getSortLabel = (
-    item: Field | TableCalculation | undefined,
+    field: Field | undefined,
     direction: SortDirection,
 ) => {
-    if (isField(item)) {
-        switch (item.type) {
-            case 'number':
-                return direction === SortDirection.ASC ? '1-9' : '9-1';
-            case 'string':
-                return direction === SortDirection.ASC ? 'A-Z' : 'Z-A';
-            default:
+    if (isDimension(field)) {
+        switch (field.type) {
+            case DimensionType.NUMBER:
                 return direction === SortDirection.ASC
-                    ? 'First-Last'
-                    : 'Last-First';
+                    ? NumericSortLabels.ASC
+                    : NumericSortLabels.DESC;
+            case DimensionType.STRING:
+                return direction === SortDirection.ASC
+                    ? StringSortLabels.ASC
+                    : StringSortLabels.DESC;
+            case DimensionType.TIMESTAMP:
+            case DimensionType.DATE:
+                return direction === SortDirection.ASC
+                    ? DateSortLabels.ASC
+                    : DateSortLabels.DESC;
+            case DimensionType.BOOLEAN:
+                return direction === SortDirection.ASC
+                    ? DefaultSortLabels.ASC
+                    : DefaultSortLabels.DESC;
+            default:
+                return assertUnreachable(field.type);
+        }
+    } else if (isMetric(field)) {
+        switch (field.type) {
+            case MetricType.AVERAGE:
+            case MetricType.COUNT:
+            case MetricType.COUNT_DISTINCT:
+            case MetricType.SUM:
+            case MetricType.MIN:
+            case MetricType.MAX:
+            case MetricType.NUMBER:
+                return direction === SortDirection.ASC
+                    ? NumericSortLabels.ASC
+                    : NumericSortLabels.DESC;
+            case MetricType.STRING:
+                return direction === SortDirection.ASC
+                    ? StringSortLabels.ASC
+                    : StringSortLabels.DESC;
+            case MetricType.DATE:
+                return direction === SortDirection.ASC
+                    ? DateSortLabels.ASC
+                    : DateSortLabels.DESC;
+            case MetricType.BOOLEAN:
+                return direction === SortDirection.ASC
+                    ? DefaultSortLabels.ASC
+                    : DefaultSortLabels.DESC;
+            default:
+                return assertUnreachable(field.type);
         }
     } else {
         return direction === SortDirection.ASC ? 'Low-High' : 'Last-First';


### PR DESCRIPTION
Closes: #3140 

### Description:
adds proper sort indicators based on field type


<img width="552" alt="CleanShot 2022-09-05 at 20 07 02@2x" src="https://user-images.githubusercontent.com/962095/188487048-c8bc0018-04e1-4a32-a1e7-47b62e9e2f0a.png">
<img width="244" alt="CleanShot 2022-09-05 at 20 07 15@2x" src="https://user-images.githubusercontent.com/962095/188487056-1aed578e-5b22-403e-a804-3f2d61b48879.png">
<img width="229" alt="CleanShot 2022-09-05 at 20 07 21@2x" src="https://user-images.githubusercontent.com/962095/188487072-ca99887d-df31-4f2a-b788-0f346796deb9.png">
<img width="218" alt="CleanShot 2022-09-05 at 20 07 27@2x" src="https://user-images.githubusercontent.com/962095/188487084-283ab804-6db0-43b3-9a1f-79a121eb42db.png">
