### PR TITLE
feat: viz config switch to checkbox

### DIFF
--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -216,10 +216,9 @@ describe('Explore', () => {
 
                     // open configuration and flip Show table names in the config
                     cy.get('button').contains('Configure').click();
-                    cy.findByText('Show table names')
-                        .next('label')
-                        .contains('Yes') // table names are not hidden by default
-                        .click();
+                    cy.findByLabelText('Show table names').click({
+                        force: true,
+                    });
 
                     // check that chart table headers are correct
                     cy.findByTestId('visualization')

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -1,8 +1,8 @@
 import {
+    Checkbox,
     HTMLSelect,
     InputGroup,
     Label,
-    Switch,
     Tab,
     Tabs,
 } from '@blueprintjs/core';
@@ -19,7 +19,7 @@ import {
     Metric,
     TableCalculation,
 } from '@lightdash/common';
-import React, { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { useToggle } from 'react-use';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
@@ -315,6 +315,7 @@ const ChartConfigTabs: FC = () => {
                                     }
                                 />
                             </InputWrapper>
+
                             {showSecondAxisRange && (
                                 <AxisMinMax
                                     label={`Auto ${
@@ -332,21 +333,22 @@ const ChartConfigTabs: FC = () => {
                                     }
                                 />
                             )}
-                            <SectionTitle>Show grid</SectionTitle>
 
-                            <GridSettings>
-                                <Switch
+                            <InputWrapper label="Show grid">
+                                <Checkbox
+                                    label={`${
+                                        dirtyLayout?.flipAxes ? 'Y' : 'X'
+                                    }-axis`}
                                     checked={!!dirtyLayout?.showGridX}
                                     onChange={(e) => {
                                         setShowGridX(!dirtyLayout?.showGridX);
                                     }}
                                 />
-                                <Label>
-                                    {dirtyLayout?.flipAxes ? 'Y' : 'X'}-axis
-                                </Label>
-                            </GridSettings>
-                            <GridSettings>
-                                <Switch
+
+                                <Checkbox
+                                    label={`${
+                                        dirtyLayout?.flipAxes ? 'X' : 'Y'
+                                    }-axis`}
                                     checked={
                                         dirtyLayout?.showGridY !== undefined
                                             ? dirtyLayout?.showGridY
@@ -360,10 +362,7 @@ const ChartConfigTabs: FC = () => {
                                         );
                                     }}
                                 />
-                                <Label>
-                                    {dirtyLayout?.flipAxes ? 'X' : 'Y'}-axis
-                                </Label>
-                            </GridSettings>
+                            </InputWrapper>
                         </>
                     }
                 />

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -3,7 +3,6 @@ import { EchartsLegend, friendlyName } from '@lightdash/common';
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
 import Checkbox from '../../ReactHookForm/Checkbox';
 import Form from '../../ReactHookForm/Form';
 import Input from '../../ReactHookForm/Input';

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -4,6 +4,7 @@ import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
+import Checkbox from '../../ReactHookForm/Checkbox';
 import Form from '../../ReactHookForm/Form';
 import Input from '../../ReactHookForm/Input';
 import Select from '../../ReactHookForm/Select';
@@ -39,11 +40,12 @@ const LegendPanel: FC = () => {
             onSubmit={() => undefined}
             onBlur={handleSubmit(setLegend)}
         >
-            <BooleanSwitch
+            <Checkbox
                 name="show"
-                label="Show legend"
+                checkboxProps={{ label: 'Show legend' }}
                 defaultValue={showDefault}
             />
+
             <Collapse
                 isOpen={
                     dirtyEchartsConfig?.legend

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -1,10 +1,9 @@
-import { Icon, Switch } from '@blueprintjs/core';
+import { Checkbox, FormGroup, Icon, Switch } from '@blueprintjs/core';
 import {
     CartesianChartLayout,
     CartesianSeriesType,
     Field,
     formatItemValue,
-    getDefaultSeriesColor,
     getItemId,
     getItemLabel,
     getSeriesId,
@@ -283,11 +282,10 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
             </GroupSeriesInputs>
             {(chartValue === CartesianSeriesType.LINE ||
                 chartValue === CartesianSeriesType.AREA) && (
-                <GroupSeriesInputs>
-                    <Switch
-                        alignIndicator={'right'}
+                <FormGroup>
+                    <Checkbox
                         checked={seriesGroup[0].showSymbol ?? true}
-                        label={'Show symbol'}
+                        label="Show symbol"
                         onChange={() => {
                             updateAllGroupedSeries(fieldKey, {
                                 showSymbol: !(
@@ -296,17 +294,16 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                             });
                         }}
                     />
-                    <Switch
-                        alignIndicator={'right'}
+                    <Checkbox
                         checked={seriesGroup[0].smooth}
-                        label={'Smooth'}
+                        label="Smooth"
                         onChange={() => {
                             updateAllGroupedSeries(fieldKey, {
                                 smooth: !(seriesGroup[0].smooth ?? true),
                             });
                         }}
                     />
-                </GroupSeriesInputs>
+                </FormGroup>
             )}
             <GroupSeriesWrapper>
                 <DragDropContext onDragEnd={onDragEnd}>

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -1,8 +1,7 @@
-import { Button, Icon, InputGroup, Switch } from '@blueprintjs/core';
+import { Button, Checkbox, FormGroup, InputGroup } from '@blueprintjs/core';
 import {
     CartesianChartLayout,
     CartesianSeriesType,
-    getSeriesId,
     Series,
 } from '@lightdash/common';
 import React, { FC } from 'react';
@@ -199,11 +198,10 @@ const SingleSeriesConfiguration: FC<Props> = ({
                 </SeriesExtraInputs>
                 {(type === CartesianSeriesType.LINE ||
                     type === CartesianSeriesType.AREA) && (
-                    <SeriesExtraInputs>
-                        <Switch
-                            alignIndicator={'right'}
+                    <FormGroup>
+                        <Checkbox
                             checked={series.showSymbol ?? true}
-                            label={'Show symbol'}
+                            label="Show symbol"
                             onChange={() => {
                                 updateSingleSeries({
                                     ...series,
@@ -211,10 +209,9 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                 });
                             }}
                         />
-                        <Switch
-                            alignIndicator={'right'}
+                        <Checkbox
                             checked={series.smooth}
-                            label={'Smooth'}
+                            label="Smooth"
                             onChange={() => {
                                 updateSingleSeries({
                                     ...series,
@@ -222,7 +219,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                 });
                             }}
                         />
-                    </SeriesExtraInputs>
+                    </FormGroup>
                 )}
             </SeriesOptionsWrapper>
         </SeriesWrapper>

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Switch } from '@blueprintjs/core';
+import { Button, Checkbox, FormGroup } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import {
     fieldId,
@@ -136,36 +136,35 @@ export const TableConfigPanel: React.FC = () => {
                             + Add
                         </AddPivotButton>
                     )}
-                    <SectionTitle>Show column total</SectionTitle>
-                    <Switch
-                        large
-                        innerLabelChecked="Yes"
-                        innerLabel="No"
-                        checked={showColumnCalculation}
-                        onChange={(e) => {
-                            setShowColumnCalculation(!showColumnCalculation);
-                        }}
-                    />
-                    <SectionTitle>Show table names</SectionTitle>
-                    <Switch
-                        large
-                        innerLabelChecked="Yes"
-                        innerLabel="No"
-                        checked={showTableNames}
-                        onChange={(e) => {
-                            setShowTableName(!showTableNames);
-                        }}
-                    />
-                    <SectionTitle>Hide row numbers</SectionTitle>
-                    <Switch
-                        large
-                        innerLabelChecked="Yes"
-                        innerLabel="No"
-                        checked={hideRowNumbers}
-                        onChange={(e) => {
-                            setHideRowNumbers(!hideRowNumbers);
-                        }}
-                    />
+
+                    <FormGroup>
+                        <Checkbox
+                            label="Show column total"
+                            checked={showColumnCalculation}
+                            onChange={(e) => {
+                                setShowColumnCalculation(
+                                    !showColumnCalculation,
+                                );
+                            }}
+                        />
+
+                        <Checkbox
+                            label="Show table names"
+                            checked={showTableNames}
+                            onChange={(e) => {
+                                setShowTableName(!showTableNames);
+                            }}
+                        />
+
+                        <Checkbox
+                            label="Hide row numbers"
+                            checked={hideRowNumbers}
+                            onChange={(e) => {
+                                setHideRowNumbers(!hideRowNumbers);
+                            }}
+                        />
+                    </FormGroup>
+
                     <SectionTitle>Columns</SectionTitle>
 
                     <ColumnConfiguration />

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -157,8 +157,8 @@ export const TableConfigPanel: React.FC = () => {
                         />
 
                         <Checkbox
-                            label="Hide row numbers"
-                            checked={hideRowNumbers}
+                            label="Show row numbers"
+                            checked={!hideRowNumbers}
                             onChange={(e) => {
                                 setHideRowNumbers(!hideRowNumbers);
                             }}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3673

### Description:

@PriPatel there are a lot of inconsistencies in the viz config in general. I have not touched anything else but let's tackle that as a separate issue.



**Table viz panel**
- [x] Show column total
- [x] Show table names
- [x] Show row numbers (note, this currently says hide so lets reverse the logic as we want all of them to say 'show'


**Series tab for line charts and area charts**
- [x] Show symbol
- [x] Smooth

**Axes tab:** 
- [x] X-axis
- [x] Y-axis
(we already say 'show grid' so the checkboxes make sense here)

Legend tab
- [x] Show legend


https://user-images.githubusercontent.com/962095/201729131-d5db135c-5f1f-40bd-9902-c8d15e903901.mp4

