### PR TITLE
feat: url can reference any value in the row

### DIFF
--- a/docs/docs/references/dimensions.mdx
+++ b/docs/docs/references/dimensions.mdx
@@ -185,10 +185,12 @@ columns:
           - label: Search for company in Google
             url: "https://google.com/search?${ value.formatted | url_encode }"
           - label: Open in CRM
-            url: "https://mycrm.com/companies/${ value.formatted | url_encode }"
+            url: "https://mycrm.com/companies/${ row.company.company_id.raw | url_encode }"
 ```
 
 The `${ value.formatted }` will be replaced with the value of the company name in the Lightdash UI at query run time.
+The `${ row.company.company_id.raw }` will be replaced with the value of the company id in the Lightdash UI at query run time.
+The action will be disabled if the column "company_id" from table "company" is not part of the query.
 
 ### Liquid Templating
 
@@ -196,10 +198,12 @@ Use templates to configure the url values depending on the query, this allows yo
 
 **Available liquid tags**
 
-| Tag                    | Description                                                                                  |
-|------------------------|----------------------------------------------------------------------------------------------|
-| `${ value.formatted }` | The exact value of the dimension as seen in the Lightdash UI. For example "$1,427.20"        |
-| `${ value.raw }`       | The raw value of the dimension returned from the underlying SQL query. For example "1427.2 " |
+| Tag                                         | Description                                                                                  |
+|---------------------------------------------|----------------------------------------------------------------------------------------------|
+| `${ value.formatted }`                      | The exact value of the dimension as seen in the Lightdash UI. For example "$1,427.20"        |
+| `${ value.raw }`                            | The raw value of the dimension returned from the underlying SQL query. For example "1427.2 " |
+| `${ row.table_name.column_name.formatted }` | The exact value of the column as seen in the Lightdash UI. For example "$1,427.20"           |
+| `${ row.table_name.column_name.raw }`       | The raw value of the dimension returned from the underlying SQL query. For example "1427.2 " |
 
 **Available liquid filters**
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -49,6 +49,7 @@ import {
     ProjectMemberProfile,
     ProjectMemberRole,
 } from './types/projectMemberProfile';
+import { ResultRow } from './types/results';
 import { SavedChart, Series } from './types/savedCharts';
 import { SearchResults } from './types/search';
 import { ShareUrl } from './types/share';
@@ -77,6 +78,7 @@ export * from './types/organization';
 export * from './types/organizationMemberProfile';
 export * from './types/personalAccessToken';
 export * from './types/projectMemberProfile';
+export * from './types/results';
 export * from './types/savedCharts';
 export * from './types/search';
 export * from './types/share';
@@ -443,14 +445,6 @@ export const snakeCaseName = (text: string): string =>
 
 export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 
-export type ResultRow = {
-    [col: string]: {
-        value: {
-            raw: any;
-            formatted: any;
-        };
-    };
-};
 export type ApiQueryResults = {
     metricQuery: MetricQuery;
     rows: ResultRow[];

--- a/packages/common/src/templating/template.mock.ts
+++ b/packages/common/src/templating/template.mock.ts
@@ -1,0 +1,57 @@
+export const valueMock = {
+    raw: 'raw',
+    formatted: 'formatted',
+};
+
+export const rowMock = {
+    customers: {
+        customer_id: {
+            raw: 'id',
+            formatted: 'id',
+        },
+        last_name: {
+            raw: 'last name',
+            formatted: 'last name',
+        },
+    },
+};
+
+export const templateWithRawValueReference = {
+    template: 'https://example.com/company/${value.raw | url_encode }',
+    expectedUrl: 'https://example.com/company/raw',
+    expectedRowReferences: [],
+};
+
+export const templateWithFormattedValueReference = {
+    template: 'https://example.com/company/${value.formatted | url_encode }',
+    expectedUrl: 'https://example.com/company/formatted',
+    expectedRowReferences: [],
+};
+
+export const templateWithRowReference = {
+    template:
+        'https://example.com/company/${row.customers.customer_id.raw | url_encode }',
+    expectedUrl: 'https://example.com/company/id',
+    expectedRowReferences: ['customers_customer_id'],
+};
+
+export const templateWithMultipleRowReferences = {
+    template:
+        'https://example.com/company/${row.customers.customer_id.raw | url_encode }/${row.customers.last_name.raw | url_encode }',
+    expectedUrl: 'https://example.com/company/id/last+name',
+    expectedRowReferences: ['customers_customer_id', 'customers_last_name'],
+};
+
+export const templateWithInvalidReference = {
+    template:
+        'https://example.com/company/${row.customer_id.raw | url_encode }',
+    expectedError:
+        'Found invalid reference "${row.customer_id.raw | url_encode }" in your url template',
+};
+
+export const templateWithRowReferenceAndInvalidReference = {
+    template:
+        'https://example.com/company/${row.customers.customer_id.raw | url_encode }/${row.customer_id.raw | url_encode }',
+    expectedError:
+        'Found invalid reference "${row.customer_id.raw | url_encode }" in your url template',
+};

--- a/packages/common/src/templating/template.test.ts
+++ b/packages/common/src/templating/template.test.ts
@@ -1,0 +1,80 @@
+import { getTemplatedUrlRowDependencies, renderTemplatedUrl } from './template';
+import {
+    rowMock,
+    templateWithFormattedValueReference,
+    templateWithInvalidReference,
+    templateWithMultipleRowReferences,
+    templateWithRawValueReference,
+    templateWithRowReference,
+    templateWithRowReferenceAndInvalidReference,
+    valueMock,
+} from './template.mock';
+
+describe('template', () => {
+    it('Render valid templates', () => {
+        expect(
+            renderTemplatedUrl(
+                templateWithRawValueReference.template,
+                valueMock,
+                rowMock,
+            ),
+        ).toBe(templateWithRawValueReference.expectedUrl);
+        expect(
+            renderTemplatedUrl(
+                templateWithFormattedValueReference.template,
+                valueMock,
+                rowMock,
+            ),
+        ).toBe(templateWithFormattedValueReference.expectedUrl);
+        expect(
+            renderTemplatedUrl(
+                templateWithRowReference.template,
+                valueMock,
+                rowMock,
+            ),
+        ).toBe(templateWithRowReference.expectedUrl);
+        expect(
+            renderTemplatedUrl(
+                templateWithMultipleRowReferences.template,
+                valueMock,
+                rowMock,
+            ),
+        ).toBe(templateWithMultipleRowReferences.expectedUrl);
+    });
+    it('Get row dependencies from valid templates', () => {
+        expect(
+            getTemplatedUrlRowDependencies(
+                templateWithRawValueReference.template,
+            ),
+        ).toStrictEqual(templateWithRawValueReference.expectedRowReferences);
+        expect(
+            getTemplatedUrlRowDependencies(
+                templateWithFormattedValueReference.template,
+            ),
+        ).toStrictEqual(
+            templateWithFormattedValueReference.expectedRowReferences,
+        );
+        expect(
+            getTemplatedUrlRowDependencies(templateWithRowReference.template),
+        ).toStrictEqual(templateWithRowReference.expectedRowReferences);
+        expect(
+            getTemplatedUrlRowDependencies(
+                templateWithMultipleRowReferences.template,
+            ),
+        ).toStrictEqual(
+            templateWithMultipleRowReferences.expectedRowReferences,
+        );
+    });
+    it('Throw error when template has invalid reference', () => {
+        expect(() =>
+            getTemplatedUrlRowDependencies(
+                templateWithInvalidReference.template,
+            ),
+        ).toThrow(templateWithInvalidReference.expectedError);
+        expect(() =>
+            getTemplatedUrlRowDependencies(
+                templateWithRowReferenceAndInvalidReference.template,
+            ),
+        ).toThrow(templateWithRowReferenceAndInvalidReference.expectedError);
+    });
+});

--- a/packages/common/src/templating/template.ts
+++ b/packages/common/src/templating/template.ts
@@ -1,4 +1,5 @@
 import { Liquid } from 'liquidjs';
+import { ResultRow } from '../types/results';
 
 const templateEngine = new Liquid({
     cache: true,
@@ -14,4 +15,5 @@ const templateEngine = new Liquid({
 export const renderTemplatedUrl = (
     templatedUrl: string,
     value: { raw: any; formatted: string },
-): string => templateEngine.parseAndRenderSync(templatedUrl, { value });
+    row: ResultRow,
+): string => templateEngine.parseAndRenderSync(templatedUrl, { value, row });

--- a/packages/common/src/templating/template.ts
+++ b/packages/common/src/templating/template.ts
@@ -1,5 +1,4 @@
 import { Liquid } from 'liquidjs';
-import { ResultRow } from '../types/results';
 
 const templateEngine = new Liquid({
     cache: true,
@@ -15,5 +14,5 @@ const templateEngine = new Liquid({
 export const renderTemplatedUrl = (
     templatedUrl: string,
     value: { raw: any; formatted: string },
-    row: ResultRow,
+    row: Record<string, Record<string, { raw: any; formatted: string }>>,
 ): string => templateEngine.parseAndRenderSync(templatedUrl, { value, row });

--- a/packages/common/src/templating/template.ts
+++ b/packages/common/src/templating/template.ts
@@ -1,4 +1,4 @@
-import { Liquid } from 'liquidjs';
+import { Liquid, TokenKind } from 'liquidjs';
 
 const templateEngine = new Liquid({
     cache: true,
@@ -10,9 +10,35 @@ const templateEngine = new Liquid({
     strictFilters: true,
 });
 
-// eslint-disable-next-line import/prefer-default-export
 export const renderTemplatedUrl = (
     templatedUrl: string,
     value: { raw: any; formatted: string },
     row: Record<string, Record<string, { raw: any; formatted: string }>>,
 ): string => templateEngine.parseAndRenderSync(templatedUrl, { value, row });
+
+export const getTemplatedUrlRowDependencies = (
+    templatedUrl: string,
+): string[] => {
+    const parts = templateEngine.parse(templatedUrl);
+    return parts.reduce<string[]>((acc, part) => {
+        if (part.token.kind === TokenKind.Output) {
+            const referenceString = part.token.getText();
+            const valueReference: undefined | string = referenceString.match(
+                /value\.(raw|formatted)/,
+            )?.[0];
+            const rowReference: undefined | string = referenceString.match(
+                /row\.([a-z\\._]+)\.([a-z\\._]+)\.(raw|formatted)/,
+            )?.[0];
+            if (!valueReference && !rowReference) {
+                throw new Error(
+                    `Found invalid reference "${referenceString}" in your url template`,
+                );
+            }
+            if (!valueReference && rowReference) {
+                const referenceParts = rowReference.split('.');
+                return [...acc, `${referenceParts[1]}_${referenceParts[2]}`];
+            }
+        }
+        return acc;
+    }, []);
+};

--- a/packages/common/src/types/results.ts
+++ b/packages/common/src/types/results.ts
@@ -1,0 +1,8 @@
+export type ResultRow = {
+    [col: string]: {
+        value: {
+            raw: any;
+            formatted: any;
+        };
+    };
+};

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,6 +1,12 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import { isField, isFilterableField, ResultRow } from '@lightdash/common';
+import {
+    Field,
+    isField,
+    isFilterableField,
+    ResultRow,
+    TableCalculation,
+} from '@lightdash/common';
 import React, { FC } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
@@ -10,8 +16,10 @@ import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataPro
 import UrlMenuItems from './UrlMenuItems';
 
 const CellContextMenu: FC<
-    Pick<CellContextMenuProps, 'cell' | 'isEditMode'>
-> = ({ cell, isEditMode }) => {
+    Pick<CellContextMenuProps, 'cell' | 'isEditMode'> & {
+        itemsMap: Record<string, Field | TableCalculation>;
+    }
+> = ({ cell, isEditMode, itemsMap }) => {
     const { addFilter } = useFilters();
     const { viewData } = useUnderlyingDataContext();
     const { track } = useTracking();
@@ -24,7 +32,11 @@ const CellContextMenu: FC<
     return (
         <Menu>
             {!!value.raw && isField(item) && (
-                <UrlMenuItems urls={item.urls} cell={cell} />
+                <UrlMenuItems
+                    urls={item.urls}
+                    cell={cell}
+                    itemsMap={itemsMap}
+                />
             )}
 
             {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,17 +1,13 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import {
-    isField,
-    isFilterableField,
-    renderTemplatedUrl,
-    ResultRow,
-} from '@lightdash/common';
-import { FC } from 'react';
+import { isField, isFilterableField, ResultRow } from '@lightdash/common';
+import React, { FC } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { CellContextMenuProps } from '../../common/Table/types';
 import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataProvider';
+import UrlMenuItems from './UrlMenuItems';
 
 const CellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell' | 'isEditMode'>
@@ -27,27 +23,9 @@ const CellContextMenu: FC<
 
     return (
         <Menu>
-            {!!value.raw &&
-                isField(item) &&
-                (item.urls || []).map((urlConfig) => (
-                    <MenuItem2
-                        key={`url_entry_${urlConfig.label}`}
-                        icon="open-application"
-                        text={urlConfig.label}
-                        onClick={() => {
-                            track({
-                                name: EventName.GO_TO_LINK_CLICKED,
-                            });
-                            window.open(
-                                renderTemplatedUrl(urlConfig.url, {
-                                    raw: value.raw,
-                                    formatted: value.formatted,
-                                }),
-                                '_blank',
-                            );
-                        }}
-                    />
-                ))}
+            {!!value.raw && isField(item) && (
+                <UrlMenuItems urls={item.urls} cell={cell} />
+            )}
 
             {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,4 +1,5 @@
 import { Colors } from '@blueprintjs/core';
+import { Field, getItemMap, TableCalculation } from '@lightdash/common';
 import React, { FC, memo, ReactNode, useCallback, useMemo } from 'react';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
@@ -40,13 +41,39 @@ export const ExplorerResults = memo(() => {
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );
-    const activeExplore = useExplore(activeTableName, {
+    const { isLoading, data: exploreData } = useExplore(activeTableName, {
         refetchOnMount: false,
     });
+    const tableCalculations = useExplorerContext(
+        (context) =>
+            context.state.unsavedChartVersion.metricQuery.tableCalculations,
+    );
+    const additionalMetrics = useExplorerContext(
+        (context) =>
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
+
+    const itemsMap: Record<string, Field | TableCalculation> | undefined =
+        useMemo(() => {
+            if (exploreData) {
+                return getItemMap(
+                    exploreData,
+                    additionalMetrics,
+                    tableCalculations,
+                );
+            }
+            return undefined;
+        }, [exploreData, additionalMetrics, tableCalculations]);
 
     const cellContextMenu = useCallback(
-        (props) => <CellContextMenu isEditMode={isEditMode} {...props} />,
-        [isEditMode],
+        (props) => (
+            <CellContextMenu
+                isEditMode={isEditMode}
+                {...props}
+                itemsMap={itemsMap}
+            />
+        ),
+        [isEditMode, itemsMap],
     );
 
     const IdleState: FC = useCallback(() => {
@@ -87,7 +114,7 @@ export const ExplorerResults = memo(() => {
 
     if (!activeTableName) return <NoTableSelected />;
 
-    if (activeExplore.isLoading) return <EmptyStateExploreLoading />;
+    if (isLoading) return <EmptyStateExploreLoading />;
 
     if (columns.length === 0) return <EmptyStateNoColumns />;
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -1,0 +1,69 @@
+import { Icon } from '@blueprintjs/core';
+import { MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
+import { FieldUrl, renderTemplatedUrl, ResultRow } from '@lightdash/common';
+import { Cell } from '@tanstack/react-table';
+import { FC } from 'react';
+import { useTracking } from '../../../providers/TrackingProvider';
+import { EventName } from '../../../types/Events';
+
+const UrlMenuItems: FC<{
+    urls: FieldUrl[] | undefined;
+    cell: Cell<ResultRow, ResultRow[0]>;
+}> = ({ urls, cell }) => {
+    const { track } = useTracking();
+
+    const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
+    return (
+        <>
+            {(urls || []).map((urlConfig) => {
+                let parsedUrl: string | undefined = undefined;
+                let error: string | undefined = undefined;
+                try {
+                    parsedUrl = renderTemplatedUrl(
+                        urlConfig.url,
+                        {
+                            raw: value.raw,
+                            formatted: value.formatted,
+                        },
+                        cell.row.original,
+                    );
+                } catch (e) {
+                    error = `${e}`;
+                }
+                return (
+                    <MenuItem2
+                        key={`url_entry_${urlConfig.label}`}
+                        icon="open-application"
+                        text={urlConfig.label}
+                        labelElement={
+                            error && (
+                                <Tooltip2
+                                    content={
+                                        <>
+                                            <p>
+                                                Error parsing the url template:{' '}
+                                                {urlConfig.url}
+                                            </p>
+                                            <p>{error}</p>
+                                        </>
+                                    }
+                                >
+                                    <Icon icon="issue" />
+                                </Tooltip2>
+                            )
+                        }
+                        disabled={!parsedUrl}
+                        onClick={() => {
+                            track({
+                                name: EventName.GO_TO_LINK_CLICKED,
+                            });
+                            window.open(parsedUrl, '_blank');
+                        }}
+                    />
+                );
+            })}
+        </>
+    );
+};
+
+export default UrlMenuItems;

--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -1,90 +1,139 @@
 import { Icon } from '@blueprintjs/core';
 import { MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
 import {
+    Field,
     FieldUrl,
+    friendlyName,
+    getItemId,
+    getItemLabel,
+    getTemplatedUrlRowDependencies,
     isField,
     renderTemplatedUrl,
     ResultRow,
+    TableCalculation,
 } from '@lightdash/common';
 import { Cell } from '@tanstack/react-table';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
+
+const UrlMenuItem: FC<{
+    urlConfig: FieldUrl;
+    itemsMap?: Record<string, Field | TableCalculation>;
+    itemIdsInRow: string[];
+    value: { raw: any; formatted: string };
+    row: Record<string, Record<string, { raw: any; formatted: string }>>;
+}> = ({ urlConfig, itemsMap, itemIdsInRow, value, row }) => {
+    const { track } = useTracking();
+    const [url, renderError] = useMemo(() => {
+        let parsedUrl: string | undefined = undefined;
+        let errorMessage: string | undefined = undefined;
+        try {
+            parsedUrl = renderTemplatedUrl(
+                urlConfig.url,
+                {
+                    raw: value.raw,
+                    formatted: value.formatted,
+                },
+                row,
+            );
+        } catch (e) {
+            errorMessage = e instanceof Error ? e.message : `${e}`;
+        }
+        return [parsedUrl, errorMessage];
+    }, [row, urlConfig, value]);
+    const validationError = useMemo(() => {
+        let errorMessage: string | undefined = undefined;
+        try {
+            const rowDependencies = getTemplatedUrlRowDependencies(
+                urlConfig.url,
+            );
+            const missingDependencies = rowDependencies.filter(
+                (rowDependency) => !itemIdsInRow.includes(rowDependency),
+            );
+            if (missingDependencies.length > 0) {
+                if (itemsMap) {
+                    errorMessage = `To use this action add ${missingDependencies
+                        .map((rowReference) => {
+                            const item = itemsMap[rowReference];
+                            const label = item
+                                ? getItemLabel(item)
+                                : friendlyName(rowReference);
+                            return `"${label}"`;
+                        })
+                        .join(' and ')} to your query`;
+                } else {
+                    errorMessage = 'Action not available for this query';
+                }
+            }
+        } catch (e) {
+            errorMessage = e instanceof Error ? e.message : `${e}`;
+        }
+        return errorMessage;
+    }, [itemIdsInRow, itemsMap, urlConfig]);
+    const error: string | undefined = validationError || renderError;
+
+    return (
+        <MenuItem2
+            key={`url_entry_${urlConfig.label}`}
+            icon="open-application"
+            text={urlConfig.label}
+            labelElement={
+                error && (
+                    <Tooltip2 content={error}>
+                        <Icon icon="issue" />
+                    </Tooltip2>
+                )
+            }
+            disabled={!url}
+            onClick={() => {
+                track({
+                    name: EventName.GO_TO_LINK_CLICKED,
+                });
+                window.open(url, '_blank');
+            }}
+        />
+    );
+};
 
 const UrlMenuItems: FC<{
     urls: FieldUrl[] | undefined;
     cell: Cell<ResultRow, ResultRow[0]>;
-}> = ({ urls, cell }) => {
-    const { track } = useTracking();
+    itemsMap?: Record<string, Field | TableCalculation>;
+}> = ({ urls, cell, itemsMap }) => {
     const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
-    const row = cell.row
-        .getAllCells()
-        .reduce<
-            Record<string, Record<string, { raw: any; formatted: string }>>
-        >((acc, rowCell) => {
-            const item = rowCell.column.columnDef.meta?.item;
-            const rowCellValue = (rowCell.getValue() as ResultRow[0])?.value;
-            if (item && isField(item) && value) {
-                acc[item.table] = acc[item.table] || {};
-                acc[item.table][item.name] = rowCellValue;
+    const [itemIdsInRow, rowData] = useMemo(() => {
+        const itemIds: string[] = [];
+        const row = cell.row
+            .getAllCells()
+            .reduce<
+                Record<string, Record<string, { raw: any; formatted: string }>>
+            >((acc, rowCell) => {
+                const item = rowCell.column.columnDef.meta?.item;
+                const rowCellValue = (rowCell.getValue() as ResultRow[0])
+                    ?.value;
+                if (item && isField(item) && rowCellValue) {
+                    itemIds.push(getItemId(item));
+                    acc[item.table] = acc[item.table] || {};
+                    acc[item.table][item.name] = rowCellValue;
+                    return acc;
+                }
                 return acc;
-            }
-            return acc;
-        }, {});
+            }, {});
+        return [itemIds, row];
+    }, [cell]);
 
     return (
         <>
-            {(urls || []).map((urlConfig) => {
-                let parsedUrl: string | undefined = undefined;
-                let error: string | undefined = undefined;
-                try {
-                    parsedUrl = renderTemplatedUrl(
-                        urlConfig.url,
-                        {
-                            raw: value.raw,
-                            formatted: value.formatted,
-                        },
-                        row,
-                    );
-                } catch (e: any) {
-                    if (e.originalError?.name === 'UndefinedVariableError') {
-                        const rowReferences = e.context.match(
-                            /row\.([a-z\\._]+)\.([a-z\\._]+)\.(raw|formatted)/g,
-                        );
-                        console.log('rowReferences', rowReferences);
-                        if (rowReferences && rowReferences.length > 0) {
-                            error = `To use this action add ${rowReferences.join(
-                                ' and ',
-                            )} to your query`;
-                        } else {
-                            error = `Value not found for reference "${e.token.content}"`;
-                        }
-                    } else {
-                        error = `${e}`;
-                    }
-                }
-                return (
-                    <MenuItem2
-                        key={`url_entry_${urlConfig.label}`}
-                        icon="open-application"
-                        text={urlConfig.label}
-                        labelElement={
-                            error && (
-                                <Tooltip2 content={error}>
-                                    <Icon icon="issue" />
-                                </Tooltip2>
-                            )
-                        }
-                        disabled={!parsedUrl}
-                        onClick={() => {
-                            track({
-                                name: EventName.GO_TO_LINK_CLICKED,
-                            });
-                            window.open(parsedUrl, '_blank');
-                        }}
-                    />
-                );
-            })}
+            {(urls || []).map((urlConfig) => (
+                <UrlMenuItem
+                    urlConfig={urlConfig}
+                    itemsMap={itemsMap}
+                    itemIdsInRow={itemIdsInRow}
+                    row={rowData}
+                    value={value}
+                />
+            ))}
         </>
     );
 };

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -12,13 +12,7 @@ const ProjectRoute: FC<ComponentProps<typeof Route>> = ({
     ...rest
 }) => {
     const { user } = useApp();
-    const {
-        data: projects,
-        isLoading,
-        isRefetching,
-        isError,
-        error,
-    } = useProjects();
+    const { data: projects, isLoading, isError, error } = useProjects();
 
     return (
         <Route

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,14 +1,12 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import { isField, renderTemplatedUrl, ResultRow } from '@lightdash/common';
-import { FC } from 'react';
-import { useTracking } from '../../providers/TrackingProvider';
-import { EventName } from '../../types/Events';
+import { isField, ResultRow } from '@lightdash/common';
+import React, { FC } from 'react';
 import { CellContextMenuProps } from '../common/Table/types';
+import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
 const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
-    const { track } = useTracking();
     const { viewData } = useUnderlyingDataContext();
 
     const meta = cell.column.columnDef.meta;
@@ -24,28 +22,9 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
     return (
         <Menu>
-            {item &&
-                value.raw &&
-                isField(item) &&
-                (item.urls || []).map((urlConfig) => (
-                    <MenuItem2
-                        key={`url_entry_${urlConfig.label}`}
-                        icon="open-application"
-                        text={urlConfig.label}
-                        onClick={() => {
-                            track({
-                                name: EventName.GO_TO_LINK_CLICKED,
-                            });
-                            window.open(
-                                renderTemplatedUrl(urlConfig.url, {
-                                    raw: value.raw,
-                                    formatted: value.formatted,
-                                }),
-                                '_blank',
-                            );
-                        }}
-                    />
-                ))}
+            {item && value.raw && isField(item) && (
+                <UrlMenuItems urls={item.urls} cell={cell} />
+            )}
             {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}
             <MenuItem2
                 text="View underlying data"

--- a/packages/frontend/src/components/UnderlyingData/CellContextMenu.tsx
+++ b/packages/frontend/src/components/UnderlyingData/CellContextMenu.tsx
@@ -1,18 +1,10 @@
 import { Menu } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
-import {
-    FieldUrl,
-    isField,
-    renderTemplatedUrl,
-    ResultRow,
-} from '@lightdash/common';
-import { FC } from 'react';
-import { useTracking } from '../../providers/TrackingProvider';
-import { EventName } from '../../types/Events';
+import { FieldUrl, isField, ResultRow } from '@lightdash/common';
+import React, { FC } from 'react';
 import { CellContextMenuProps } from '../common/Table/types';
+import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 
 const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
-    const { track } = useTracking();
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
@@ -25,25 +17,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     }
     return (
         <Menu>
-            {urls.map((urlConfig) => (
-                <MenuItem2
-                    key={`url_entry_${urlConfig.label}`}
-                    icon="open-application"
-                    text={urlConfig.label}
-                    onClick={() => {
-                        track({
-                            name: EventName.GO_TO_LINK_CLICKED,
-                        });
-                        window.open(
-                            renderTemplatedUrl(urlConfig.url, {
-                                raw: value.raw,
-                                formatted: value.formatted,
-                            }),
-                            '_blank',
-                        );
-                    }}
-                />
-            ))}
+            <UrlMenuItems urls={urls} cell={cell} />
         </Menu>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3465 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- create component to render urls, so it can be reused in results table, simple table, underlying data table
- disable url menu when url can't be parsed and display error in tooltip for easy debug
- allow template to access row values

Error messages:
![urls from row values and error messages](https://user-images.githubusercontent.com/9117144/195609632-87c76c0e-c26c-4939-ac4b-5cfc37817293.gif)


Example yml referencing a value from the row:
Reference column `customer_id` from table `customers` 
```
              - label: "Open company"
                url: "https://example.com/company/${row.customers.customer_id.raw | url_encode }"
```
