### PR TITLE
feat: refresh command

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -213,6 +213,7 @@ type ProjectCompiledEvent = BaseTrack & {
     event: 'project.compiled';
     userId?: string;
     properties: {
+        requestMethod: RequestMethod;
         projectId: string;
         projectName: string;
         projectType: DbtProjectType;
@@ -231,6 +232,7 @@ type ProjectErrorEvent = BaseTrack & {
     event: 'project.error';
     userId?: string;
     properties: {
+        requestMethod: RequestMethod;
         projectId: string;
         name: string;
         statusCode: number;

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -4,6 +4,7 @@ import {
     DbtProjectType,
     LightdashMode,
     OrganizationMemberRole,
+    RequestMethod,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
     SEED_ORG_1_ADMIN_EMAIL,
@@ -172,6 +173,7 @@ export async function seed(knex: Knex): Promise<void> {
     const explores = await projectService.refreshAllTables(
         { userUuid: SEED_ORG_1_ADMIN.user_uuid },
         SEED_PROJECT.project_uuid,
+        RequestMethod.UNKNOWN,
     );
     await projectModel.saveExploresToCache(SEED_PROJECT.project_uuid, explores);
 }

--- a/packages/backend/src/routers/jobsRouter.ts
+++ b/packages/backend/src/routers/jobsRouter.ts
@@ -1,5 +1,8 @@
 import express from 'express';
-import { isAuthenticated } from '../controllers/authentication';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../controllers/authentication';
 import { projectService } from '../services/services';
 
 export const jobsRouter = express.Router({ mergeParams: true });
@@ -8,15 +11,20 @@ jobsRouter.get('/', isAuthenticated, async (req, res, next) => {
     next('Not implemented');
 });
 
-jobsRouter.get('/:jobUuid', isAuthenticated, async (req, res, next) => {
-    try {
-        const { jobUuid } = req.params;
-        const job = await projectService.getJobStatus(jobUuid, req.user!);
-        res.json({
-            status: 'ok',
-            results: job,
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+jobsRouter.get(
+    '/:jobUuid',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const { jobUuid } = req.params;
+            const job = await projectService.getJobStatus(jobUuid, req.user!);
+            res.json({
+                status: 'ok',
+                results: job,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -7,12 +7,10 @@ import {
     getRequestMethod,
     LightdashRequestMethodHeader,
     MetricQuery,
-    ParameterError,
     ProjectCatalog,
     TablesConfiguration,
 } from '@lightdash/common';
 import express from 'express';
-import { lightdashConfig } from '../config/lightdashConfig';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -29,19 +27,24 @@ import { integrationsRouter } from './integrations/intergrationsRouter';
 
 export const projectRouter = express.Router({ mergeParams: true });
 
-projectRouter.get('/', isAuthenticated, async (req, res, next) => {
-    try {
-        res.json({
-            status: 'ok',
-            results: await projectService.getProject(
-                req.params.projectUuid,
-                req.user!,
-            ),
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.get(
+    '/',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            res.json({
+                status: 'ok',
+                results: await projectService.getProject(
+                    req.params.projectUuid,
+                    req.user!,
+                ),
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 
 projectRouter.patch(
     '/',
@@ -228,6 +231,7 @@ projectRouter.get(
 
 projectRouter.post(
     '/refresh',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -235,6 +239,7 @@ projectRouter.post(
             const results = await projectService.compileProject(
                 req.user!,
                 req.params.projectUuid,
+                getRequestMethod(req.header(LightdashRequestMethodHeader)),
             );
             res.json({
                 status: 'ok',

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -97,6 +97,26 @@ type CliPreviewError = BaseTrack & {
     };
 };
 
+type CliRefreshStarted = BaseTrack & {
+    event: 'refresh.started';
+    properties: {
+        projectId: string;
+    };
+};
+type CliRefreshCompleted = BaseTrack & {
+    event: 'refresh.completed';
+    properties: {
+        projectId: string;
+    };
+};
+type CliRefreshError = BaseTrack & {
+    event: 'refresh.error';
+    properties: {
+        projectId: string;
+        error: string;
+    };
+};
+
 type CliCompileStarted = BaseTrack & {
     event: 'compile.started';
     properties: {};
@@ -179,6 +199,9 @@ type Track =
     | CliPreviewStarted
     | CliPreviewCompleted
     | CliPreviewError
+    | CliRefreshStarted
+    | CliRefreshCompleted
+    | CliRefreshError
     | CliCompileStarted
     | CliCompileCompleted
     | CliCompileError

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -36,7 +36,10 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     const headers = {
         'Content-Type': 'application/json',
         Authorization: `ApiKey ${config.context.apiKey}`,
-        [LightdashRequestMethodHeader]: RequestMethod.CLI,
+        [LightdashRequestMethodHeader]:
+            process.env.CI === 'true'
+                ? RequestMethod.CLI_CI
+                : RequestMethod.CLI,
     };
     const fullUrl = new URL(url, config.context.serverUrl).href;
     if (verbose) console.error(`> Making HTTP query to: ${fullUrl}`);

--- a/packages/cli/src/handlers/dbt/refresh.ts
+++ b/packages/cli/src/handlers/dbt/refresh.ts
@@ -1,0 +1,158 @@
+import {
+    ApiRefreshResults,
+    AuthorizationError,
+    DbtProjectType,
+    Job,
+    JobStatusType,
+    JobStep,
+    JobStepStatusType,
+    ParameterError,
+    Project,
+} from '@lightdash/common';
+import ora from 'ora';
+import { LightdashAnalytics } from '../../analytics/analytics';
+import { getConfig } from '../../config';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { checkLightdashVersion, lightdashApi } from './apiClient';
+
+const getProject = async (projectUuid: string, verbose: boolean) =>
+    lightdashApi<Project>({
+        method: 'GET',
+        url: `/api/v1/projects/${projectUuid}`,
+        body: undefined,
+        verbose,
+    });
+
+const refreshProject = async (projectUuid: string, verbose: boolean) =>
+    lightdashApi<ApiRefreshResults>({
+        method: 'POST',
+        url: `/api/v1/projects/${projectUuid}/refresh`,
+        body: undefined,
+        verbose,
+    });
+
+const getJobState = async (jobUuid: string, verbose: boolean) =>
+    lightdashApi<Job>({
+        method: 'GET',
+        url: `/api/v1/jobs/${jobUuid}`,
+        body: undefined,
+        verbose,
+    });
+
+function delay(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export const getRunningStepsMessage = (steps: JobStep[]): string => {
+    const runningStep = steps.find(
+        (step) => step.stepStatus === JobStepStatusType.RUNNING,
+    );
+    const numberOfCompletedSteps = steps.filter(
+        (step) => step.stepStatus === JobStepStatusType.DONE,
+    ).length;
+    return `step ${Math.min(numberOfCompletedSteps + 1, steps.length)}/${
+        steps.length
+    }: ${runningStep?.stepLabel || ''}`;
+};
+
+export const getErrorStepsMessage = (steps: JobStep[]): string => {
+    const errorStep = steps.find(
+        (step) => step.stepStatus === JobStepStatusType.ERROR,
+    );
+    const numberOfCompletedSteps = steps.filter(
+        (step) => step.stepStatus === JobStepStatusType.DONE,
+    ).length;
+    return `step ${Math.min(numberOfCompletedSteps + 1, steps.length)}/${
+        steps.length
+    }: ${errorStep?.stepLabel || ''} error ${errorStep?.stepError}`;
+};
+
+const REFETCH_JOB_INTERVAL = 3000;
+
+const getFinalJobState = async (
+    jobUuid: string,
+    verbose: boolean,
+): Promise<Job> => {
+    const job = await getJobState(jobUuid, verbose);
+
+    if (job.jobStatus === JobStatusType.DONE) {
+        return job;
+    }
+    if (job.jobStatus === JobStatusType.ERROR) {
+        throw new Error(getErrorStepsMessage(job.steps));
+    }
+    const spinner = GlobalState.getActiveSpinner();
+    spinner?.start(
+        `  Refreshing dbt project, ${getRunningStepsMessage(job.steps)}`,
+    );
+    return delay(REFETCH_JOB_INTERVAL).then(() =>
+        getFinalJobState(jobUuid, verbose),
+    );
+};
+
+type RefreshHandlerOptions = {
+    verbose: boolean;
+};
+
+export const refreshHandler = async (options: RefreshHandlerOptions) => {
+    await checkLightdashVersion();
+
+    const config = await getConfig();
+    if (!(config.context?.project && config.context.serverUrl)) {
+        throw new AuthorizationError(
+            `No active Lightdash project. Run 'lightdash login --help'`,
+        );
+    }
+    const projectUuid = config.context.project;
+
+    const project = await getProject(projectUuid, options.verbose);
+
+    if (project.dbtConnection.type === DbtProjectType.NONE) {
+        throw new ParameterError('Project is not connected to a repository');
+    }
+
+    const spinner = ora(`  Refreshing dbt project`).start();
+    GlobalState.setActiveSpinner(spinner);
+    try {
+        await LightdashAnalytics.track({
+            event: 'refresh.started',
+            properties: {
+                projectId: projectUuid,
+            },
+        });
+        const refreshResults = await refreshProject(
+            projectUuid,
+            options.verbose,
+        );
+
+        await getFinalJobState(refreshResults.jobUuid, options.verbose);
+
+        await LightdashAnalytics.track({
+            event: 'refresh.completed',
+            properties: {
+                projectId: projectUuid,
+            },
+        });
+        spinner.stop();
+    } catch (e) {
+        await LightdashAnalytics.track({
+            event: 'refresh.error',
+            properties: {
+                projectId: projectUuid,
+                error: `Error refreshing project: ${e}`,
+            },
+        });
+        spinner.fail();
+        throw e;
+    }
+
+    const displayUrl = `${config.context?.serverUrl}/projects/${projectUuid}/home`;
+
+    console.error(`${styles.bold('Successfully refreshed project:')}`);
+    console.error('');
+    console.error(`      ${styles.bold(`⚡️ ${displayUrl}`)}`);
+    console.error('');
+};

--- a/packages/cli/src/handlers/dbt/refresh.ts
+++ b/packages/cli/src/handlers/dbt/refresh.ts
@@ -111,7 +111,9 @@ export const refreshHandler = async (options: RefreshHandlerOptions) => {
     const project = await getProject(projectUuid, options.verbose);
 
     if (project.dbtConnection.type === DbtProjectType.NONE) {
-        throw new ParameterError('Project is not connected to a repository');
+        throw new ParameterError(
+            'Lightdash project must be connected to a remote repository. eg: GitHub, Gitlab, etc',
+        );
     }
 
     const spinner = ora(`  Refreshing dbt project`).start();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { program } from 'commander';
 import * as os from 'os';
 import * as path from 'path';
 import { compileHandler } from './handlers/compile';
+import { refreshHandler } from './handlers/dbt/refresh';
 import { dbtRunHandler } from './handlers/dbt/run';
 import { deployHandler } from './handlers/deploy';
 import { generateHandler } from './handlers/generate';
@@ -371,6 +372,19 @@ program
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
 
     .action(deployHandler);
+
+program
+    .command('refresh')
+    .description('Refresh Lightdash project with remote repository')
+    .addHelpText(
+        'after',
+        `
+${styles.bold('Examples:')}
+  ${styles.title('⚡')}️lightdash ${styles.bold('refresh')}
+`,
+    )
+    .option('--verbose', undefined, false)
+    .action(refreshHandler);
 
 program
     .command('generate')

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1,5 +1,6 @@
 export enum RequestMethod {
     CLI = 'CLI',
+    CLI_CI = 'CLI_CI',
     WEB_APP = 'WEB_APP',
     UNKNOWN = 'UNKNOWN',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3615 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- enable token authentication on 3 endpoints: get project, get token, refresh project
- add `refresh` CLI command 
- track from where the refresh was triggered from

![refresh](https://user-images.githubusercontent.com/9117144/199037263-d9d8291a-c3ba-41cb-b924-60f3ead05f50.gif)


Github action to refresh the Lightdash project can be simplified over the existing `deploy` command:
```
name: refresh-lightdash

on:
  push:
    branches: [ "main", "master" ]

jobs:
  deploy:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/setup-node@v3.4.1

      - name: Get lightdash version 
        uses: sergeysova/jq-action@v2
        id: version 
        env:
          LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}   
        with: 
          cmd: curl -s "${LIGHTDASH_URL}/api/v1/health" | jq -r '.results.version'

      - name: Install lightdash CLI
        run: npm install -g "@lightdash/cli@${{ steps.version.outputs.value }}" || npm install -g @lightdash/cli@latest

      - name: Lightdash CLI deploy 
        env:
          LIGHTDASH_API_KEY: ${{ secrets.LIGHTDASH_API_KEY }}          
          LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
          LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }} 
        run: lightdash refresh
```

PR to update github actions templates: https://github.com/lightdash/cli-actions/pull/9


