### PR TITLE
fix: missing FROM clause from metric filter reference

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -264,6 +264,12 @@ export const compileMetricSql = (
                 tables,
                 quoteChar,
             );
+            if (compiledDimension.tablesReferences) {
+                tablesReferences = new Set([
+                    ...tablesReferences,
+                    ...compiledDimension.tablesReferences,
+                ]);
+            }
             return renderFilterRuleSql(filter, compiledDimension, quoteChar);
         });
         renderedSql = `CASE WHEN (${conditions.join(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3664<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Include table reference from metric filters

Example:
```
            total_completed_order_amount:
              type: sum
              format: usd
              round: 2
              filters:
                - customers.first_name: "Paul"
```

![Screenshot 2022-11-03 at 12 20 11](https://user-images.githubusercontent.com/9117144/199719423-baeb6828-1a17-4b31-a033-396d7f3ee57d.png)
