### PR TITLE
fix: hide recover password button when email client isnt configured

### DIFF
--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -146,11 +146,13 @@ const Login: FC = () => {
                 loading={isLoading}
                 data-cy="login-button"
             />
-            <AnchorLinkWrapper>
-                <AnchorLink href="/recover-password">
-                    Forgot your password ?
-                </AnchorLink>
-            </AnchorLinkWrapper>
+            {health.data?.hasEmailClient && (
+                <AnchorLinkWrapper>
+                    <AnchorLink href="/recover-password">
+                        Forgot your password ?
+                    </AnchorLink>
+                </AnchorLinkWrapper>
+            )}
         </Form>
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 3430 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

![Screenshot 2022-10-07 at 17 14 53](https://user-images.githubusercontent.com/9117144/194600526-af3f65ee-f924-4efc-9d13-665871da0add.png)

