### PR TITLE
fix(2829): `group` should be unavailable if you only have dimensions in your chart

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -1,11 +1,16 @@
 import {
     Button,
     ButtonGroup,
+    Callout,
     Colors,
     FormGroup,
     Switch,
 } from '@blueprintjs/core';
 import styled from 'styled-components';
+
+type CustomAxisGroup = {
+    disabled?: boolean;
+};
 
 export const InputWrapper = styled(FormGroup)`
     margin: 1.357em 0 0;
@@ -44,8 +49,19 @@ export const GridFieldLabel = styled.span`
     }
 `;
 
-export const AxisGroup = styled.div`
+export const AxisGroup = styled.div<CustomAxisGroup>`
     margin-top: 1.286em;
+
+    ${({ disabled }) =>
+        disabled &&
+        `
+        opacity: 0.4;
+        pointer-events: none;
+    `}
+`;
+
+export const GroupInfoCallout = styled(Callout)`
+    margin-top: 5px;
 `;
 
 export const AxisTitleWrapper = styled.div`

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -1,11 +1,11 @@
 import {
     Button,
     ButtonGroup,
-    Callout,
     Colors,
     FormGroup,
     Switch,
 } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 
 type CustomAxisGroup = {
@@ -60,8 +60,8 @@ export const AxisGroup = styled.div<CustomAxisGroup>`
     `}
 `;
 
