### PR TITLE
fix: Revert previous alias on CLI and fix error

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -24,6 +24,7 @@ type CompiledModel = {
     rootPath: string;
     originalFilePath: string;
     patchPath: string | null | undefined;
+    alias?: string;
 };
 
 type GetDatabaseTableForModelArgs = {
@@ -37,9 +38,10 @@ export const getWarehouseTableForModel = async ({
     const tableRef = {
         database: model.database,
         schema: model.schema,
-        table: model.name,
+        table: model.alias || model.name,
     };
     const catalog = await warehouseClient.getCatalog([tableRef]);
+
     const table =
         catalog[tableRef.database]?.[tableRef.schema]?.[tableRef.table];
     if (!table) {
@@ -437,5 +439,6 @@ export const getCompiledModelsFromManifest = ({
         rootPath: modelLookup[nodeId].root_path,
         originalFilePath: modelLookup[nodeId].original_file_path,
         patchPath: modelLookup[nodeId].patch_path,
+        alias: modelLookup[nodeId].alias,
     }));
 };

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -308,12 +308,7 @@ export const getModelsFromManifest = (
                 model.config?.materialized &&
                 model.config.materialized !== 'ephemeral',
         )
-        .map((model) =>
-            normaliseModelDatabase(
-                { ...model, name: model.alias || model.name },
-                adapterType,
-            ),
-        );
+        .map((model) => normaliseModelDatabase(model, adapterType));
 };
 
 type MethodSelectorArgs = {


### PR DESCRIPTION
Reverts lightdash/lightdash#3540

Closes: https://github.com/lightdash/lightdash/issues/3543

Ok so the previous alias implementation was replacing too much stuff. So I am reverting back that change, and just fixing the bug mentioned on the original ticket

If I add  an alias to my model : 

![image](https://user-images.githubusercontent.com/1983672/198968274-a10aea5a-0b75-476f-bc97-e4972ca8b2e2.png)

Before:
![image](https://user-images.githubusercontent.com/1983672/198968048-585114c8-2db7-4170-83e0-7be75b2346cb.png)


After:

![image](https://user-images.githubusercontent.com/1983672/198968020-1b1310ec-6411-4262-8455-df86ae60a699.png)
