### PR TITLE
feat: increase dashboard tile grid points

### DIFF
--- a/packages/backend/src/database/migrations/20220907161709_multiply-dashboard-tile-size.ts
+++ b/packages/backend/src/database/migrations/20220907161709_multiply-dashboard-tile-size.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+import { DashboardTilesTableName } from '../entities/dashboards';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex(DashboardTilesTableName).update({
+        // @ts-ignore
+        x_offset: knex.raw<number>('?? * 3', ['x_offset']),
+        // @ts-ignore
+        y_offset: knex.raw<number>('?? * 3', ['y_offset']),
+        // @ts-ignore
+        width: knex.raw<number>('?? * 3', ['width']),
+        // @ts-ignore
+        height: knex.raw<number>('?? * 3', ['height']),
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(DashboardTilesTableName).update({
+        // @ts-ignore
+        x_offset: knex.raw<number>('?? / 3', ['x_offset']),
+        // @ts-ignore
+        y_offset: knex.raw<number>('?? / 3', ['y_offset']),
+        // @ts-ignore
+        width: knex.raw<number>('?? / 3', ['width']),
+        // @ts-ignore
+        height: knex.raw<number>('?? / 3', ['height']),
+    });
+}

--- a/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
+++ b/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
@@ -43,8 +43,8 @@ export async function seed(knex: Knex): Promise<void> {
         uuid: uuidv4(),
         x: 0,
         y: 0,
-        w: 6,
-        h: 3,
+        w: 18,
+        h: 9,
         type: DashboardTileTypes.LOOM,
         properties: {
             title: 'Tutorial: Creating your first metrics and dimensions',
@@ -54,10 +54,10 @@ export async function seed(knex: Knex): Promise<void> {
 
     const markdownTile: DashboardMarkdownTile = {
         uuid: uuidv4(),
-        x: 6,
+        x: 18,
         y: 0,
-        w: 6,
-        h: 3,
+        w: 18,
+        h: 9,
         type: DashboardTileTypes.MARKDOWN,
         properties: {
             title: 'Welcome to Lightdash!',
@@ -68,9 +68,9 @@ export async function seed(knex: Knex): Promise<void> {
     const markdownRevenueTile: DashboardMarkdownTile = {
         uuid: uuidv4(),
         x: 0,
-        y: 3,
-        w: 12,
-        h: 1,
+        y: 9,
+        w: 36,
+        h: 3,
         type: DashboardTileTypes.MARKDOWN,
         properties: {
             title: '💸 Revenue',
@@ -81,19 +81,19 @@ export async function seed(knex: Knex): Promise<void> {
     const barChart: DashboardChartTile = {
         uuid: uuidv4(),
         x: 0,
-        y: 4,
-        w: 8,
-        h: 3,
+        y: 12,
+        w: 24,
+        h: 9,
         type: DashboardTileTypes.SAVED_CHART,
         properties: { savedChartUuid: queries[0].uuid },
     };
 
     const bigNumberTile: DashboardChartTile = {
         uuid: uuidv4(),
-        x: 8,
-        y: 4,
-        w: 4,
-        h: 3,
+        x: 24,
+        y: 12,
+        w: 12,
+        h: 9,
         type: DashboardTileTypes.SAVED_CHART,
         properties: { savedChartUuid: queries[1].uuid },
     };
@@ -101,19 +101,19 @@ export async function seed(knex: Knex): Promise<void> {
     const lineChartTile: DashboardChartTile = {
         uuid: uuidv4(),
         x: 0,
-        y: 8,
-        w: 6,
-        h: 3,
+        y: 24,
+        w: 18,
+        h: 9,
         type: DashboardTileTypes.SAVED_CHART,
         properties: { savedChartUuid: queries[2].uuid },
     };
 
     const barTile: DashboardChartTile = {
         uuid: uuidv4(),
-        x: 6,
-        y: 8,
-        w: 6,
-        h: 3,
+        x: 18,
+        y: 24,
+        w: 18,
+        h: 9,
         type: DashboardTileTypes.SAVED_CHART,
         properties: { savedChartUuid: queries[3].uuid },
     };
@@ -121,9 +121,9 @@ export async function seed(knex: Knex): Promise<void> {
     const tableTile: DashboardChartTile = {
         uuid: uuidv4(),
         x: 0,
-        y: 11,
-        w: 12,
-        h: 3,
+        y: 33,
+        w: 36,
+        h: 9,
         type: DashboardTileTypes.SAVED_CHART,
         properties: { savedChartUuid: queries[4].uuid },
     };
@@ -131,9 +131,9 @@ export async function seed(knex: Knex): Promise<void> {
     const markdownOrdersTile: DashboardMarkdownTile = {
         uuid: uuidv4(),
         x: 0,
-        y: 7,
-        w: 12,
-        h: 1,
+        y: 21,
+        w: 36,
+        h: 3,
         type: DashboardTileTypes.MARKDOWN,
         properties: {
             title: '📨 Orders',

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -131,8 +131,8 @@ export const isDashboardVersionedFields = (
 ): data is DashboardVersionedFields => 'tiles' in data && !!data.tiles;
 
 export const defaultTileSize = {
-    h: 3,
-    w: 5,
+    h: 9,
+    w: 15,
     x: 0,
     y: 0,
 };
@@ -143,8 +143,8 @@ export const getDefaultChartTileSize = (
     switch (chartType) {
         case 'big_number':
             return {
-                h: 2,
-                w: 3,
+                h: 6,
+                w: 9,
                 x: 0,
                 y: 0,
             };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -122,6 +122,8 @@ const Dashboard = () => {
     const layouts = useMemo(
         () => ({
             lg: dashboardTiles.map<Layout>((tile) => ({
+                minH: 2,
+                minW: 6,
                 x: tile.x,
                 y: tile.y,
                 w: tile.w,
@@ -379,7 +381,8 @@ const Dashboard = () => {
                     onDragStop={updateTiles}
                     onResizeStop={updateTiles}
                     breakpoints={{ lg: 1200, md: 996, sm: 768 }}
-                    cols={{ lg: 12, md: 10, sm: 6 }}
+                    cols={{ lg: 36, md: 30, sm: 18 }}
+                    rowHeight={50}
                     layouts={layouts}
                 >
                     {dashboardTiles.map((tile) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2954 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- Increased grid points by 3x.
   - Height increases by 50px ( before 150px )
   - Width has 36 points relative to window width ( before 12 ) 
- Set min width and height with sane values
  - Height 100px
  - Width 6 points 
- migrate all tiles to match the new scale



![tile grid](https://user-images.githubusercontent.com/9117144/188938250-e60f3154-6266-4c16-b2bb-e719e8de9336.gif)
