### PR TITLE
feat: multisort for booleans

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -12,7 +12,11 @@ import { useFilters } from '../../../hooks/useFilters';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
-import { getSortLabel, SortDirection } from '../../../utils/sortUtils';
+import {
+    getSortDirectionOrder,
+    getSortLabel,
+    SortDirection,
+} from '../../../utils/sortUtils';
 import { HeaderProps, TableColumn } from '../../common/Table/types';
 import {
     DeleteTableCalculationModal,
@@ -56,8 +60,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
     if (item && isField(item) && isFilterableField(item)) {
         const sort = meta.sort?.sort;
         const hasSort = !!sort;
-        const isAscending = hasSort && !sort.descending;
-        const isDescending = hasSort && sort.descending;
+        const selectedSortDirection = sort
+            ? sort.descending
+                ? SortDirection.DESC
+                : SortDirection.ASC
+            : undefined;
         const itemFieldId = fieldId(item);
 
         return (
@@ -77,41 +84,30 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 <Divider />
 
-                <MenuItem2
-                    roleStructure="listoption"
-                    selected={hasSort && isAscending}
-                    text={
-                        <>
-                            Sort{' '}
-                            <BolderLabel>
-                                {getSortLabel(item, SortDirection.ASC)}
-                            </BolderLabel>
-                        </>
-                    }
-                    onClick={() =>
-                        hasSort && isAscending
-                            ? removeSortField(itemFieldId)
-                            : addSortField(itemFieldId, { descending: false })
-                    }
-                />
-
-                <MenuItem2
-                    roleStructure="listoption"
-                    selected={hasSort && isDescending}
-                    text={
-                        <>
-                            Sort{' '}
-                            <BolderLabel>
-                                {getSortLabel(item, SortDirection.DESC)}
-                            </BolderLabel>
-                        </>
-                    }
-                    onClick={() =>
-                        hasSort && isDescending
-                            ? removeSortField(itemFieldId)
-                            : addSortField(itemFieldId, { descending: true })
-                    }
-                />
+                {getSortDirectionOrder(item).map((sortDirection) => (
+                    <MenuItem2
+                        key={sortDirection}
+                        roleStructure="listoption"
+                        selected={
+                            hasSort && selectedSortDirection === sortDirection
+                        }
+                        text={
+                            <>
+                                Sort{' '}
+                                <BolderLabel>
+                                    {getSortLabel(item, sortDirection)}
+                                </BolderLabel>
+                            </>
+                        }
+                        onClick={() =>
+                            hasSort && selectedSortDirection === sortDirection
+                                ? removeSortField(itemFieldId)
+                                : addSortField(itemFieldId, {
+                                      descending: false,
+                                  })
+                        }
+                    />
+                ))}
 
                 <Divider />
 

--- a/packages/frontend/src/components/SortButton/SortButton.styles.ts
+++ b/packages/frontend/src/components/SortButton/SortButton.styles.ts
@@ -11,7 +11,7 @@ export const PopoverGlobalStyles = createGlobalStyle`
 
 export const StyledButtonGroup = styled(ButtonGroup)`
     button {
-        min-width: 70px !important;
+        min-width: 60px !important;
         font-size: 12px;
     }
 `;

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -6,7 +6,11 @@ import {
     DraggableProvidedDragHandleProps,
 } from 'react-beautiful-dnd';
 import { ExplorerContext } from '../../providers/ExplorerProvider';
-import { getSortLabel, SortDirection } from '../../utils/sortUtils';
+import {
+    getSortDirectionOrder,
+    getSortLabel,
+    SortDirection,
+} from '../../utils/sortUtils';
 import { TableColumn } from '../common/Table/types';
 import {
     ColumnNameWrapper,
@@ -46,8 +50,9 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
         },
         ref,
     ) => {
-        const isDescending = !!sort.descending;
-        const isAscending = !isDescending;
+        const selectedSortDirection = sort.descending
+            ? SortDirection.DESC
+            : SortDirection.ASC;
 
         const item = column?.meta?.item;
 
@@ -84,29 +89,27 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                 <StretchSpacer />
 
                 <StyledButtonGroup>
-                    <Button
-                        small
-                        intent={isAscending ? 'primary' : 'none'}
-                        onClick={() =>
-                            isAscending
-                                ? undefined
-                                : onAddSortField({ descending: false })
-                        }
-                    >
-                        {getSortLabel(item, SortDirection.ASC)}
-                    </Button>
-
-                    <Button
-                        small
-                        intent={isDescending ? 'primary' : 'none'}
-                        onClick={() =>
-                            isDescending
-                                ? undefined
-                                : onAddSortField({ descending: true })
-                        }
-                    >
-                        {getSortLabel(item, SortDirection.DESC)}
-                    </Button>
+                    {getSortDirectionOrder(item).map((direction) => (
+                        <Button
+                            key={direction}
+                            small
+                            intent={
+                                selectedSortDirection === direction
+                                    ? 'primary'
+                                    : 'none'
+                            }
+                            onClick={() =>
+                                selectedSortDirection === direction
+                                    ? undefined
+                                    : onAddSortField({
+                                          descending:
+                                              direction === SortDirection.DESC,
+                                      })
+                            }
+                        >
+                            {getSortLabel(item, direction)}
+                        </Button>
+                    ))}
                 </StyledButtonGroup>
 
                 <Spacer $width={6} />

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -96,6 +96,6 @@ export const getSortLabel = (field: Field, direction: SortDirection) => {
                 return assertUnreachable(field.type);
         }
     } else {
-        return direction === SortDirection.ASC ? 'Low-High' : 'Last-First';
+        throw new Error('Field is not a Dimension or Metric');
     }
 };

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -11,6 +11,16 @@ export enum SortDirection {
     DESC = 'DESC',
 }
 
+export const getSortDirectionOrder = (field: Field) => {
+    switch (field.type) {
+        case DimensionType.BOOLEAN:
+        case MetricType.BOOLEAN:
+            return [SortDirection.DESC, SortDirection.ASC];
+        default:
+            return [SortDirection.ASC, SortDirection.DESC];
+    }
+};
+
 enum NumericSortLabels {
     ASC = '1-9',
     DESC = '9-1',
@@ -26,19 +36,16 @@ enum DateSortLabels {
     DESC = 'New-Old',
 }
 
-enum DefaultSortLabels {
-    ASC = 'First-Last',
-    DESC = 'Last-First',
+enum BooleanSortLabels {
+    ASC = 'No-Yes',
+    DESC = 'Yes-No',
 }
 
 const assertUnreachable = (_x: never): never => {
     throw new Error("Didn't expect to get here");
 };
 
-export const getSortLabel = (
-    field: Field | undefined,
-    direction: SortDirection,
-) => {
+export const getSortLabel = (field: Field, direction: SortDirection) => {
     if (isDimension(field)) {
         switch (field.type) {
             case DimensionType.NUMBER:
@@ -56,8 +63,8 @@ export const getSortLabel = (
                     : DateSortLabels.DESC;
             case DimensionType.BOOLEAN:
                 return direction === SortDirection.ASC
-                    ? DefaultSortLabels.ASC
-                    : DefaultSortLabels.DESC;
+                    ? BooleanSortLabels.ASC
+                    : BooleanSortLabels.DESC;
             default:
                 return assertUnreachable(field.type);
         }
@@ -83,8 +90,8 @@ export const getSortLabel = (
                     : DateSortLabels.DESC;
             case MetricType.BOOLEAN:
                 return direction === SortDirection.ASC
-                    ? DefaultSortLabels.ASC
-                    : DefaultSortLabels.DESC;
+                    ? BooleanSortLabels.ASC
+                    : BooleanSortLabels.DESC;
             default:
                 return assertUnreachable(field.type);
         }


### PR DESCRIPTION
### Description:

previously: 
![image](https://user-images.githubusercontent.com/962095/189604954-094095e8-c342-4e55-8104-66ff66ad78d8.png)
![image](https://user-images.githubusercontent.com/962095/189604972-f49944ca-b791-45ba-8364-818c37579019.png)

- Flips sort order for boolean fields. (because false is Ascending and true is Descending)
- Changes boolean labels from First-Last to Yes-No