### PR TITLE
fix: save table config

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -165,11 +165,15 @@ const SavedChartsHeader: FC = () => {
                                         minimal
                                     />
                                 )}
-                                <RenameSavedChartModal
-                                    savedChartUuid={savedChart.uuid}
-                                    isOpen={isRenamingChart}
-                                    onClose={() => setIsRenamingChart(false)}
-                                />
+                                {isRenamingChart && (
+                                    <RenameSavedChartModal
+                                        savedChartUuid={savedChart.uuid}
+                                        isOpen={isRenamingChart}
+                                        onClose={() =>
+                                            setIsRenamingChart(false)
+                                        }
+                                    />
+                                )}
                             </PageTitleContainer>
 
                             <PageDetailsContainer>
@@ -341,7 +345,7 @@ const SavedChartsHeader: FC = () => {
                     onClose={() => setIsQueryModalOpen(false)}
                 />
             )}
-            {savedChart && (
+            {savedChart && isAddToDashboardModalOpen && (
                 <AddTilesToDashboardModal
                     isOpen={isAddToDashboardModalOpen}
                     savedChart={savedChart}

--- a/packages/frontend/src/components/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/ColumnConfiguration.tsx
@@ -20,7 +20,7 @@ export const ColumnConfiguration: React.FC = () => {
     const pivotDimension = pivotDimensions?.[0];
     return (
         <ColumnConfigurationWrapper>
-            {selectedItemIds.map((fieldId) => {
+            {selectedItemIds?.map((fieldId) => {
                 return (
                     <ColumnWrapper>
                         <InputGroup

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -44,7 +44,10 @@ const useTableConfig = (
     >(tableChartConfig?.columns === undefined ? {} : tableChartConfig?.columns);
 
     const selectedItemIds = useMemo(
-        () => itemsInMetricQuery(resultsData?.metricQuery),
+        () =>
+            resultsData
+                ? itemsInMetricQuery(resultsData.metricQuery)
+                : undefined,
         [resultsData],
     );
     const itemsMap = useMemo(() => {
@@ -95,7 +98,7 @@ const useTableConfig = (
         error?: string;
     }>(() => {
         const pivotDimension = pivotDimensions?.[0];
-        if (!resultsData) {
+        if (!resultsData || !selectedItemIds) {
             return {
                 rows: [],
                 columns: [],
@@ -135,7 +138,7 @@ const useTableConfig = (
 
     // Remove columProperties from map if the column has been removed from results
     useEffect(() => {
-        if (Object.keys(columnProperties).length > 0) {
+        if (Object.keys(columnProperties).length > 0 && selectedItemIds) {
             const columnsRemoved = Object.keys(columnProperties).filter(
                 (field) => !selectedItemIds.includes(field),
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3312 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

The config was being saved. 
The problem was when loading the saved chart. 
The useTableConfig has a hook that removes column config from columns that are no longer present in the results. The problem was that this was validating before the results were ready so it was removing all the column config. 

I also made changes so 2 modals are only loaded when they are open to prevent unnecessary network requests and renders.

![save table config](https://user-images.githubusercontent.com/9117144/194093565-a509ea62-7332-4cc0-86b3-002165fb8f75.gif)

