### PR TITLE
fix: dashboard chart underlying data

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -254,7 +254,6 @@ const DashboardChartTile: FC<Props> = (props) => {
 
             const underlyingData = getDataFromChartClick(
                 e,
-                pivot,
                 allItemsMap,
                 series,
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3655 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fix wrong amount of arguments that was throwing a silent error and preventing users to see underlying data of dashboard charts.

Before: 

![error](https://user-images.githubusercontent.com/9117144/199708190-6e6246e4-20a5-486e-aa9c-cb44672f5d43.gif)


After:


![fix](https://user-images.githubusercontent.com/9117144/199708203-6b74ec21-3d4d-40ea-8f65-76c6194eafd9.gif)
