### PR TITLE
feat: leave only one share button for explores and charts

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/ExplorerHeader.styles.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/ExplorerHeader.styles.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components';
 export const Wrapper = styled.div`
     height: 60px;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    button {
-        margin: 0;
-    }
+`;
+
+export const Spacer = styled.div`
+    flex: 1;
 `;

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,12 +1,12 @@
-import React, { FC, memo } from 'react';
-import { useApp } from '../../../providers/AppProvider';
+import { FC, memo } from 'react';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
+import { Can } from '../../common/Authorization';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import SaveChartButton from '../SaveChartButton';
-import { Wrapper } from './ExplorerHeader.styles';
+import { Spacer, Wrapper } from './ExplorerHeader.styles';
 
 const ExplorerHeader: FC = memo(() => {
     const isEditMode = useExplorerContext(
@@ -18,25 +18,25 @@ const ExplorerHeader: FC = memo(() => {
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
     );
-    const { user } = useApp();
 
     return (
         <Wrapper>
             {isEditMode ? (
                 <>
                     <RefreshDbtButton />
-                    <div>
-                        <RefreshButton />
-                        {!savedChart &&
-                            user.data?.ability?.can('manage', 'SavedChart') && (
-                                <SaveChartButton isExplorer />
-                            )}
-                        <ShareShortLinkButton disabled={!isValidQuery} />
-                    </div>
+                    <Spacer />
+                    <RefreshButton />
+                    {!savedChart && (
+                        <Can I="manage" a="SavedChart">
+                            <SaveChartButton isExplorer />
+                        </Can>
+                    )}
                 </>
             ) : (
                 <ExploreFromHereButton />
             )}
+
+            <ShareShortLinkButton disabled={!isValidQuery} />
         </Wrapper>
     );
 });

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -232,10 +232,6 @@ const SavedChartsHeader: FC = () => {
                             </>
                         )}
 
-                        <ShareLinkButton
-                            url={`${window.location.origin}/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`}
-                        />
-
                         <Popover2
                             placement="bottom"
                             disabled={!unsavedChartVersion.tableName}

--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -25,6 +25,7 @@ const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
             });
         }
     }, [newShareUrl, showToastSuccess]);
+
     return (
         <ShareLink
             onClick={() => {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3609

### Description:
- removes share button from the edit mode header for saved charts
- adds button for explore/charts next to a run query button (always)
- always copies minified URL


https://user-images.githubusercontent.com/962095/199081267-6dedaba7-9254-4e71-85b0-a77025d19622.mp4

