### PR TITLE
fix: exclude hidden tables and fields from global search

### DIFF
--- a/packages/e2e/cypress/e2e/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/globalSearch.cy.ts
@@ -65,13 +65,13 @@ describe('Global search', () => {
         search('First order');
         cy.get('.bp4-omnibar')
             .findByRole('menuitem', {
-                name: 'Customers - First order Dimension • Date of the customers first order',
+                name: 'Payments - Orders - Date of first order Metric • Min of Order date',
                 exact: false,
             })
             .click();
         cy.url().should(
             'include',
-            `/projects/${SEED_PROJECT.project_uuid}/tables/customers?create_saved_chart_version`,
+            `/projects/${SEED_PROJECT.project_uuid}/tables/payments?create_saved_chart_version`,
         );
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3637<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->


<!-- Even better add a screenshot/gif / loom -->
Example with `orders` hidden metric and table configuration only has `orders` visible.
```
      - name: gift_card_amount
        description: Amount of the order (AUD) paid for by gift card
        tests:
          - not_null
        meta:
          dimension:
            hidden: true
```

![global search](https://user-images.githubusercontent.com/9117144/199217671-305e2c6b-175f-44c7-9c90-1bceb511f969.gif)

