### PR TITLE
fix: time interval backwards compatibility

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -374,7 +374,7 @@ export const getDefaultTimeFrames = (type: DimensionType) =>
           ]
         : [TimeFrames.DAY, TimeFrames.WEEK, TimeFrames.MONTH, TimeFrames.YEAR];
 
-const isTimeInterval = (value: string): value is TimeFrames =>
+export const isTimeInterval = (value: string): value is TimeFrames =>
     Object.keys(timeFrameConfigs).includes(value);
 
 export const validateTimeFrames = (values: string[]): TimeFrames[] =>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -52,11 +52,6 @@ const TreeSingleNode: FC<{ node: Node; depth: number }> = ({ node, depth }) => {
         return null;
     }
 
-    if (isDimension(item) && item.timeInterval) {
-        // @ts-ignore
-        item.timeInterval = 'day';
-    }
-
     const timeIntervalLabel =
         isDimension(item) &&
         item.timeInterval &&

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -4,6 +4,7 @@ import {
     DimensionType,
     isAdditionalMetric,
     isDimension,
+    isTimeInterval,
     MetricType,
     timeFrameConfigs,
 } from '@lightdash/common';
@@ -51,10 +52,18 @@ const TreeSingleNode: FC<{ node: Node; depth: number }> = ({ node, depth }) => {
         return null;
     }
 
-    const label: string =
-        isDimension(item) && item.timeInterval
+    if (isDimension(item) && item.timeInterval) {
+        // @ts-ignore
+        item.timeInterval = 'day';
+    }
+
+    const timeIntervalLabel =
+        isDimension(item) &&
+        item.timeInterval &&
+        isTimeInterval(item.timeInterval)
             ? timeFrameConfigs[item.timeInterval].getLabel()
-            : item.label || item.name;
+            : undefined;
+    const label: string = timeIntervalLabel || item.label || item.name;
     return (
         <Row
             depth={depth}

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -23,6 +23,7 @@ import {
     isCompleteLayout,
     isDimension,
     isField,
+    isTimeInterval,
     Metric,
     MetricType,
     Series,
@@ -514,6 +515,7 @@ const getEchartAxis = ({
         const axisMinInterval =
             isDimension(field) &&
             field.timeInterval &&
+            isTimeInterval(field.timeInterval) &&
             timeFrameConfigs[field.timeInterval].getAxisMinInterval();
         const axisConfig: Record<string, any> = {};
         if (field && (hasFormatOrRound || axisMinInterval)) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3444<!-- reference the related issue e.g. #150 -->
Closes: #3443

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

For users that haven't synced their repo recently, their cached explores might have unsupported time intervals. 

Since this is a temporary problem I don't want to change the type to support `string`.

Instead I'm just validating the value is a valid time interval
