### PR TITLE
fix: filter auto complete values

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -596,7 +596,7 @@ export class ProjectService {
         fieldId: string,
         search: string,
         limit: number,
-    ): Promise<Array<any>> {
+    ): Promise<Array<unknown>> {
         const { organizationUuid } =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -663,6 +663,7 @@ type ApiResults =
     | FilterableField[]
     | ProjectSavedChartStatus
     | undefined
+    | Array<unknown>
     | ApiJobStartedResults
     | ApiCreateUserTokenResults
     | CreatePersonalAccessToken

--- a/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/autoCompleteUtils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/autoCompleteUtils.ts
@@ -26,6 +26,9 @@ export function itemPredicate(
     return item.toLowerCase().includes(query.toLowerCase());
 }
 
+const isString = (value: unknown): value is string =>
+    !!value && typeof value === 'string';
+
 const useDebouncedSearch = (
     projectUuid: string,
     fieldId: string,
@@ -57,7 +60,10 @@ const useDebouncedSearch = (
         setCachedItems((prev) => {
             return {
                 ...prev,
-                [fieldId]: new Set([...(prev[fieldId] || []), ...(data || [])]),
+                [fieldId]: new Set([
+                    ...(prev[fieldId] || []),
+                    ...(data || []).filter(isString),
+                ]),
             };
         });
     }, [fieldId, data]);

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -8,7 +8,7 @@ const getFieldValues = async (
     value: string,
     limit: number,
 ) =>
-    lightdashApi<Array<any>>({
+    lightdashApi<Array<unknown>>({
         url: `/projects/${projectId}/field/${fieldId}/search?value=${encodeURIComponent(
             value,
         )}&limit=${limit}`,
@@ -23,7 +23,7 @@ export const useFieldValues = (
     limit: number,
     enabled: boolean,
 ) => {
-    return useQuery<Array<any>, ApiError>({
+    return useQuery<Array<unknown>, ApiError>({
         queryKey: ['project', projectId, fieldId, search],
         queryFn: () => getFieldValues(projectId, fieldId, search, limit),
         enabled: enabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Code assumed the values for the auto complete were strings. 
When the values weren't strings there was a blank page with the error: 

TypeError
t.toLowerCase is not a function. (In 't.toLowerCase()', 't.toLowerCase' is undefined)


Changes:
- improve type safety by changing the type from `any` to `unknown` 
- filter values that aren't strings
