### PR TITLE
feat: project settings breadcrumbs

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -183,16 +183,6 @@ const App = () => (
                                                     <Switch>
                                                         <ProjectRoute path="/projects/:projectUuid">
                                                             <Switch>
-                                                                <Route path="/projects/:projectUuid/settings/:tab?">
-                                                                    <NavBar />
-                                                                    <TrackPage
-                                                                        name={
-                                                                            PageName.PROJECT_SETTINGS
-                                                                        }
-                                                                    >
-                                                                        <ProjectSettings />
-                                                                    </TrackPage>
-                                                                </Route>
                                                                 <Route path="/projects/:projectUuid/saved/:savedQueryUuid/:mode?">
                                                                     <NavBar />
                                                                     <TrackPage

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
 import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
 import '@blueprintjs/select/lib/css/blueprint-select.css';
 import '@blueprintjs/table/lib/css/table.css';
-import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import {
@@ -34,7 +33,6 @@ import Login from './pages/Login';
 import PasswordRecovery from './pages/PasswordRecovery';
 import PasswordReset from './pages/PasswordReset';
 import { Projects } from './pages/Projects';
-import ProjectSettings from './pages/ProjectSettings';
 import Register from './pages/Register';
 import SavedDashboards from './pages/SavedDashboards';
 import SavedExplorer from './pages/SavedExplorer';

--- a/packages/frontend/src/components/DbtCloudSettings/index.tsx
+++ b/packages/frontend/src/components/DbtCloudSettings/index.tsx
@@ -20,9 +20,12 @@ import Form from '../ReactHookForm/Form';
 import Input from '../ReactHookForm/Input';
 import PasswordInput from '../ReactHookForm/PasswordInput';
 
-const DbtCloudSettings: FC = () => {
-    const dbtCloudSettings = useProjectDbtCloud();
-    const update = useProjectDbtCloudUpdateMutation();
+interface DbtCloudSettingsProps {
+    projectUuid: string;
+}
+const DbtCloudSettings: FC<DbtCloudSettingsProps> = ({ projectUuid }) => {
+    const dbtCloudSettings = useProjectDbtCloud(projectUuid);
+    const update = useProjectDbtCloudUpdateMutation(projectUuid);
     const methods = useForm<CreateDbtCloudIntegration>({
         mode: 'onSubmit',
         defaultValues: {
@@ -42,68 +45,65 @@ const DbtCloudSettings: FC = () => {
         update.mutate(data);
     };
     return (
-        <Content>
-            <ContentContainer>
-                <Header>
-                    <TitleWrapper>
-                        <Title marginBottom>Connect to dbt Cloud</Title>
-                    </TitleWrapper>
-                </Header>
-                <Subtitle>
-                    Connect Lightdash to your dbt Cloud account to start
-                    consuming metrics from the dbt semantic layer and using dbt
-                    jinja in your queries. To get started we recommend following
-                    the{' '}
-                    <a href="https://docs.lightdash.com/guides/dbt-semantic-layer">
-                        dbt cloud semantic layer guide
-                    </a>{' '}
-                    in the Lightdash docs.
-                </Subtitle>
-                <Card>
-                    {dbtCloudSettings.error ? (
-                        <NonIdealState
-                            title={dbtCloudSettings.error.error.message}
-                            icon="error"
+        <>
+            <Header>
+                <TitleWrapper>
+                    <Title marginBottom>Connect to dbt Cloud</Title>
+                </TitleWrapper>
+            </Header>
+            <Subtitle>
+                Connect Lightdash to your dbt Cloud account to start consuming
+                metrics from the dbt semantic layer and using dbt jinja in your
+                queries. To get started we recommend following the{' '}
+                <a href="https://docs.lightdash.com/guides/dbt-semantic-layer">
+                    dbt cloud semantic layer guide
+                </a>{' '}
+                in the Lightdash docs.
+            </Subtitle>
+            <Card>
+                {dbtCloudSettings.error ? (
+                    <NonIdealState
+                        title={dbtCloudSettings.error.error.message}
+                        icon="error"
+                    />
+                ) : (
+                    <Form
+                        name="integration_dbt_cloud"
+                        methods={methods}
+                        onSubmit={handleSubmit}
+                    >
+                        <PasswordInput
+                            name="serviceToken"
+                            label="Service Token"
+                            disabled={dbtCloudSettings.isLoading}
+                            placeholder="Enter your token..."
+                            rules={{
+                                required: 'Required field',
+                            }}
+                            labelHelp="Service tokens can be found in your dbt Cloud account settings: https://cloud.getdbt.com/next/settings - token needs at least 'metadata only' permissions."
                         />
-                    ) : (
-                        <Form
-                            name="integration_dbt_cloud"
-                            methods={methods}
-                            onSubmit={handleSubmit}
-                        >
-                            <PasswordInput
-                                name="serviceToken"
-                                label="Service Token"
-                                disabled={dbtCloudSettings.isLoading}
-                                placeholder="Enter your token..."
-                                rules={{
-                                    required: 'Required field',
-                                }}
-                                labelHelp="Service tokens can be found in your dbt Cloud account settings: https://cloud.getdbt.com/next/settings - token needs at least 'metadata only' permissions."
-                            />
 
-                            <Input
-                                name="metricsJobId"
-                                label="Job ID"
-                                disabled={dbtCloudSettings.isLoading}
-                                rules={{
-                                    required: 'Required field',
-                                }}
-                                labelHelp="Your Job ID can be found by clicking Deploy > Jobs in the top bar in dbt Cloud. The Job ID in is the number in the URL after /jobs/12345."
+                        <Input
+                            name="metricsJobId"
+                            label="Job ID"
+                            disabled={dbtCloudSettings.isLoading}
+                            rules={{
+                                required: 'Required field',
+                            }}
+                            labelHelp="Your Job ID can be found by clicking Deploy > Jobs in the top bar in dbt Cloud. The Job ID in is the number in the URL after /jobs/12345."
+                        />
+                        <ButtonsWrapper>
+                            <SaveButton
+                                type="submit"
+                                intent={Intent.PRIMARY}
+                                text="Save"
+                                loading={dbtCloudSettings.isLoading}
                             />
-                            <ButtonsWrapper>
-                                <SaveButton
-                                    type="submit"
-                                    intent={Intent.PRIMARY}
-                                    text="Save"
-                                    loading={dbtCloudSettings.isLoading}
-                                />
-                            </ButtonsWrapper>
-                        </Form>
-                    )}
-                </Card>
-            </ContentContainer>
-        </Content>
+                        </ButtonsWrapper>
+                    </Form>
+                )}
+            </Card>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -40,7 +40,7 @@ const BasePanel = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const errorLogs = useErrorLogs();
     const [search, setSearch] = useState<string>('');
-    const exploresResult = useExplores(true);
+    const exploresResult = useExplores(projectUuid, true);
 
     const filteredTables = useMemo(() => {
         const validSearch = search ? search.toLowerCase() : '';

--- a/packages/frontend/src/components/NavBar/SettingsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu/index.tsx
@@ -43,7 +43,7 @@ const SettingsMenu: FC = () => {
                             text="Project settings"
                             onClick={() => {
                                 history.push(
-                                    `/projects/${activeProjectUuid}/settings`,
+                                    `/generalSettings/projectManagement/${activeProjectUuid}`,
                                 );
                             }}
                         />

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -16,8 +16,7 @@ import {
     ProjectMemberProfile,
     ProjectMemberRole,
 } from '@lightdash/common';
-import React, { FC, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { FC, useMemo, useState } from 'react';
 import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
 import {
     useProjectAccess,
@@ -156,10 +155,13 @@ const relevantOrgRolesForProjectRole: Record<
     [ProjectMemberRole.ADMIN]: [],
 };
 
-const ProjectAccess: FC = () => {
+interface ProjectAccessProps {
+    projectUuid: string;
+}
+
+const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
     const { user } = useApp();
     const ability = useAbilityContext();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { mutate: revokeAccess } =
         useRevokeProjectAccessMutation(projectUuid);
     const { mutate: updateAccess } =

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
@@ -8,9 +8,8 @@ import {
     ProjectMemberRole,
     validateEmail,
 } from '@lightdash/common';
-import React, { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
@@ -42,11 +41,16 @@ const renderItem: ItemRenderer<string> = (item, { modifiers, handleClick }) => {
     );
 };
 
-const ProjectAccessCreation: FC<{
+interface ProjectAccessCreationProps {
+    projectUuid: string;
     onBackClick: () => void;
-}> = ({ onBackClick }) => {
+}
+
+const ProjectAccessCreation: FC<ProjectAccessCreationProps> = ({
+    onBackClick,
+    projectUuid,
+}) => {
     const { track } = useTracking();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
 
     const { showToastSuccess } = useToaster();
     const {
@@ -219,7 +223,7 @@ const ProjectAccessCreation: FC<{
 
                     <SubmitButton
                         intent={Intent.PRIMARY}
-                        text={'Give access'}
+                        text="Give access"
                         type="submit"
                         disabled={isLoading || isInvitationLoading}
                     />

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -2,14 +2,12 @@ import { Colors, Icon } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { FC, useState } from 'react';
 import {
-    ContentContainer,
     Header,
     Title,
     TitleWrapper,
 } from '../../pages/ProjectSettings.styles';
 import { useApp } from '../../providers/AppProvider';
 import { Can } from '../common/Authorization';
-import Content from '../common/Page/Content';
 import ProjectAccess from './ProjectAccess';
 import { AddUserButton } from './ProjectAccess.styles';
 import ProjectAccessCreation from './ProjectAccessCreation';

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -27,6 +27,7 @@ const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
         <>
             {showProjectAccessCreate ? (
                 <ProjectAccessCreation
+                    projectUuid={projectUuid}
                     onBackClick={() => {
                         setShowProjectAccessCreate(false);
                     }}

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -1,7 +1,6 @@
 import { Colors, Icon } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
-import React, { FC, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { FC, useState } from 'react';
 import {
     ContentContainer,
     Header,
@@ -15,59 +14,61 @@ import ProjectAccess from './ProjectAccess';
 import { AddUserButton } from './ProjectAccess.styles';
 import ProjectAccessCreation from './ProjectAccessCreation';
 
-const ProjectUserAccess: FC = () => {
+interface ProjectUserAccessProps {
+    projectUuid: string;
+}
+
+const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
     const { user } = useApp();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const [showProjectAccessCreate, setShowProjectAccessCreate] =
         useState<boolean>(false);
+
     return (
-        <Content>
-            <ContentContainer>
-                {showProjectAccessCreate ? (
-                    <ProjectAccessCreation
-                        onBackClick={() => {
-                            setShowProjectAccessCreate(false);
-                        }}
-                    />
-                ) : (
-                    <>
-                        <Header>
-                            <TitleWrapper>
-                                <Title>Project access</Title>
-                                <a
-                                    role="button"
-                                    href="https://docs.lightdash.com/references/roles"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    style={{ color: Colors.GRAY5 }}
-                                >
-                                    <Icon icon="info-sign" />
-                                </a>
-                            </TitleWrapper>
-                            {!showProjectAccessCreate && (
-                                <Can
-                                    I={'manage'}
-                                    this={subject('Project', {
-                                        organizationUuid:
-                                            user.data?.organizationUuid,
-                                        projectUuid,
-                                    })}
-                                >
-                                    <AddUserButton
-                                        intent="primary"
-                                        onClick={() => {
-                                            setShowProjectAccessCreate(true);
-                                        }}
-                                        text="Add user"
-                                    />
-                                </Can>
-                            )}
-                        </Header>
-                        <ProjectAccess />
-                    </>
-                )}
-            </ContentContainer>
-        </Content>
+        <>
+            {showProjectAccessCreate ? (
+                <ProjectAccessCreation
+                    onBackClick={() => {
+                        setShowProjectAccessCreate(false);
+                    }}
+                />
+            ) : (
+                <>
+                    <Header>
+                        <TitleWrapper>
+                            <Title>Project access</Title>
+                            <a
+                                role="button"
+                                href="https://docs.lightdash.com/references/roles"
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{ color: Colors.GRAY5 }}
+                            >
+                                <Icon icon="info-sign" />
+                            </a>
+                        </TitleWrapper>
+                        {!showProjectAccessCreate && (
+                            <Can
+                                I={'manage'}
+                                this={subject('Project', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <AddUserButton
+                                    intent="primary"
+                                    onClick={() => {
+                                        setShowProjectAccessCreate(true);
+                                    }}
+                                    text="Add user"
+                                />
+                            </Can>
+                        )}
+                    </Header>
+                    <ProjectAccess projectUuid={projectUuid} />
+                </>
+            )}
+        </>
     );
 };
 

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
@@ -16,6 +16,8 @@ export const WarehouseLogo = styled.img`
 `;
 
 export const FormWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
     width: 800px;
     margin: 0 auto;
 `;

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
@@ -20,7 +20,9 @@ export const FormWrapper = styled.div`
     margin: 0 auto;
 `;
 
-export const CompileProjectButton = styled(Button)``;
+export const CompileProjectButton = styled(Button)`
+    align-self: flex-end;
+`;
 
 export const AdvancedButtonWrapper = styled.div`
     display: flex;

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
@@ -15,31 +15,6 @@ export const WarehouseLogo = styled.img`
     width: 30px;
 `;
 
-export const CompileProjectWrapper = styled.div<{ fixedButton?: boolean }>`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    position: sticky;
-    background: ${Colors.WHITE};
-    border-top: 1px solid ${Colors.LIGHT_GRAY1};
-    bottom: 0;
-    margin-top: auto;
-    padding: 20px 0;
-    ${({ fixedButton }) =>
-        fixedButton &&
-        `
-            position: fixed;
-            z-index: 1;
-        `}
-`;
-
-export const CompileProjectFixedWidthContainer = styled.div`
-    width: 800px;
-    display: flex;
-    justify-content: flex-end;
-`;
-
 export const FormWrapper = styled.div`
     width: 800px;
     margin: 0 auto;

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -385,16 +385,16 @@ export const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                         defaultType={health.data?.defaultProject?.type}
                         selectedWarehouse={selectedWarehouse}
                     />
+
+                    <CompileProjectButton
+                        large
+                        type="submit"
+                        intent={Intent.PRIMARY}
+                        text="Test &amp; compile project"
+                        loading={isSaving || activeJobIsRunning}
+                    />
                 </FormWrapper>
             </ProjectFormProvider>
-
-            <CompileProjectButton
-                large
-                type="submit"
-                intent={Intent.PRIMARY}
-                text="Test &amp; compile project"
-                loading={isSaving || activeJobIsRunning}
-            />
         </FormContainer>
     );
 };

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -30,8 +30,6 @@ import DbtLogo from './ProjectConnectFlow/Assets/dbt.svg';
 import { getWarehouseLabel } from './ProjectConnectFlow/SelectWarehouse';
 import {
     CompileProjectButton,
-    CompileProjectFixedWidthContainer,
-    CompileProjectWrapper,
     FormContainer,
     FormWrapper,
     WarehouseLogo,
@@ -306,18 +304,14 @@ export const UpdateProjectConnection: FC<{
                     mutation={updateMutation}
                 />
             )}
-            <CompileProjectWrapper>
-                <CompileProjectFixedWidthContainer>
-                    <CompileProjectButton
-                        large
-                        type="submit"
-                        intent={Intent.PRIMARY}
-                        text="Test &amp; compile project"
-                        loading={isSaving}
-                        disabled={isDisabled}
-                    />
-                </CompileProjectFixedWidthContainer>
-            </CompileProjectWrapper>
+            <CompileProjectButton
+                large
+                type="submit"
+                intent={Intent.PRIMARY}
+                text="Test &amp; compile project"
+                loading={isSaving}
+                disabled={isDisabled}
+            />
         </FormContainer>
     );
 };
@@ -393,17 +387,14 @@ export const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                     />
                 </FormWrapper>
             </ProjectFormProvider>
-            <CompileProjectWrapper fixedButton>
-                <CompileProjectFixedWidthContainer>
-                    <CompileProjectButton
-                        large
-                        type="submit"
-                        intent={Intent.PRIMARY}
-                        text="Test &amp; compile project"
-                        loading={isSaving || activeJobIsRunning}
-                    />
-                </CompileProjectFixedWidthContainer>
-            </CompileProjectWrapper>
+
+            <CompileProjectButton
+                large
+                type="submit"
+                intent={Intent.PRIMARY}
+                text="Test &amp; compile project"
+                loading={isSaving || activeJobIsRunning}
+            />
         </FormContainer>
     );
 };

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -259,6 +259,7 @@ const ProjectTablesConfiguration: FC<{
                     </RadioGroup>
                 </RightPanel>
             </CardWrapper>
+
             {canUpdateTableConfiguration && (
                 <SaveButton
                     type="submit"

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -42,7 +42,8 @@ const ProjectTablesConfiguration: FC<{
     const ability = useAbilityContext();
     const [isListOpen, toggleList] = useToggle(false);
 
-    const { data: explores, isLoading: isLoadingExplores } = useExplores();
+    const { data: explores, isLoading: isLoadingExplores } =
+        useExplores(projectUuid);
     const { data, isLoading } = useProjectTablesConfiguration(projectUuid);
     const {
         mutate: update,

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -3,7 +3,6 @@ import {
     ButtonGroup,
     Classes,
     Dialog,
-    H5,
     Intent,
 } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
@@ -19,6 +18,7 @@ import {
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
 import LinkButton from '../../common/LinkButton';
+import { PanelTitle } from '../AccessTokensPanel/AccessTokens.styles';
 import {
     HeaderActions,
     ItemContent,
@@ -144,7 +144,7 @@ const ProjectManagementPanel: FC = () => {
     return (
         <ProjectManagementPanelWrapper>
             <HeaderActions>
-                <H5>Project management settings</H5>
+                <PanelTitle>Project management settings</PanelTitle>
                 <Can I="create" a="Project">
                     <Button
                         intent="primary"

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -62,7 +62,7 @@ const ProjectListItem: FC<{
                         icon="cog"
                         outlined
                         text="Settings"
-                        href={`/projects/${projectUuid}/settings`}
+                        href={`/generalSettings/projectManagement/${projectUuid}/settings`}
                     />
                     <Can
                         I="delete"

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -62,7 +62,7 @@ const ProjectListItem: FC<{
                         icon="cog"
                         outlined
                         text="Settings"
-                        href={`/generalSettings/projectManagement/${projectUuid}/settings`}
+                        href={`/generalSettings/projectManagement/${projectUuid}`}
                     />
                     <Can
                         I="delete"

--- a/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
+++ b/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
@@ -15,8 +15,7 @@ const get = async (projectUuid: string) =>
         body: undefined,
     });
 
-export const useProjectDbtCloud = () => {
-    const { projectUuid } = useParams<{ projectUuid?: string }>();
+export const useProjectDbtCloud = (projectUuid: string) => {
     if (projectUuid === undefined) {
         throw new Error(
             'Must use useProjectDbtCloud hook under react-router path with projectUuid available',
@@ -35,8 +34,7 @@ const post = async (projectUuid: string, data: CreateDbtCloudIntegration) =>
         body: JSON.stringify(data),
     });
 
-export const useProjectDbtCloudUpdateMutation = () => {
-    const { projectUuid } = useParams<{ projectUuid?: string }>();
+export const useProjectDbtCloudUpdateMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
     if (projectUuid === undefined) {

--- a/packages/frontend/src/hooks/useExplores.tsx
+++ b/packages/frontend/src/hooks/useExplores.tsx
@@ -1,6 +1,5 @@
 import { ApiError, ApiExploresResults } from '@lightdash/common';
 import { useQuery } from 'react-query';
-import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import useQueryError from './useQueryError';
 
@@ -13,8 +12,7 @@ const getExplores = async (projectUuid: string, filtered?: boolean) =>
         body: undefined,
     });
 
-export const useExplores = (filtered?: boolean) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+export const useExplores = (projectUuid: string, filtered?: boolean) => {
     const setErrorResponse = useQueryError();
     const queryKey = ['tables', projectUuid, filtered ? 'filtered' : 'all'];
     return useQuery<ApiExploresResults, ApiError>({

--- a/packages/frontend/src/pages/ProjectSettings.styles.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.styles.tsx
@@ -7,18 +7,6 @@ export const ContentContainer = styled.div`
     margin: 0 auto;
 `;
 
-export const UpdateProjectWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow-y: scroll;
-`;
-
-export const UpdateHeaderWrapper = styled.div`
-    width: 800px;
-    margin: 40px auto 0;
-`;
-
 export const Header = styled.div`
     display: flex;
     flex-direction: row;

--- a/packages/frontend/src/pages/ProjectSettings.styles.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.styles.tsx
@@ -12,6 +12,7 @@ export const Header = styled.div`
     flex-direction: row;
     align-items: center;
 `;
+
 export const TitleWrapper = styled.div`
     display: flex;
     flex-direction: row;
@@ -47,4 +48,8 @@ export const ButtonsWrapper = styled.div`
 
 export const SaveButton = styled(BigButton)`
     width: 170px;
+`;
+
+export const TabsWrapper = styled.div`
+    margin: 30px 0 20px 0;
 `;

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,4 +1,5 @@
 import { NonIdealState, Spinner, Tab, Tabs } from '@blueprintjs/core';
+import { Breadcrumbs2 } from '@blueprintjs/popover2';
 import { FC } from 'react';
 import {
     Redirect,
@@ -12,7 +13,6 @@ import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectTablesConfiguration from '../components/ProjectTablesConfiguration/ProjectTablesConfiguration';
 import { useProject } from '../hooks/useProject';
-import { Title } from './ProjectSettings.styles';
 
 enum Integrations {
     DBT_CLOUD = 'dbt-cloud',
@@ -31,7 +31,7 @@ const ProjectSettings: FC = () => {
         tab?: SettingsTabs | Integrations;
     }>();
 
-    const { isLoading, data, error } = useProject(projectUuid);
+    const { isLoading, data: project, error } = useProject(projectUuid);
     const basePath = `/generalSettings/projectManagement/${projectUuid}`;
 
     const changeTab = (newTab: SettingsTabs | Integrations) => {
@@ -59,7 +59,7 @@ const ProjectSettings: FC = () => {
         return <Redirect to={`${basePath}/settings`} />;
     }
 
-    if (isLoading || !data) {
+    if (isLoading || !project) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <NonIdealState title="Loading project" icon={<Spinner />} />
@@ -69,6 +69,21 @@ const ProjectSettings: FC = () => {
 
     return (
         <>
+            <Breadcrumbs2
+                items={[
+                    {
+                        text: 'All projects',
+                        className: 'home-breadcrumb',
+                        onClick: (e) => {
+                            history.push('/generalSettings/projectManagement');
+                        },
+                    },
+                    {
+                        text: project.name,
+                    },
+                ]}
+            />
+
             <Tabs id="TabsExample" selectedTabId={tab} onChange={changeTab}>
                 <Tab id={SettingsTabs.SETTINGS} title="Project Settings" />
                 <Tab

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,18 +1,7 @@
-import {
-    Colors,
-    Divider,
-    H3,
-    Menu,
-    MenuDivider,
-    NonIdealState,
-    Spinner,
-} from '@blueprintjs/core';
-import React, { FC, useMemo } from 'react';
+import { Colors, Divider, H3, NonIdealState, Spinner } from '@blueprintjs/core';
+import { FC } from 'react';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import Content from '../components/common/Page/Content';
-import PageWithSidebar from '../components/common/Page/PageWithSidebar';
-import Sidebar from '../components/common/Page/Sidebar';
-import RouterMenuItem from '../components/common/RouterMenuItem';
 import DbtCloudSettings from '../components/DbtCloudSettings';
 import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
@@ -29,10 +18,7 @@ import {
 const ProjectSettings: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isLoading, data, error } = useProject(projectUuid);
-    const basePath = useMemo(
-        () => `/projects/${projectUuid}/settings`,
-        [projectUuid],
-    );
+    const basePath = `/generalSettings/projectManagement/${projectUuid}`;
 
     if (error) {
         return (
@@ -52,14 +38,14 @@ const ProjectSettings: FC = () => {
             </div>
         );
     }
-    return (
-        <PageWithSidebar>
-            <Sidebar title="Project settings" noMargin>
+
+    {
+        /* <Sidebar title="Project settings" noMargin>
                 <Menu>
                     <RouterMenuItem
                         text="Project connections"
                         exact
-                        to={basePath}
+                        to={`${basePath}/settings`}
                     />
                     <MenuDivider />
                     <RouterMenuItem
@@ -80,66 +66,57 @@ const ProjectSettings: FC = () => {
                         to={`${basePath}/integration/dbt-cloud`}
                     />
                 </Menu>
-            </Sidebar>
+            </Sidebar> */
+    }
 
-            <Switch>
-                <Route
-                    exact
-                    path="/projects/:projectUuid/settings/tablesConfiguration"
-                >
-                    <Content>
-                        <ContentContainer>
-                            <H3 style={{ marginTop: 10, marginBottom: 0 }}>
-                                Your project has connected successfully! 🎉
-                            </H3>
-                            <Divider style={{ margin: '20px 0' }} />
-                            <p
-                                style={{
-                                    marginBottom: 20,
-                                    color: Colors.GRAY1,
-                                }}
-                            >
-                                Before you start exploring your data, pick the
-                                dbt models you want to appear as tables in
-                                Lightdash. You can always adjust this in your
-                                project settings later.
-                            </p>
-                            <ProjectTablesConfiguration
-                                projectUuid={projectUuid}
-                            />
-                        </ContentContainer>
-                    </Content>
-                </Route>
+    return (
+        <Switch>
+            <Route exact path={`${basePath}/tablesConfiguration}`}>
+                <Content>
+                    <ContentContainer>
+                        <H3 style={{ marginTop: 10, marginBottom: 0 }}>
+                            Your project has connected successfully! 🎉
+                        </H3>
+                        <Divider style={{ margin: '20px 0' }} />
+                        <p
+                            style={{
+                                marginBottom: 20,
+                                color: Colors.GRAY1,
+                            }}
+                        >
+                            Before you start exploring your data, pick the dbt
+                            models you want to appear as tables in Lightdash.
+                            You can always adjust this in your project settings
+                            later.
+                        </p>
+                        <ProjectTablesConfiguration projectUuid={projectUuid} />
+                    </ContentContainer>
+                </Content>
+            </Route>
 
-                <Route exact path="/projects/:projectUuid/settings">
-                    <ProjectConnectionContainer>
-                        <UpdateProjectWrapper>
-                            <UpdateHeaderWrapper>
-                                <Title marginBottom>
-                                    Edit your project connection
-                                </Title>
-                            </UpdateHeaderWrapper>
-                            <UpdateProjectConnection
-                                projectUuid={projectUuid}
-                            />
-                        </UpdateProjectWrapper>
-                    </ProjectConnectionContainer>
-                </Route>
-                <Route
-                    exact
-                    path="/projects/:projectUuid/settings/projectAccess"
-                >
-                    <ProjectUserAccess />
-                </Route>
-                <Route
-                    exact
-                    path="/projects/:projectUuid/settings/integration/dbt-cloud"
-                >
-                    <DbtCloudSettings />
-                </Route>
-                <Redirect to={basePath} />
-            </Switch>
-        </PageWithSidebar>
+            <Route exact path={`${basePath}/settings`}>
+                <ProjectConnectionContainer>
+                    <UpdateProjectWrapper>
+                        <UpdateHeaderWrapper>
+                            <Title marginBottom>
+                                Edit your project connection
+                            </Title>
+                        </UpdateHeaderWrapper>
+                        <UpdateProjectConnection projectUuid={projectUuid} />
+                    </UpdateProjectWrapper>
+                </ProjectConnectionContainer>
+            </Route>
+
+            <Route exact path={`${basePath}/projectAccess`}>
+                <ProjectUserAccess />
+            </Route>
+
+            <Route exact path={`${basePath}/integration/dbt-cloud`}>
+                <DbtCloudSettings />
+            </Route>
+
+            <Redirect to={basePath} />
+        </Switch>
     );
 };
 

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -42,8 +42,6 @@ const ProjectSettings: FC = () => {
         }
     };
 
-    console.log(projectUuid, tab);
-
     if (error) {
         return (
             <div style={{ marginTop: '20px' }}>

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -54,7 +54,7 @@ const ProjectSettings: FC = () => {
     }
 
     if (!tab) {
-        return <Redirect to={`${basePath}/settings`} />;
+        return <Redirect to={`${basePath}/${SettingsTabs.SETTINGS}`} />;
     }
 
     if (isLoading || !project) {

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,6 +1,12 @@
-import { Colors, Divider, H3, NonIdealState, Spinner } from '@blueprintjs/core';
+import { NonIdealState, Spinner, Tab, Tabs } from '@blueprintjs/core';
 import { FC } from 'react';
-import { Redirect, Route, Switch, useParams } from 'react-router-dom';
+import {
+    Redirect,
+    Route,
+    Switch,
+    useHistory,
+    useParams,
+} from 'react-router-dom';
 import Content from '../components/common/Page/Content';
 import DbtCloudSettings from '../components/DbtCloudSettings';
 import ProjectUserAccess from '../components/ProjectAccess';
@@ -16,7 +22,12 @@ import {
 } from './ProjectSettings.styles';
 
 const ProjectSettings: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const history = useHistory();
+    const { projectUuid, tab } = useParams<{
+        projectUuid: string;
+        tab?: string;
+    }>();
+
     const { isLoading, data, error } = useProject(projectUuid);
     const basePath = `/generalSettings/projectManagement/${projectUuid}`;
 
@@ -31,6 +42,12 @@ const ProjectSettings: FC = () => {
         );
     }
 
+    console.log({ tab });
+
+    if (!tab) {
+        return <Redirect to={`${basePath}/settings`} />;
+    }
+
     if (isLoading || !data) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -39,84 +56,53 @@ const ProjectSettings: FC = () => {
         );
     }
 
-    {
-        /* <Sidebar title="Project settings" noMargin>
-                <Menu>
-                    <RouterMenuItem
-                        text="Project connections"
-                        exact
-                        to={`${basePath}/settings`}
-                    />
-                    <MenuDivider />
-                    <RouterMenuItem
-                        text="Tables configuration"
-                        exact
-                        to={`${basePath}/tablesConfiguration`}
-                    />
-                    <MenuDivider />
-                    <RouterMenuItem
-                        text="Project access"
-                        exact
-                        to={`${basePath}/projectAccess`}
-                    />
-                    <MenuDivider />
-                    <RouterMenuItem
-                        text="dbt Cloud"
-                        exact
-                        to={`${basePath}/integration/dbt-cloud`}
-                    />
-                </Menu>
-            </Sidebar> */
-    }
-
     return (
-        <Switch>
-            <Route exact path={`${basePath}/tablesConfiguration}`}>
-                <Content>
-                    <ContentContainer>
-                        <H3 style={{ marginTop: 10, marginBottom: 0 }}>
-                            Your project has connected successfully! 🎉
-                        </H3>
-                        <Divider style={{ margin: '20px 0' }} />
-                        <p
-                            style={{
-                                marginBottom: 20,
-                                color: Colors.GRAY1,
-                            }}
-                        >
-                            Before you start exploring your data, pick the dbt
-                            models you want to appear as tables in Lightdash.
-                            You can always adjust this in your project settings
-                            later.
-                        </p>
-                        <ProjectTablesConfiguration projectUuid={projectUuid} />
-                    </ContentContainer>
-                </Content>
-            </Route>
+        <>
+            <Tabs
+                id="TabsExample"
+                selectedTabId={tab}
+                onChange={(newTab) => {
+                    history.push(`${basePath}/${newTab}`);
+                }}
+            >
+                <Tab id="settings" title="Project Settings" />
+                <Tab id="tablesConfiguration" title="Tables Configuration" />
+                <Tab id="projectAccess" title="Project Access" />
+                <Tab id="integrations/dbt-cloud" title="dbt Cloud" />
+            </Tabs>
 
-            <Route exact path={`${basePath}/settings`}>
-                <ProjectConnectionContainer>
-                    <UpdateProjectWrapper>
-                        <UpdateHeaderWrapper>
-                            <Title marginBottom>
-                                Edit your project connection
-                            </Title>
-                        </UpdateHeaderWrapper>
-                        <UpdateProjectConnection projectUuid={projectUuid} />
-                    </UpdateProjectWrapper>
-                </ProjectConnectionContainer>
-            </Route>
+            <Switch>
+                <Route exact path={`${basePath}/settings`}>
+                    <ProjectConnectionContainer>
+                        <UpdateProjectWrapper>
+                            <UpdateProjectConnection
+                                projectUuid={projectUuid}
+                            />
+                        </UpdateProjectWrapper>
+                    </ProjectConnectionContainer>
+                </Route>
 
-            <Route exact path={`${basePath}/projectAccess`}>
-                <ProjectUserAccess />
-            </Route>
+                <Route exact path={`${basePath}/tablesConfiguration}`}>
+                    <Content>
+                        <ContentContainer>
+                            <ProjectTablesConfiguration
+                                projectUuid={projectUuid}
+                            />
+                        </ContentContainer>
+                    </Content>
+                </Route>
 
-            <Route exact path={`${basePath}/integration/dbt-cloud`}>
-                <DbtCloudSettings />
-            </Route>
+                <Route exact path={`${basePath}/projectAccess`}>
+                    <ProjectUserAccess />
+                </Route>
 
-            <Redirect to={basePath} />
-        </Switch>
+                <Route exact path={`${basePath}/integration/dbt-cloud`}>
+                    <DbtCloudSettings />
+                </Route>
+
+                <Redirect to={basePath} />
+            </Switch>
+        </>
     );
 };
 

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -37,7 +37,7 @@ const ProjectSettings: FC = () => {
 
     const changeTab = (newTab: SettingsTabs | Integrations) => {
         if (newTab === Integrations.DBT_CLOUD) {
-            history.push(`${basePath}/integration/${newTab}`);
+            history.push(`${basePath}/integrations/${newTab}`);
         } else {
             history.push(`${basePath}/${newTab}`);
         }
@@ -117,7 +117,7 @@ const ProjectSettings: FC = () => {
 
                 <Route
                     exact
-                    path={`${basePath}/integration/${Integrations.DBT_CLOUD}`}
+                    path={`${basePath}/integrations/${Integrations.DBT_CLOUD}`}
                 >
                     <DbtCloudSettings projectUuid={projectUuid} />
                 </Route>

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -13,6 +13,7 @@ import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectTablesConfiguration from '../components/ProjectTablesConfiguration/ProjectTablesConfiguration';
 import { useProject } from '../hooks/useProject';
+import { TabsWrapper } from './ProjectSettings.styles';
 
 enum Integrations {
     DBT_CLOUD = 'dbt-cloud',
@@ -80,15 +81,20 @@ const ProjectSettings: FC = () => {
                 ]}
             />
 
-            <Tabs id="TabsExample" selectedTabId={tab} onChange={changeTab}>
-                <Tab id={SettingsTabs.SETTINGS} title="Project Settings" />
-                <Tab
-                    id={SettingsTabs.TABLES_CONFIGURATION}
-                    title="Tables Configuration"
-                />
-                <Tab id={SettingsTabs.PROJECT_ACCESS} title="Project Access" />
-                <Tab id={Integrations.DBT_CLOUD} title="dbt Cloud" />
-            </Tabs>
+            <TabsWrapper>
+                <Tabs id="TabsExample" selectedTabId={tab} onChange={changeTab}>
+                    <Tab id={SettingsTabs.SETTINGS} title="Project Settings" />
+                    <Tab
+                        id={SettingsTabs.TABLES_CONFIGURATION}
+                        title="Tables Configuration"
+                    />
+                    <Tab
+                        id={SettingsTabs.PROJECT_ACCESS}
+                        title="Project Access"
+                    />
+                    <Tab id={Integrations.DBT_CLOUD} title="dbt Cloud" />
+                </Tabs>
+            </TabsWrapper>
 
             <Switch>
                 <Route exact path={`${basePath}/${SettingsTabs.SETTINGS}`}>

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -7,29 +7,42 @@ import {
     useHistory,
     useParams,
 } from 'react-router-dom';
-import Content from '../components/common/Page/Content';
 import DbtCloudSettings from '../components/DbtCloudSettings';
 import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectTablesConfiguration from '../components/ProjectTablesConfiguration/ProjectTablesConfiguration';
 import { useProject } from '../hooks/useProject';
-import {
-    ContentContainer,
-    ProjectConnectionContainer,
-    Title,
-    UpdateHeaderWrapper,
-    UpdateProjectWrapper,
-} from './ProjectSettings.styles';
+import { Title } from './ProjectSettings.styles';
+
+enum Integrations {
+    DBT_CLOUD = 'dbt-cloud',
+}
+
+enum SettingsTabs {
+    SETTINGS = 'settings',
+    TABLES_CONFIGURATION = 'tablesConfiguration',
+    PROJECT_ACCESS = 'projectAccess',
+}
 
 const ProjectSettings: FC = () => {
     const history = useHistory();
     const { projectUuid, tab } = useParams<{
         projectUuid: string;
-        tab?: string;
+        tab?: SettingsTabs | Integrations;
     }>();
 
     const { isLoading, data, error } = useProject(projectUuid);
     const basePath = `/generalSettings/projectManagement/${projectUuid}`;
+
+    const changeTab = (newTab: SettingsTabs | Integrations) => {
+        if (newTab === Integrations.DBT_CLOUD) {
+            history.push(`${basePath}/integration/${newTab}`);
+        } else {
+            history.push(`${basePath}/${newTab}`);
+        }
+    };
+
+    console.log(projectUuid, tab);
 
     if (error) {
         return (
@@ -41,8 +54,6 @@ const ProjectSettings: FC = () => {
             </div>
         );
     }
-
-    console.log({ tab });
 
     if (!tab) {
         return <Redirect to={`${basePath}/settings`} />;
@@ -58,45 +69,39 @@ const ProjectSettings: FC = () => {
 
     return (
         <>
-            <Tabs
-                id="TabsExample"
-                selectedTabId={tab}
-                onChange={(newTab) => {
-                    history.push(`${basePath}/${newTab}`);
-                }}
-            >
-                <Tab id="settings" title="Project Settings" />
-                <Tab id="tablesConfiguration" title="Tables Configuration" />
-                <Tab id="projectAccess" title="Project Access" />
-                <Tab id="integrations/dbt-cloud" title="dbt Cloud" />
+            <Tabs id="TabsExample" selectedTabId={tab} onChange={changeTab}>
+                <Tab id={SettingsTabs.SETTINGS} title="Project Settings" />
+                <Tab
+                    id={SettingsTabs.TABLES_CONFIGURATION}
+                    title="Tables Configuration"
+                />
+                <Tab id={SettingsTabs.PROJECT_ACCESS} title="Project Access" />
+                <Tab id={Integrations.DBT_CLOUD} title="dbt Cloud" />
             </Tabs>
 
             <Switch>
-                <Route exact path={`${basePath}/settings`}>
-                    <ProjectConnectionContainer>
-                        <UpdateProjectWrapper>
-                            <UpdateProjectConnection
-                                projectUuid={projectUuid}
-                            />
-                        </UpdateProjectWrapper>
-                    </ProjectConnectionContainer>
+                <Route exact path={`${basePath}/${SettingsTabs.SETTINGS}`}>
+                    <UpdateProjectConnection projectUuid={projectUuid} />
                 </Route>
 
-                <Route exact path={`${basePath}/tablesConfiguration}`}>
-                    <Content>
-                        <ContentContainer>
-                            <ProjectTablesConfiguration
-                                projectUuid={projectUuid}
-                            />
-                        </ContentContainer>
-                    </Content>
+                <Route
+                    exact
+                    path={`${basePath}/${SettingsTabs.TABLES_CONFIGURATION}`}
+                >
+                    <ProjectTablesConfiguration projectUuid={projectUuid} />
                 </Route>
 
-                <Route exact path={`${basePath}/projectAccess`}>
+                <Route
+                    exact
+                    path={`${basePath}/${SettingsTabs.PROJECT_ACCESS}`}
+                >
                     <ProjectUserAccess />
                 </Route>
 
-                <Route exact path={`${basePath}/integration/dbt-cloud`}>
+                <Route
+                    exact
+                    path={`${basePath}/integration/${Integrations.DBT_CLOUD}`}
+                >
                     <DbtCloudSettings />
                 </Route>
 

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -106,14 +106,14 @@ const ProjectSettings: FC = () => {
                     exact
                     path={`${basePath}/${SettingsTabs.PROJECT_ACCESS}`}
                 >
-                    <ProjectUserAccess />
+                    <ProjectUserAccess projectUuid={projectUuid} />
                 </Route>
 
                 <Route
                     exact
                     path={`${basePath}/integration/${Integrations.DBT_CLOUD}`}
                 >
-                    <DbtCloudSettings />
+                    <DbtCloudSettings projectUuid={projectUuid} />
                 </Route>
 
                 <Redirect to={basePath} />

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -73,10 +73,8 @@ const ProjectSettings: FC = () => {
                 items={[
                     {
                         text: 'All projects',
-                        className: 'home-breadcrumb',
-                        onClick: (e) => {
-                            history.push('/generalSettings/projectManagement');
-                        },
+                        onClick: () =>
+                            history.push('/generalSettings/projectManagement'),
                     },
                     {
                         text: project.name,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { Collapse } from '@blueprintjs/core';
-import React, { FC, useMemo, useState } from 'react';
+import { FC, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import Content from '../components/common/Page/Content';
 import PageWithSidebar from '../components/common/Page/PageWithSidebar';

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -195,7 +195,13 @@ const Settings: FC = () => {
                 {orgData &&
                     !orgData.needsProject &&
                     user.data?.ability?.can('manage', 'Project') && (
-                        <Route path="/generalSettings/projectManagement/:projectUuid/settings/:tab?">
+                        <Route
+                            exact
+                            path={[
+                                '/generalSettings/projectManagement/:projectUuid/:tab?',
+                                '/generalSettings/projectManagement/:projectUuid/:tab/:integration',
+                            ]}
+                        >
                             <TrackPage name={PageName.PROJECT_SETTINGS}>
                                 <Content>
                                     <ContentWrapper>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -199,7 +199,7 @@ const Settings: FC = () => {
                             exact
                             path={[
                                 '/generalSettings/projectManagement/:projectUuid/:tab?',
-                                '/generalSettings/projectManagement/:projectUuid/:tab/:integration',
+                                '/generalSettings/projectManagement/:projectUuid/integration/:tab',
                             ]}
                         >
                             <TrackPage name={PageName.PROJECT_SETTINGS}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -16,7 +16,10 @@ import SocialLoginsPanel from '../components/UserSettings/SocialLoginsPanel';
 import UserManagementPanel from '../components/UserSettings/UserManagementPanel';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
 import { useApp } from '../providers/AppProvider';
+import { TrackPage } from '../providers/TrackingProvider';
+import { PageName } from '../types/Events';
 import { PasswordRecoveryForm } from './PasswordRecoveryForm';
+import ProjectSettings from './ProjectSettings';
 import {
     CardContainer,
     CollapseTrigger,
@@ -55,7 +58,7 @@ const Settings: FC = () => {
         !health.data?.auth.disablePasswordAuthentication;
     const { data: orgData, isLoading } = useOrganisation();
 
-    const basePath = useMemo(() => `/generalSettings`, []);
+    const basePath = `/generalSettings`;
 
     if (isLoading) {
         return <PageSpinner />;
@@ -113,7 +116,6 @@ const Settings: FC = () => {
                             user.data?.ability?.can('view', 'Project') && (
                                 <RouterMenuItem
                                     text="Project management"
-                                    exact
                                     to={`${basePath}/projectManagement`}
                                 />
                             )}
@@ -187,6 +189,20 @@ const Settings: FC = () => {
                                     <ProjectManagementPanel />
                                 </ContentWrapper>
                             </Content>
+                        </Route>
+                    )}
+
+                {orgData &&
+                    !orgData.needsProject &&
+                    user.data?.ability?.can('manage', 'Project') && (
+                        <Route path="/generalSettings/projectManagement/:projectUuid/settings/:tab?">
+                            <TrackPage name={PageName.PROJECT_SETTINGS}>
+                                <Content>
+                                    <ContentWrapper>
+                                        <ProjectSettings />
+                                    </ContentWrapper>
+                                </Content>
+                            </TrackPage>
                         </Route>
                     )}
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -199,7 +199,7 @@ const Settings: FC = () => {
                             exact
                             path={[
                                 '/generalSettings/projectManagement/:projectUuid/:tab?',
-                                '/generalSettings/projectManagement/:projectUuid/integration/:tab',
+                                '/generalSettings/projectManagement/:projectUuid/integrations/:tab',
                             ]}
                         >
                             <TrackPage name={PageName.PROJECT_SETTINGS}>


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3429

### Description:

- [x] Add breadcrumbs so that the user can go back to access 'All Projects'. This means the settings sidebar should never change!
- [x] URLs should now be something like /generalSettings/projects/projectName
- [x] Split `Settings`, `Tables` and `Manage access` into tabs up top.


**Table configuration tab**
- [x] Get rid of the `Your project has connected successfully!` 🎉' copy.
- [x] Get rid of the '`Before you start exploring your data, pick the dbt models you want to appear as tables in Lightdash. You can always adjust this in your project settings later`. copy
- [x] Update the `Start Exploring` CTA to `Save changes`



https://user-images.githubusercontent.com/962095/198115089-14352489-3e1d-42d8-afb5-d849dfa301bb.mp4

