### PR TITLE
docs: fix self reference example

### DIFF
--- a/docs/docs/references/dimensions.mdx
+++ b/docs/docs/references/dimensions.mdx
@@ -61,7 +61,7 @@ models:
             type: string
             label: 'Total revenue' # this is the label you'll see in Lightdash
             description: 'My custom description' # you can override the description you'll see in Lightdash here
-            sql: "IF(${revenue_gbp_total_est} = NULL, 0, ${registered_user_email})" # custom SQL applied to the column from dbt used to define the dimension
+            sql: "IF(${TABLE}.revenue_gbp_total_est = NULL, 0, ${registered_user_email})" # custom SQL applied to the column from dbt used to define the dimension
             hidden: false
             round: 2
             format: 'gbp'


### PR DESCRIPTION

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


The difference is that we reference the table and then have the column name as a string instead of a reference. When there is a reference, we will copy the SQL from that reference, that’s why it causes issues when referencing itself.