### PR TITLE
fix: get default bigquery location if missing in profiles

### DIFF
--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -34,37 +34,36 @@ export const convertBigquerySchema = async (
     }
     const getLocation = async () => {
         if (target.location) return target.location;
-        
-            const config = await getConfig();
 
-            switch (config.context?.serverUrl) {
-                case 'https://eu1.lightdash.cloud':
-                    console.error(
-                        `\n${styles.title(
-                            'Warning',
-                        )}: Missing location in profiles.yml, using EU by default`,
-                    );
+        const config = await getConfig();
 
-                    return 'EU';
-                case 'https://app.lightdash.cloud':
-                    console.error(
-                        `\n${styles.title(
-                            'Warning',
-                        )}: Missing location in profiles.yml, using US by default`,
-                    );
+        switch (config.context?.serverUrl) {
+            case 'https://eu1.lightdash.cloud':
+                console.error(
+                    `\n${styles.title(
+                        'Warning',
+                    )}: Missing location in profiles.yml, using EU by default`,
+                );
 
-                    return 'US';
-                default:
-                    console.error(
-                        `\n${styles.title(
-                            'Warning',
-                        )}: Missing location in profiles.yml and can't find valid serverUrl on config "${
-                            config.context?.serverUrl
-                        }", using US by default`,
-                    );
-                    return 'US';
-            }
-        
+                return 'EU';
+            case 'https://app.lightdash.cloud':
+                console.error(
+                    `\n${styles.title(
+                        'Warning',
+                    )}: Missing location in profiles.yml, using US by default`,
+                );
+
+                return 'US';
+            default:
+                console.error(
+                    `\n${styles.title(
+                        'Warning',
+                    )}: Missing location in profiles.yml and can't find valid serverUrl on config "${
+                        config.context?.serverUrl
+                    }", using US by default`,
+                );
+                return 'US';
+        }
     };
     return {
         type: WarehouseTypes.BIGQUERY,

--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -3,6 +3,8 @@ import {
     ParseError,
     WarehouseTypes,
 } from '@lightdash/common';
+import { getConfig } from '../../../config';
+import * as styles from '../../../styles';
 import { Target } from '../../types';
 import { getBigqueryCredentialsFromOauth } from './oauth';
 import {
@@ -30,6 +32,40 @@ export const convertBigquerySchema = async (
                 `BigQuery method ${target.method} is not yet supported`,
             );
     }
+    const getLocation = async () => {
+        if (target.location) return target.location;
+        
+            const config = await getConfig();
+
+            switch (config.context?.serverUrl) {
+                case 'https://eu1.lightdash.cloud':
+                    console.error(
+                        `\n${styles.title(
+                            'Warning',
+                        )}: Missing location in profiles.yml, using EU by default`,
+                    );
+
+                    return 'EU';
+                case 'https://app.lightdash.cloud':
+                    console.error(
+                        `\n${styles.title(
+                            'Warning',
+                        )}: Missing location in profiles.yml, using US by default`,
+                    );
+
+                    return 'US';
+                default:
+                    console.error(
+                        `\n${styles.title(
+                            'Warning',
+                        )}: Missing location in profiles.yml and can't find valid serverUrl on config "${
+                            config.context?.serverUrl
+                        }", using US by default`,
+                    );
+                    return 'US';
+            }
+        
+    };
     return {
         type: WarehouseTypes.BIGQUERY,
         project: target.project,
@@ -38,7 +74,7 @@ export const convertBigquerySchema = async (
         priority: target.priority,
         keyfileContents: await getBigqueryCredentials(target),
         retries: target.retries,
-        location: target.location,
+        location: await getLocation(),
         maximumBytesBilled: target.maximum_bytes_billed,
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:#3355

### Description:
With location:
![Screenshot from 2022-10-03 17-07-25](https://user-images.githubusercontent.com/1983672/193612042-8abbac0a-f91d-42d8-8c39-ae3061002c73.png)


WIthout location with server eu1.lightdash.cloud: 
![Screenshot from 2022-10-03 17-04-21](https://user-images.githubusercontent.com/1983672/193612081-a01201fe-3667-4f6c-9a93-5b780ce79e52.png)


Unknown cloud server: 

![image](https://user-images.githubusercontent.com/1983672/193613111-19eb0855-2413-4691-a6a4-8095c3bec1f4.png)
