### PR TITLE
Feat scroll legend

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
@@ -7,6 +7,11 @@ export const SectionTitle = styled.p`
     margin-bottom: 0.286em;
 `;
 
+export const InputTitle = styled.p`
+    font-weight: 500;
+    gap: 3px;
+}
+`;
 export const SectionRow = styled.div`
     display: inline-flex;
     gap: 10px;

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -1,4 +1,4 @@
-import { Collapse } from '@blueprintjs/core';
+import { Collapse, Switch } from '@blueprintjs/core';
 import { EchartsLegend, friendlyName } from '@lightdash/common';
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
@@ -7,9 +7,9 @@ import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
 import Form from '../../ReactHookForm/Form';
 import Input from '../../ReactHookForm/Input';
 import Select from '../../ReactHookForm/Select';
-import { SectionRow, SectionTitle } from './Legend.styles';
+import { InputTitle, SectionRow, SectionTitle } from './Legend.styles';
 
-const triggerSubmitFields = ['show', 'type', 'orient'];
+const triggerSubmitFields = ['show', 'orient', 'scroll'];
 
 const LegendPanel: FC = () => {
     const {
@@ -31,7 +31,6 @@ const LegendPanel: FC = () => {
     }, [handleSubmit, setLegend, watch]);
 
     const showDefault = (dirtyEchartsConfig?.series || []).length > 1;
-
     return (
         <Form
             name="legend"
@@ -51,6 +50,21 @@ const LegendPanel: FC = () => {
                         : showDefault
                 }
             >
+                <InputTitle>Scroll</InputTitle>
+                <Switch
+                    large
+                    checked={dirtyEchartsConfig?.legend?.type !== 'plain'}
+                    onChange={() => {
+                        if (dirtyEchartsConfig?.legend) {
+                            const type: 'scroll' | 'plain' =
+                                dirtyEchartsConfig?.legend?.type === 'plain'
+                                    ? 'scroll'
+                                    : 'plain';
+                            methods.setValue('type', type);
+                            handleSubmit(setLegend)();
+                        }
+                    }}
+                />
                 <SectionTitle>Position</SectionTitle>
                 <SectionRow>
                     <Input name="top" label="Top" placeholder={'auto'} />
@@ -60,15 +74,6 @@ const LegendPanel: FC = () => {
                 </SectionRow>
                 <SectionTitle>Appearance</SectionTitle>
                 <SectionRow>
-                    <Select
-                        name="type"
-                        label="Type"
-                        options={['plain', 'scroll'].map((x) => ({
-                            value: x,
-                            label: friendlyName(x),
-                        }))}
-                        defaultValue="plain"
-                    />
                     <Select
                         name="orient"
                         label="Orientation"

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -55,14 +55,12 @@ const LegendPanel: FC = () => {
                     large
                     checked={dirtyEchartsConfig?.legend?.type !== 'plain'}
                     onChange={() => {
-                        if (dirtyEchartsConfig?.legend) {
-                            const type: 'scroll' | 'plain' =
-                                dirtyEchartsConfig?.legend?.type === 'plain'
-                                    ? 'scroll'
-                                    : 'plain';
-                            methods.setValue('type', type);
-                            handleSubmit(setLegend)();
-                        }
+                        const type: 'scroll' | 'plain' =
+                            dirtyEchartsConfig?.legend?.type !== 'plain'
+                                ? 'plain'
+                                : 'scroll';
+                        methods.setValue('type', type);
+                        handleSubmit(setLegend)();
                     }}
                 />
                 <SectionTitle>Position</SectionTitle>

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -996,6 +996,7 @@ const useEcharts = () => {
                 validCartesianConfig?.eChartsConfig.legend,
             ) || {
                 show: series.length > 1,
+                type: 'scroll',
             },
             dataset: {
                 id: 'lightdashResults',

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -144,6 +144,7 @@ const useTableConfig = (
         getHeader,
         getDefaultColumnLabel,
         showTableNames,
+        isColumnFrozen,
     ]);
 
     // Remove columProperties from map if the column has been removed from results


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3474

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

We don't need to do any magic serie.size calculation to dynamically enable scroll. If scroll is not needed, it will display like always. So instead of this, I'm enabling scroll by default. (It will no longer show series in 2 rows until the issue on echarts is fixed (see #3474) ) 

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 11-11-22 16:16:13.webm](https://user-images.githubusercontent.com/1983672/201371771-18772bb0-0bee-4302-a959-110e34d35271.webm)
