### PR TITLE
feat: backend space share

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -84,7 +84,12 @@ import {
 } from '../database/entities/savedCharts';
 import { SessionTable, SessionTableName } from '../database/entities/sessions';
 import { ShareTable, ShareTableName } from '../database/entities/share';
-import { SpaceTable, SpaceTableName } from '../database/entities/spaces';
+import {
+    SpaceShareTable,
+    SpaceShareTableName,
+    SpaceTable,
+    SpaceTableName,
+} from '../database/entities/spaces';
 import { UserTable, UserTableName } from '../database/entities/users';
 import {
     WarehouseCredentialTable,
@@ -127,5 +132,6 @@ declare module 'knex/types/tables' {
         [ProjectMembershipsTableName]: ProjectMembershipsTable;
         [DbtCloudIntegrationsTableName]: DbtCloudIntegrationsTable;
         [ShareTableName]: ShareTable;
+        [SpaceShareTableName]: SpaceShareTable;
     }
 }

--- a/packages/backend/src/controllers/authenticationRoles.ts
+++ b/packages/backend/src/controllers/authenticationRoles.ts
@@ -1,0 +1,12 @@
+import {
+    inheritedProjectRoleFromOrgRole,
+    OrganizationMemberRole,
+    ProjectMemberRole,
+} from '@lightdash/common';
+
+export const getProjectRoleOrInheritedFromOrganization = (
+    projectRole: ProjectMemberRole | null | undefined,
+    organizationRole: OrganizationMemberRole,
+): ProjectMemberRole =>
+    // if user has not project role, it inherits rol from org
+    projectRole || inheritedProjectRoleFromOrgRole(organizationRole);