-export const GroupInfoCallout = styled(Callout)`
-    margin-top: 5px;
+export const BlockTooltip = styled(Tooltip2)`
+    display: block !important;
 `;
 
 export const AxisTitleWrapper = styled.div`

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -8,10 +8,6 @@ import {
 import { Tooltip2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 
-type CustomAxisGroup = {
-    disabled?: boolean;
-};
-
 export const InputWrapper = styled(FormGroup)`
     margin: 1.357em 0 0;
     & label.bp4-label {
@@ -49,15 +45,8 @@ export const GridFieldLabel = styled.span`
     }
 `;
 
-export const AxisGroup = styled.div<CustomAxisGroup>`
+export const AxisGroup = styled.div`
     margin-top: 1.286em;
-
-    ${({ disabled }) =>
-        disabled &&
-        `
-        opacity: 0.4;
-        pointer-events: none;
-    `}
 `;
 
 export const BlockTooltip = styled(Tooltip2)`

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -2,7 +2,6 @@ import { Button } from '@blueprintjs/core';
 import {
     CartesianSeriesType,
     Field,
-    FieldType,
     getItemId,
     isDimension,
     TableCalculation,
@@ -84,7 +83,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         return items.filter((item) => isDimension(item));
     }, [items]);
 
-    const chartInvolvesMetrics = useMemo(() => {
+    const chartHasMetricOrTableCalc = useMemo(() => {
         if (!validCartesianConfig) return false;
 
         const {
@@ -94,9 +93,9 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         if (!xField || !yField) return false;
 
         const chartAxes = [xField, ...yField];
-        return items
-            .filter((item) => (item as Field)?.fieldType === FieldType.METRIC)
-            .some((metric) => chartAxes.includes(getItemId(metric)));
+        return items.some(
+            (item) => !isDimension(item) && chartAxes.includes(getItemId(item)),
+        );
     }, [validCartesianConfig, items]);
 
     return (
@@ -171,7 +170,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
             </AxisGroup>
             <BlockTooltip
                 content="You need at least one metric in your chart to add a group"
-                disabled={chartInvolvesMetrics}
+                disabled={chartHasMetricOrTableCalc}
             >
                 <AxisGroup>
                     <AxisTitle>Group</AxisTitle>
@@ -180,14 +179,14 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                             fields={availableDimensions}
                             placeholder="Select a field to group by"
                             activeField={
-                                chartInvolvesMetrics
+                                chartHasMetricOrTableCalc
                                     ? groupSelectedField
                                     : undefined
                             }
                             onChange={(item) => {
                                 setPivotDimensions([getItemId(item)]);
                             }}
-                            disabled={!chartInvolvesMetrics}
+                            disabled={!chartHasMetricOrTableCalc}
                         />
                         {groupSelectedField && (
                             <DeleteFieldButton

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -18,6 +18,7 @@ import {
     AxisTitleWrapper,
     DeleteFieldButton,
     GridLabel,
+    GroupInfoCallout,
     StackButton,
     StackingWrapper,
 } from './ChartConfigPanel.styles';
@@ -156,7 +157,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                     </Button>
                 )}
             </AxisGroup>
-            <AxisGroup>
+            <AxisGroup disabled>
                 <AxisTitle>Group</AxisTitle>
                 <AxisFieldDropdown>
                     <FieldAutoComplete
@@ -178,6 +179,9 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                     )}
                 </AxisFieldDropdown>
             </AxisGroup>
+            <GroupInfoCallout icon="help">
+                You need at least one metric in your chart to add a group
+            </GroupInfoCallout>
             {pivotDimension && canBeStacked && (
                 <AxisGroup>
                     <GridLabel>Stacking</GridLabel>

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -2,8 +2,8 @@ import { Button } from '@blueprintjs/core';
 import {
     CartesianSeriesType,
     Field,
+    FieldType,
     getItemId,
-    getMetrics,
     isDimension,
     TableCalculation,
 } from '@lightdash/common';
@@ -86,7 +86,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
     }, [items]);
 
     const chartInvolvesMetrics = useMemo(() => {
-        if (!validCartesianConfig || !explore) return false;
+        if (!validCartesianConfig) return false;
 
         const {
             layout: { xField, yField },
@@ -95,10 +95,10 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         if (!xField || !yField) return false;
 
         const chartAxes = [xField, ...yField];
-        return getMetrics(explore).some((metric) =>
-            chartAxes.includes(getItemId(metric)),
-        );
-    }, [validCartesianConfig, explore]);
+        return items
+            .filter((item) => (item as Field)?.fieldType === FieldType.METRIC)
+            .some((metric) => chartAxes.includes(getItemId(metric)));
+    }, [validCartesianConfig, items]);
 
     return (
         <>

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -43,7 +43,6 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         pivotDimensions,
         cartesianConfig,
         setPivotDimensions,
-        explore,
     } = useVisualizationContext();
 
     const pivotDimension = pivotDimensions?.[0];

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -45,6 +45,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         setPivotDimensions,
         explore,
     } = useVisualizationContext();
+
     const pivotDimension = pivotDimensions?.[0];
 
     const cartesianType = cartesianConfig.dirtyChartType;
@@ -95,7 +96,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
 
         const chartAxes = [xField, ...yField];
         return getMetrics(explore).some((metric) =>
-            chartAxes.includes(`${metric.table}_${metric.name}`),
+            chartAxes.includes(getItemId(metric)),
         );
     }, [validCartesianConfig, explore]);
 

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -87,14 +87,13 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
         if (!validCartesianConfig) return false;
 
         const {
-            layout: { xField, yField },
+            layout: { yField },
         } = validCartesianConfig;
 
-        if (!xField || !yField) return false;
+        if (!yField) return false;
 
-        const chartAxes = [xField, ...yField];
         return items.some(
-            (item) => !isDimension(item) && chartAxes.includes(getItemId(item)),
+            (item) => !isDimension(item) && yField.includes(getItemId(item)),
         );
     }, [validCartesianConfig, items]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 --> https://github.com/lightdash/lightdash/issues/2829

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Disable group option in configure chart if no metrics in chart

<details>
<summary>Screenshot</summary>
<br />
<img width="881" alt="Screenshot 2022-09-16 at 8 19 31 PM" src="https://user-images.githubusercontent.com/62111075/190667333-f02ac262-b610-4079-92a2-75c7e1c4057f.png">
</details> 
