### PR TITLE
fix: missing unixodbc dep for CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.1",
         "nunjucks": "^3.2.3",
+        "odbc": "^2.4.2",
         "ora": "5.4.1",
         "unique-names-generator": "^4.7.1",
         "uuid": "^8.3.2"
@@ -49,7 +50,6 @@
         "ts-jest": "^28.0.5",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.3",
-        "unixodbc": "2.3.11"
     },
     "scripts": {
         "test": "jest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,6 @@
         "nunjucks": "^3.2.3",
         "ora": "5.4.1",
         "unique-names-generator": "^4.7.1",
-        "unixodbc": "2.3.11",
         "uuid": "^8.3.2"
     },
     "description": "Lightdash CLI tool",
@@ -49,7 +48,8 @@
         "prettier-plugin-organize-imports": "^2.3.4",
         "ts-jest": "^28.0.5",
         "ts-node": "^9.1.1",
-        "typescript": "^4.2.3"
+        "typescript": "^4.2.3",
+        "unixodbc": "2.3.11"
     },
     "scripts": {
         "test": "jest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
         "nunjucks": "^3.2.3",
         "ora": "5.4.1",
         "unique-names-generator": "^4.7.1",
+        "unixodbc": "2.3.11",
         "uuid": "^8.3.2"
     },
     "description": "Lightdash CLI tool",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
         "prettier-plugin-organize-imports": "^2.3.4",
         "ts-jest": "^28.0.5",
         "ts-node": "^9.1.1",
-        "typescript": "^4.2.3",
+        "typescript": "^4.2.3"
     },
     "scripts": {
         "test": "jest",


### PR DESCRIPTION
Closes: #3361 

### Description:
Installing the Lightdash CLI fails without having unixODBC installed. Adding to the cli packages to prevent this happening.