--- a/packages/backend/src/controllers/authenticationRoles.ts
+++ b/packages/backend/src/controllers/authenticationRoles.ts
@@ -6,9 +6,10 @@ import {
 
 const inheritedProjectRoleFromOrgRole = (
     orgRole: OrganizationMemberRole,
-): ProjectMemberRole => {
+): ProjectMemberRole | null => {
     switch (orgRole) {
         case OrganizationMemberRole.MEMBER:
+            return null;
         case OrganizationMemberRole.VIEWER:
             return ProjectMemberRole.VIEWER;
         case OrganizationMemberRole.EDITOR:
@@ -26,6 +27,6 @@ const inheritedProjectRoleFromOrgRole = (
 export const getProjectRoleOrInheritedFromOrganization = (
     projectRole: ProjectMemberRole | null | undefined,
     organizationRole: OrganizationMemberRole,
-): ProjectMemberRole =>
+): ProjectMemberRole | null =>
     // if user has not project role, it inherits rol from org
     projectRole || inheritedProjectRoleFromOrgRole(organizationRole);

--- a/packages/backend/src/controllers/authenticationRoles.ts
+++ b/packages/backend/src/controllers/authenticationRoles.ts
@@ -1,8 +1,27 @@
 import {
-    inheritedProjectRoleFromOrgRole,
+    assertUnreachable,
     OrganizationMemberRole,
     ProjectMemberRole,
 } from '@lightdash/common';
+
+const inheritedProjectRoleFromOrgRole = (
+    orgRole: OrganizationMemberRole,
+): ProjectMemberRole => {
+    switch (orgRole) {
+        case OrganizationMemberRole.MEMBER:
+        case OrganizationMemberRole.VIEWER:
+            return ProjectMemberRole.VIEWER;
+        case OrganizationMemberRole.EDITOR:
+            return ProjectMemberRole.EDITOR;
+        case OrganizationMemberRole.ADMIN:
+            return ProjectMemberRole.ADMIN;
+        default:
+            return assertUnreachable(
+                orgRole,
+                `Organization role ${orgRole} does not match Project roles`,
+            );
+    }
+};
 
 export const getProjectRoleOrInheritedFromOrganization = (
     projectRole: ProjectMemberRole | null | undefined,

--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -6,6 +6,7 @@ export type DbSpace = {
     space_id: number;
     space_uuid: string;
     name: string;
+    is_private: boolean;
     created_at: Date;
     project_id: number;
     organization_uuid: string;
@@ -15,6 +16,20 @@ type CreateDbSpace = Pick<DbSpace, 'name' | 'project_id'>;
 
 export type SpaceTable = Knex.CompositeTableType<DbSpace, CreateDbSpace>;
 export const SpaceTableName = 'spaces';
+
+export type DbSpaceShare = {
+    space_id: number;
+    user_id: number;
+};
+
+type CreateDbSpaceShare = Pick<DbSpaceShare, 'space_id' | 'user_id'>;
+
+export type SpaceShareTable = Knex.CompositeTableType<
+    DbSpaceShare,
+    CreateDbSpaceShare
+>;
+
+export const SpaceShareTableName = 'space_share';
 
 export const getSpace = async (
     db: Knex,
@@ -95,6 +110,7 @@ export const getSpaceWithQueries = async (
         organizationUuid: space.organization_uuid,
         uuid: space.space_uuid,
         name: space.name,
+        isPrivate: space.is_private,
         queries: savedQueries.map((savedQuery) => ({
             uuid: savedQuery.saved_query_uuid,
             name: savedQuery.name,
@@ -109,6 +125,7 @@ export const getSpaceWithQueries = async (
         })),
         projectUuid,
         dashboards: [],
+        access: [],
     };
 };
 

--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -12,7 +12,7 @@ export type DbSpace = {
     organization_uuid: string;
 };
 
-type CreateDbSpace = Pick<DbSpace, 'name' | 'project_id'>;
+type CreateDbSpace = Pick<DbSpace, 'name' | 'project_id' | 'is_private'>;
 
 export type SpaceTable = Knex.CompositeTableType<DbSpace, CreateDbSpace>;
 export const SpaceTableName = 'spaces';

--- a/packages/backend/src/database/migrations/20210728093219_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20210728093219_saved_queries.ts
@@ -211,6 +211,7 @@ export async function up(knex: Knex): Promise<void> {
             .insert({
                 name: orgs[0].organization_name,
                 project_id: project.project_id,
+                is_private: false,
             })
             .returning('*');
     }

--- a/packages/backend/src/database/migrations/20210728093219_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20210728093219_saved_queries.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { DbSpace } from '../entities/spaces';
 
 type DbProject = {
     project_id: number;
@@ -207,11 +208,10 @@ export async function up(knex: Knex): Promise<void> {
                 .returning('*')
         )[0];
 
-        await knex('spaces')
+        await knex<Pick<DbSpace, 'name' | 'project_id'>>('spaces')
             .insert({
                 name: orgs[0].organization_name,
                 project_id: project.project_id,
-                is_private: false,
             })
             .returning('*');
     }

--- a/packages/backend/src/database/migrations/20221109083433_space_permission.ts
+++ b/packages/backend/src/database/migrations/20221109083433_space_permission.ts
@@ -6,7 +6,7 @@ const isPrivateColumnName = 'is_private';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.table(SHARE_TABLE, (table) => {
-        table.boolean(isPrivateColumnName).defaultTo(true);
+        table.boolean(isPrivateColumnName).defaultTo(false);
     });
 
     await knex.schema.createTable(SPACE_SHARE_TABLE, (tableBuilder) => {

--- a/packages/backend/src/database/migrations/20221109083433_space_permission.ts
+++ b/packages/backend/src/database/migrations/20221109083433_space_permission.ts
@@ -1,0 +1,37 @@
+import { Knex } from 'knex';
+
+const SPACE_SHARE_TABLE = 'space_share';
+const SHARE_TABLE = 'spaces';
+const isPrivateColumnName = 'is_private';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.table(SHARE_TABLE, (table) => {
+        table.boolean(isPrivateColumnName).defaultTo(true);
+    });
+
+    await knex.schema.createTable(SPACE_SHARE_TABLE, (tableBuilder) => {
+        tableBuilder
+            .integer('user_id')
+            .notNullable()
+            .references('user_id')
+            .inTable('users')
+            .onDelete('CASCADE');
+        tableBuilder
+            .integer('space_id')
+            .notNullable()
+            .references('space_id')
+            .inTable(SHARE_TABLE)
+            .onDelete('CASCADE');
+        tableBuilder.unique(['user_id', 'space_id']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SHARE_TABLE, isPrivateColumnName)) {
+        await knex.schema.table(SHARE_TABLE, (table) => {
+            table.dropColumn(isPrivateColumnName);
+        });
+    }
+
+    await knex.schema.dropTableIfExists(SPACE_SHARE_TABLE);
+}

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -168,7 +168,11 @@ export async function seed(knex: Knex): Promise<void> {
         warehouse_type: 'postgres',
     });
 
-    await knex('spaces').insert({ ...SEED_SPACE, project_id: projectId });
+    await knex('spaces').insert({
+        ...SEED_SPACE,
+        is_private: false,
+        project_id: projectId,
+    });
 
     const explores = await projectService.refreshAllTables(
         { userUuid: SEED_ORG_1_ADMIN.user_uuid },

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -118,6 +118,7 @@ export const spaceEntry: SpaceTable['base'] = {
     space_id: 0,
     space_uuid: '123',
     name: 'space name',
+    is_private: false,
     created_at: new Date(),
     project_id: 0,
     organization_uuid: 'organizationUuid',

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -227,6 +227,7 @@ export class ProjectModel {
                 await trx('spaces').insert({
                     project_id: project.project_id,
                     name: 'Shared',
+                    is_private: false,
                 });
 
                 return project.project_uuid;

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -331,7 +331,7 @@ export class SpaceModel {
         const [space] = await this.database(SpaceTableName)
             .insert({
                 project_id: project.project_id,
-                is_private: true,
+                is_private: false, // TODO change to true once we support private spaces in the UI,
                 name,
             })
             .returning('*');

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -397,7 +397,18 @@ export class SpaceModel {
             .delete();
     }
 
-    async clearSpaceAccess(spaceUuid: string): Promise<void> {
-        await this.database('spaces').where('space_uuid', spaceUuid).delete();
+    async clearSpaceAccess(spaceUuid: string, userUuid: string): Promise<void> {
+        const [space] = await this.database('spaces')
+            .select('space_id')
+            .where('space_uuid', spaceUuid);
+
+        const [user] = await this.database('users')
+            .select('user_id')
+            .where('user_uuid', userUuid);
+
+        await this.database('space_share')
+            .where('space_id', space.space_id)
+            .andWhereNot('user_id', user.user_id)
+            .delete();
     }
 }

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -317,7 +317,7 @@ export class SpaceModel {
         );
     }
 
-    async getWithQueriesAndDashboards(spaceUuid: string): Promise<Space> {
+    async getFullSpace(spaceUuid: string): Promise<Space> {
         const space = await this.get(spaceUuid);
         return {
             organizationUuid: space.organizationUuid,
@@ -339,6 +339,7 @@ export class SpaceModel {
         const [space] = await this.database(SpaceTableName)
             .insert({
                 project_id: project.project_id,
+                is_private: true,
                 name,
             })
             .returning('*');
@@ -347,7 +348,7 @@ export class SpaceModel {
             organizationUuid: space.organization_uuid,
             name: space.name,
             queries: [],
-            isPrivate: true,
+            isPrivate: space.is_private,
             uuid: space.space_uuid,
             projectUuid,
             dashboards: [],
@@ -365,7 +366,7 @@ export class SpaceModel {
         await this.database(SpaceTableName)
             .update<UpdateSpace>(space)
             .where('space_uuid', spaceUuid);
-        return this.getWithQueriesAndDashboards(spaceUuid);
+        return this.getFullSpace(spaceUuid);
     }
 
     async addSpaceAccess(spaceUuid: string, userUuid: string): Promise<void> {

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -356,7 +356,10 @@ export class SpaceModel {
 
     async update(spaceUuid: string, space: UpdateSpace): Promise<Space> {
         await this.database(SpaceTableName)
-            .update<UpdateSpace>(space)
+            .update<UpdateSpace>({
+                name: space.name,
+                is_private: space.isPrivate,
+            })
             .where('space_uuid', spaceUuid);
         return this.getFullSpace(spaceUuid);
     }

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1,6 +1,5 @@
 import {
     DashboardBasicDetails,
-    inheritedProjectRoleFromOrgRole,
     NotFoundError,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -10,29 +9,24 @@ import {
     UpdateSpace,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { getProjectRoleOrInheritedFromOrganization } from '../controllers/authenticationRoles';
 import {
     DashboardsTableName,
     DashboardVersionsTableName,
 } from '../database/entities/dashboards';
-import {
-    DbOrganizationMembership,
-    OrganizationMembershipsTableName,
-} from '../database/entities/organizationMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import {
     DbOrganization,
     OrganizationTableName,
 } from '../database/entities/organizations';
-import {
-    DbProjectMembership,
-    ProjectMembershipsTableName,
-} from '../database/entities/projectMemberships';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { DbProject, ProjectTableName } from '../database/entities/projects';
 import {
     DbSpace,
     SpaceShareTableName,
     SpaceTableName,
 } from '../database/entities/spaces';
-import { DbUser, UserTable, UserTableName } from '../database/entities/users';
+import { UserTableName } from '../database/entities/users';
 import { GetDashboardDetailsQuery } from './DashboardModel/DashboardModel';
 
 type Dependencies = {
@@ -212,16 +206,15 @@ export class SpaceModel {
                 last_name,
                 project_role,
                 organization_role,
-            }) => {
-                const projectRoleFromOrg =
-                    inheritedProjectRoleFromOrgRole(organization_role);
-                return {
-                    userUuid: user_uuid,
-                    firstName: first_name,
-                    lastName: last_name,
-                    role: project_role || projectRoleFromOrg, // if user has not project role, it inherits rol from org
-                };
-            },
+            }) => ({
+                userUuid: user_uuid,
+                firstName: first_name,
+                lastName: last_name,
+                role: getProjectRoleOrInheritedFromOrganization(
+                    project_role,
+                    organization_role,
+                ),
+            }),
         );
     }
 

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -396,4 +396,8 @@ export class SpaceModel {
             .andWhere('user_id', user.user_id)
             .delete();
     }
+
+    async clearSpaceAccess(spaceUuid: string): Promise<void> {
+        await this.database('spaces').where('space_uuid', spaceUuid).delete();
+    }
 }

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -186,7 +186,6 @@ export class SpaceModel {
                 `${UserTableName}.user_id`,
                 `${ProjectMembershipsTableName}.user_id`,
             )
-            // .select<(DbUser & DbProjectMembership & DbOrganizationMembership)[]>(['user.user_uuid', 'user.first_name'])
             .select<
                 {
                     user_uuid: string;

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -386,6 +386,42 @@ projectRouter.patch(
     },
 );
 
+projectRouter.post(
+    '/spaces/:spaceUUid/share',
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        spaceService
+            .addSpaceShare(req.user!, req.params.spaceUUid, req.body.userUuid)
+            .then(() => {
+                res.json({
+                    status: 'ok',
+                });
+            })
+            .catch(next);
+    },
+);
+
+projectRouter.delete(
+    '/spaces/:spaceUUid/share/:userUuid',
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        spaceService
+            .removeSpaceShare(
+                req.user!,
+                req.params.spaceUUid,
+                req.params.userUuid,
+            )
+            .then(() => {
+                res.json({
+                    status: 'ok',
+                });
+            })
+            .catch(next);
+    },
+);
+
 projectRouter.get('/dashboards', isAuthenticated, async (req, res, next) => {
     const chartUuid: string | undefined =
         typeof req.query.chartUuid === 'string'

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -38,6 +38,7 @@ export const space: SpaceTable['base'] = {
     space_id: 0,
     space_uuid: '123',
     name: 'space name',
+    is_private: true,
     created_at: new Date(),
     project_id: 0,
     organization_uuid: user.organizationUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -240,6 +240,7 @@ export const spacesWithSavedCharts: Space[] = [
     {
         organizationUuid: user.organizationUuid,
         name: 'sapce',
+        isPrivate: false,
         uuid: 'uuid',
         queries: [
             {
@@ -251,6 +252,7 @@ export const spacesWithSavedCharts: Space[] = [
         ],
         projectUuid,
         dashboards: [],
+        access: [],
     },
 ];
 
@@ -261,7 +263,9 @@ export const spacesWithNoSavedCharts: Space[] = [
         uuid: 'uuid',
         queries: [],
         projectUuid,
+        isPrivate: false,
         dashboards: [],
+        access: [],
     },
 ];
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -17,7 +17,7 @@ type Dependencies = {
 
 const hasSpaceAccess = (space: Space, userUuid: string): boolean =>
     // TODO enable this once UI for space access is done
-    // return !space.isPrivate || space.access.find(userAccess => userAccess.userUuid === userUuid) !== undefined
+    // return !space.isPrivate || space.access.find(userAccess => userAccess.userUuid === userUuid && userAccess.role !== null ) !== undefined
 
     true;
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -16,10 +16,11 @@ type Dependencies = {
 };
 
 const hasSpaceAccess = (space: Space, userUuid: string): boolean =>
-    // TODO enable this once UI for space access is done
-    // return !space.isPrivate || space.access.find(userAccess => userAccess.userUuid === userUuid && userAccess.role !== null ) !== undefined
-
-    true;
+    !space.isPrivate ||
+    space.access.find(
+        (userAccess) =>
+            userAccess.userUuid === userUuid && userAccess.role !== null,
+    ) !== undefined;
 
 export class SpaceService {
     private readonly projectModel: ProjectModel;

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -15,9 +15,11 @@ type Dependencies = {
     spaceModel: SpaceModel;
 };
 
-const hasSpaceAccess = (space: Space, userUuid: string): boolean => true;
-// TODO enable this once UI for space access is done
-// return space.access.find(userAccess => userAccess.userUuid === userUuid) !== undefined
+const hasSpaceAccess = (space: Space, userUuid: string): boolean =>
+    // TODO enable this once UI for space access is done
+    // return !space.isPrivate || space.access.find(userAccess => userAccess.userUuid === userUuid) !== undefined
+
+    true;
 
 export class SpaceService {
     private readonly projectModel: ProjectModel;

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -125,7 +125,8 @@ export class SpaceService {
 
         if (space.isPrivate !== updateSpace.isPrivate) {
             // Switching public and private spaces switches between their defaults
-            await this.spaceModel.clearSpaceAccess(spaceUuid);
+            // it will remove access to all users except for this `user.userUuid`
+            await this.spaceModel.clearSpaceAccess(spaceUuid, user.userUuid);
         }
         const updatedSpace = await this.spaceModel.update(
             spaceUuid,

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -122,6 +122,11 @@ export class SpaceService {
         ) {
             throw new ForbiddenError();
         }
+
+        if (space.isPrivate !== updateSpace.isPrivate) {
+            // Switching public and private spaces switches between their defaults
+            await this.spaceModel.clearSpaceAccess(spaceUuid);
+        }
         const updatedSpace = await this.spaceModel.update(
             spaceUuid,
             updateSpace,

--- a/packages/common/src/types/projectMemberProfile.ts
+++ b/packages/common/src/types/projectMemberProfile.ts
@@ -1,3 +1,6 @@
+import assertUnreachable from '../utils/assertUnreachable';
+import { OrganizationMemberRole } from './organizationMemberProfile';
+
 export enum ProjectMemberRole {
     VIEWER = 'viewer',
     EDITOR = 'editor',
@@ -16,3 +19,22 @@ export type ProjectMemberProfile = {
 export type ProjectMemberProfileUpdate = Partial<
     Pick<ProjectMemberProfile, 'role'>
 >;
+
+export const inheritedProjectRoleFromOrgRole = (
+    orgRole: OrganizationMemberRole,
+): ProjectMemberRole => {
+    switch (orgRole) {
+        case OrganizationMemberRole.MEMBER:
+        case OrganizationMemberRole.VIEWER:
+            return ProjectMemberRole.VIEWER;
+        case OrganizationMemberRole.EDITOR:
+            return ProjectMemberRole.EDITOR;
+        case OrganizationMemberRole.ADMIN:
+            return ProjectMemberRole.ADMIN;
+        default:
+            return assertUnreachable(
+                orgRole,
+                `Organization role ${orgRole} does not match Project roles`,
+            );
+    }
+};

--- a/packages/common/src/types/projectMemberProfile.ts
+++ b/packages/common/src/types/projectMemberProfile.ts
@@ -19,22 +19,3 @@ export type ProjectMemberProfile = {
 export type ProjectMemberProfileUpdate = Partial<
     Pick<ProjectMemberProfile, 'role'>
 >;
-
-export const inheritedProjectRoleFromOrgRole = (
-    orgRole: OrganizationMemberRole,
-): ProjectMemberRole => {
-    switch (orgRole) {
-        case OrganizationMemberRole.MEMBER:
-        case OrganizationMemberRole.VIEWER:
-            return ProjectMemberRole.VIEWER;
-        case OrganizationMemberRole.EDITOR:
-            return ProjectMemberRole.EDITOR;
-        case OrganizationMemberRole.ADMIN:
-            return ProjectMemberRole.ADMIN;
-        default:
-            return assertUnreachable(
-                orgRole,
-                `Organization role ${orgRole} does not match Project roles`,
-            );
-    }
-};

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -1,15 +1,25 @@
 import { DashboardBasicDetails } from './dashboard';
+import { ProjectMemberRole } from './projectMemberProfile';
 import { SpaceQuery } from './savedCharts';
 
 export type Space = {
     organizationUuid: string;
     uuid: string;
     name: string;
+    isPrivate: boolean;
     queries: SpaceQuery[];
     projectUuid: string;
     dashboards: DashboardBasicDetails[];
+    access: SpaceShare[];
 };
 
 export type CreateSpace = Pick<Space, 'name'>;
 
-export type UpdateSpace = Pick<Space, 'name'>;
+export type UpdateSpace = Pick<Space, 'name' | 'isPrivate'>;
+
+export type SpaceShare = {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
+    role: ProjectMemberRole;
+};

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -21,5 +21,5 @@ export type SpaceShare = {
     userUuid: string;
     firstName: string;
     lastName: string;
-    role: ProjectMemberRole;
+    role: ProjectMemberRole | null;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Closes: #3202

### User Acceptance Criteria (backend only) 
- [x] New spaces are created as `restricted` by default (only the person who created the space has access to it)

> Existing charts will have `isPrivate: false`
> New created charts will have `isPrivate: true` and the user will be added to the list of `access` 


- [x] Once I'm in a space, I can adjust the access to that space (using the 'share' button) 

> Built required endpoints

- [x] I can switch a space between "full access" vs. "no access" 

> You can use `patch space` endpoint to change isPrivate 

  - [x] Switching between these just switches between their defaults (e.g. if I have a restricted space where I've also invited Priyanka, then I switch it to "shared", then I switch it back to "restricted", it would restrict the access to just me, it wouldn't keep the old configurations and add Priyanka too)
- [x] You're either given access to a space, or you aren't. There's no option to add someone as an editor vs. viewer when you're inviting an individual.
- [x] Everyone inherits the permissions that they have at a project level. There's no way to change these permissions in the spaces modal. 
- [x] if a space is restricted, I can only add individuals to the space (for now). I can't add groups of individuals (e.g. editors).

>  Built a new endpoint 

- [x] I can remove someone I've added to a restricted space 

>  Built a new endpoint 
> Added a limitation: there must be at least 1 user on the access list 


### Description:

![image](https://user-images.githubusercontent.com/1983672/200810563-f6671bdf-8e40-405d-8bc9-160ab5777a1d.png)

`Jaffle shop` is public (is_private=false) and `private space` is private but I'm in the access list as admin (from org) 

![Screenshot from 2022-11-09 12-06-22](https://user-images.githubusercontent.com/1983672/200814860-bd02b407-0a8b-4d35-b74b-f090bed7cc6a.png)


`Jaffle shop` becomes private (and I'm not in the access list) 
![Screenshot from 2022-11-09 12-08-10](https://user-images.githubusercontent.com/1983672/200814893-db2d1c23-a621-4708-8fcb-ead86f14f945.png)



<!-- Even better add a screenshot / gif / loom -->
## backend endpoints 

To change `isPrivate` call existing endpoint ` patch /spaces/:spaceUuid with `isPrivate` in body

```
# SPACE SHARE

### Create space share 
POST {{base_url}}/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces/f99afb8b-07e0-4025-b797-92961248ebb2/share
Content-Type: application/json

{
  "userUuid": "b264d83a-9000-426a-85ec-3f9c20f368ce"
}

### Delete space share 
DELETE {{base_url}}/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces/f99afb8b-07e0-4025-b797-92961248ebb2/share/b264d83a-9000-426a-85ec-3f9c20f368ce

```
