### PR TITLE
fix: adapt axis interval to dimension time interval

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -242,6 +242,7 @@ type TimeFrameConfig = {
         originalSql: string,
         type: DimensionType,
     ) => string;
+    getAxisMinInterval: () => number | null;
 };
 
 export const timeFrameConfigs: Record<TimeFrames, TimeFrameConfig> = {
@@ -249,96 +250,115 @@ export const timeFrameConfigs: Record<TimeFrames, TimeFrameConfig> = {
         getLabel: () => 'Raw',
         getDimensionType: (fallback) => fallback,
         getSql: (_adapterType, _timeInterval, originalSql) => originalSql,
+        getAxisMinInterval: () => null,
     },
     MILLISECOND: {
         getLabel: () => 'Millisecond',
         getDimensionType: () => DimensionType.TIMESTAMP,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     SECOND: {
         getLabel: () => 'Second',
         getDimensionType: () => DimensionType.TIMESTAMP,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     MINUTE: {
         getLabel: () => 'Minute',
         getDimensionType: () => DimensionType.TIMESTAMP,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     HOUR: {
         getLabel: () => 'Hour',
         getDimensionType: () => DimensionType.TIMESTAMP,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     DAY: {
         getLabel: () => 'Day',
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     WEEK: {
         getLabel: () => 'Week',
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => null,
     },
     MONTH: {
         getLabel: () => 'Month',
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => 2629800000,
     },
     QUARTER: {
         getLabel: () => 'Quarter',
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => 7889400000,
     },
     YEAR: {
         getLabel: () => 'Year',
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
+        getAxisMinInterval: () => 31557600000,
     },
     MONTH_NUM: {
         getLabel: () => 'Month (number)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     DAY_OF_WEEK_INDEX: {
         getLabel: () => 'Day of the week (index)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     DAY_OF_MONTH_NUM: {
         getLabel: () => 'Day of the month (number)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     DAY_OF_YEAR_NUM: {
         getLabel: () => 'Day of the year (number)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     QUARTER_NUM: {
         getLabel: () => 'Quarter (number)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     YEAR_NUM: {
         getLabel: () => 'Year (number)',
         getDimensionType: () => DimensionType.NUMBER,
         getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
     },
     DAY_OF_WEEK_NAME: {
         getLabel: () => 'Day of the week (name)',
         getDimensionType: () => DimensionType.STRING,
         getSql: getSqlForDatePartName,
+        getAxisMinInterval: () => null,
     },
     MONTH_NAME: {
         getLabel: () => 'Month (name)',
         getDimensionType: () => DimensionType.STRING,
         getSql: getSqlForDatePartName,
+        getAxisMinInterval: () => null,
     },
     QUARTER_NAME: {
         getLabel: () => 'Quarter (name)',
         getDimensionType: () => DimensionType.STRING,
         getSql: getSqlForDatePartName,
+        getAxisMinInterval: () => null,
     },
 };
 

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -27,7 +27,7 @@ import {
     MetricType,
     Series,
     TableCalculation,
-    TimeFrames,
+    timeFrameConfigs,
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { defaultGrid } from '../../components/ChartConfigPanel/Grid';
@@ -511,21 +511,22 @@ const getEchartAxis = ({
             items.find((item) => getItemId(axisItem) === getItemId(item));
         const hasFormatOrRound =
             isField(field) && (field.format || field.round);
-        const isQuarterTimeInterval =
-            isDimension(field) && field.timeInterval === TimeFrames.QUARTER;
-        return (
-            field &&
-            (hasFormatOrRound || isQuarterTimeInterval) && {
-                axisLabel: {
-                    formatter: (value: any) => {
-                        return formatItemValue(field, value);
-                    },
+        const axisMinInterval =
+            isDimension(field) &&
+            field.timeInterval &&
+            timeFrameConfigs[field.timeInterval].getAxisMinInterval();
+        const axisConfig: Record<string, any> = {};
+        if (field && (hasFormatOrRound || axisMinInterval)) {
+            axisConfig.axisLabel = {
+                formatter: (value: any) => {
+                    return formatItemValue(field, value);
                 },
-                interval: 7889400000,
-                minInterval: 7889400000,
-                maxInterval: 7889400000,
-            }
-        );
+            };
+        }
+        if (axisMinInterval) {
+            axisConfig.minInterval = axisMinInterval;
+        }
+        return axisConfig;
     };
 
     const showGridX = !!validCartesianConfig.layout.showGridX;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

When using big time intervals ( MONTH, QUARTER, YEAR ) the chart axis should adapt to use the same time interval and labels.

Before:
![Screenshot 2022-09-29 at 17 30 35](https://user-images.githubusercontent.com/9117144/193087556-551abb40-be46-4921-bcee-aa4351312a73.png)

After (month, quarter, year):
![Screenshot 2022-09-30 at 10 05 41](https://user-images.githubusercontent.com/9117144/193235605-de56e155-369b-408b-b61f-c3d6cdc0abeb.png)
![Screenshot 2022-09-30 at 10 05 28](https://user-images.githubusercontent.com/9117144/193235611-544c7b91-7939-4dec-a21b-2e18d0fe2422.png)
![Screenshot 2022-09-30 at 10 05 15](https://user-images.githubusercontent.com/9117144/193235609-602ad94f-9e22-4cd1-b4ff-d7390e3c74c3.png)


![chart min interval](https://user-images.githubusercontent.com/9117144/193235624-2a7a50d3-866e-4ac3-b0b5-5b60b5056d74.gif)

