### PR TITLE
fix: members/viewers/editors redirect to createProject flow (onboarding) if they don't have a project access

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -69,6 +69,9 @@ describe('Organization member permissions', () => {
                 ),
             ).toEqual(false);
         });
+        it('can create Project', () => {
+            expect(ability.can('create', 'Project')).toEqual(true);
+        });
     });
 
     describe('when user is an editor', () => {
@@ -108,6 +111,9 @@ describe('Organization member permissions', () => {
         it('can run SQL Queries', () => {
             expect(ability.can('manage', 'SqlRunner')).toEqual(true);
         });
+        it('can create Project', () => {
+            expect(ability.can('create', 'Project')).toEqual(false);
+        });
     });
     describe('when user is a member', () => {
         beforeEach(() => {
@@ -127,6 +133,9 @@ describe('Organization member permissions', () => {
         it('cannot view charts', () => {
             expect(ability.can('view', 'SavedChart')).toEqual(false);
         });
+        it('can create Project', () => {
+            expect(ability.can('create', 'Project')).toEqual(false);
+        });
     });
     describe('when user is a viewer', () => {
         beforeEach(() => {
@@ -141,7 +150,7 @@ describe('Organization member permissions', () => {
             expect(ability.can('create', 'InviteLink')).toEqual(true);
         });
         it('can create Project', () => {
-            expect(ability.can('create', 'Project')).toEqual(true);
+            expect(ability.can('create', 'Project')).toEqual(false);
         });
         it('cannot create any resource', () => {
             expect(ability.can('create', 'Space')).toEqual(false);
@@ -242,6 +251,9 @@ describe('Organization member permissions', () => {
                     subject('Job', { userUuid: 'another-user-uuid' }),
                 ),
             ).toEqual(false);
+        });
+        it('can create Project', () => {
+            expect(ability.can('create', 'Project')).toEqual(false);
         });
     });
 });

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -23,9 +23,6 @@ export const organizationMemberAbilities: Record<
         can('view', 'OrganizationMemberProfile', {
             organizationUuid: member.organizationUuid,
         });
-        can('create', 'Project', {
-            organizationUuid: member.organizationUuid,
-        });
         can('create', 'Job');
         can('view', 'Job', { userUuid: member.userUuid });
     },
@@ -65,6 +62,9 @@ export const organizationMemberAbilities: Record<
     },
     admin(member, { can }) {
         organizationMemberAbilities.editor(member, { can });
+        can('create', 'Project', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'Project', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,45 +1,65 @@
 import { NonIdealState } from '@blueprintjs/core';
-import React, { ComponentProps, FC } from 'react';
+import { subject } from '@casl/ability';
+import { ComponentProps, FC } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
 import { useApp } from '../providers/AppProvider';
 import PageSpinner from './PageSpinner';
 
 const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
-    const { health } = useApp();
-    const orgRequest = useOrganisation();
+    const {
+        health: {
+            data: health,
+            isLoading: isLoadingHealth,
+            error: healthError,
+        },
+        user: { data: user, isLoading: isLoadingUser, error: userError },
+    } = useApp();
+    const {
+        data: organization,
+        error: organizationError,
+        isLoading: isLoadingOrganization,
+    } = useOrganisation();
+
+    if (isLoadingHealth || isLoadingUser || isLoadingOrganization) {
+        return <PageSpinner />;
+    }
+
+    if (healthError || userError || organizationError) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <NonIdealState
+                    title="Unexpected error"
+                    description={
+                        healthError?.error.message ||
+                        userError?.error.message ||
+                        organizationError?.error.message
+                    }
+                />
+            </div>
+        );
+    }
+
+    if (!health || !user || !organization) return null;
+
+    const canUserCreateProject = user.ability.can(
+        'create',
+        subject('Project', {
+            organizationUuid: organization.organizationUuid,
+        }),
+    );
 
     return (
         <Route
             {...rest}
-            render={({ location }) => {
-                if (health.isLoading || orgRequest.isLoading) {
-                    return <PageSpinner />;
+            render={() => {
+                if (organization.needsProject && canUserCreateProject) {
+                    return <Redirect to="/createProject" />;
+                } else if (organization.needsProject && !canUserCreateProject) {
+                    return <Redirect to="/no-project-access" />;
+                } else {
+                    return children;
                 }
-
-                if (orgRequest.error || health.error) {
-                    return (
-                        <div style={{ marginTop: '20px' }}>
-                            <NonIdealState
-                                title="Unexpected error"
-                                description={orgRequest.error?.error.message}
-                            />
-                        </div>
-                    );
-                }
-
-                if (orgRequest.data?.needsProject) {
-                    return (
-                        <Redirect
-                            to={{
-                                pathname: '/createProject',
-                                state: { from: location },
-                            }}
-                        />
-                    );
-                }
-
-                return children;
             }}
         />
     );

--- a/packages/frontend/src/pages/CreateProject.tsx
+++ b/packages/frontend/src/pages/CreateProject.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { getDateFormat, TimeFrames } from '@lightdash/common';
 import moment from 'moment';
 import { FC, useEffect, useState } from 'react';
@@ -25,11 +26,12 @@ enum ConnectMethod {
 
 const CreateProject: FC = () => {
     const history = useHistory();
-    const { isLoading: isLoadingOrganisation, data: organisation } =
+    const { isLoading: isLoadingOrganization, data: organization } =
         useOrganisation();
 
     const {
         health: { data: health, isLoading: isLoadingHealth },
+        user: { data: user, isLoading: isLoadingUser },
     } = useApp();
 
     const {
@@ -62,14 +64,27 @@ const CreateProject: FC = () => {
     if (
         isLoadingHealth ||
         !health ||
-        isLoadingOrganisation ||
-        !organisation ||
+        isLoadingUser ||
+        !user ||
+        isLoadingOrganization ||
+        !organization ||
         isTokenCreating
     ) {
         return <PageSpinner />;
     }
 
-    const isCreatingFirstProject = !!organisation.needsProject;
+    const canUserCreateProject = user.ability.can(
+        'create',
+        subject('Project', {
+            organizationUuid: organization.organizationUuid,
+        }),
+    );
+
+    if (!canUserCreateProject) {
+        return <Redirect to="/" />;
+    }
+
+    const isCreatingFirstProject = !!organization.needsProject;
 
     return (
         <ProjectFormProvider>


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3477

### Description:
little bit confused here.. should viewers/members/editors be able to create project? even tho they can't manage them? if yes, I'll close this PR but seems little odd.

I moved create project permission to admin level and added appropriate checks