### PR TITLE
docs: removes show underlying values from dim reference doc

### DIFF
--- a/docs/docs/guides/exploring-your-content.mdx
+++ b/docs/docs/guides/exploring-your-content.mdx
@@ -48,7 +48,7 @@ By default, we show all of the dimensions from the Table. If you have fields fro
 
 If you don't want all of the fields from your Table shown, then you can specify which fields you want users to see when they click on `show underlying data` for a field. 
 
-Check out the [dimension](/references/dimensions.mdx#show-underlying-values) or [metric](/references/metrics.md#show-underlying-values) reference docs to see how to do this in your Table's `.yml` file.
+Check out the [metric](/references/metrics.mdx#show-underlying-values) reference docs to see how to do this in your Table's `.yml` file.
 
 ## Exploring data in a dashboard
 

--- a/docs/docs/guides/how-to-create-metrics.mdx
+++ b/docs/docs/guides/how-to-create-metrics.mdx
@@ -34,9 +34,9 @@ models:
               type: sum
 ```
 
-You can [see the full list of metric types](/references/metrics.md#metric-types) that you can use in your Lightdash project.
+You can [see the full list of metric types](/references/metrics.mdx#metric-types) that you can use in your Lightdash project.
 
-We support metrics defined using either Lightdash or dbt syntax! You can read more about the two methods [in our reference docs here](/references/metrics.md#adding-metrics-to-your-project).
+We support metrics defined using either Lightdash or dbt syntax! You can read more about the two methods [in our reference docs here](/references/metrics.mdx#adding-metrics-to-your-project).
 
 Once you've added your metrics, you can use them in Lightdash to build charts and filter results. Metrics appear in the Explore view, above dimensions and, if selected, pop us as brownish-yellow fields in your results table.
 

--- a/docs/docs/references/dimensions.mdx
+++ b/docs/docs/references/dimensions.mdx
@@ -1,5 +1,4 @@
 import ClickableDimension from './assets/clickable-dimension-link.jpg';
-import UnderlyingData from '../guides/assets/underlying-data.jpg';
 
 # Dimensions reference sheet
 
@@ -78,10 +77,6 @@ models:
                 url: "https://finance.com/forceasts/weeks/${ value.raw }"
               - label: Open in Google Calendar
                 url: 'https://calendar.google.com/calendar/u/0/r/day/${ value.formatted |split: "-" |join: "/"}'
-            show_underlying_values:
-              - revenue_gbp_total_est
-              - actual_date
-              - web_sessions.session_id # field from joined table
 ```
 
 All the properties you can customize:
@@ -98,7 +93,6 @@ All the properties you can customize:
 | format                                            | No       | string                           | This option will format the output value on the result table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'percent']`                                                                                              |
 | group_label                                       | No       | string                           | If you set this property, the dimension will be grouped in the sidebar with other dimensions with the same group label.                                                                                                                                    |
 | [urls](#urls)                                     | No       | Array of { url, label }          | Adding urls to a dimension allows your users to click dimension values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension. |
-| [show_underlying_values](#show-underlying-values) | No       | Array of dimension names         | You can limit which dimensions are shown for a field when a user clicks `View underlying data`. The list must only include dimension names from the base model or from any joined models.                                                                  |
 
 ## Time intervals
 
@@ -218,36 +212,3 @@ Filters can be used to make small transformations of your values:
 | append     | Append a string to another                                             | `${value.formatted \ | append: ".html"}`|
 
 There are [many more filters available in the Liquid documentation](https://liquidjs.com/filters/overview.html).
-
-## Show underlying values
-
-By default, we show all of the dimensions from the Table when you click `View underlying data`. If you have fields from a joined table included in your results table, then we'll also show you all of the fields from the joined Table.
-
-<img src={UnderlyingData} width="1103" height="580" style={{display: "block", margin: "0 auto 20px auto"}}/>
-
-You can limit which dimensions are shown for a field when a user clicks `View underlying data` by adding the list of dimensions to your `.yml` files:
-
-```yaml
-version: 2
-
-models:
-  - name: sales_stats
-    meta:
-      joins:
-        - join: web_sessions
-          sql_on: ${web_sessions.date} = ${sales_stats.date}
-    columns:
-      - name: forecast_date
-        description: "Date of the forecasting."
-        meta:
-          dimension:
-            type: date
-            show_underlying_values:
-              - revenue_gbp_total_est
-              - actual_date
-              - web_sessions.session_id # field from joined table
-...
-```
-
-The list of fields must be made of dimension names (no metrics) from the base table or from any joined tables. To reference a field from a joined table, you just need to prefix the dimension name with the joined table name, like this: `my_joined_table_name.my_dimension`.
-

--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -1,6 +1,4 @@
----
-sidebar_position: 4
----
+import UnderlyingData from '../guides/assets/underlying-data.jpg';
 
 # Metrics reference sheet
 
@@ -168,7 +166,7 @@ Here are all of the properties you can customize:
 | format                                                            | No       | string                   | This option will format the output value on the result table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'percent']`                                                                                                                       |
 | group_label                                                       | No       | string                   | If you set this property, the dimension will be grouped in the sidebar with other dimensions with the same group label.                                                                                                                                                             |
 | [urls](./dimensions.mdx#urls)                                     | No       | Array of { url, label }  | Adding urls to a metric allows your users to click metric values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension.                                |
-| [show_underlying_values](./dimensions.mdx#show-underlying-values) | No       | Array of dimension names | You can limit which dimensions are shown for a field when a user clicks `View underlying data`. The list must only include dimension names from the base model or from any joined models.                                                                                          |
+| [show_underlying_values](#show-underlying-values)                 | No       | Array of dimension names | You can limit which dimensions are shown for a field when a user clicks `View underlying data`. The list must only include dimension names from the base model or from any joined models.                                                                                          |
 
 ## Metric types
 
@@ -421,3 +419,39 @@ metrics:
     type: number
     sql: "(${num_unique_users} - ${growth_model.num_unique_users_lag_1d}) / NULLIF(${growth_model.num_unique_users_lag_1d}, 0)"
 ```
+
+## Show underlying values
+
+By default, we show all of the dimensions from the Table when you click `View underlying data`. If you have fields from a joined table included in your results table, then we'll also show you all of the fields from the joined Table.
+
+<img src={UnderlyingData} width="1103" height="580" style={{display: "block", margin: "0 auto 20px auto"}}/>
+
+You can limit which dimensions are shown for a field when a user clicks `View underlying data` by adding the list of dimensions to your `.yml` files:
+
+```yaml
+version: 2
+
+models:
+  - name: sales_stats
+    meta:
+      joins:
+        - join: web_sessions
+          sql_on: ${web_sessions.date} = ${sales_stats.date}
+    columns:
+      - name: user_id
+        description: "Unique ID for users."
+        meta:
+          dimension:
+            type: string
+          metrics:
+            count_users:
+              type: count_distinct
+              show_underlying_values:
+                - revenue_gbp_total_est
+                - actual_date
+                - web_sessions.session_id # field from joined table
+...
+```
+
+The list of fields must be made of dimension names (no metrics) from the base table or from any joined tables. To reference a field from a joined table, you just need to prefix the dimension name with the joined table name, like this: `my_joined_table_name.my_dimension`.
+


### PR DESCRIPTION
### Description

We included `show_underlying_values` as a parameter in the dimensions reference doc, but it's only actually availble for metrics. 

This removes teh reference.