### PR TITLE
fix: disable table configuration settings for the viewer

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/MultiSelect.tsx
+++ b/packages/frontend/src/components/ReactHookForm/MultiSelect.tsx
@@ -1,7 +1,7 @@
 import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     ItemRenderer,
-    MultiSelect as BlueprintMultiSelect,
+    MultiSelect2 as BlueprintMultiSelect,
 } from '@blueprintjs/select';
 import React, { FC } from 'react';
 import { ControllerRenderProps, FieldValues } from 'react-hook-form';


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3751

### Description:
deprecated MultiSelect does not support `disabled` prop

<img width="834" alt="CleanShot 2022-11-14 at 12 32 56@2x" src="https://user-images.githubusercontent.com/962095/201613040-d0956339-40ee-4d3a-9a1d-71273180f371.png">
