### PR TITLE
fix: chart underlying data

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -17,6 +17,7 @@ import {
     friendlyName,
     getDimensions,
     getFields,
+    getItemMap,
     getResultValues,
     getVisibleFields,
     isFilterableField,
@@ -244,10 +245,16 @@ const DashboardChartTile: FC<Props> = (props) => {
                 top: e.event.event.pageY,
             });
 
+            const allItemsMap = getItemMap(
+                explore,
+                savedQuery?.metricQuery.additionalMetrics,
+                savedQuery?.metricQuery.tableCalculations,
+            );
+
             const underlyingData = getDataFromChartClick(
                 e,
                 pivot,
-                explore,
+                allItemsMap,
                 series,
             );
             const queryDimensions = savedQuery?.metricQuery.dimensions || [];
@@ -256,11 +263,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                 dimensions: queryDimensions,
             });
         },
-        [
-            explore,
-            savedQuery?.pivotConfig?.columns,
-            savedQuery?.metricQuery.dimensions,
-        ],
+        [explore, savedQuery],
     );
     // START DASHBOARD FILTER LOGIC
     // TODO: move this logic out of component

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -4,10 +4,12 @@ import {
     Popover2,
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
+import { getItemMap } from '@lightdash/common';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
+import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import { EchartSeriesClickEvent } from '../../SimpleChart';
 import {
     getDataFromChartClick,
@@ -24,6 +26,8 @@ export const SeriesContextMenu: FC<{
         (context) => context.state.unsavedChartVersion.tableName,
     );
     const { data: explore } = useExplore(tableName);
+    const context = useVisualizationContext();
+    const { resultsData: { metricQuery } = {} } = context;
 
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const { viewData } = useUnderlyingDataContext();
@@ -47,10 +51,16 @@ export const SeriesContextMenu: FC<{
 
     const viewUnderlyingData = useCallback(() => {
         if (explore !== undefined && echartSeriesClickEvent !== undefined) {
+            const allItemsMap = getItemMap(
+                explore,
+                metricQuery?.additionalMetrics,
+                metricQuery?.tableCalculations,
+            );
+
             const underlyingData = getDataFromChartClick(
                 echartSeriesClickEvent,
                 pivot,
-                explore,
+                allItemsMap,
                 series || [],
             );
 
@@ -62,7 +72,15 @@ export const SeriesContextMenu: FC<{
                 underlyingData.pivot,
             );
         }
-    }, [explore, echartSeriesClickEvent, viewData, pivot, dimensions, series]);
+    }, [
+        explore,
+        echartSeriesClickEvent,
+        metricQuery,
+        pivot,
+        series,
+        viewData,
+        dimensions,
+    ]);
     const contextMenuRenderTarget = useCallback(
         ({ ref }: Popover2TargetProps) => (
             <Portal>

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataProvider.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataProvider.tsx
@@ -1,10 +1,10 @@
 import {
-    Explore,
-    fieldId as getFieldId,
+    Field,
     Filters,
-    getDimensions,
-    getFields,
+    getItemId,
+    isDimension,
     ResultRow,
+    TableCalculation,
 } from '@lightdash/common';
 import React, {
     createContext,
@@ -43,21 +43,21 @@ type UnderlyingDataContext = {
 export const getDataFromChartClick = (
     e: EchartSeriesClickEvent,
     pivot: string | undefined,
-    explore: Explore,
+    itemsMap: Record<string, Field | TableCalculation>,
     series: EChartSeries[],
 ) => {
-    const selectedFields = getFields(explore).filter((field) =>
-        e.dimensionNames.includes(getFieldId(field)),
+    const selectedFields = Object.values(itemsMap).filter((item) =>
+        e.dimensionNames.includes(getItemId(item)),
     );
-    const selectedDimensions = getDimensions(explore).filter((dimension) =>
-        e.dimensionNames.includes(getFieldId(dimension)),
+    const selectedMetricsAndTableCalculations = selectedFields.filter(
+        (item) => !isDimension(item),
     );
 
     const selectedField =
-        selectedDimensions.length > 0
-            ? selectedDimensions[0]
+        selectedMetricsAndTableCalculations.length > 0
+            ? selectedMetricsAndTableCalculations[0]
             : selectedFields[0];
-    const selectedValue = e.data[getFieldId(selectedField)];
+    const selectedValue = e.data[getItemId(selectedField)];
     const row: ResultRow = Object.entries(e.data as Record<string, any>).reduce(
         (acc, entry) => {
             const [key, val] = entry;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3318 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Changes:
- Use selected metric to show chart underlying data ( so it shows the same results as viewing metric underlying data from results table )
- User correct field when using pivot

Applying metric show_underlying_values
``` 
         metrics:
            count_users:
              type: count_distinct
              show_underlying_values:
                - first_name
                - last_name
```
![underlying data chart](https://user-images.githubusercontent.com/9117144/194072732-bc6b479b-536a-4f4e-8bc1-72087f8aabf1.gif)

With pivot
![underlying data with pivot](https://user-images.githubusercontent.com/9117144/194072757-54ea7399-cdb0-493b-baca-28591472c70b.gif)

