### PR TITLE
fix: display 5 most recent charts instead of all

### DIFF
--- a/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
+++ b/packages/frontend/src/components/Home/LatestSavedCharts/index.tsx
@@ -1,7 +1,7 @@
 import { AnchorButton } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSavedCharts } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
@@ -31,11 +31,22 @@ const LatestSavedCharts: FC<Props> = ({ projectUuid }) => {
         history.push(`/projects/${projectUuid}/tables`);
     };
 
+    const featuredCharts = useMemo(() => {
+        return savedCharts
+            .sort((a, b) => {
+                return (
+                    new Date(b.updatedAt).getTime() -
+                    new Date(a.updatedAt).getTime()
+                );
+            })
+            .slice(0, 5);
+    }, [savedCharts]);
+
     return (
         <ResourceList
             resourceIcon="chart"
             resourceType="chart"
-            resourceList={savedCharts}
+            resourceList={featuredCharts}
             enableSorting={false}
             defaultSort={{
                 updatedAt: SortDirection.DESC,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3681

### Description:
select 5 most recent chart instead of all

<img width="844" alt="CleanShot 2022-11-04 at 16 16 58@2x" src="https://user-images.githubusercontent.com/962095/199970691-ea41409b-b44f-4545-b600-061d34247154.png">
