### PR TITLE
fix: check for env variable in reset-db script

### DIFF
--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ ! -v PGPASSWORD ]; then
+if [ -z ${PGPASSWORD+x} ]; then
     echo "Can't find ENV variables (PGPASSWORD), have you loaded '.env' environments variable file?"
     exit 1
 fi


### PR DESCRIPTION
### Description:

```bash
﹩ ./scripts/reset-db.sh
./scripts/reset-db.sh: line 4: [: -v: unary operator expected
```

fixes error above ^