### PR TITLE
fix: show fields to filter from new tiles

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -14,10 +14,8 @@ const ActiveFilters: FC = () => {
         removeDimensionDashboardFilter,
         dashboardTiles,
     } = useDashboardContext();
-    const { data: filterableFields } = useAvailableDashboardFilterTargets(
-        dashboard,
-        dashboardTiles,
-    );
+    const { data: filterableFields } =
+        useAvailableDashboardFilterTargets(dashboardTiles);
 
     const fieldMap = filterableFields.reduce<Record<FieldId, FilterableField>>(
         (acc, field) => ({ ...acc, [fieldId(field)]: field }),

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -30,7 +30,8 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         dashboardTiles,
     } = useDashboardContext();
     const { isLoading, data: filterableFields } =
-        useAvailableDashboardFilterTargets(dashboard, dashboardTiles);
+        useAvailableDashboardFilterTargets(dashboardTiles);
+
     const hasChartTiles =
         dashboardTiles.filter(
             (tile) => tile.type === DashboardTileTypes.SAVED_CHART,

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -62,11 +62,8 @@ export const getChartAvailableFilters = async (savedChartUuid: string) =>
     });
 
 export const useAvailableDashboardFilterTargets = (
-    dashboard: Dashboard | undefined,
-    availableTiles: Dashboard['tiles'],
+    availableTilesToFilter: Dashboard['tiles'],
 ): { isLoading: boolean; data: FilterableField[] } => {
-    const availableTilesToFilter =
-        dashboard?.tiles.length !== 0 ? dashboard?.tiles : availableTiles;
     const queries = useMemo(() => {
         const savedChartUuids = (availableTilesToFilter || [])
             .map((tile) =>

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -68,10 +68,9 @@ export const DashboardProvider: React.FC = ({ children }) => {
     const [dashboardTiles, setDashboardTiles] = useState<
         Dashboard['tiles'] | []
     >([]);
-    const { data: filterableFields } = useAvailableDashboardFilterTargets(
-        dashboard,
-        dashboardTiles,
-    );
+    const { data: filterableFields } =
+        useAvailableDashboardFilterTargets(dashboardTiles);
+
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
     const [dashboardTemporaryFilters, setDashboardTemporaryFilters] =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3390

### Description:

Fields for filters was extracted for saved dashboard (if tiles > 0) . I updated it to always take the files from the `unsaved` tiles 
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

https://user-images.githubusercontent.com/1983672/195590815-442f972a-9a21-45c2-9d35-5e567fa9e687.mov

