### PR TITLE
chore: rename numberStyle types, utils and vars to compact

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -1,8 +1,4 @@
-import {
-    ChartConfig,
-    DBFieldTypes,
-    NumberStyleOrAlias,
-} from '@lightdash/common';
+import { ChartConfig, CompactOrAlias, DBFieldTypes } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const SavedChartsTableName = 'saved_queries';
@@ -124,7 +120,7 @@ export type DbSavedChartAdditionalMetric = {
     sql?: string;
     hidden?: boolean;
     round?: number;
-    compact?: NumberStyleOrAlias;
+    compact?: CompactOrAlias;
     format?: string;
     saved_queries_version_id: number;
 };

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
 import {
+    Compact,
     DimensionType,
     formatFieldValue,
     formatItemValue,
     formatValue,
     getFilterRuleWithDefaultValue,
     MetricType,
-    NumberStyle,
 } from '.';
 import {
     dateDayDimension,
@@ -252,44 +252,42 @@ describe('Common index', () => {
         });
 
         test('formatValue should return the right style', async () => {
-            const T = NumberStyle.THOUSANDS;
-            const M = NumberStyle.MILLIONS;
-            const B = NumberStyle.BILLIONS;
-            expect(formatValue(5, { numberStyle: T })).toEqual('0.01K');
-            expect(formatValue(5, { numberStyle: M })).toEqual('0.00M');
-            expect(formatValue(500000, { numberStyle: B })).toEqual('0.00B');
-            expect(formatValue(5, { numberStyle: B })).toEqual('0.00B');
-            expect(formatValue(5, { numberStyle: M, round: 2 })).toEqual(
-                '0.00M',
-            );
+            const T = Compact.THOUSANDS;
+            const M = Compact.MILLIONS;
+            const B = Compact.BILLIONS;
+            expect(formatValue(5, { compact: T })).toEqual('0.01K');
+            expect(formatValue(5, { compact: M })).toEqual('0.00M');
+            expect(formatValue(500000, { compact: B })).toEqual('0.00B');
+            expect(formatValue(5, { compact: B })).toEqual('0.00B');
+            expect(formatValue(5, { compact: M, round: 2 })).toEqual('0.00M');
 
             expect(
-                formatValue(5000, { numberStyle: T, round: 2, format: 'km' }),
+                formatValue(5000, { compact: T, round: 2, format: 'km' }),
             ).toEqual('5.00K km');
             expect(
                 formatValue(50000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 4,
                     format: 'mi',
                 }),
             ).toEqual('50.0000K mi');
             expect(
                 formatValue(5000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$5.00K');
             expect(
                 formatValue(5000000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$5,000.00K');
             expect(
                 formatValue(5000000, {
-                    numberStyle: M,
+                    compact: M,
                     round: 2,
                     format: 'usd',
                 }),
@@ -297,14 +295,14 @@ describe('Common index', () => {
 
             expect(
                 formatValue(4, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$0.00K');
             expect(
                 formatValue(4, {
-                    numberStyle: T,
+                    compact: T,
                     round: 3,
                     format: 'usd',
                 }),
@@ -312,21 +310,21 @@ describe('Common index', () => {
 
             expect(
                 formatValue(5000000, {
-                    numberStyle: M,
+                    compact: M,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$5.00M');
             expect(
                 formatValue(5000000000, {
-                    numberStyle: M,
+                    compact: M,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$5,000.00M');
             expect(
                 formatValue(5000000000, {
-                    numberStyle: B,
+                    compact: B,
                     round: 2,
                     format: 'usd',
                 }),
@@ -334,42 +332,42 @@ describe('Common index', () => {
 
             expect(
                 formatValue(5000.0, {
-                    numberStyle: T,
+                    compact: T,
                     round: 0,
                     format: 'usd',
                 }),
             ).toEqual('$5K');
             expect(
                 formatValue('5000', {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'usd',
                 }),
             ).toEqual('$5.00K');
             expect(
                 formatValue(5000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'gbp',
                 }),
             ).toEqual('£5.00K');
             expect(
                 formatValue(5000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'eur',
                 }),
             ).toEqual('€5.00K');
             expect(
                 formatValue(0.05, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: 'percent',
                 }),
             ).toEqual('5.00%'); // No affects percent
             expect(
                 formatValue(5000, {
-                    numberStyle: T,
+                    compact: T,
                     round: 2,
                     format: '',
                 }),

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -3,13 +3,13 @@ import assertUnreachable from '../utils/assertUnreachable';
 import { ColumnInfo, CompiledModelNode, ParsedMetric } from './dbtFromSchema';
 import { DbtError, ParseError } from './errors';
 import {
+    CompactOrAlias,
     DimensionType,
     FieldType,
     FieldUrl,
     friendlyName,
     Metric,
     MetricType,
-    NumberStyleOrAlias,
     Source,
 } from './field';
 import { parseFilters } from './filterGrammar';
@@ -71,7 +71,7 @@ type DbtColumnLightdashDimension = {
     time_intervals?: 'default' | 'OFF' | TimeFrames[];
     hidden?: boolean;
     round?: number;
-    compact?: NumberStyleOrAlias;
+    compact?: CompactOrAlias;
     format?: string;
     group_label?: string;
     urls?: FieldUrl[];
@@ -84,7 +84,7 @@ export type DbtColumnLightdashMetric = {
     sql?: string;
     hidden?: boolean;
     round?: number;
-    compact?: NumberStyleOrAlias;
+    compact?: CompactOrAlias;
     format?: string;
     group_label?: string;
     urls?: FieldUrl[];

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -1,14 +1,14 @@
 import { FilterRule } from './filter';
 import { TimeFrames } from './timeFrames';
 
-export enum NumberStyle {
+export enum Compact {
     THOUSANDS = 'thousands',
     MILLIONS = 'millions',
     BILLIONS = 'billions',
     TRILLIONS = 'trillions',
 }
 
-const NumberStyleAlias = [
+const CompactAlias = [
     'K',
     'thousand',
     'M',
@@ -19,40 +19,40 @@ const NumberStyleAlias = [
     'trillion',
 ] as const;
 
-type NumberStyleConfig = {
-    numberStyle: NumberStyle;
-    alias: Array<typeof NumberStyleAlias[number]>;
+type CompactConfig = {
+    compact: Compact;
+    alias: Array<typeof CompactAlias[number]>;
     convertFn: (value: number) => number;
     label: string;
     suffix: string;
 };
 
-export type NumberStyleOrAlias = NumberStyle | typeof NumberStyleAlias[number];
+export type CompactOrAlias = Compact | typeof CompactAlias[number];
 
-export const NumberStyleConfigMap: Record<NumberStyle, NumberStyleConfig> = {
-    [NumberStyle.THOUSANDS]: {
-        numberStyle: NumberStyle.THOUSANDS,
+export const CompactConfigMap: Record<Compact, CompactConfig> = {
+    [Compact.THOUSANDS]: {
+        compact: Compact.THOUSANDS,
         alias: ['K', 'thousand'],
         convertFn: (value: number) => value / 1000,
         label: 'thousands (K)',
         suffix: 'K',
     },
-    [NumberStyle.MILLIONS]: {
-        numberStyle: NumberStyle.MILLIONS,
+    [Compact.MILLIONS]: {
+        compact: Compact.MILLIONS,
         alias: ['M', 'million'],
         convertFn: (value: number) => value / 1000000,
         label: 'millions (M)',
         suffix: 'M',
     },
-    [NumberStyle.BILLIONS]: {
-        numberStyle: NumberStyle.BILLIONS,
+    [Compact.BILLIONS]: {
+        compact: Compact.BILLIONS,
         alias: ['B', 'billion'],
         convertFn: (value: number) => value / 1000000000,
         label: 'billions (B)',
         suffix: 'B',
     },
-    [NumberStyle.TRILLIONS]: {
-        numberStyle: NumberStyle.TRILLIONS,
+    [Compact.TRILLIONS]: {
+        compact: Compact.TRILLIONS,
         alias: ['T', 'trillion'],
         convertFn: (value: number) => value / 1000000000000,
         label: 'trillions (T)',
@@ -60,13 +60,12 @@ export const NumberStyleConfigMap: Record<NumberStyle, NumberStyleConfig> = {
     },
 };
 
-export function findNumberStyleConfig(
-    numberStyleOrAlias: NumberStyleOrAlias,
-): NumberStyleConfig | undefined {
-    return Object.values(NumberStyleConfigMap).find(
-        ({ numberStyle, alias }) =>
-            numberStyle === numberStyleOrAlias ||
-            alias.includes(numberStyleOrAlias as any),
+export function findCompactConfig(
+    compactOrAlias: CompactOrAlias,
+): CompactConfig | undefined {
+    return Object.values(CompactConfigMap).find(
+        ({ compact, alias }) =>
+            compact === compactOrAlias || alias.includes(compactOrAlias as any),
     );
 }
 
@@ -92,7 +91,7 @@ export interface Field {
     description?: string;
     source?: Source | undefined;
     hidden: boolean;
-    compact?: NumberStyleOrAlias;
+    compact?: CompactOrAlias;
     round?: number;
     format?: string;
     groupLabel?: string;

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -1,9 +1,9 @@
 import {
+    CompactOrAlias,
     CompiledMetric,
     FieldId,
     friendlyName,
     MetricType,
-    NumberStyleOrAlias,
 } from './field';
 import { Filters } from './filter';
 
@@ -24,7 +24,7 @@ export interface AdditionalMetric {
     sql: string;
     hidden?: boolean;
     round?: number;
-    compact?: NumberStyleOrAlias;
+    compact?: CompactOrAlias;
     format?: string;
     table: string;
     name: string;

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1,4 +1,4 @@
-import { NumberStyleOrAlias } from './field';
+import { CompactOrAlias } from './field';
 import { MetricQuery } from './metricQuery';
 import { UpdatedByUser } from './user';
 
@@ -9,7 +9,7 @@ export enum ChartType {
 }
 export type BigNumber = {
     label?: string;
-    style?: NumberStyleOrAlias;
+    style?: CompactOrAlias;
     selectedField?: string;
 };
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,12 +1,12 @@
 import moment, { MomentInput } from 'moment';
 import {
+    CompactOrAlias,
     DimensionType,
     Field,
-    findNumberStyleConfig,
+    findCompactConfig,
     isDimension,
     isField,
     MetricType,
-    NumberStyleOrAlias,
 } from '../types/field';
 import {
     AdditionalMetric,
@@ -102,14 +102,14 @@ function roundNumber(
     options?: {
         format?: string;
         round?: number;
-        numberStyle?: NumberStyleOrAlias;
+        compact?: CompactOrAlias;
     },
 ): string {
-    const { format, round, numberStyle } = options || {};
+    const { format, round, compact } = options || {};
 
     const invalidRound = round === undefined || round < 0;
     if (invalidRound && !format) {
-        return numberStyle && !Number.isInteger(value)
+        return compact && !Number.isInteger(value)
             ? `${value}`
             : new Intl.NumberFormat('en-US').format(Number(value));
     }
@@ -138,22 +138,20 @@ function styleNumber(
     options?: {
         format?: string;
         round?: number;
-        numberStyle?: NumberStyleOrAlias;
+        compact?: CompactOrAlias;
     },
 ): string {
-    const { format, round, numberStyle } = options || {};
-    if (numberStyle) {
-        const numberStyleRound =
-            numberStyle && round === undefined && format === undefined
-                ? 2
-                : round;
-        const numberStyleConfig = findNumberStyleConfig(numberStyle);
-        if (numberStyleConfig) {
-            return `${roundNumber(numberStyleConfig.convertFn(Number(value)), {
+    const { format, round, compact } = options || {};
+    if (compact) {
+        const compactRound =
+            compact && round === undefined && format === undefined ? 2 : round;
+        const compactConfig = findCompactConfig(compact);
+        if (compactConfig) {
+            return `${roundNumber(compactConfig.convertFn(Number(value)), {
                 format,
-                round: numberStyleRound,
-                numberStyle,
-            })}${numberStyleConfig.suffix}`;
+                round: compactRound,
+                compact,
+            })}${compactConfig.suffix}`;
         }
     }
     return `${new Intl.NumberFormat('en-US').format(Number(value))}`;
@@ -164,7 +162,7 @@ export function formatValue(
     options?: {
         format?: string;
         round?: number;
-        numberStyle?: NumberStyleOrAlias;
+        compact?: CompactOrAlias;
     },
 ): string {
     if (value === null) return '∅';
@@ -172,9 +170,9 @@ export function formatValue(
     if (!isNumber(value)) {
         return `${value}`;
     }
-    const { format, round, numberStyle } = options || {};
+    const { format, round, compact } = options || {};
 
-    const styledValue = numberStyle
+    const styledValue = compact
         ? styleNumber(value, options)
         : roundNumber(value, { round, format });
     switch (format) {
@@ -224,7 +222,7 @@ export function formatFieldValue(
         case MetricType.COUNT:
         case MetricType.COUNT_DISTINCT:
         case MetricType.SUM:
-            return formatValue(value, { format, round, numberStyle: compact });
+            return formatValue(value, { format, round, compact });
         case DimensionType.BOOLEAN:
         case MetricType.BOOLEAN:
             return formatBoolean(value);
@@ -250,7 +248,7 @@ export function formatFieldValue(
                     convertToUTC,
                 );
             }
-            return formatValue(value, { format, round, numberStyle: compact });
+            return formatValue(value, { format, round, compact });
         }
         default: {
             return `${value}`;

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -1,10 +1,6 @@
 import { Button, FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import {
-    getItemId,
-    NumberStyleConfigMap,
-    NumberStyleOrAlias,
-} from '@lightdash/common';
+import { CompactConfigMap, CompactOrAlias, getItemId } from '@lightdash/common';
 import React, { useState } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
@@ -12,8 +8,8 @@ import { InputWrapper } from './BigNumberConfig.styles';
 
 const StyleOptions = [
     { value: '', label: 'none' },
-    ...Object.values(NumberStyleConfigMap).map(({ numberStyle, label }) => ({
-        value: numberStyle,
+    ...Object.values(CompactConfigMap).map(({ compact, label }) => ({
+        value: compact,
         label,
     })),
 ];
@@ -79,8 +75,7 @@ export const BigNumberConfigPanel: React.FC = () => {
                                         setBigNumberStyle(undefined);
                                     } else {
                                         setBigNumberStyle(
-                                            e.target
-                                                .value as NumberStyleOrAlias,
+                                            e.target.value as CompactOrAlias,
                                         );
                                     }
                                 }}

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -306,7 +306,7 @@ const getPivotSeries = ({
                                 format: formats[series.encode.yRef.field]
                                     .format,
                                 round: formats[series.encode.yRef.field].round,
-                                numberStyle:
+                                compact:
                                     formats[series.encode.yRef.field].compact,
                             }),
                     }),
@@ -376,7 +376,7 @@ const getSimpleSeries = ({
                         formatValue(value?.value?.[yFieldHash], {
                             format: formats[yFieldHash].format,
                             round: formats[yFieldHash].round,
-                            numberStyle: formats[yFieldHash].compact,
+                            compact: formats[yFieldHash].compact,
                         }),
                 }),
         },

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -145,7 +145,7 @@ const useBigNumberConfig = (
                   : isField(item)
                   ? item.round
                   : undefined,
-              numberStyle: bigNumberStyle,
+              compact: bigNumberStyle,
           });
 
     const showStyle = isNumber && (!isField(item) || item.format !== 'percent');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3702 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Refactor common package **numberStyle** types, utils and vars to **compact**