### PR TITLE
feat: space label in add chart to dashboard modal

### DIFF
--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -39,7 +39,7 @@ describe('Dashboard', () => {
 
         cy.findByText('Add tile').click();
         cy.findByText('Saved chart').click();
-        cy.findByText('Select saved charts').parent().find('input').click();
+        cy.findByRole('dialog').findByPlaceholderText('Search...').click();
         cy.contains('How much revenue').click();
         cy.findByText('Add').click();
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3268

### Description:
- [x] show label in add chart to dashboard modal
- [x] If there is only one Space in the organization there is not need to show the Space name.


before:
<img width="560" alt="CleanShot 2022-10-10 at 14 18 55@2x" src="https://user-images.githubusercontent.com/962095/194847473-56a1b5af-bfdb-442a-9879-54cee9789cdd.png">

after:
<img width="564" alt="CleanShot 2022-10-10 at 14 26 56@2x" src="https://user-images.githubusercontent.com/962095/194847470-f2f3f89a-5ca1-4cd9-bd84-a61b36c5da0d.png">
