### PR TITLE
feat: resource list empty states

### DIFF
--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -15,7 +15,6 @@ describe('Dashboard', () => {
         // wiat for the dashboard to load
         cy.findByText('Loading dashboards').should('not.exist');
 
-        cy.contains('a', 'Jaffle dashboard').should('exist').wait(1000); // TODO: hack for react-table rerenders
         cy.contains('a', 'Jaffle dashboard').click();
 
         cy.findByText("What's our total revenue to date?");

--- a/packages/e2e/cypress/e2e/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/savedDashboards.cy.ts
@@ -34,7 +34,6 @@ describe('Dashboard List', () => {
         cy.findByRole('button', { name: 'Browse' }).click();
         cy.findByRole('menuitem', { name: 'All dashboards' }).click();
         // open actions menu
-        cy.contains('tr', 'Untitled dashboard').find('button').wait(1000); // TODO: hack for react-table rerenders
         cy.contains('tr', 'Untitled dashboard').find('button').click();
         // click on rename
         cy.findByRole('button', { name: 'Rename' }).click();
@@ -51,7 +50,6 @@ describe('Dashboard List', () => {
         cy.findByRole('button', { name: 'Browse' }).click();
         cy.findByRole('menuitem', { name: 'All dashboards' }).click();
         // open actions menu
-        cy.contains('tr', 'e2e dashboard').find('button').wait(1000); // TODO: hack for react-table rerenders
         cy.contains('tr', 'e2e dashboard').find('button').click();
         // click on delete
         cy.findByRole('button', { name: 'Delete' }).click();

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -61,6 +61,7 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             {spaces.length === 0 ? (
                 <ResourceEmptyState
                     resourceType="space"
+                    resourceIcon="folder-close"
                     onClickCTA={handleCreateSpace}
                 />
             ) : (

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -49,7 +49,7 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             }
         >
             <SpaceListWrapper>
-                {spaces?.map(({ uuid, name, dashboards, queries }) => (
+                {spaces.map(({ uuid, name, dashboards, queries }) => (
                     <SpaceItem
                         key={uuid}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@blueprintjs/core';
+import { AnchorButton, Button } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
 import { FC, useState } from 'react';
@@ -25,7 +25,14 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             headerTitle="Spaces"
             showCount={false}
             headerAction={
-                !isDemo && (
+                spaces.length === 0 ? (
+                    <AnchorButton
+                        text="Learn"
+                        minimal
+                        target="_blank"
+                        href="https://docs.lightdash.com/guides/spaces/"
+                    />
+                ) : !isDemo ? (
                     <Can
                         I="create"
                         this={subject('Space', {
@@ -45,7 +52,7 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                             Create new
                         </Button>
                     </Can>
-                )
+                ) : null
             }
         >
             <SpaceListWrapper>

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -5,6 +5,7 @@ import { FC, useState } from 'react';
 import { useSpaces } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
+import ResourceEmptyState from '../../common/ResourceList/ResourceEmptyState';
 import ResourceListWrapper from '../../common/ResourceList/ResourceListWrapper';
 import { CreateSpaceModal } from './CreateSpaceModal';
 import { DeleteSpaceModal } from './DeleteSpaceModal';
@@ -19,6 +20,10 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { data: spaces = [], isLoading } = useSpaces(projectUuid);
     const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
     const isDemo = health.data?.mode === LightdashMode.DEMO;
+
+    const handleCreateSpace = () => {
+        setIsCreateModalOpen(true);
+    };
 
     return (
         <ResourceListWrapper
@@ -45,9 +50,7 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                             intent="primary"
                             icon="plus"
                             loading={isLoading}
-                            onClick={() => {
-                                setIsCreateModalOpen(true);
-                            }}
+                            onClick={handleCreateSpace}
                         >
                             Create new
                         </Button>
@@ -55,20 +58,27 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 ) : null
             }
         >
-            <SpaceListWrapper>
-                {spaces.map(({ uuid, name, dashboards, queries }) => (
-                    <SpaceItem
-                        key={uuid}
-                        projectUuid={projectUuid}
-                        uuid={uuid}
-                        name={name}
-                        dashboardsCount={dashboards.length}
-                        queriesCount={queries.length}
-                        onRename={() => setUpdateSpaceUuid(uuid)}
-                        onDelete={() => setDeleteSpaceUuid(uuid)}
-                    />
-                ))}
-            </SpaceListWrapper>
+            {spaces.length === 0 ? (
+                <ResourceEmptyState
+                    resourceType="space"
+                    onClickCTA={handleCreateSpace}
+                />
+            ) : (
+                <SpaceListWrapper>
+                    {spaces.map(({ uuid, name, dashboards, queries }) => (
+                        <SpaceItem
+                            key={uuid}
+                            projectUuid={projectUuid}
+                            uuid={uuid}
+                            name={name}
+                            dashboardsCount={dashboards.length}
+                            queriesCount={queries.length}
+                            onRename={() => setUpdateSpaceUuid(uuid)}
+                            onDelete={() => setDeleteSpaceUuid(uuid)}
+                        />
+                    ))}
+                </SpaceListWrapper>
+            )}
 
             <CreateSpaceModal
                 isOpen={isCreateModalOpen}

--- a/packages/frontend/src/components/Home/LandingPanel/LandingPanel.styles.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/LandingPanel.styles.tsx
@@ -1,5 +1,6 @@
 import { Colors, H3 } from '@blueprintjs/core';
 import styled from 'styled-components';
+import LinkButton from '../../common/LinkButton';
 
 export const LandingPanelWrapper = styled.div`
     width: 54.857em;
@@ -23,4 +24,8 @@ export const Title = styled(H3)`
 
 export const Intro = styled.p`
     color: ${Colors.GRAY1};
+`;
+
+export const StyledLinkButton = styled(LinkButton)`
+    font-size: 14px !important;
 `;

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import LinkButton from '../../common/LinkButton';
 import SpaceBrowser from '../../Explorer/SpaceBrowser';
 import LatestDashboards from '../LatestDashboards';
 import LatestSavedCharts from '../LatestSavedCharts';
@@ -7,6 +6,7 @@ import {
     Intro,
     LandingHeaderWrapper,
     LandingPanelWrapper,
+    StyledLinkButton,
     Title,
     WelcomeText,
 } from './LandingPanel.styles';
@@ -34,14 +34,14 @@ const LandingPanel: FC<Props> = ({ hasSavedChart, userName, projectUuid }) => {
                     </Intro>
                 </WelcomeText>
 
-                <LinkButton
+                <StyledLinkButton
                     large
                     href={`/projects/${projectUuid}/tables`}
                     intent="primary"
-                    icon="database"
+                    icon="series-search"
                 >
                     Run a query
-                </LinkButton>
+                </StyledLinkButton>
             </LandingHeaderWrapper>
 
             <SpaceBrowser projectUuid={projectUuid} />

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -12,12 +12,11 @@ import {
 } from './LandingPanel.styles';
 
 interface Props {
-    hasSavedChart: boolean;
     userName: string | undefined;
     projectUuid: string;
 }
 
-const LandingPanel: FC<Props> = ({ hasSavedChart, userName, projectUuid }) => {
+const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
     return (
         <LandingPanelWrapper>
             <LandingHeaderWrapper>
@@ -46,7 +45,7 @@ const LandingPanel: FC<Props> = ({ hasSavedChart, userName, projectUuid }) => {
 
             <SpaceBrowser projectUuid={projectUuid} />
 
-            {hasSavedChart && <LatestDashboards projectUuid={projectUuid} />}
+            <LatestDashboards projectUuid={projectUuid} />
 
             <LatestSavedCharts projectUuid={projectUuid} />
         </LandingPanelWrapper>

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -14,9 +14,10 @@ import {
 interface Props {
     userName: string | undefined;
     projectUuid: string;
+    hasSavedChart: boolean;
 }
 
-const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
+const LandingPanel: FC<Props> = ({ userName, projectUuid, hasSavedChart }) => {
     return (
         <LandingPanelWrapper>
             <LandingHeaderWrapper>
@@ -45,7 +46,7 @@ const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
 
             <SpaceBrowser projectUuid={projectUuid} />
 
-            <LatestDashboards projectUuid={projectUuid} />
+            {hasSavedChart && <LatestDashboards projectUuid={projectUuid} />}
 
             <LatestSavedCharts projectUuid={projectUuid} />
         </LandingPanelWrapper>

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -2,6 +2,7 @@ import { AnchorButton } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
 import { FC, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useSavedCharts } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import LinkButton from '../../common/LinkButton';
@@ -13,6 +14,7 @@ interface Props {
 
 const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
     const { user, health } = useApp();
+    const history = useHistory();
     const isDemo = health.data?.mode === LightdashMode.DEMO;
     const { data: savedCharts = [] } = useSavedCharts(projectUuid);
 
@@ -34,6 +36,10 @@ const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
             projectUuid,
         }),
     );
+
+    const handleCreateChart = () => {
+        history.push(`/projects/${projectUuid}/tables`);
+    };
 
     return (
         <ResourceList
@@ -61,6 +67,9 @@ const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
                         href={`/projects/${projectUuid}/saved`}
                     />
                 ) : null
+            }
+            onClickCTA={
+                !isDemo && userCanManageCharts ? handleCreateChart : undefined
             }
         />
     );

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -1,47 +1,67 @@
 import { AnchorButton } from '@blueprintjs/core';
-import { FC } from 'react';
+import { subject } from '@casl/ability';
+import { LightdashMode } from '@lightdash/common';
+import { FC, useMemo } from 'react';
 import { useSavedCharts } from '../../../hooks/useSpaces';
+import { useApp } from '../../../providers/AppProvider';
 import LinkButton from '../../common/LinkButton';
 import ResourceList from '../../common/ResourceList';
 
-const LatestSavedCharts: FC<{ projectUuid: string }> = ({ projectUuid }) => {
-    const savedChartsRequest = useSavedCharts(projectUuid);
-    const savedCharts = savedChartsRequest.data || [];
-    const featuredCharts = savedCharts
-        .sort(
-            (a, b) =>
-                new Date(b.updatedAt).getTime() -
-                new Date(a.updatedAt).getTime(),
-        )
-        .slice(0, 5);
+interface Props {
+    projectUuid: string;
+}
+
+const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
+    const { user, health } = useApp();
+    const isDemo = health.data?.mode === LightdashMode.DEMO;
+    const { data: savedCharts = [] } = useSavedCharts(projectUuid);
+
+    const featuredCharts = useMemo(() => {
+        return savedCharts
+            .sort((a, b) => {
+                return (
+                    new Date(b.updatedAt).getTime() -
+                    new Date(a.updatedAt).getTime()
+                );
+            })
+            .slice(0, 5);
+    }, [savedCharts]);
+
+    const userCanManageCharts = user.data?.ability?.can(
+        'manage',
+        subject('SavedChart', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
 
     return (
         <ResourceList
             resourceIcon="chart"
-            resourceType="saved_chart"
+            resourceType="chart"
             resourceList={featuredCharts}
             showSpaceColumn
             enableSorting={false}
             showCount={false}
+            getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
             headerTitle="Recently updated charts"
             headerAction={
-                savedCharts.length > 0 ? (
-                    <LinkButton
-                        text={`View all ${savedCharts.length}`}
-                        minimal
-                        intent="primary"
-                        href={`/projects/${projectUuid}/saved`}
-                    />
-                ) : (
+                savedCharts.length === 0 ? (
                     <AnchorButton
                         target="_blank"
                         text="Learn"
                         minimal
                         href="https://docs.lightdash.com/get-started/exploring-data/sharing-insights"
                     />
-                )
+                ) : userCanManageCharts && !isDemo ? (
+                    <LinkButton
+                        text={`View all ${savedCharts.length}`}
+                        minimal
+                        intent="primary"
+                        href={`/projects/${projectUuid}/saved`}
+                    />
+                ) : null
             }
-            getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
         />
     );
 };

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -44,6 +44,22 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
     const [addToSpace, setAddToSpace] = useState<AddToSpaceResources>();
     const [createToSpace, setCreateToSpace] = useState<AddToSpaceResources>();
 
+    const userCanManageDashboards = user.data?.ability?.can(
+        'manage',
+        subject('Dashboard', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
+    const userCanManageCharts = user.data?.ability?.can(
+        'manage',
+        subject('SavedChart', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
     return (
         <PageContentWrapper>
             <PageHeader>
@@ -107,8 +123,8 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                     `/projects/${projectUuid}/dashboards/${uuid}/view`
                 }
                 headerAction={
-                    user.data?.ability?.can('manage', 'Dashboard') &&
-                    !isDemo && (
+                    !isDemo &&
+                    userCanManageDashboards && (
                         <AddResourceToSpaceMenu
                             resourceType={AddToSpaceResources.DASHBOARD}
                             onAdd={() =>
@@ -128,11 +144,11 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                 headerTitle="Saved charts"
                 resourceList={orderedCharts}
                 resourceIcon="chart"
-                resourceType="saved_chart"
+                resourceType="chart"
                 getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
                 headerAction={
                     !isDemo &&
-                    user.data?.ability?.can('manage', 'SavedChart') && (
+                    userCanManageCharts && (
                         <AddResourceToSpaceMenu
                             resourceType={AddToSpaceResources.CHART}
                             onAdd={() =>

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -119,6 +119,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                 resourceIcon="control"
                 resourceType="dashboard"
                 resourceList={savedDashboards}
+                showSpaceColumn={false}
                 getURL={({ uuid }) =>
                     `/projects/${projectUuid}/dashboards/${uuid}/view`
                 }
@@ -145,6 +146,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                 resourceList={orderedCharts}
                 resourceIcon="chart"
                 resourceType="chart"
+                showSpaceColumn={false}
                 getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
                 headerAction={
                     !isDemo &&

--- a/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.styles.ts
@@ -1,0 +1,20 @@
+import { Colors, H4, Icon } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+interface EmptyStateWrapperProps {
+    $large?: boolean;
+}
+
+export const EmptyStateWrapper = styled.div<EmptyStateWrapperProps>`
+    margin: ${(props) => (props.$large ? '40px' : '20px')} auto;
+`;
+
+export const EmptyStateIcon = styled(Icon)`
+    path {
+        fill: ${Colors.GRAY3};
+    }
+`;
+
+export const EmptyStateText = styled(H4)`
+    margin: 18px auto;
+`;

--- a/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
@@ -7,11 +7,9 @@ import {
     EmptyStateWrapper,
 } from './ResourceEmptyState.styles';
 
-type Props = Pick<
-    ResourceListProps,
-    'headerAction' | 'resourceIcon' | 'onClickCTA'
-> & {
+type Props = Pick<ResourceListProps, 'headerAction' | 'onClickCTA'> & {
     resourceType: ResourceListProps['resourceType'] | 'space';
+    resourceIcon?: ResourceListProps['resourceIcon'];
 };
 
 const ResourceEmptyState: FC<Props> = ({
@@ -24,7 +22,9 @@ const ResourceEmptyState: FC<Props> = ({
             <NonIdealState
                 description={
                     <EmptyStateWrapper>
-                        <EmptyStateIcon icon={resourceIcon} size={40} />
+                        {resourceIcon && (
+                            <EmptyStateIcon icon={resourceIcon} size={40} />
+                        )}
 
                         <EmptyStateText>
                             No {resourceType}s added yet

--- a/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
@@ -1,0 +1,43 @@
+import { Icon, NonIdealState } from '@blueprintjs/core';
+import { FC } from 'react';
+import { ResourceListProps } from '.';
+import {
+    EmptyStateIcon,
+    EmptyStateText,
+    EmptyStateWrapper,
+} from './ResourceEmptyState.styles';
+
+type Props = Pick<
+    ResourceListProps,
+    'headerAction' | 'resourceType' | 'resourceIcon'
+> & {
+    onClickCTA?: () => void;
+};
+
+const ResourceEmptyState: FC<Props> = ({
+    resourceType,
+    resourceIcon,
+    onClickCTA,
+}) => {
+    return (
+        <EmptyStateWrapper>
+            <NonIdealState
+                description={
+                    <EmptyStateWrapper>
+                        <EmptyStateIcon icon={resourceIcon} size={40} />
+
+                        <EmptyStateText>
+                            No {resourceType}s added yet
+                        </EmptyStateText>
+
+                        <p>
+                            Hit <Icon icon="plus" size={14} /> to get started.
+                        </p>
+                    </EmptyStateWrapper>
+                }
+            />
+        </EmptyStateWrapper>
+    );
+};
+
+export default ResourceEmptyState;

--- a/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
@@ -1,4 +1,4 @@
-import { Icon, NonIdealState } from '@blueprintjs/core';
+import { Button, NonIdealState } from '@blueprintjs/core';
 import { FC } from 'react';
 import { ResourceListProps } from '.';
 import {
@@ -9,9 +9,9 @@ import {
 
 type Props = Pick<
     ResourceListProps,
-    'headerAction' | 'resourceType' | 'resourceIcon'
+    'headerAction' | 'resourceIcon' | 'onClickCTA'
 > & {
-    onClickCTA?: () => void;
+    resourceType: ResourceListProps['resourceType'] | 'space';
 };
 
 const ResourceEmptyState: FC<Props> = ({
@@ -30,9 +30,14 @@ const ResourceEmptyState: FC<Props> = ({
                             No {resourceType}s added yet
                         </EmptyStateText>
 
-                        <p>
-                            Hit <Icon icon="plus" size={14} /> to get started.
-                        </p>
+                        {onClickCTA && (
+                            <Button
+                                text={`Create ${resourceType}`}
+                                icon="plus"
+                                intent="primary"
+                                onClick={onClickCTA}
+                            />
+                        )}
                     </EmptyStateWrapper>
                 }
             />

--- a/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
@@ -67,12 +67,12 @@ export const ResourceSpaceLink = styled(Link)`
 `;
 
 export const EmptyStateWrapper = styled.div`
-    padding: 20px;
+    margin: 20px;
 `;
 
 export const EmptyStateIcon = styled(Icon)`
     path {
-        fill: ${Colors.LIGHT_GRAY3};
+        fill: ${Colors.GRAY4};
     }
 `;
 

--- a/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
@@ -1,4 +1,4 @@
-import { Card, Colors, H3, H4, Icon, Tag } from '@blueprintjs/core';
+import { Card, Colors, H3, Tag } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -64,18 +64,4 @@ export const ResourceSpaceLink = styled(Link)`
     &:hover {
         color: ${Colors.GRAY1};
     }
-`;
-
-export const EmptyStateWrapper = styled.div`
-    margin: 20px;
-`;
-
-export const EmptyStateIcon = styled(Icon)`
-    path {
-        fill: ${Colors.GRAY4};
-    }
-`;
-
-export const EmptyStateText = styled(H4)`
-    margin: 18px auto;
 `;

--- a/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
@@ -1,5 +1,4 @@
 import { Card, Colors, H3, Tag } from '@blueprintjs/core';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const paddingX = 20;
@@ -44,24 +43,4 @@ export const ResourceTag = styled(Tag)`
     font-weight: bold;
     background-color: ${Colors.LIGHT_GRAY2};
     color: ${Colors.DARK_GRAY1};
-`;
-
-export const ResourceLink = styled(Link)`
-    font-size: 13px;
-    font-weight: 600;
-    color: ${Colors.DARK_GRAY4};
-
-    &:hover {
-        color: ${Colors.DARK_GRAY1};
-    }
-`;
-
-export const ResourceSpaceLink = styled(Link)`
-    font-size: 13px;
-    font-weight: 500;
-    color: ${Colors.GRAY2};
-
-    &:hover {
-        color: ${Colors.GRAY1};
-    }
 `;

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/ResourceTable.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/ResourceTable.styles.ts
@@ -1,4 +1,5 @@
 import { Colors, HTMLTable } from '@blueprintjs/core';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const paddingX = 20;
@@ -11,15 +12,22 @@ export const StyledTHead = styled.thead`
     background-color: ${Colors.LIGHT_GRAY5};
 `;
 
-export const StyledTr = styled.tr``;
+export const StyledTr = styled.tr`
+    position: relative;
+
+    :hover {
+        background-color: ${Colors.LIGHT_GRAY5}75;
+    }
+
+    > td > *:not(a.full-row-link) {
+        position: relative;
+        z-index: 2;
+    }
+`;
 
 export const StyledTBody = styled.tbody`
     ${StyledTr}:not(:last-child) {
         box-shadow: inset 0 -1px 0 0 ${Colors.LIGHT_GRAY3} !important;
-    }
-
-    ${StyledTr}:hover {
-        background-color: ${Colors.LIGHT_GRAY5};
     }
 `;
 
@@ -67,4 +75,37 @@ export const Flex = styled.div`
 
 export const Spacer = styled.div<SpacerProps>`
     width: ${(props) => props.$width}px;
+`;
+
+export const NoLinkContainer = styled.div`
+    pointer-events: none;
+`;
+
+export const ResourceLink = styled(Link)`
+    font-size: 13px;
+    font-weight: 600;
+    color: ${Colors.DARK_GRAY4};
+
+    &:hover {
+        color: ${Colors.DARK_GRAY1};
+    }
+
+    &.full-row-link {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1;
+    }
+`;
+
+export const ResourceSpaceLink = styled(Link)`
+    font-size: 13px;
+    font-weight: 500;
+    color: ${Colors.GRAY2};
+
+    &:hover {
+        color: ${Colors.GRAY1};
+    }
 `;

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/ResourceTable.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/ResourceTable.styles.ts
@@ -81,15 +81,13 @@ export const NoLinkContainer = styled.div`
     pointer-events: none;
 `;
 
-export const ResourceLink = styled(Link)`
+export const ResourceName = styled.div`
     font-size: 13px;
     font-weight: 600;
     color: ${Colors.DARK_GRAY4};
+`;
 
-    &:hover {
-        color: ${Colors.DARK_GRAY1};
-    }
-
+export const ResourceLink = styled(Link)`
     &.full-row-link {
         position: absolute;
         top: 0;

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
@@ -10,6 +10,7 @@ import {
     Flex,
     NoLinkContainer,
     ResourceLink,
+    ResourceName,
     ResourceSpaceLink,
     Spacer,
     StyledTable,
@@ -109,7 +110,7 @@ const ResourceTable: FC<ResourceTableProps> = ({
                                     content={row.description}
                                     position={Position.TOP}
                                 >
-                                    {row.name}
+                                    <ResourceName>{row.name}</ResourceName>
                                 </Tooltip2>
                             </Flex>
                         </NoLinkContainer>

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
@@ -1,14 +1,5 @@
 import { Colors, Icon, Position } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import {
-    createColumnHelper,
-    flexRender,
-    getCoreRowModel,
-    getSortedRowModel,
-    SortingState,
-    useReactTable,
-    VisibilityState,
-} from '@tanstack/react-table';
 import React, { FC, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AcceptedResources, ResourceListProps } from '..';
@@ -28,7 +19,16 @@ import {
     ThInteractiveWrapper,
 } from './ResourceTable.styles';
 
-const columnHelper = createColumnHelper<AcceptedResources>();
+enum SortDirection {
+    ASC = 'asc',
+    DESC = 'desc',
+}
+
+type SortingState = null | SortDirection;
+
+type SortingStateMap = Map<string, SortingState>;
+
+type ColumnVisibilityMap = Map<string, boolean>;
 
 interface ResourceTableProps
     extends Pick<
@@ -40,6 +40,7 @@ interface ResourceTableProps
         | 'showSpaceColumn'
         | 'enableSorting'
     > {
+    enableMultiSort?: boolean;
     onChangeAction: React.Dispatch<
         React.SetStateAction<{
             actionType: number;
@@ -48,59 +49,73 @@ interface ResourceTableProps
     >;
 }
 
+const sortOrder = [SortDirection.ASC, SortDirection.DESC, null];
+
+const getNextSortDirection = (current: SortingState): SortingState => {
+    const currentIndex = sortOrder.indexOf(current);
+    return sortOrder.concat(sortOrder[0])[currentIndex + 1];
+};
+
 const ResourceTable: FC<ResourceTableProps> = ({
     resourceList,
     resourceType,
     resourceIcon,
     showSpaceColumn = false,
     enableSorting = true,
+    enableMultiSort = true,
     getURL,
     onChangeAction,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: spaces = [] } = useSpaces(projectUuid);
-    const [sorting, setSorting] = useState<SortingState>([]);
-    const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-        space: showSpaceColumn,
-    });
+    const [columnSorts, setColumnSorts] = useState<SortingStateMap>(new Map());
+    const [columnVisibility] = useState<ColumnVisibilityMap>(
+        new Map([['space', showSpaceColumn]]),
+    );
+
+    const handleSort = (columnId: string, direction: null | SortDirection) => {
+        setColumnSorts(
+            enableMultiSort
+                ? (prev) => new Map(prev).set(columnId, direction)
+                : new Map().set(columnId, direction),
+        );
+    };
 
     const columns = useMemo(() => {
         return [
-            columnHelper.accessor('name', {
+            {
                 id: 'name',
-                header: () => 'Name',
-                cell: (info) => (
+                header: 'Name',
+                cell: (row: AcceptedResources) => (
                     <Flex>
                         <Icon icon={resourceIcon} color={Colors.BLUE5} />
                         <Spacer $width={16} />
 
                         <Tooltip2
                             lazy
-                            disabled={!info.row.original.description}
-                            content={info.row.original.description}
+                            disabled={!row.description}
+                            content={row.description}
                             position={Position.TOP}
                         >
-                            <ResourceLink to={getURL(info.row.original)}>
-                                {info.getValue()}
+                            <ResourceLink to={getURL(row)}>
+                                {row.name}
                             </ResourceLink>
                         </Tooltip2>
                     </Flex>
                 ),
-                enableSorting: resourceList.length > 1,
-                sortingFn: (a, b) => {
-                    return a.original.name.localeCompare(b.original.name);
+                enableSorting: enableSorting && resourceList.length > 1,
+                sortingFn: (a: AcceptedResources, b: AcceptedResources) => {
+                    return a.name.localeCompare(b.name);
                 },
                 meta: {
-                    width: showSpaceColumn ? 50 : 75,
+                    width: showSpaceColumn ? '50%' : '75%',
                 },
-            }),
-            columnHelper.display({
+            },
+            {
                 id: 'space',
-                header: () => 'Space',
-                cell: (info) => {
-                    const space = spaces.find(
-                        (s) => s.uuid === info.row.original.spaceUuid,
-                    );
+                header: 'Space',
+                cell: (row: AcceptedResources) => {
+                    const space = spaces.find((s) => s.uuid === row.spaceUuid);
 
                     return space ? (
                         <ResourceSpaceLink
@@ -110,156 +125,154 @@ const ResourceTable: FC<ResourceTableProps> = ({
                         </ResourceSpaceLink>
                     ) : null;
                 },
-                enableSorting: resourceList.length > 1,
-                sortingFn: (a, b) => {
-                    const space1 = spaces.find(
-                        (s) => s.uuid === a.original.spaceUuid,
-                    );
-                    const space2 = spaces.find(
-                        (s) => s.uuid === b.original.spaceUuid,
-                    );
-
+                enableSorting: enableSorting && resourceList.length > 1,
+                sortingFn: (a: AcceptedResources, b: AcceptedResources) => {
+                    const space1 = spaces.find((s) => s.uuid === a.spaceUuid);
+                    const space2 = spaces.find((s) => s.uuid === b.spaceUuid);
                     return space1?.name.localeCompare(space2?.name || '') || 0;
                 },
                 meta: {
-                    width: showSpaceColumn ? 25 : undefined,
+                    width: showSpaceColumn ? '25%' : undefined,
                 },
-            }),
-            columnHelper.accessor('updatedAt', {
+            },
+            {
                 id: 'updatedAt',
-                header: () => 'Last Edited',
-                cell: (info) => (
-                    <ResourceLastEdited resource={info.row.original} />
+                header: 'Last Edited',
+                cell: (row: AcceptedResources) => (
+                    <ResourceLastEdited resource={row} />
                 ),
-                enableSorting: resourceList.length > 1,
-                sortingFn: (a, b) => {
+                enableSorting: enableSorting && resourceList.length > 1,
+                sortingFn: (a: AcceptedResources, b: AcceptedResources) => {
                     return (
-                        new Date(a.original.updatedAt).getTime() -
-                        new Date(b.original.updatedAt).getTime()
+                        new Date(a.updatedAt).getTime() -
+                        new Date(b.updatedAt).getTime()
                     );
                 },
                 meta: {
-                    width: 25,
+                    width: '25%',
                 },
-            }),
-            columnHelper.display({
+            },
+            {
                 id: 'actions',
-                cell: (cell) => (
+                cell: (row: AcceptedResources) => (
                     <ResourceActionMenu
-                        data={cell.row.original}
+                        data={row}
                         spaces={spaces}
-                        url={getURL(cell.row.original)}
+                        url={getURL(row)}
                         setActionState={onChangeAction}
                         isChart={resourceType === 'chart'}
                     />
                 ),
                 enableSorting: false,
                 meta: {
-                    width: 1,
+                    width: '1px',
                 },
-            }),
-        ];
+            },
+        ].filter((c) =>
+            columnVisibility.has(c.id) ? columnVisibility.get(c.id) : true,
+        );
     }, [
+        columnVisibility,
         resourceIcon,
         resourceType,
         resourceList.length,
         showSpaceColumn,
+        enableSorting,
         spaces,
         projectUuid,
         onChangeAction,
         getURL,
     ]);
 
-    const table = useReactTable({
-        data: resourceList,
-        columns,
-        state: {
-            sorting,
-            columnVisibility,
-        },
-        enableSorting,
-        onColumnVisibilityChange: setColumnVisibility,
-        onSortingChange: setSorting,
-        getSortedRowModel: getSortedRowModel(),
-        getCoreRowModel: getCoreRowModel(),
-    });
+    const sortedResourceList = useMemo(() => {
+        if (columnSorts.size === 0) {
+            return resourceList;
+        } else {
+            return resourceList.sort((a, b) => {
+                return [...columnSorts.entries()].reduce(
+                    (acc, [columnId, sortDirection]) => {
+                        const column = columns.find((c) => c.id === columnId);
+
+                        const sortResult = column?.sortingFn?.(a, b) ?? 0;
+
+                        switch (sortDirection) {
+                            case SortDirection.ASC:
+                                return acc + sortResult;
+                            case SortDirection.DESC:
+                                return acc - sortResult;
+                            default:
+                                return acc;
+                        }
+                    },
+                    0,
+                );
+            });
+        }
+    }, [resourceList, columnSorts, columns]);
 
     return (
         <StyledTable>
             <StyledTHead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                    <StyledTr key={headerGroup.id}>
-                        {headerGroup.headers.map((header) => {
-                            const isColumnSorted = header.column.getIsSorted();
-                            const canSortColumn = header.column.getCanSort();
+                <StyledTr>
+                    {columns.map((column) => {
+                        const columnSort = columnSorts.get(column.id) || null;
 
-                            return (
-                                <StyledTh
-                                    key={header.id}
-                                    colSpan={header.colSpan}
-                                    style={{
-                                        width:
-                                            header.column.columnDef.meta
-                                                ?.width + '%',
-                                    }}
+                        return (
+                            <StyledTh
+                                key={column.id}
+                                style={{
+                                    width: column.meta.width,
+                                }}
+                            >
+                                <ThInteractiveWrapper
+                                    $isInteractive={column.enableSorting}
+                                    onClick={() =>
+                                        column.enableSorting &&
+                                        handleSort(
+                                            column.id,
+                                            getNextSortDirection(columnSort),
+                                        )
+                                    }
                                 >
-                                    {header.isPlaceholder ? null : (
-                                        <ThInteractiveWrapper
-                                            $isInteractive={canSortColumn}
-                                            onClick={header.column.getToggleSortingHandler()}
-                                        >
-                                            <Flex>
-                                                {flexRender(
-                                                    header.column.columnDef
-                                                        .header,
-                                                    header.getContext(),
-                                                )}
+                                    <Flex>
+                                        {column?.header}
 
-                                                {isColumnSorted ? (
-                                                    <>
-                                                        <Spacer $width={5} />
+                                        {columnSort ? (
+                                            <>
+                                                <Spacer $width={5} />
 
-                                                        {
-                                                            {
-                                                                asc: (
-                                                                    <Icon
-                                                                        icon="chevron-up"
-                                                                        size={
-                                                                            12
-                                                                        }
-                                                                    />
-                                                                ),
-                                                                desc: (
-                                                                    <Icon
-                                                                        icon="chevron-down"
-                                                                        size={
-                                                                            12
-                                                                        }
-                                                                    />
-                                                                ),
-                                                            }[isColumnSorted]
-                                                        }
-                                                    </>
-                                                ) : null}
-                                            </Flex>
-                                        </ThInteractiveWrapper>
-                                    )}
-                                </StyledTh>
-                            );
-                        })}
-                    </StyledTr>
-                ))}
+                                                {
+                                                    {
+                                                        asc: (
+                                                            <Icon
+                                                                icon="chevron-up"
+                                                                size={12}
+                                                            />
+                                                        ),
+                                                        desc: (
+                                                            <Icon
+                                                                icon="chevron-down"
+                                                                size={12}
+                                                            />
+                                                        ),
+                                                    }[columnSort]
+                                                }
+                                            </>
+                                        ) : null}
+                                    </Flex>
+                                </ThInteractiveWrapper>
+                            </StyledTh>
+                        );
+                    })}
+                </StyledTr>
             </StyledTHead>
 
             <StyledTBody>
-                {table.getRowModel().rows.map((row) => (
-                    <StyledTr key={row.id}>
-                        {row.getVisibleCells().map((cell) => (
-                            <StyledTd key={cell.id}>
-                                {flexRender(
-                                    cell.column.columnDef.cell,
-                                    cell.getContext(),
-                                )}
+                {sortedResourceList.map((row) => (
+                    <StyledTr key={row.uuid}>
+                        {columns.map((column) => (
+                            <StyledTd key={column.id}>
+                                {column.cell(row)}
                             </StyledTd>
                         ))}
                     </StyledTr>

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
@@ -150,7 +150,7 @@ const ResourceTable: FC<ResourceTableProps> = ({
                         spaces={spaces}
                         url={getURL(cell.row.original)}
                         setActionState={onChangeAction}
-                        isChart={resourceType === 'saved_chart'}
+                        isChart={resourceType === 'chart'}
                     />
                 ),
                 enableSorting: false,

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
@@ -6,9 +6,11 @@ import { AcceptedResources, ResourceListProps } from '..';
 import { useSpaces } from '../../../../hooks/useSpaces';
 import ResourceActionMenu from '../ResourceActionMenu';
 import ResourceLastEdited from '../ResourceLastEdited';
-import { ResourceLink, ResourceSpaceLink } from '../ResourceList.styles';
 import {
     Flex,
+    NoLinkContainer,
+    ResourceLink,
+    ResourceSpaceLink,
     Spacer,
     StyledTable,
     StyledTBody,
@@ -87,21 +89,31 @@ const ResourceTable: FC<ResourceTableProps> = ({
                 id: 'name',
                 header: 'Name',
                 cell: (row: AcceptedResources) => (
-                    <Flex>
-                        <Icon icon={resourceIcon} color={Colors.BLUE5} />
-                        <Spacer $width={16} />
+                    <>
+                        <ResourceLink
+                            className="full-row-link"
+                            to={getURL(row)}
+                        />
 
-                        <Tooltip2
-                            lazy
-                            disabled={!row.description}
-                            content={row.description}
-                            position={Position.TOP}
-                        >
-                            <ResourceLink to={getURL(row)}>
-                                {row.name}
-                            </ResourceLink>
-                        </Tooltip2>
-                    </Flex>
+                        <NoLinkContainer>
+                            <Flex>
+                                <Icon
+                                    icon={resourceIcon}
+                                    color={Colors.BLUE5}
+                                />
+                                <Spacer $width={16} />
+
+                                <Tooltip2
+                                    lazy
+                                    disabled={!row.description}
+                                    content={row.description}
+                                    position={Position.TOP}
+                                >
+                                    {row.name}
+                                </Tooltip2>
+                            </Flex>
+                        </NoLinkContainer>
+                    </>
                 ),
                 enableSorting: enableSorting && resourceList.length > 1,
                 sortingFn: (a: AcceptedResources, b: AcceptedResources) => {
@@ -139,7 +151,9 @@ const ResourceTable: FC<ResourceTableProps> = ({
                 id: 'updatedAt',
                 header: 'Last Edited',
                 cell: (row: AcceptedResources) => (
-                    <ResourceLastEdited resource={row} />
+                    <NoLinkContainer>
+                        <ResourceLastEdited resource={row} />
+                    </NoLinkContainer>
                 ),
                 enableSorting: enableSorting && resourceList.length > 1,
                 sortingFn: (a: AcceptedResources, b: AcceptedResources) => {

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -41,6 +41,7 @@ export type ResourceListProps<T extends AcceptedResources = AcceptedResources> =
         enableSorting?: boolean;
         showCount?: boolean;
         getURL: (data: T) => string;
+        onClickCTA?: () => void;
     };
 
 const ResourceList: React.FC<ResourceListProps> = ({
@@ -53,6 +54,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
     enableSorting = true,
     showCount = true,
     getURL,
+    onClickCTA,
 }) => {
     const [actionState, setActionState] = useState<ActionStateWithData>({
         actionType: ActionTypeModal.CLOSE,
@@ -102,6 +104,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
                         resourceIcon={resourceIcon}
                         resourceType={resourceType}
                         headerAction={headerAction}
+                        onClickCTA={onClickCTA}
                     />
                 ) : (
                     <ResourceTable

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -1,4 +1,4 @@
-import { IconName, NonIdealState } from '@blueprintjs/core';
+import { IconName } from '@blueprintjs/core';
 import {
     assertUnreachable,
     DashboardBasicDetails,
@@ -16,29 +16,14 @@ import SavedQueryForm from '../../SavedQueries/SavedQueryForm';
 import { ActionTypeModal } from '../modal/ActionModal';
 import DeleteActionModal from '../modal/DeleteActionModal';
 import UpdateActionModal from '../modal/UpdateActionModal';
-import {
-    EmptyStateIcon,
-    EmptyStateText,
-    EmptyStateWrapper,
-} from './ResourceList.styles';
+import ResourceEmptyState from './ResourceEmptyState';
 import ResourceListWrapper, {
     ResourceListWrapperProps,
 } from './ResourceListWrapper';
 import ResourceTable from './ResourceTable';
 
 export type AcceptedResources = SpaceQuery | DashboardBasicDetails;
-export type AcceptedResourceTypes = 'saved_chart' | 'dashboard';
-
-const getResourceLabel = (resourceType: AcceptedResourceTypes) => {
-    switch (resourceType) {
-        case 'dashboard':
-            return 'dashboard';
-        case 'saved_chart':
-            return 'chart';
-        default:
-            assertUnreachable(resourceType);
-    }
-};
+export type AcceptedResourceTypes = 'chart' | 'dashboard';
 
 interface ActionStateWithData {
     actionType: ActionTypeModal;
@@ -74,7 +59,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
     });
 
     const { moveChart, moveDashboard } = useMoveToSpace(
-        resourceType === 'saved_chart',
+        resourceType === 'chart',
         actionState.data,
     );
 
@@ -85,7 +70,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
                     update: useUpdateDashboardName,
                     moveToSpace: moveDashboard,
                 };
-            case 'saved_chart':
+            case 'chart':
                 return {
                     update: useUpdateMutation,
                     moveToSpace: moveChart,
@@ -113,25 +98,11 @@ const ResourceList: React.FC<ResourceListProps> = ({
                 showCount={showCount}
             >
                 {resourceList.length === 0 ? (
-                    <EmptyStateWrapper>
-                        <NonIdealState
-                            description={
-                                <EmptyStateWrapper>
-                                    <EmptyStateIcon
-                                        icon={resourceIcon}
-                                        size={40}
-                                    />
-                                    <EmptyStateText>
-                                        No {getResourceLabel(resourceType)}s
-                                        added yet
-                                    </EmptyStateText>
-                                    <p>
-                                        Hit <b>+</b> to get started.
-                                    </p>
-                                </EmptyStateWrapper>
-                            }
-                        />
-                    </EmptyStateWrapper>
+                    <ResourceEmptyState
+                        resourceIcon={resourceIcon}
+                        resourceType={resourceType}
+                        headerAction={headerAction}
+                    />
                 ) : (
                     <ResourceTable
                         resourceType={resourceType}
@@ -146,7 +117,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
             </ResourceListWrapper>
 
             {actionState.actionType === ActionTypeModal.UPDATE &&
-                (resourceType === 'saved_chart' ? (
+                (resourceType === 'chart' ? (
                     <UpdateActionModal
                         useActionModalState={[actionState, setActionState]}
                         useUpdate={actions.update}
@@ -172,7 +143,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
                         }}
                         uuid={actionState.data.uuid}
                         name={actionState.data.name}
-                        isChart={resourceType === 'saved_chart'}
+                        isChart={resourceType === 'chart'}
                     />
                 )}
 

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { NonIdealState, Spinner } from '@blueprintjs/core';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
 import Page from '../components/common/Page/Page';
@@ -39,6 +39,7 @@ const Home: FC = () => {
             </div>
         );
     }
+
     if (error) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -49,6 +50,7 @@ const Home: FC = () => {
             </div>
         );
     }
+
     if (!project.data || !onboarding.data) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -70,7 +72,6 @@ const Home: FC = () => {
                     />
                 ) : (
                     <LandingPanel
-                        hasSavedChart={!!savedChartStatus.data}
                         userName={user.data?.firstName}
                         projectUuid={project.data.projectUuid}
                     />

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -7,10 +7,7 @@ import { PageContentWrapper } from '../components/common/Page/Page.styles';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import LandingPanel from '../components/Home/LandingPanel';
 import OnboardingPanel from '../components/Home/OnboardingPanel/index';
-import {
-    useOnboardingStatus,
-    useProjectSavedChartStatus,
-} from '../hooks/useOnboardingStatus';
+import { useOnboardingStatus } from '../hooks/useOnboardingStatus';
 import { useProject } from '../hooks/useProject';
 import { useApp } from '../providers/AppProvider';
 
@@ -21,11 +18,10 @@ const Home: FC = () => {
     const onboarding = useOnboardingStatus();
 
     const { user } = useApp();
-    const savedChartStatus = useProjectSavedChartStatus(selectedProjectUuid);
-    const isLoading =
-        onboarding.isLoading || project.isLoading || savedChartStatus.isLoading;
 
-    const error = onboarding.error || project.error || savedChartStatus.error;
+    const isLoading = onboarding.isLoading || project.isLoading;
+    const error = onboarding.error || project.error;
+
     useUnmount(() => onboarding.remove());
 
     if (user.data?.ability?.cannot('view', 'SavedChart')) {

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -7,20 +7,25 @@ import { PageContentWrapper } from '../components/common/Page/Page.styles';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import LandingPanel from '../components/Home/LandingPanel';
 import OnboardingPanel from '../components/Home/OnboardingPanel/index';
-import { useOnboardingStatus } from '../hooks/useOnboardingStatus';
+import {
+    useOnboardingStatus,
+    useProjectSavedChartStatus,
+} from '../hooks/useOnboardingStatus';
 import { useProject } from '../hooks/useProject';
 import { useApp } from '../providers/AppProvider';
 
 const Home: FC = () => {
     const params = useParams<{ projectUuid: string }>();
     const selectedProjectUuid = params.projectUuid;
+    const savedChartStatus = useProjectSavedChartStatus(selectedProjectUuid);
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
 
     const { user } = useApp();
 
-    const isLoading = onboarding.isLoading || project.isLoading;
-    const error = onboarding.error || project.error;
+    const isLoading =
+        onboarding.isLoading || project.isLoading || savedChartStatus.isLoading;
+    const error = onboarding.error || project.error || savedChartStatus.error;
 
     useUnmount(() => onboarding.remove());
 
@@ -68,6 +73,7 @@ const Home: FC = () => {
                     />
                 ) : (
                     <LandingPanel
+                        hasSavedChart={!!savedChartStatus.data}
                         userName={user.data?.firstName}
                         projectUuid={project.data.projectUuid}
                     />

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,5 +1,5 @@
 import { Button, NonIdealState, Spinner } from '@blueprintjs/core';
-import { Breadcrumbs2 } from '@blueprintjs/popover2';
+import { Breadcrumbs2, Tooltip2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
@@ -63,6 +63,13 @@ const SavedDashboards = () => {
         );
     }
 
+    const handleCreateDashboard = () => {
+        createDashboard({
+            name: DEFAULT_DASHBOARD_NAME,
+            tiles: [],
+        });
+    };
+
     return (
         <Page>
             <PageContentWrapper>
@@ -94,26 +101,27 @@ const SavedDashboards = () => {
                         />
                     </PageBreadcrumbsWrapper>
 
-                    {userCanManageDashboards && !isDemo && (
-                        <Button
-                            text="Create dashboard"
-                            icon="plus"
-                            loading={isCreatingDashboard}
-                            onClick={() =>
-                                createDashboard({
-                                    name: DEFAULT_DASHBOARD_NAME,
-                                    tiles: [],
-                                })
-                            }
-                            disabled={hasNoSpaces}
-                            title={
-                                hasNoSpaces
-                                    ? 'First you must create a space for this dashboard'
-                                    : ''
-                            }
-                            intent="primary"
-                        />
-                    )}
+                    {userCanManageDashboards &&
+                        !isDemo &&
+                        (dashboards.length > 0 || hasNoSpaces) && (
+                            <Tooltip2
+                                content={
+                                    hasNoSpaces
+                                        ? 'First you must create a space for this dashboard'
+                                        : undefined
+                                }
+                                interactionKind="hover"
+                            >
+                                <Button
+                                    text="Create dashboard"
+                                    icon="plus"
+                                    loading={isCreatingDashboard}
+                                    onClick={handleCreateDashboard}
+                                    disabled={hasNoSpaces}
+                                    intent="primary"
+                                />
+                            </Tooltip2>
+                        )}
                 </PageHeader>
 
                 <ResourceList
@@ -121,6 +129,13 @@ const SavedDashboards = () => {
                     resourceIcon="control"
                     resourceList={dashboards}
                     showSpaceColumn
+                    onClickCTA={
+                        isDemo
+                            ? undefined
+                            : hasNoSpaces
+                            ? undefined
+                            : handleCreateDashboard
+                    }
                     getURL={({ uuid }) =>
                         `/projects/${projectUuid}/dashboards/${uuid}/view`
                     }

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -130,11 +130,9 @@ const SavedDashboards = () => {
                     resourceList={dashboards}
                     showSpaceColumn
                     onClickCTA={
-                        isDemo
-                            ? undefined
-                            : hasNoSpaces
-                            ? undefined
-                            : handleCreateDashboard
+                        !isDemo && !hasNoSpaces && userCanManageDashboards
+                            ? handleCreateDashboard
+                            : undefined
                     }
                     getURL={({ uuid }) =>
                         `/projects/${projectUuid}/dashboards/${uuid}/view`

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -44,6 +44,10 @@ const SavedQueries: FC = () => {
         );
     }
 
+    const handleCreateChart = () => {
+        history.push(`/projects/${projectUuid}/tables`);
+    };
+
     return (
         <Page>
             <PageContentWrapper>
@@ -75,23 +79,24 @@ const SavedQueries: FC = () => {
                         />
                     </PageBreadcrumbsWrapper>
 
-                    {userCanManageCharts && !isDemo && (
-                        <Button
-                            text="Create chart"
-                            icon="plus"
-                            onClick={() =>
-                                history.push(`/projects/${projectUuid}/tables`)
-                            }
-                            intent="primary"
-                        />
-                    )}
+                    {userCanManageCharts &&
+                        !isDemo &&
+                        savedQueries.length > 0 && (
+                            <Button
+                                text="Create chart"
+                                icon="plus"
+                                intent="primary"
+                                onClick={handleCreateChart}
+                            />
+                        )}
                 </PageHeader>
 
                 <ResourceList
                     resourceIcon="chart"
                     resourceType="chart"
-                    resourceList={savedQueries || []}
+                    resourceList={savedQueries}
                     showSpaceColumn
+                    onClickCTA={isDemo ? undefined : handleCreateChart}
                     getURL={({ uuid }) =>
                         `/projects/${projectUuid}/saved/${uuid}`
                     }

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -89,7 +89,7 @@ const SavedQueries: FC = () => {
 
                 <ResourceList
                     resourceIcon="chart"
-                    resourceType="saved_chart"
+                    resourceType="chart"
                     resourceList={savedQueries || []}
                     showSpaceColumn
                     getURL={({ uuid }) =>

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -96,7 +96,11 @@ const SavedQueries: FC = () => {
                     resourceType="chart"
                     resourceList={savedQueries}
                     showSpaceColumn
-                    onClickCTA={isDemo ? undefined : handleCreateChart}
+                    onClickCTA={
+                        !isDemo && userCanManageCharts
+                            ? handleCreateChart
+                            : undefined
+                    }
                     getURL={({ uuid }) =>
                         `/projects/${projectUuid}/saved/${uuid}`
                     }


### PR DESCRIPTION
## Description:
- normalises empty states for resource lists.

### spaces page

<img width="852" alt="CleanShot 2022-09-17 at 01 56 21@2x" src="https://user-images.githubusercontent.com/962095/191197365-c8ca54da-382a-4882-b2af-103e274ac6f0.png">

### home page

#### home page: no spaces / no charts (hides dashboard list (same as it was previously implemented (I can change that if needed)))

<img width="854" alt="CleanShot 2022-09-17 at 01 56 37@2x" src="https://user-images.githubusercontent.com/962095/191197482-ce0e17f1-5c07-4111-aa54-c9dfabd563a8.png">

#### home page: has spaces / no charts / (hides dashboard)
<img width="854" alt="CleanShot 2022-09-17 at 01 56 47@2x" src="https://user-images.githubusercontent.com/962095/191197582-74bbc207-684c-4f64-9def-10c0e61ccc7c.png">

#### home page: has spaces / has charts / shows dashboard empty state
<img width="830" alt="CleanShot 2022-09-17 at 01 57 08@2x" src="https://user-images.githubusercontent.com/962095/191197620-8210204a-4d9b-4775-be64-656d31baa33c.png">

### charts page
<img width="869" alt="CleanShot 2022-09-17 at 01 57 54@2x" src="https://user-images.githubusercontent.com/962095/191198245-65083707-5ddf-4bae-9e16-b56ab272f31d.png">

### dashboards page
<img width="856" alt="CleanShot 2022-09-17 at 01 58 08@2x" src="https://user-images.githubusercontent.com/962095/191198269-45ea4178-792b-4265-92f7-3c4c86183d32.png">

> ⚠️ spaces resource does not have an icon, any suggestions what to use? @PriPatel 
