### PR TITLE
fix: underlying data of multi pivot table

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -21,6 +21,7 @@ import {
     getResultValues,
     getVisibleFields,
     isFilterableField,
+    PivotReference,
     ResultRow,
     SavedChart,
 } from '@lightdash/common';
@@ -188,7 +189,7 @@ const DashboardChartTile: FC<Props> = (props) => {
         meta: TableColumn['meta'];
         row: ResultRow;
         dimensions: string[];
-        pivot?: { fieldId: string; value: any };
+        pivotReference?: PivotReference;
     }>();
     const { user } = useApp();
 
@@ -423,14 +424,14 @@ const DashboardChartTile: FC<Props> = (props) => {
                                                         meta,
                                                         row,
                                                         dimensions,
-                                                        pivot,
+                                                        pivotReference,
                                                     } = viewUnderlyingDataOptions;
                                                     viewData(
                                                         value,
                                                         meta,
                                                         row,
                                                         dimensions,
-                                                        pivot,
+                                                        pivotReference,
                                                         dashboardFilters,
                                                     );
                                                 }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -69,7 +69,7 @@ export const SeriesContextMenu: FC<{
                 underlyingData.meta,
                 underlyingData.row,
                 dimensions,
-                underlyingData.pivot,
+                underlyingData.pivotReference,
             );
         }
     }, [

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -13,12 +13,6 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const item = meta?.item;
 
     const value: ResultRow[0]['value'] = cell.getValue()?.value || {};
-    const pivot = meta?.pivotReference?.pivotValues?.[0]
-        ? {
-              fieldId: meta?.pivotReference?.pivotValues?.[0].field,
-              value: meta?.pivotReference?.pivotValues?.[0].value,
-          }
-        : undefined;
 
     return (
         <Menu>
@@ -35,7 +29,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                         meta,
                         cell.row.original || {},
                         undefined,
-                        pivot,
+                        meta?.pivotReference,
                     );
                 }}
             />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before it was only filtering by the first pivot value.
Now is filtering by all pivot values.

Filter underlying data for all pivot values

![multi pivot underlying data](https://user-images.githubusercontent.com/9117144/197730353-71e4b7a0-9698-42e3-91dd-309d1b195e6b.gif)

