### PR TITLE
fix: do not skip onboarding screens from the cli

### DIFF
--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -149,7 +149,7 @@ export const deployHandler = async (options: DeployHandlerOptions) => {
     console.error('');
     console.error(
         `      ${styles.bold(
-            `⚡️ ${config.context?.serverUrl}/projects/${projectUuid}/tables`,
+            `⚡️ ${config.context?.serverUrl}/createProject/cli?projectUuid=${projectUuid}`,
         )}`,
     );
     console.error('');

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
@@ -27,7 +27,7 @@ const ConnectSuccess: FC<ConnectSuccessProps> = ({ projectUuid }) => {
                 <LinkButton
                     large
                     intent="primary"
-                    href={`/projects/${projectUuid}`}
+                    href={`/projects/${projectUuid}/home`}
                 >
                     Let's do some data!
                 </LinkButton>


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3376

### Description:
- redirect to project home instead of an explorer from the CLI