### PR TITLE
fix: member role migration rollback

### DIFF
--- a/packages/backend/src/database/migrations/20220615070629_add_member_role.ts
+++ b/packages/backend/src/database/migrations/20220615070629_add_member_role.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 
+const organizationMembershipsTableName = 'organization_memberships';
 const organizationMembershipRolesTableName = 'organization_membership_roles';
 
 export async function up(knex: Knex): Promise<void> {
@@ -7,6 +8,9 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex(organizationMembershipsTableName)
+        .update('role', 'viewer')
+        .where('role', 'member');
     await knex(organizationMembershipRolesTableName)
         .where('role', 'member')
         .delete();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3187 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Make sure we update all users role from `member` to `viewer` before deleting the `member` role.
