### PR TITLE
feat: resource list default sort

### DIFF
--- a/packages/frontend/src/components/Home/LatestDashboards/index.tsx
+++ b/packages/frontend/src/components/Home/LatestDashboards/index.tsx
@@ -8,6 +8,7 @@ import { useDashboards } from '../../../hooks/dashboard/useDashboards';
 import { useApp } from '../../../providers/AppProvider';
 import LinkButton from '../../common/LinkButton';
 import ResourceList from '../../common/ResourceList';
+import { SortDirection } from '../../common/ResourceList/ResourceTable';
 import { DEFAULT_DASHBOARD_NAME } from '../../SpacePanel';
 
 interface Props {
@@ -65,8 +66,10 @@ const LatestDashboards: FC<Props> = ({ projectUuid }) => {
             resourceIcon="control"
             resourceType="dashboard"
             resourceList={featuredDashboards}
-            showSpaceColumn
             enableSorting={false}
+            defaultSort={{
+                updatedAt: SortDirection.DESC,
+            }}
             showCount={false}
             getURL={({ uuid }) =>
                 `/projects/${projectUuid}/dashboards/${uuid}/view`

--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -1,12 +1,13 @@
 import { AnchorButton } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSavedCharts } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import LinkButton from '../../common/LinkButton';
 import ResourceList from '../../common/ResourceList';
+import { SortDirection } from '../../common/ResourceList/ResourceTable';
 
 interface Props {
     projectUuid: string;
@@ -17,17 +18,6 @@ const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
     const history = useHistory();
     const isDemo = health.data?.mode === LightdashMode.DEMO;
     const { data: savedCharts = [] } = useSavedCharts(projectUuid);
-
-    const featuredCharts = useMemo(() => {
-        return savedCharts
-            .sort((a, b) => {
-                return (
-                    new Date(b.updatedAt).getTime() -
-                    new Date(a.updatedAt).getTime()
-                );
-            })
-            .slice(0, 5);
-    }, [savedCharts]);
 
     const userCanManageCharts = user.data?.ability?.can(
         'manage',
@@ -45,9 +35,11 @@ const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
         <ResourceList
             resourceIcon="chart"
             resourceType="chart"
-            resourceList={featuredCharts}
-            showSpaceColumn
+            resourceList={savedCharts}
             enableSorting={false}
+            defaultSort={{
+                updatedAt: SortDirection.DESC,
+            }}
             showCount={false}
             getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
             headerTitle="Recently updated charts"

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -12,6 +12,7 @@ import {
     PageHeader,
 } from '../common/Page/Page.styles';
 import ResourceList from '../common/ResourceList';
+import { SortDirection } from '../common/ResourceList/ResourceTable';
 import SpaceActionModal, { ActionType } from '../common/SpaceActionModal';
 import AddResourceToSpaceMenu from '../Explorer/SpaceBrowser/AddResourceToSpaceMenu';
 import AddResourceToSpaceModal, {
@@ -33,10 +34,6 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
     const history = useHistory();
     const savedDashboards = space.dashboards;
     const savedCharts = space.queries;
-    const orderedCharts = savedCharts.sort(
-        (a, b) =>
-            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
 
     const [updateSpace, setUpdateSpace] = useState<boolean>(false);
     const [deleteSpace, setDeleteSpace] = useState<boolean>(false);
@@ -125,7 +122,10 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                 resourceIcon="control"
                 resourceType="dashboard"
                 resourceList={savedDashboards}
-                showSpaceColumn={false}
+                defaultSort={{
+                    updatedAt: SortDirection.DESC,
+                }}
+                defaultColumnVisibility={{ space: false }}
                 getURL={({ uuid }) =>
                     `/projects/${projectUuid}/dashboards/${uuid}/view`
                 }
@@ -149,10 +149,13 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
 
             <ResourceList
                 headerTitle="Saved charts"
-                resourceList={orderedCharts}
+                resourceList={savedCharts}
                 resourceIcon="chart"
                 resourceType="chart"
-                showSpaceColumn={false}
+                defaultSort={{
+                    updatedAt: SortDirection.DESC,
+                }}
+                defaultColumnVisibility={{ space: false }}
                 getURL={({ uuid }) => `/projects/${projectUuid}/saved/${uuid}`}
                 headerAction={
                     !isDemo &&

--- a/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceEmptyState.tsx
@@ -1,15 +1,15 @@
 import { Button, NonIdealState } from '@blueprintjs/core';
 import { FC } from 'react';
-import { ResourceListProps } from '.';
+import { ResourceListCommonProps } from '.';
 import {
     EmptyStateIcon,
     EmptyStateText,
     EmptyStateWrapper,
 } from './ResourceEmptyState.styles';
 
-type Props = Pick<ResourceListProps, 'headerAction' | 'onClickCTA'> & {
-    resourceType: ResourceListProps['resourceType'] | 'space';
-    resourceIcon?: ResourceListProps['resourceIcon'];
+type Props = Pick<ResourceListCommonProps, 'headerAction' | 'onClickCTA'> & {
+    resourceType: ResourceListCommonProps['resourceType'] | 'space';
+    resourceIcon?: ResourceListCommonProps['resourceIcon'];
 };
 
 const ResourceEmptyState: FC<Props> = ({

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable/index.tsx
@@ -96,7 +96,6 @@ const ResourceTable: FC<ResourceTableProps> = ({
     const enableSorting = enableSortingProp && resourceList.length > 1;
 
     const columns = useMemo(() => {
-        console.log(columnVisibility.get('space'));
         return [
             {
                 id: 'name',

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -20,7 +20,7 @@ import ResourceEmptyState from './ResourceEmptyState';
 import ResourceListWrapper, {
     ResourceListWrapperProps,
 } from './ResourceListWrapper';
-import ResourceTable from './ResourceTable';
+import ResourceTable, { ResourceTableCommonProps } from './ResourceTable';
 
 export type AcceptedResources = SpaceQuery | DashboardBasicDetails;
 export type AcceptedResourceTypes = 'chart' | 'dashboard';
@@ -30,19 +30,22 @@ interface ActionStateWithData {
     data?: any;
 }
 
-export type ResourceListProps<T extends AcceptedResources = AcceptedResources> =
-    ResourceListWrapperProps & {
-        headerTitle?: string;
-        headerAction?: React.ReactNode;
-        resourceList: T[];
-        resourceType: AcceptedResourceTypes;
-        resourceIcon: IconName;
-        showSpaceColumn?: boolean;
-        enableSorting?: boolean;
-        showCount?: boolean;
-        getURL: (data: T) => string;
-        onClickCTA?: () => void;
-    };
+export interface ResourceListCommonProps<
+    T extends AcceptedResources = AcceptedResources,
+> {
+    headerTitle?: string;
+    headerAction?: React.ReactNode;
+    resourceList: T[];
+    resourceType: AcceptedResourceTypes;
+    resourceIcon: IconName;
+    showCount?: boolean;
+    getURL: (data: T) => string;
+    onClickCTA?: () => void;
+}
+
+type ResourceListProps = ResourceListCommonProps &
+    ResourceTableCommonProps &
+    ResourceListWrapperProps;
 
 const ResourceList: React.FC<ResourceListProps> = ({
     headerTitle,
@@ -50,8 +53,10 @@ const ResourceList: React.FC<ResourceListProps> = ({
     resourceIcon,
     resourceList,
     resourceType,
-    showSpaceColumn = false,
-    enableSorting = true,
+    enableSorting,
+    enableMultiSort,
+    defaultColumnVisibility,
+    defaultSort,
     showCount = true,
     getURL,
     onClickCTA,
@@ -113,8 +118,10 @@ const ResourceList: React.FC<ResourceListProps> = ({
                         resourceType={resourceType}
                         resourceIcon={resourceIcon}
                         resourceList={resourceList}
-                        showSpaceColumn={showSpaceColumn}
                         enableSorting={enableSorting}
+                        enableMultiSort={enableMultiSort}
+                        defaultColumnVisibility={defaultColumnVisibility}
+                        defaultSort={defaultSort}
                         getURL={getURL}
                         onChangeAction={setActionState}
                     />

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -14,6 +14,7 @@ import {
     ResourceBreadcrumbTitle,
     ResourceTag,
 } from '../components/common/ResourceList/ResourceList.styles';
+import { SortDirection } from '../components/common/ResourceList/ResourceTable';
 import { useCreateMutation } from '../hooks/dashboard/useDashboard';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
 import { useSpaces } from '../hooks/useSpaces';
@@ -128,7 +129,9 @@ const SavedDashboards = () => {
                     resourceType="dashboard"
                     resourceIcon="control"
                     resourceList={dashboards}
-                    showSpaceColumn
+                    defaultSort={{
+                        updatedAt: SortDirection.DESC,
+                    }}
                     onClickCTA={
                         !isDemo && !hasNoSpaces && userCanManageDashboards
                             ? handleCreateDashboard

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -15,6 +15,7 @@ import {
     ResourceBreadcrumbTitle,
     ResourceTag,
 } from '../components/common/ResourceList/ResourceList.styles';
+import { SortDirection } from '../components/common/ResourceList/ResourceTable';
 import { useSavedCharts } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
@@ -95,7 +96,9 @@ const SavedQueries: FC = () => {
                     resourceIcon="chart"
                     resourceType="chart"
                     resourceList={savedQueries}
-                    showSpaceColumn
+                    defaultSort={{
+                        updatedAt: SortDirection.DESC,
+                    }}
                     onClickCTA={
                         !isDemo && userCanManageCharts
                             ? handleCreateChart


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3334

### Description:
- add default sort for resource list
- add default column visibility for resource list
- improve component API
- sort order [desc (down arrow), asc (up arrow), none]
- hide sort icon if table is not interactive

> sort disabled for 1 item
> another is interactive with icon
<img width="841" alt="CleanShot 2022-09-30 at 20 21 42@2x" src="https://user-images.githubusercontent.com/962095/193314205-ab47a4f1-4df4-4b2a-8da8-54d472ccbd44.png">

> sorted but its not interactive (hiding icon) if I still should show the icon
<img width="802" alt="CleanShot 2022-09-30 at 20 22 06@2x" src="https://user-images.githubusercontent.com/962095/193314277-9212ef46-747d-4c35-be09-cecc8deb607e.png">
