### PR TITLE
feat: results table min cell width

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -29,6 +29,7 @@ const SimpleTable: FC = () => {
     return (
         <TableWrapper>
             <Table
+                isFullWidth
                 status={'success'}
                 data={rows}
                 columns={columns}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -5,13 +5,18 @@ import TableFooter from './TableFooter';
 import TableHeader from './TableHeader';
 
 const ScrollableTable = () => {
-    const { footer, scrollableWrapperRef } = useTableContext();
+    const { footer, isFullWidth, scrollableWrapperRef } = useTableContext();
 
     return (
         <TableScrollableWrapper
             ref={(ref) => (scrollableWrapperRef.current = ref || undefined)}
         >
-            <Table bordered condensed showFooter={!!footer?.show}>
+            <Table
+                bordered
+                condensed
+                showFooter={!!footer?.show}
+                isFullWidth={isFullWidth}
+            >
                 <TableHeader />
                 <TableBody />
                 <TableFooter />

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -152,7 +152,9 @@ export const ThActionsContainer = styled.div`
     }
 `;
 
-export const TableHeaderLabelContainer = styled.div``;
+export const TableHeaderLabelContainer = styled.div`
+    white-space: nowrap;
+`;
 
 export const TableHeaderRegularLabel = styled.span`
     font-weight: 400;

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -15,8 +15,14 @@ export const TableScrollableWrapper = styled.div`
     min-height: 90px;
 `;
 
-export const Table = styled(HTMLTable)<{ showFooter: boolean }>`
-    width: 100%;
+interface TableProps {
+    showFooter: boolean;
+    isFullWidth?: boolean;
+}
+
+export const Table = styled(HTMLTable)<TableProps>`
+    ${({ isFullWidth }) => (isFullWidth ? `width: 100%;` : '')}
+
     border-left: 1px solid #dcdcdd;
     border-right: 1px solid #dcdcdd;
 

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -33,6 +33,7 @@ type Props = {
         show?: boolean;
         defaultScroll?: boolean;
     };
+    isFullWidth?: boolean;
     footer?: {
         show?: boolean;
     };


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3052

### Description:
- removes 100% width by default from the tables.
  - removed width from results/underlying data/sql runner tables
  - its still 100% for table viz.
- adds nowrap to table cell header labels

@PriPatel
please watch the loom and let me know what you think.

https://www.loom.com/share/11139dfd1d6945779a5b1d8979279002

🤔 🤔 🤔 🤔 🤔 

- sql runner
<img width="598" alt="CleanShot 2022-09-06 at 19 01 05@2x" src="https://user-images.githubusercontent.com/962095/188669667-9ce1f1c1-e6eb-4a8e-a2aa-dec3b4e6f74b.png">

- underlying data
<img width="1437" alt="CleanShot 2022-09-06 at 18 57 59@2x" src="https://user-images.githubusercontent.com/962095/188669678-df296fb8-d82c-49f4-9fa5-b43e79e14d2e.png">

- table viz + results table
<img width="1030" alt="CleanShot 2022-09-06 at 18 57 54@2x" src="https://user-images.githubusercontent.com/962095/188669686-d3056d68-d62e-47fc-a6dd-291df458023e.png">

🤔 🤔 🤔 🤔 🤔 