### PR TITLE
fix: dashboard table padding

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -93,7 +93,7 @@ const ValidDashboardChartTile: FC<{
             onSeriesContextMenu={onSeriesContextMenu}
             columnOrder={data.tableConfig.columnOrder}
         >
-            <LightdashVisualization isDashboard />
+            <LightdashVisualization isDashboard $padding={0} />
         </VisualizationProvider>
     );
 };

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -8,6 +8,7 @@ import { useVisualizationContext } from './VisualizationProvider';
 interface LightdashVisualizationProps {
     isDashboard?: boolean;
     className?: string;
+    $padding?: number;
     'data-testid'?: string;
 }
 
@@ -30,6 +31,7 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
                         isDashboard={!!isDashboard}
                         className={className}
                         $shouldExpand
+                        $padding={props.$padding}
                         data-testid={props['data-testid']}
                         {...props}
                     />

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -9,6 +9,7 @@ import DashboardCellContextMenu from './DashboardCellContextMenu';
 type SimpleTableProps = {
     isDashboard: boolean;
     className?: string;
+    $padding?: number;
     $shouldExpand?: boolean;
 };
 
@@ -16,6 +17,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     isDashboard,
     className,
     $shouldExpand,
+    $padding,
     ...rest
 }) => {
     const {
@@ -47,6 +49,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     return (
         <Table
             $shouldExpand={$shouldExpand}
+            $padding={$padding}
             className={className}
             status="success"
             data={rows}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -13,7 +13,7 @@ const ScrollableTable: FC<ScrollableTableProps> = ({ $shouldExpand }) => {
     const { footer } = useTableContext();
 
     return (
-        <TableScrollableWrapper $shouldExpand={$shouldExpand}>
+        <TableScrollableWrapper>
             <Table bordered condensed showFooter={!!footer?.show}>
                 <TableHeader />
                 <TableBody />

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -1,11 +1,7 @@
 import { Colors, HTMLTable } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
-interface ExpandableProps {
-    $shouldExpand?: boolean;
-}
-
-export const TableScrollableWrapper = styled.div<ExpandableProps>`
+export const TableScrollableWrapper = styled.div`
     display: flex;
     flex-direction: column;
 
@@ -14,10 +10,15 @@ export const TableScrollableWrapper = styled.div<ExpandableProps>`
     min-width: 100%;
 `;
 
-export const TableContainer = styled.div<ExpandableProps>`
+interface TableContainerProps {
+    $shouldExpand?: boolean;
+    $padding?: number;
+}
+
+export const TableContainer = styled.div<TableContainerProps>`
     display: flex;
     flex-direction: column;
-    padding: 10px;
+    padding: ${({ $padding = 10 }) => `${$padding}px`};
     min-width: 100%;
     overflow: hidden;
 

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -13,11 +13,13 @@ type Props = ComponentProps<typeof TableProvider> & {
     hideRowNumbers?: boolean;
     className?: string;
     $shouldExpand?: boolean;
+    $padding?: number;
     'data-testid'?: string;
 };
 
-const ResultsTable: FC<Props> = ({
+const Table: FC<Props> = ({
     $shouldExpand,
+    $padding,
     status,
     loadingState,
     idleState,
@@ -41,6 +43,7 @@ const ResultsTable: FC<Props> = ({
             <TableContainer
                 className={`cohere-block${className ? ` ${className}` : ''}`}
                 $shouldExpand={$shouldExpand}
+                $padding={$padding}
                 data-testid={dataTestId}
             >
                 <ScrollableTable $shouldExpand={$shouldExpand} />
@@ -55,4 +58,4 @@ const ResultsTable: FC<Props> = ({
     );
 };
 
-export default ResultsTable;
+export default Table;


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3705

### Description:
removes extra padding from the dashboard table viz

<img width="690" alt="CleanShot 2022-11-09 at 11 59 09@2x" src="https://user-images.githubusercontent.com/962095/200771832-da3f035f-bda9-4261-9511-58fdbc8dd4b7.png">
