### PR TITLE
feat: tile filters

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,7 @@
         "@types/snowflake-sdk": "^1.6.1",
         "copyfiles": "^2.4.1",
         "jest-fetch-mock": "^3.0.3",
-        "knex-mock-client": "^1.6.0"
+        "knex-mock-client": "^1.11.0"
     },
     "dependencies": {
         "@casl/ability": "^5.4.3",
@@ -65,12 +65,12 @@
         "passport-strategy": "^1.0.0",
         "pg": "^8.7.1",
         "pg-connection-string": "^2.5.0",
+        "puppeteer": "^18.0.5",
         "redoc-express": "^1.0.0",
         "simple-git": "^3.5.0",
         "tempy": "^1.0.1",
         "uuid": "^8.3.2",
-        "winston": "^3.3.3",
-        "puppeteer": "^18.0.5"
+        "winston": "^3.3.3"
     },
     "scripts": {
         "dev": "HEADLESS=true nodemon src/index.ts",

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -191,14 +191,14 @@ export const dashboardTileWithSavedChartEntry = {
 export const loomTileEntry = {
     ...dashboardTileEntry,
     type: DashboardTileTypes.LOOM,
-    loomTitle: 'my loom title',
+    title: 'my loom title',
     url: 'my loom url',
 };
 
 export const markdownTileEntry = {
     ...dashboardTileEntry,
     type: DashboardTileTypes.MARKDOWN,
-    markdownTitle: 'my markdown title',
+    title: 'my markdown title',
     content: 'my markdown content',
 };
 
@@ -222,6 +222,8 @@ export const expectedDashboard: Dashboard = {
             type: dashboardTileEntry.type,
             properties: {
                 savedChartUuid: savedChartEntry.saved_query_uuid,
+                hideTitle: false,
+                title: '',
             },
             x: dashboardTileEntry.x_offset,
             y: dashboardTileEntry.y_offset,
@@ -232,7 +234,8 @@ export const expectedDashboard: Dashboard = {
             uuid: dashboardTileEntry.dashboard_tile_uuid,
             type: DashboardTileTypes.LOOM,
             properties: {
-                title: loomTileEntry.loomTitle,
+                title: loomTileEntry.title,
+                hideTitle: false,
                 url: loomTileEntry.url,
             },
             x: dashboardTileEntry.x_offset,
@@ -244,8 +247,9 @@ export const expectedDashboard: Dashboard = {
             uuid: dashboardTileEntry.dashboard_tile_uuid,
             type: DashboardTileTypes.MARKDOWN,
             properties: {
-                title: markdownTileEntry.markdownTitle,
+                title: markdownTileEntry.title,
                 content: markdownTileEntry.content,
+                hideTitle: false,
             },
             x: dashboardTileEntry.x_offset,
             y: dashboardTileEntry.y_offset,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -2,6 +2,7 @@ import {
     CreateDashboardLoomTile,
     CreateDashboardMarkdownTile,
     DashboardChartTile,
+    deepEqual,
     LightdashMode,
     NotFoundError,
 } from '@lightdash/common';
@@ -56,7 +57,7 @@ function queryMatcher(
         sql.includes(tableName) &&
         params.length === bindings.length &&
         params.reduce(
-            (valid, arg, index) => valid && bindings[index] === arg,
+            (valid, arg, index) => valid && deepEqual(bindings[index], arg),
             true,
         );
 }
@@ -217,6 +218,15 @@ describe('DashboardModel', () => {
                 loomTileEntry,
                 markdownTileEntry,
             ]);
+        tracker.on
+            .update(
+                queryMatcher(DashboardViewsTableName, [
+                    addDashboardVersionWithoutChart.filters,
+                    dashboardVersionEntry.dashboard_version_id,
+                ]),
+            )
+            .response([]);
+
         jest.spyOn(model, 'getById').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
@@ -225,6 +235,7 @@ describe('DashboardModel', () => {
 
         expect(tracker.history.select).toHaveLength(2);
         expect(tracker.history.insert).toHaveLength(5);
+        expect(tracker.history.update).toHaveLength(1);
     });
     test('should update dashboard', async () => {
         const dashboardUuid = 'dashboard uuid';
@@ -419,6 +430,15 @@ describe('DashboardModel', () => {
                 ]),
             )
             .response([]);
+        tracker.on
+            .update(
+                queryMatcher(DashboardViewsTableName, [
+                    addDashboardVersionWithoutChart.filters,
+                    dashboardVersionEntry.dashboard_version_id,
+                ]),
+            )
+            .response([]);
+
         jest.spyOn(model, 'getById').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
@@ -431,6 +451,7 @@ describe('DashboardModel', () => {
 
         expect(tracker.history.select).toHaveLength(2);
         expect(tracker.history.insert).toHaveLength(8);
+        expect(tracker.history.update).toHaveLength(1);
     });
     test('should create dashboard version with ids', async () => {
         tracker.on
@@ -486,6 +507,15 @@ describe('DashboardModel', () => {
                 ]),
             )
             .response([]);
+        tracker.on
+            .update(
+                queryMatcher(DashboardViewsTableName, [
+                    addDashboardVersionWithoutChart.filters,
+                    dashboardVersionEntry.dashboard_version_id,
+                ]),
+            )
+            .response([]);
+
         jest.spyOn(model, 'getById').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
@@ -498,6 +528,7 @@ describe('DashboardModel', () => {
 
         expect(tracker.history.select).toHaveLength(2);
         expect(tracker.history.insert).toHaveLength(4);
+        expect(tracker.history.update).toHaveLength(1);
     });
     test('should create dashboard version without a chart', async () => {
         tracker.on
@@ -534,6 +565,16 @@ describe('DashboardModel', () => {
                 ]),
             )
             .response([dashboardTileEntry]);
+
+        tracker.on
+            .update(
+                queryMatcher(DashboardViewsTableName, [
+                    addDashboardVersionWithoutChart.filters,
+                    dashboardVersionEntry.dashboard_version_id,
+                ]),
+            )
+            .response([]);
+
         jest.spyOn(model, 'getById').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
@@ -546,6 +587,7 @@ describe('DashboardModel', () => {
 
         expect(tracker.history.select).toHaveLength(1);
         expect(tracker.history.insert).toHaveLength(3);
+        expect(tracker.history.update).toHaveLength(1);
     });
     test("should error on create dashboard version if saved chart isn't found", async () => {
         tracker.on

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -3,6 +3,10 @@ import {
     CreateDashboard,
     Dashboard,
     DashboardBasicDetails,
+    DashboardChartTile,
+    DashboardLoomTile,
+    DashboardMarkdownTile,
+    DashboardTile,
     DashboardTileTypes,
     DashboardUnversionedFields,
     DashboardVersionedFields,
@@ -465,34 +469,39 @@ export class DashboardModel {
                         w: width,
                     };
 
+                    const commonProperties: Pick<
+                        DashboardTile['properties'],
+                        'title' | 'hideTitle'
+                    > = {
+                        title: title ?? '',
+                        hideTitle: hide_title ?? false,
+                    };
+
                     switch (type) {
                         case DashboardTileTypes.SAVED_CHART:
-                            return {
+                            return <DashboardChartTile>{
                                 ...base,
                                 type: DashboardTileTypes.SAVED_CHART,
                                 properties: {
+                                    ...commonProperties,
                                     savedChartUuid: saved_query_uuid,
-                                    title: title || '',
-                                    hideTitle: hide_title || false,
                                 },
                             };
                         case DashboardTileTypes.MARKDOWN:
-                            return {
+                            return <DashboardMarkdownTile>{
                                 ...base,
                                 type: DashboardTileTypes.MARKDOWN,
                                 properties: {
-                                    title: title || '',
-                                    hideTitle: hide_title || false,
+                                    ...commonProperties,
                                     content: content || '',
                                 },
                             };
                         case DashboardTileTypes.LOOM:
-                            return {
+                            return <DashboardLoomTile>{
                                 ...base,
                                 type: DashboardTileTypes.LOOM,
                                 properties: {
-                                    title: title || '',
-                                    hideTitle: hide_title || false,
+                                    ...commonProperties,
                                     url: url || '',
                                 },
                             };

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -469,10 +469,7 @@ export class DashboardModel {
                         w: width,
                     };
 
-                    const commonProperties: Pick<
-                        DashboardTile['properties'],
-                        'title' | 'hideTitle'
-                    > = {
+                    const commonProperties = {
                         title: title ?? '',
                         hideTitle: hide_title ?? false,
                     };

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -89,12 +89,13 @@ export class DashboardModel {
             },
             ['dashboard_version_id', 'updated_by_user_uuid'],
         );
+
         await trx(DashboardViewsTableName).insert({
             dashboard_version_id: versionId.dashboard_version_id,
             name: 'Default',
-            filters: {
-                dimensions: version.filters?.dimensions ?? [],
-                metrics: version.filters?.metrics ?? [],
+            filters: version.filters || {
+                dimensions: [],
+                metrics: [],
             },
         });
 
@@ -177,7 +178,6 @@ export class DashboardModel {
                 );
 
         await trx(DashboardViewsTableName)
-            .where({ dashboard_version_id: versionId.dashboard_version_id })
             .update({
                 filters: {
                     dimensions:
@@ -195,7 +195,8 @@ export class DashboardModel {
                                 : undefined,
                         })) ?? [],
                 },
-            });
+            })
+            .where({ dashboard_version_id: versionId.dashboard_version_id });
     }
 
     async getAllByProject(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4,6 +4,7 @@ import {
     AlreadyProcessingError,
     ApiQueryResults,
     ApiSqlQueryResults,
+    AvailableFiltersForSavedQuery,
     countTotalFilterRules,
     CreateDbtCloudIntegration,
     CreateJob,
@@ -12,7 +13,6 @@ import {
     Explore,
     ExploreError,
     fieldId as getFieldId,
-    FilterableField,
     FilterOperator,
     findFieldByIdInExplore,
     ForbiddenError,
@@ -1130,7 +1130,7 @@ export class ProjectService {
     async getAvailableFiltersForSavedQuery(
         user: SessionUser,
         savedChartUuid: string,
-    ): Promise<FilterableField[]> {
+    ): Promise<AvailableFiltersForSavedQuery> {
         const savedChart = await this.savedChartModel.get(savedChartUuid);
 
         if (user.ability.cannot('view', subject('SavedChart', savedChart))) {
@@ -1141,9 +1141,13 @@ export class ProjectService {
             savedChart.projectUuid,
             savedChart.tableName,
         );
-        return getDimensions(explore).filter(
-            (field) => isFilterableDimension(field) && !field.hidden,
-        );
+        return {
+            name: savedChart.name,
+            uuid: savedChart.uuid,
+            filters: getDimensions(explore).filter(
+                (field) => isFilterableDimension(field) && !field.hidden,
+            ),
+        };
     }
 
     async hasSavedCharts(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4,7 +4,6 @@ import {
     AlreadyProcessingError,
     ApiQueryResults,
     ApiSqlQueryResults,
-    AvailableFiltersForSavedQuery,
     countTotalFilterRules,
     CreateDbtCloudIntegration,
     CreateJob,
@@ -13,6 +12,7 @@ import {
     Explore,
     ExploreError,
     fieldId as getFieldId,
+    FilterableField,
     FilterOperator,
     findFieldByIdInExplore,
     ForbiddenError,
@@ -1130,7 +1130,7 @@ export class ProjectService {
     async getAvailableFiltersForSavedQuery(
         user: SessionUser,
         savedChartUuid: string,
-    ): Promise<AvailableFiltersForSavedQuery> {
+    ): Promise<FilterableField[]> {
         const savedChart = await this.savedChartModel.get(savedChartUuid);
 
         if (user.ability.cannot('view', subject('SavedChart', savedChart))) {
@@ -1141,13 +1141,9 @@ export class ProjectService {
             savedChart.projectUuid,
             savedChart.tableName,
         );
-        return {
-            name: savedChart.name,
-            uuid: savedChart.uuid,
-            filters: getDimensions(explore).filter(
-                (field) => isFilterableDimension(field) && !field.hidden,
-            ),
-        };
+        return getDimensions(explore).filter(
+            (field) => isFilterableDimension(field) && !field.hidden,
+        );
     }
 
     async hasSavedCharts(

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -20,6 +20,5 @@ module.exports = {
             'warn',
             { argsIgnorePattern: '^_' },
         ],
-        'import/no-cycle': ['warn', { maxDepth: 1 }],
     },
 };

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
             'warn',
             { argsIgnorePattern: '^_' },
         ],
+        'import/no-cycle': ['warn', { maxDepth: 1 }],
     },
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,3 @@
-import moment from 'moment';
-import { v4 as uuidv4 } from 'uuid';
 import { Dashboard, DashboardBasicDetails } from './types/dashboard';
 import { convertAdditionalMetric } from './types/dbt';
 import {
@@ -11,31 +9,16 @@ import {
     CompiledDimension,
     CompiledField,
     CompiledMetric,
-    Dimension,
     DimensionType,
     Field,
     FieldId,
     fieldId,
-    FilterableDimension,
     FilterableField,
     isDimension,
     isField,
-    isFilterableDimension,
     Metric,
     MetricType,
 } from './types/field';
-import {
-    DashboardFieldTarget,
-    DashboardFilterRule,
-    DateFilterRule,
-    FilterOperator,
-    FilterRule,
-    Filters,
-    FilterType,
-    getFilterGroupItemsPropertyName,
-    getItemsFromFilterGroup,
-    UnitOfTime,
-} from './types/filter';
 import {
     AdditionalMetric,
     isAdditionalMetric,
@@ -60,10 +43,8 @@ import { SearchResults } from './types/search';
 import { ShareUrl } from './types/share';
 import { Space } from './types/space';
 import { TableBase } from './types/table';
-import { TimeFrames } from './types/timeFrames';
 import { LightdashUser } from './types/user';
-import assertUnreachable from './utils/assertUnreachable';
-import { formatDate, formatItemValue } from './utils/formatting';
+import { formatItemValue } from './utils/formatting';
 import { WeekDay } from './utils/timeFrames';
 
 export * from './authorization/index';
@@ -97,6 +78,7 @@ export * from './types/timeFrames';
 export * from './types/user';
 export * from './utils/api';
 export { default as assertUnreachable } from './utils/assertUnreachable';
+export * from './utils/filters';
 export * from './utils/formatting';
 export * from './utils/timeFrames';
 
@@ -247,281 +229,6 @@ export const findFieldByIdInExplore = (
     id: FieldId,
 ): Field | undefined =>
     getFields(explore).find((field) => fieldId(field) === id);
-
-export enum FilterGroupOperator {
-    and = 'and',
-    or = 'or',
-}
-
-export const filterableDimensionsOnly = (
-    dimensions: Dimension[],
-): FilterableDimension[] => dimensions.filter(isFilterableDimension);
-
-export const getFilterTypeFromField = (field: FilterableField): FilterType => {
-    const fieldType = field.type;
-    switch (field.type) {
-        case DimensionType.STRING:
-        case MetricType.STRING:
-            return FilterType.STRING;
-        case DimensionType.NUMBER:
-        case MetricType.NUMBER:
-        case MetricType.AVERAGE:
-        case MetricType.COUNT:
-        case MetricType.COUNT_DISTINCT:
-        case MetricType.SUM:
-        case MetricType.MIN:
-        case MetricType.MAX:
-            return FilterType.NUMBER;
-        case DimensionType.TIMESTAMP:
-        case DimensionType.DATE:
-        case MetricType.DATE:
-            return FilterType.DATE;
-        case DimensionType.BOOLEAN:
-        case MetricType.BOOLEAN:
-            return FilterType.BOOLEAN;
-        default: {
-            return assertUnreachable(
-                field,
-                `No filter type found for field type: ${fieldType}`,
-            );
-        }
-    }
-};
-
-export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
-    field: FilterableField,
-    filterRule: T,
-    values?: any[],
-): T => {
-    const filterType = getFilterTypeFromField(field);
-    const filterRuleDefaults: Partial<FilterRule> = {};
-
-    if (
-        ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
-            filterRule.operator,
-        )
-    ) {
-        switch (filterType) {
-            case FilterType.DATE: {
-                const value = values ? values[0] : undefined;
-
-                const isTimestamp = field.type === DimensionType.TIMESTAMP;
-                if (filterRule.operator === FilterOperator.IN_THE_PAST) {
-                    const numberValue =
-                        value === undefined || typeof value !== 'number'
-                            ? 1
-                            : value;
-
-                    filterRuleDefaults.values = [numberValue];
-                    filterRuleDefaults.settings = {
-                        unitOfTime: UnitOfTime.days,
-                        completed: false,
-                    } as DateFilterRule['settings'];
-                } else if (isTimestamp) {
-                    const valueIsDate =
-                        value !== undefined && typeof value !== 'number';
-
-                    const timestampValue = valueIsDate
-                        ? moment(value).format('YYYY-MM-DDTHH:mm:ssZ')
-                        : moment().utc(true).format('YYYY-MM-DDTHH:mm:ssZ');
-
-                    filterRuleDefaults.values = [timestampValue];
-                } else {
-                    const valueIsDate =
-                        value !== undefined && typeof value !== 'number';
-
-                    const defaultTimeIntervalValues: Record<
-                        string,
-                        moment.Moment
-                    > = {
-                        [TimeFrames.DAY]: moment(),
-                        [TimeFrames.WEEK]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('week'),
-                        [TimeFrames.MONTH]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('month'),
-                        [TimeFrames.YEAR]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('year'),
-                    };
-
-                    const defaultDate =
-                        isDimension(field) &&
-                        field.timeInterval &&
-                        defaultTimeIntervalValues[field.timeInterval]
-                            ? defaultTimeIntervalValues[field.timeInterval]
-                            : moment();
-
-                    const dateValue = valueIsDate
-                        ? formatDate(value, undefined, false)
-                        : formatDate(defaultDate, undefined, false);
-                    filterRuleDefaults.values = [dateValue];
-                }
-                break;
-            }
-            case FilterType.BOOLEAN: {
-                filterRuleDefaults.values =
-                    values !== undefined ? values : [false];
-                break;
-            }
-            default:
-                break;
-        }
-    }
-    return {
-        ...filterRule,
-        values: values !== undefined && values !== null ? values : [],
-        settings: undefined,
-        ...filterRuleDefaults,
-    };
-};
-
-export const createFilterRuleFromField = (
-    field: FilterableField,
-    value?: any,
-): FilterRule =>
-    getFilterRuleWithDefaultValue(
-        field,
-        {
-            id: uuidv4(),
-            target: {
-                fieldId: fieldId(field),
-            },
-            operator:
-                value === null ? FilterOperator.NULL : FilterOperator.EQUALS,
-        },
-        value ? [value] : [],
-    );
-
-export const matchFieldExact = (a: FilterableField) => (b: FilterableField) =>
-    a.type === b.type && a.name === b.name && a.table === b.table;
-
-export const matchFieldByTypeAndName =
-    (a: FilterableField) => (b: FilterableField) =>
-        a.type === b.type && a.name === b.name;
-
-export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
-    a.type === b.type;
-
-const getDefaultTileFieldTargetOverride = (
-    field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
-) =>
-    Object.entries(tilesSavedQueryFilters).reduce<
-        Record<string, DashboardFieldTarget>
-    >((acc, [tileUuid, savedQueryFilters]) => {
-        const filterableField = savedQueryFilters.find(matchFieldExact(field));
-        if (!filterableField) return acc;
-
-        return {
-            ...acc,
-            [tileUuid]: {
-                fieldId: fieldId(filterableField),
-                tableName: filterableField.table,
-            },
-        };
-    }, {});
-
-export const applyDefaultTileFieldTargetOverride = (
-    filterRule: DashboardFilterRule<
-        FilterOperator,
-        DashboardFieldTarget,
-        any,
-        any
-    >,
-    field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
-) => {
-    if (!filterRule.tileTargetOverride) {
-        return {
-            ...filterRule,
-            tileTargetOverride: getDefaultTileFieldTargetOverride(
-                field,
-                tilesSavedQueryFilters,
-            ),
-        };
-    }
-    return filterRule;
-};
-
-export const createDashboardFilterRuleFromField = (
-    field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
-): DashboardFilterRule =>
-    getFilterRuleWithDefaultValue(field, {
-        id: uuidv4(),
-        operator: FilterOperator.EQUALS,
-        target: {
-            fieldId: fieldId(field),
-            tableName: field.table,
-        },
-        tileTargetOverride: getDefaultTileFieldTargetOverride(
-            field,
-            tilesSavedQueryFilters,
-        ),
-    });
-
-type AddFilterRuleArgs = {
-    filters: Filters;
-    field: FilterableField;
-    value?: any;
-};
-export const addFilterRule = ({
-    filters,
-    field,
-    value,
-}: AddFilterRuleArgs): Filters => {
-    const groupKey = isDimension(field) ? 'dimensions' : 'metrics';
-    const group = filters[groupKey];
-    return {
-        ...filters,
-        [groupKey]: {
-            id: uuidv4(),
-            ...group,
-            [getFilterGroupItemsPropertyName(group)]: [
-                ...getItemsFromFilterGroup(group),
-                createFilterRuleFromField(field, value),
-            ],
-        },
-    };
-};
-
-export const getFilterRulesByFieldType = (
-    fields: Field[],
-    filterRules: FilterRule[],
-): {
-    dimensions: FilterRule[];
-    metrics: FilterRule[];
-} =>
-    filterRules.reduce<{
-        dimensions: FilterRule[];
-        metrics: FilterRule[];
-    }>(
-        (sum, filterRule) => {
-            const fieldInRule = fields.find(
-                (field) => fieldId(field) === filterRule.target.fieldId,
-            );
-            if (fieldInRule) {
-                if (isDimension(fieldInRule)) {
-                    return {
-                        ...sum,
-                        dimensions: [...sum.dimensions, filterRule],
-                    };
-                }
-                return {
-                    ...sum,
-                    metrics: [...sum.metrics, filterRule],
-                };
-            }
-
-            return sum;
-        },
-        {
-            dimensions: [],
-            metrics: [],
-        },
-    );
 
 export const snakeCaseName = (text: string): string =>
     text

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1111,13 +1111,17 @@ export const getItemId = (item: Field | AdditionalMetric | TableCalculation) =>
     isField(item) || isAdditionalMetric(item) ? fieldId(item) : item.name;
 export const getItemLabel = (item: Field | TableCalculation) =>
     isField(item) ? `${item.tableLabel} ${item.label}` : item.displayName;
-export const getItemIcon = (item: Field | TableCalculation) => {
+export const getItemIcon = (
+    item: Field | TableCalculation | AdditionalMetric,
+) => {
     if (isField(item)) {
         return isDimension(item) ? 'tag' : 'numerical';
     }
     return 'function';
 };
-export const getItemColor = (item: Field | TableCalculation) => {
+export const getItemColor = (
+    item: Field | TableCalculation | AdditionalMetric,
+) => {
     if (isField(item)) {
         return isDimension(item) ? '#0E5A8A' : '#A66321';
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -407,21 +407,23 @@ export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
 
 const getDefaultTileFieldTargetOverride = (
     field: FilterableField,
-    tilesWithSavedQuery: Record<string, AvailableFiltersForSavedQuery>,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
 ): TileFieldTargetOverride[] =>
-    Object.entries(tilesWithSavedQuery)
-        .map<TileFieldTargetOverride | undefined>(([tileUuid, savedQuery]) => {
-            const filterableField = savedQuery.filters.find(
-                matchFieldExact(field),
-            );
-            if (!filterableField) return undefined;
+    Object.entries(tilesSavedQueryFilters)
+        .map<TileFieldTargetOverride | undefined>(
+            ([tileUuid, savedQueryFilters]) => {
+                const filterableField = savedQueryFilters.find(
+                    matchFieldExact(field),
+                );
+                if (!filterableField) return undefined;
 
-            return {
-                tileUuid,
-                fieldId: fieldId(filterableField),
-                tableName: filterableField.table,
-            };
-        })
+                return {
+                    tileUuid,
+                    fieldId: fieldId(filterableField),
+                    tableName: filterableField.table,
+                };
+            },
+        )
         .filter(
             (tileConfig): tileConfig is TileFieldTargetOverride => !!tileConfig,
         );
@@ -434,14 +436,14 @@ export const applyDefaultTileFieldTargetOverride = (
         any
     >,
     field: FilterableField,
-    tilesWithSavedQuery: Record<string, AvailableFiltersForSavedQuery>,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
 ) => {
     if (!filterRule.tileTargetOverride) {
         return {
             ...filterRule,
             tileTargetOverride: getDefaultTileFieldTargetOverride(
                 field,
-                tilesWithSavedQuery,
+                tilesSavedQueryFilters,
             ),
         };
     }
@@ -450,7 +452,7 @@ export const applyDefaultTileFieldTargetOverride = (
 
 export const createDashboardFilterRuleFromField = (
     field: FilterableField,
-    tilesWithSavedQuery: Record<string, AvailableFiltersForSavedQuery>,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
 ): DashboardFilterRule =>
     getFilterRuleWithDefaultValue(field, {
         id: uuidv4(),
@@ -461,7 +463,7 @@ export const createDashboardFilterRuleFromField = (
         operator: FilterOperator.EQUALS,
         tileTargetOverride: getDefaultTileFieldTargetOverride(
             field,
-            tilesWithSavedQuery,
+            tilesSavedQueryFilters,
         ),
     });
 
@@ -564,12 +566,6 @@ export type TablesConfiguration = {
         type: TableSelectionType;
         value: string[] | null;
     };
-};
-
-export type AvailableFiltersForSavedQuery = {
-    uuid: string;
-    name: string;
-    filters: FilterableField[];
 };
 
 export type CreateProjectMember = {
@@ -765,8 +761,7 @@ type ApiResults =
     | Space
     | DbtCloudMetadataResponseMetrics
     | DbtCloudIntegration
-    | ShareUrl
-    | AvailableFiltersForSavedQuery;
+    | ShareUrl;
 
 export type ApiResponse = {
     status: 'ok';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -411,11 +411,11 @@ const getDefaultTileConfigForFilterableField = (
     applicableTiles: AvailableFiltersForSavedQuery[],
 ): DashboardTileFilterConfig[] =>
     applicableTiles
-        .map((tile) => {
-            const filter = tile.filters.find(fieldMatchExact(field));
-            if (!filter) return undefined;
+        .map<DashboardTileFilterConfig | undefined>((tile) => {
+            const filterableField = tile.filters.find(fieldMatchExact(field));
+            if (!filterableField) return undefined;
 
-            return { tileUuid: tile.uuid, filter };
+            return { tileUuid: tile.uuid, fieldId: fieldId(filterableField) };
         })
         .filter(
             (tileConfig): tileConfig is DashboardTileFilterConfig =>

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -395,13 +395,14 @@ export const createFilterRuleFromField = (
         value ? [value] : [],
     );
 
-export const byFieldExact = (a: FilterableField) => (b: FilterableField) =>
+export const matchFieldExact = (a: FilterableField) => (b: FilterableField) =>
     a.type === b.type && a.name === b.name && a.table === b.table;
 
-export const byTypeAndName = (a: FilterableField) => (b: FilterableField) =>
-    a.type === b.type && a.name === b.name;
+export const matchFieldByTypeAndName =
+    (a: FilterableField) => (b: FilterableField) =>
+        a.type === b.type && a.name === b.name;
 
-export const byType = (a: FilterableField) => (b: FilterableField) =>
+export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
     a.type === b.type;
 
 const getDefaultTileConfigForFilterableField = (
@@ -412,7 +413,7 @@ const getDefaultTileConfigForFilterableField = (
         .map<DashboardTileFilterConfig | undefined>(
             ([tileUuid, savedQuery]) => {
                 const filterableField = savedQuery.filters.find(
-                    byFieldExact(field),
+                    matchFieldExact(field),
                 );
                 if (!filterableField) return undefined;
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -372,6 +372,7 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
         ...filterRule,
         values: values !== undefined && values !== null ? values : [],
         settings: undefined,
+        tileUuids: [],
         ...filterRuleDefaults,
     };
 };
@@ -389,6 +390,7 @@ export const createFilterRuleFromField = (
             },
             operator:
                 value === null ? FilterOperator.NULL : FilterOperator.EQUALS,
+            tileUuids: [],
         },
         value ? [value] : [],
     );
@@ -403,6 +405,7 @@ export const createDashboardFilterRuleFromField = (
             tableName: field.table,
         },
         operator: FilterOperator.EQUALS,
+        tileUuids: [],
     });
 
 type AddFilterRuleArgs = {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -506,6 +506,12 @@ export type TablesConfiguration = {
     };
 };
 
+export type AvailableFiltersForSavedQuery = {
+    uuid: string;
+    name: string;
+    filters: FilterableField[];
+};
+
 export type CreateProjectMember = {
     email: string;
     role: ProjectMemberRole;
@@ -699,7 +705,8 @@ type ApiResults =
     | Space
     | DbtCloudMetadataResponseMetrics
     | DbtCloudIntegration
-    | ShareUrl;
+    | ShareUrl
+    | AvailableFiltersForSavedQuery;
 
 export type ApiResponse = {
     status: 'ok';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -374,7 +374,6 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
         ...filterRule,
         values: values !== undefined && values !== null ? values : [],
         settings: undefined,
-        tileUuids: [],
         ...filterRuleDefaults,
     };
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -397,6 +397,7 @@ export const createFilterRuleFromField = (
 
 export const createDashboardFilterRuleFromField = (
     field: FilterableField,
+    applicableTileUuids: string[],
 ): DashboardFilterRule =>
     getFilterRuleWithDefaultValue(field, {
         id: uuidv4(),
@@ -405,7 +406,7 @@ export const createDashboardFilterRuleFromField = (
             tableName: field.table,
         },
         operator: FilterOperator.EQUALS,
-        tileUuids: [],
+        tileUuids: applicableTileUuids,
     });
 
 type AddFilterRuleArgs = {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -228,12 +228,8 @@ export type ArgumentsOf<F extends Function> = F extends (
     : never;
 
 // Helper function to get a list of all dimensions in an explore
-export const getDimensions = (explore: Explore): CompiledDimension[] => {
-    console.log(explore);
-    return Object.values(explore.tables).flatMap((t) =>
-        Object.values(t.dimensions),
-    );
-};
+export const getDimensions = (explore: Explore): CompiledDimension[] =>
+    Object.values(explore.tables).flatMap((t) => Object.values(t.dimensions));
 
 // Helper function to get a list of all metrics in an explore
 export const getMetrics = (explore: Explore): CompiledMetric[] =>

--- a/packages/common/src/openapi/schemas/DashboardFilterRule.json
+++ b/packages/common/src/openapi/schemas/DashboardFilterRule.json
@@ -26,12 +26,15 @@
         "settings": {
             "type": "object"
         },
-        "tileConfigs": {
+        "tileTargetOverride": {
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
                     "fieldId": {
+                        "type": "string"
+                    },
+                    "tableName": {
                         "type": "string"
                     },
                     "tileUuid": {

--- a/packages/common/src/openapi/schemas/DashboardFilterRule.json
+++ b/packages/common/src/openapi/schemas/DashboardFilterRule.json
@@ -25,6 +25,20 @@
         },
         "settings": {
             "type": "object"
+        },
+        "tileConfigs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "fieldId": {
+                        "type": "string"
+                    },
+                    "tileUuid": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "required": ["id", "target", "operator"]

--- a/packages/common/src/openapi/schemas/DashboardFilterRule.json
+++ b/packages/common/src/openapi/schemas/DashboardFilterRule.json
@@ -26,7 +26,7 @@
         "settings": {
             "type": "object"
         },
-        "tileTargetOverride": {
+        "tileTargets": {
             "type": "object",
             "properties": {
                 "tileUuid": {

--- a/packages/common/src/openapi/schemas/DashboardFilterRule.json
+++ b/packages/common/src/openapi/schemas/DashboardFilterRule.json
@@ -27,18 +27,17 @@
             "type": "object"
         },
         "tileTargetOverride": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "fieldId": {
-                        "type": "string"
-                    },
-                    "tableName": {
-                        "type": "string"
-                    },
-                    "tileUuid": {
-                        "type": "string"
+            "type": "object",
+            "properties": {
+                "tileUuid": {
+                    "type": "object",
+                    "properties": {
+                        "fieldId": {
+                            "type": "string"
+                        },
+                        "tableName": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1862,12 +1862,15 @@
                     "settings": {
                         "type": "object"
                     },
-                    "tileConfigs": {
+                    "tileTargetOverride": {
                         "type": "array",
                         "items": {
                             "type": "object",
                             "properties": {
                                 "fieldId": {
+                                    "type": "string"
+                                },
+                                "tableName": {
                                     "type": "string"
                                 },
                                 "tileUuid": {

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1862,7 +1862,7 @@
                     "settings": {
                         "type": "object"
                     },
-                    "tileTargetOverride": {
+                    "tileTargets": {
                         "type": "object",
                         "properties": {
                             "tileUuid": {

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1863,18 +1863,17 @@
                         "type": "object"
                     },
                     "tileTargetOverride": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "fieldId": {
-                                    "type": "string"
-                                },
-                                "tableName": {
-                                    "type": "string"
-                                },
-                                "tileUuid": {
-                                    "type": "string"
+                        "type": "object",
+                        "properties": {
+                            "tileUuid": {
+                                "type": "object",
+                                "properties": {
+                                    "fieldId": {
+                                        "type": "string"
+                                    },
+                                    "tableName": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -1861,6 +1861,20 @@
                     },
                     "settings": {
                         "type": "object"
+                    },
+                    "tileConfigs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "fieldId": {
+                                    "type": "string"
+                                },
+                                "tileUuid": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 },
                 "required": ["id", "target", "operator"]

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -77,7 +77,7 @@ export type DashboardTile =
     | DashboardMarkdownTile
     | DashboardLoomTile;
 
-export const byDashbordChartTileType = (
+export const isDashboardChartTileType = (
     tile: DashboardTile,
 ): tile is DashboardChartTile => tile.type === DashboardTileTypes.SAVED_CHART;
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -15,32 +15,32 @@ type CreateDashboardTileBase = {
     y: number;
     h: number;
     w: number;
+    properties: {
+        title: string;
+        hideTitle: boolean;
+    };
 };
 
 type DashboardTileBase = Required<CreateDashboardTileBase>;
 
 export type DashboardMarkdownTileProperties = {
     type: DashboardTileTypes.MARKDOWN;
-    properties: {
-        title: string;
+    properties: CreateDashboardTileBase['properties'] & {
         content: string;
     };
 };
 
 export type DashboardLoomTileProperties = {
     type: DashboardTileTypes.LOOM;
-    properties: {
-        title: string;
+    properties: CreateDashboardTileBase['properties'] & {
         url: string;
-        hideTitle?: boolean;
     };
 };
 
 export type DashboardChartTileProperties = {
     type: DashboardTileTypes.SAVED_CHART;
-    properties: {
+    properties: CreateDashboardTileBase['properties'] & {
         savedChartUuid: string | null;
-        hideTitle?: boolean;
     };
 };
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -15,31 +15,32 @@ type CreateDashboardTileBase = {
     y: number;
     h: number;
     w: number;
-    properties: {
-        title: string;
-        hideTitle: boolean;
-    };
 };
 
 type DashboardTileBase = Required<CreateDashboardTileBase>;
 
 export type DashboardMarkdownTileProperties = {
     type: DashboardTileTypes.MARKDOWN;
-    properties: CreateDashboardTileBase['properties'] & {
+    properties: {
+        title: string;
         content: string;
     };
 };
 
 export type DashboardLoomTileProperties = {
     type: DashboardTileTypes.LOOM;
-    properties: CreateDashboardTileBase['properties'] & {
+    properties: {
+        title: string;
+        hideTitle?: boolean;
         url: string;
     };
 };
 
 export type DashboardChartTileProperties = {
     type: DashboardTileTypes.SAVED_CHART;
-    properties: CreateDashboardTileBase['properties'] & {
+    properties: {
+        title?: string;
+        hideTitle?: boolean;
         savedChartUuid: string | null;
     };
 };

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -76,6 +76,10 @@ export type DashboardTile =
     | DashboardMarkdownTile
     | DashboardLoomTile;
 
+export const byDashbordChartTileType = (
+    tile: DashboardTile,
+): tile is DashboardChartTile => tile.type === DashboardTileTypes.SAVED_CHART;
+
 export type Dashboard = {
     organizationUuid: string;
     projectUuid: string;

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -71,6 +71,11 @@ export type CreateDashboard = {
     spaceUuid?: string;
 };
 
+export type DashboardTile =
+    | DashboardChartTile
+    | DashboardMarkdownTile
+    | DashboardLoomTile;
+
 export type Dashboard = {
     organizationUuid: string;
     projectUuid: string;
@@ -78,9 +83,7 @@ export type Dashboard = {
     name: string;
     description?: string;
     updatedAt: Date;
-    tiles: Array<
-        DashboardChartTile | DashboardMarkdownTile | DashboardLoomTile
-    >;
+    tiles: Array<DashboardTile>;
     filters: DashboardFilters;
     updatedByUser?: UpdatedByUser;
     spaceUuid: string;

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -59,6 +59,7 @@ export type FilterRule<
     operator: O;
     settings?: S;
     values?: V[];
+    tileUuids: string[];
 };
 
 export type DashboardFieldTarget = {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,6 +1,3 @@
-import { Field, FilterableField } from './field';
-import { TableCalculation } from './metricQuery';
-
 export enum FilterType {
     STRING = 'string',
     NUMBER = 'number',
@@ -116,8 +113,6 @@ export type DashboardFilters = {
     dimensions: DashboardFilterRule[];
     metrics: DashboardFilterRule[];
 };
-
-export type FilterItem = Field | TableCalculation | FilterableField;
 
 /* Utils */
 

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,3 +1,6 @@
+import { Field, FilterableField } from './field';
+import { TableCalculation } from './metricQuery';
+
 export enum FilterType {
     STRING = 'string',
     NUMBER = 'number',
@@ -114,6 +117,8 @@ export type DashboardFilters = {
     dimensions: DashboardFilterRule[];
     metrics: DashboardFilterRule[];
 };
+
+export type FilterItem = Field | TableCalculation | FilterableField;
 
 /* Utils */
 

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -126,46 +126,7 @@ export const isFilterGroup = (value: FilterGroupItem): value is FilterGroup =>
 export const isFilterRule = (value: FilterGroupItem): value is FilterRule =>
     'target' in value && 'operator' in value;
 
-export const getFilterRulesFromGroup = (
-    filterGroup: FilterGroup | undefined,
-): FilterRule[] => {
-    if (filterGroup) {
-        const items = isAndFilterGroup(filterGroup)
-            ? filterGroup.and
-            : filterGroup.or;
-        return items.reduce<FilterRule[]>(
-            (sum, item) =>
-                isFilterGroup(item)
-                    ? [...sum, ...getFilterRulesFromGroup(item)]
-                    : [...sum, item],
-            [],
-        );
-    }
-    return [];
-};
-
-export const getTotalFilterRules = (filters: Filters): FilterRule[] => [
-    ...getFilterRulesFromGroup(filters.dimensions),
-    ...getFilterRulesFromGroup(filters.metrics),
-];
-
-export const countTotalFilterRules = (filters: Filters): number =>
-    getTotalFilterRules(filters).length;
-
-export const getItemsFromFilterGroup = (
-    filterGroup: FilterGroup | undefined,
-): FilterGroupItem[] => {
-    if (filterGroup) {
-        return isAndFilterGroup(filterGroup) ? filterGroup.and : filterGroup.or;
-    }
-    return [];
-};
-
-export const getFilterGroupItemsPropertyName = (
-    filterGroup: FilterGroup | undefined,
-): 'and' | 'or' => {
-    if (filterGroup) {
-        return isAndFilterGroup(filterGroup) ? 'and' : 'or';
-    }
-    return 'and';
-};
+export enum FilterGroupOperator {
+    and = 'and',
+    or = 'or',
+}

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -72,7 +72,7 @@ export type DashboardFilterRule<
     V = any,
     S = any,
 > = FilterRule<O, T, V, S> & {
-    tileTargetOverride?: Record<string, DashboardFieldTarget>;
+    tileTargets?: Record<string, DashboardFieldTarget>;
 };
 
 export type DateFilterRule = FilterRule<

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -59,7 +59,7 @@ export type FilterRule<
     operator: O;
     settings?: S;
     values?: V[];
-    tileUuids: string[];
+    tileUuids?: string[];
 };
 
 export type DashboardFieldTarget = {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -51,11 +51,6 @@ export type FieldTarget = {
     fieldId: string;
 };
 
-export type DashboardTileFilterConfig = {
-    tileUuid: string;
-    fieldId: string;
-};
-
 export type FilterRule<
     O = FilterOperator,
     T = FieldTarget,
@@ -74,13 +69,17 @@ export type DashboardFieldTarget = {
     tableName: string;
 };
 
+export type TileFieldTargetOverride = DashboardFieldTarget & {
+    tileUuid: string;
+};
+
 export type DashboardFilterRule<
     O = FilterOperator,
     T = DashboardFieldTarget,
     V = any,
     S = any,
 > = FilterRule<O, T, V, S> & {
-    tileConfigs?: DashboardTileFilterConfig[];
+    tileTargetOverride?: TileFieldTargetOverride[];
 };
 
 export type DateFilterRule = FilterRule<

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,3 +1,5 @@
+import { FilterableField } from './field';
+
 export enum FilterType {
     STRING = 'string',
     NUMBER = 'number',
@@ -48,6 +50,11 @@ export type FieldTarget = {
     fieldId: string;
 };
 
+export type DashboardTileFilterConfig = {
+    tileUuid: string;
+    filter: FilterableField;
+};
+
 export type FilterRule<
     O = FilterOperator,
     T = FieldTarget,
@@ -59,7 +66,6 @@ export type FilterRule<
     operator: O;
     settings?: S;
     values?: V[];
-    tileUuids?: string[];
 };
 
 export type DashboardFieldTarget = {
@@ -72,7 +78,9 @@ export type DashboardFilterRule<
     T = DashboardFieldTarget,
     V = any,
     S = any,
-> = FilterRule<O, T, V, S>;
+> = FilterRule<O, T, V, S> & {
+    tileConfigs?: DashboardTileFilterConfig[];
+};
 
 export type DateFilterRule = FilterRule<
     FilterOperator,

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,5 +1,3 @@
-import { FilterableField } from './field';
-
 export enum FilterType {
     STRING = 'string',
     NUMBER = 'number',
@@ -52,7 +50,7 @@ export type FieldTarget = {
 
 export type DashboardTileFilterConfig = {
     tileUuid: string;
-    filter: FilterableField;
+    fieldId: string;
 };
 
 export type FilterRule<

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -66,17 +66,13 @@ export type DashboardFieldTarget = {
     tableName: string;
 };
 
-export type TileFieldTargetOverride = DashboardFieldTarget & {
-    tileUuid: string;
-};
-
 export type DashboardFilterRule<
     O = FilterOperator,
     T = DashboardFieldTarget,
     V = any,
     S = any,
 > = FilterRule<O, T, V, S> & {
-    tileTargetOverride?: TileFieldTargetOverride[];
+    tileTargetOverride?: Record<string, DashboardFieldTarget>;
 };
 
 export type DateFilterRule = FilterRule<

--- a/packages/common/src/types/projectMemberProfile.ts
+++ b/packages/common/src/types/projectMemberProfile.ts
@@ -1,6 +1,3 @@
-import assertUnreachable from '../utils/assertUnreachable';
-import { OrganizationMemberRole } from './organizationMemberProfile';
-
 export enum ProjectMemberRole {
     VIEWER = 'viewer',
     EDITOR = 'editor',

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -224,7 +224,7 @@ export const matchFieldByTypeAndName =
 export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
     a.type === b.type;
 
-const getDefaultTileFieldTargetOverride = (
+const getDefaultTileTargets = (
     field: FilterableField,
     tilesSavedQueryFilters: Record<string, FilterableField[]>,
 ) =>
@@ -243,7 +243,7 @@ const getDefaultTileFieldTargetOverride = (
         };
     }, {});
 
-export const applyDefaultTileFieldTargetOverride = (
+export const applyDefaultTileTargets = (
     filterRule: DashboardFilterRule<
         FilterOperator,
         DashboardFieldTarget,
@@ -253,13 +253,10 @@ export const applyDefaultTileFieldTargetOverride = (
     field: FilterableField,
     tilesSavedQueryFilters: Record<string, FilterableField[]>,
 ) => {
-    if (!filterRule.tileTargetOverride) {
+    if (!filterRule.tileTargets) {
         return {
             ...filterRule,
-            tileTargetOverride: getDefaultTileFieldTargetOverride(
-                field,
-                tilesSavedQueryFilters,
-            ),
+            tileTargets: getDefaultTileTargets(field, tilesSavedQueryFilters),
         };
     }
     return filterRule;
@@ -276,10 +273,7 @@ export const createDashboardFilterRuleFromField = (
             fieldId: fieldId(field),
             tableName: field.table,
         },
-        tileTargetOverride: getDefaultTileFieldTargetOverride(
-            field,
-            tilesSavedQueryFilters,
-        ),
+        tileTargets: getDefaultTileTargets(field, tilesSavedQueryFilters),
     });
 
 type AddFilterRuleArgs = {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1,0 +1,345 @@
+import moment from 'moment';
+import { v4 as uuidv4 } from 'uuid';
+import {
+    Dimension,
+    DimensionType,
+    Field,
+    fieldId,
+    FilterableDimension,
+    FilterableField,
+    isDimension,
+    isFilterableDimension,
+    MetricType,
+} from '../types/field';
+import {
+    DashboardFieldTarget,
+    DashboardFilterRule,
+    DateFilterRule,
+    FilterGroup,
+    FilterGroupItem,
+    FilterOperator,
+    FilterRule,
+    Filters,
+    FilterType,
+    isAndFilterGroup,
+    isFilterGroup,
+    UnitOfTime,
+} from '../types/filter';
+import { TimeFrames } from '../types/timeFrames';
+import assertUnreachable from './assertUnreachable';
+import { formatDate } from './formatting';
+
+export const getFilterRulesFromGroup = (
+    filterGroup: FilterGroup | undefined,
+): FilterRule[] => {
+    if (filterGroup) {
+        const items = isAndFilterGroup(filterGroup)
+            ? filterGroup.and
+            : filterGroup.or;
+        return items.reduce<FilterRule[]>(
+            (sum, item) =>
+                isFilterGroup(item)
+                    ? [...sum, ...getFilterRulesFromGroup(item)]
+                    : [...sum, item],
+            [],
+        );
+    }
+    return [];
+};
+
+export const getTotalFilterRules = (filters: Filters): FilterRule[] => [
+    ...getFilterRulesFromGroup(filters.dimensions),
+    ...getFilterRulesFromGroup(filters.metrics),
+];
+
+export const countTotalFilterRules = (filters: Filters): number =>
+    getTotalFilterRules(filters).length;
+
+export const getItemsFromFilterGroup = (
+    filterGroup: FilterGroup | undefined,
+): FilterGroupItem[] => {
+    if (filterGroup) {
+        return isAndFilterGroup(filterGroup) ? filterGroup.and : filterGroup.or;
+    }
+    return [];
+};
+
+export const getFilterGroupItemsPropertyName = (
+    filterGroup: FilterGroup | undefined,
+): 'and' | 'or' => {
+    if (filterGroup) {
+        return isAndFilterGroup(filterGroup) ? 'and' : 'or';
+    }
+    return 'and';
+};
+
+export const filterableDimensionsOnly = (
+    dimensions: Dimension[],
+): FilterableDimension[] => dimensions.filter(isFilterableDimension);
+
+export const getFilterTypeFromField = (field: FilterableField): FilterType => {
+    const fieldType = field.type;
+    switch (field.type) {
+        case DimensionType.STRING:
+        case MetricType.STRING:
+            return FilterType.STRING;
+        case DimensionType.NUMBER:
+        case MetricType.NUMBER:
+        case MetricType.AVERAGE:
+        case MetricType.COUNT:
+        case MetricType.COUNT_DISTINCT:
+        case MetricType.SUM:
+        case MetricType.MIN:
+        case MetricType.MAX:
+            return FilterType.NUMBER;
+        case DimensionType.TIMESTAMP:
+        case DimensionType.DATE:
+        case MetricType.DATE:
+            return FilterType.DATE;
+        case DimensionType.BOOLEAN:
+        case MetricType.BOOLEAN:
+            return FilterType.BOOLEAN;
+        default: {
+            return assertUnreachable(
+                field,
+                `No filter type found for field type: ${fieldType}`,
+            );
+        }
+    }
+};
+
+export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
+    field: FilterableField,
+    filterRule: T,
+    values?: any[],
+): T => {
+    const filterType = getFilterTypeFromField(field);
+    const filterRuleDefaults: Partial<FilterRule> = {};
+
+    if (
+        ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
+            filterRule.operator,
+        )
+    ) {
+        switch (filterType) {
+            case FilterType.DATE: {
+                const value = values ? values[0] : undefined;
+
+                const isTimestamp = field.type === DimensionType.TIMESTAMP;
+                if (filterRule.operator === FilterOperator.IN_THE_PAST) {
+                    const numberValue =
+                        value === undefined || typeof value !== 'number'
+                            ? 1
+                            : value;
+
+                    filterRuleDefaults.values = [numberValue];
+                    filterRuleDefaults.settings = {
+                        unitOfTime: UnitOfTime.days,
+                        completed: false,
+                    } as DateFilterRule['settings'];
+                } else if (isTimestamp) {
+                    const valueIsDate =
+                        value !== undefined && typeof value !== 'number';
+
+                    const timestampValue = valueIsDate
+                        ? moment(value).format('YYYY-MM-DDTHH:mm:ssZ')
+                        : moment().utc(true).format('YYYY-MM-DDTHH:mm:ssZ');
+
+                    filterRuleDefaults.values = [timestampValue];
+                } else {
+                    const valueIsDate =
+                        value !== undefined && typeof value !== 'number';
+
+                    const defaultTimeIntervalValues: Record<
+                        string,
+                        moment.Moment
+                    > = {
+                        [TimeFrames.DAY]: moment(),
+                        [TimeFrames.WEEK]: moment(
+                            valueIsDate ? value : undefined,
+                        ).startOf('week'),
+                        [TimeFrames.MONTH]: moment(
+                            valueIsDate ? value : undefined,
+                        ).startOf('month'),
+                        [TimeFrames.YEAR]: moment(
+                            valueIsDate ? value : undefined,
+                        ).startOf('year'),
+                    };
+
+                    const defaultDate =
+                        isDimension(field) &&
+                        field.timeInterval &&
+                        defaultTimeIntervalValues[field.timeInterval]
+                            ? defaultTimeIntervalValues[field.timeInterval]
+                            : moment();
+
+                    const dateValue = valueIsDate
+                        ? formatDate(value, undefined, false)
+                        : formatDate(defaultDate, undefined, false);
+                    filterRuleDefaults.values = [dateValue];
+                }
+                break;
+            }
+            case FilterType.BOOLEAN: {
+                filterRuleDefaults.values =
+                    values !== undefined ? values : [false];
+                break;
+            }
+            default:
+                break;
+        }
+    }
+    return {
+        ...filterRule,
+        values: values !== undefined && values !== null ? values : [],
+        settings: undefined,
+        ...filterRuleDefaults,
+    };
+};
+
+export const createFilterRuleFromField = (
+    field: FilterableField,
+    value?: any,
+): FilterRule =>
+    getFilterRuleWithDefaultValue(
+        field,
+        {
+            id: uuidv4(),
+            target: {
+                fieldId: fieldId(field),
+            },
+            operator:
+                value === null ? FilterOperator.NULL : FilterOperator.EQUALS,
+        },
+        value ? [value] : [],
+    );
+
+export const matchFieldExact = (a: FilterableField) => (b: FilterableField) =>
+    a.type === b.type && a.name === b.name && a.table === b.table;
+
+export const matchFieldByTypeAndName =
+    (a: FilterableField) => (b: FilterableField) =>
+        a.type === b.type && a.name === b.name;
+
+export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
+    a.type === b.type;
+
+const getDefaultTileFieldTargetOverride = (
+    field: FilterableField,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+) =>
+    Object.entries(tilesSavedQueryFilters).reduce<
+        Record<string, DashboardFieldTarget>
+    >((acc, [tileUuid, savedQueryFilters]) => {
+        const filterableField = savedQueryFilters.find(matchFieldExact(field));
+        if (!filterableField) return acc;
+
+        return {
+            ...acc,
+            [tileUuid]: {
+                fieldId: fieldId(filterableField),
+                tableName: filterableField.table,
+            },
+        };
+    }, {});
+
+export const applyDefaultTileFieldTargetOverride = (
+    filterRule: DashboardFilterRule<
+        FilterOperator,
+        DashboardFieldTarget,
+        any,
+        any
+    >,
+    field: FilterableField,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+) => {
+    if (!filterRule.tileTargetOverride) {
+        return {
+            ...filterRule,
+            tileTargetOverride: getDefaultTileFieldTargetOverride(
+                field,
+                tilesSavedQueryFilters,
+            ),
+        };
+    }
+    return filterRule;
+};
+
+export const createDashboardFilterRuleFromField = (
+    field: FilterableField,
+    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+): DashboardFilterRule =>
+    getFilterRuleWithDefaultValue(field, {
+        id: uuidv4(),
+        operator: FilterOperator.EQUALS,
+        target: {
+            fieldId: fieldId(field),
+            tableName: field.table,
+        },
+        tileTargetOverride: getDefaultTileFieldTargetOverride(
+            field,
+            tilesSavedQueryFilters,
+        ),
+    });
+
+type AddFilterRuleArgs = {
+    filters: Filters;
+    field: FilterableField;
+    value?: any;
+};
+
+export const addFilterRule = ({
+    filters,
+    field,
+    value,
+}: AddFilterRuleArgs): Filters => {
+    const groupKey = isDimension(field) ? 'dimensions' : 'metrics';
+    const group = filters[groupKey];
+    return {
+        ...filters,
+        [groupKey]: {
+            id: uuidv4(),
+            ...group,
+            [getFilterGroupItemsPropertyName(group)]: [
+                ...getItemsFromFilterGroup(group),
+                createFilterRuleFromField(field, value),
+            ],
+        },
+    };
+};
+
+export const getFilterRulesByFieldType = (
+    fields: Field[],
+    filterRules: FilterRule[],
+): {
+    dimensions: FilterRule[];
+    metrics: FilterRule[];
+} =>
+    filterRules.reduce<{
+        dimensions: FilterRule[];
+        metrics: FilterRule[];
+    }>(
+        (sum, filterRule) => {
+            const fieldInRule = fields.find(
+                (field) => fieldId(field) === filterRule.target.fieldId,
+            );
+            if (fieldInRule) {
+                if (isDimension(fieldInRule)) {
+                    return {
+                        ...sum,
+                        dimensions: [...sum.dimensions, filterRule],
+                    };
+                }
+                return {
+                    ...sum,
+                    metrics: [...sum.metrics, filterRule],
+                };
+            }
+
+            return sum;
+        },
+        {
+            dimensions: [],
+            metrics: [],
+        },
+    );

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -226,12 +226,12 @@ export const matchFieldByType = (a: FilterableField) => (b: FilterableField) =>
 
 const getDefaultTileTargets = (
     field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+    availableTileFilters: Record<string, FilterableField[]>,
 ) =>
-    Object.entries(tilesSavedQueryFilters).reduce<
+    Object.entries(availableTileFilters).reduce<
         Record<string, DashboardFieldTarget>
-    >((acc, [tileUuid, savedQueryFilters]) => {
-        const filterableField = savedQueryFilters.find(matchFieldExact(field));
+    >((acc, [tileUuid, availableFilters]) => {
+        const filterableField = availableFilters.find(matchFieldExact(field));
         if (!filterableField) return acc;
 
         return {
@@ -251,12 +251,12 @@ export const applyDefaultTileTargets = (
         any
     >,
     field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+    availableTileFilters: Record<string, FilterableField[]>,
 ) => {
     if (!filterRule.tileTargets) {
         return {
             ...filterRule,
-            tileTargets: getDefaultTileTargets(field, tilesSavedQueryFilters),
+            tileTargets: getDefaultTileTargets(field, availableTileFilters),
         };
     }
     return filterRule;
@@ -264,7 +264,7 @@ export const applyDefaultTileTargets = (
 
 export const createDashboardFilterRuleFromField = (
     field: FilterableField,
-    tilesSavedQueryFilters: Record<string, FilterableField[]>,
+    availableTileFilters: Record<string, FilterableField[]>,
 ): DashboardFilterRule =>
     getFilterRuleWithDefaultValue(field, {
         id: uuidv4(),
@@ -273,7 +273,7 @@ export const createDashboardFilterRuleFromField = (
             fieldId: fieldId(field),
             tableName: field.table,
         },
-        tileTargets: getDefaultTileTargets(field, tilesSavedQueryFilters),
+        tileTargets: getDefaultTileTargets(field, availableTileFilters),
     });
 
 type AddFilterRuleArgs = {

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -1,6 +1,13 @@
 import { Button, FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { CompactConfigMap, CompactOrAlias, getItemId } from '@lightdash/common';
+import {
+    CompactConfigMap,
+    CompactOrAlias,
+    CompiledDimension,
+    getItemId,
+    Metric,
+    TableCalculation,
+} from '@lightdash/common';
 import React, { useState } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -1,13 +1,6 @@
 import { Button, FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import {
-    CompactConfigMap,
-    CompactOrAlias,
-    CompiledDimension,
-    getItemId,
-    Metric,
-    TableCalculation,
-} from '@lightdash/common';
+import { CompactConfigMap, CompactOrAlias, getItemId } from '@lightdash/common';
 import React, { useState } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';

--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -7,7 +7,7 @@ import {
     replaceStringInArray,
     TableCalculation,
 } from '@lightdash/common';
-import React, { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import SimpleButton from '../common/SimpleButton';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,7 +1,7 @@
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesSavedQueryFilters } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardAvailableTileFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
@@ -30,12 +30,12 @@ const ActiveFilter: FC<Props> = ({
     onUpdate,
 }) => {
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesSavedQueryFilters, isLoading } =
-        useDashboardTilesSavedQueryFilters(dashboardTiles);
+    const { data: availableTileFilters, isLoading } =
+        useDashboardAvailableTileFilters(dashboardTiles);
 
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesSavedQueryFilters) {
+    if (isLoading || !availableTileFilters) {
         return null;
     }
 
@@ -57,7 +57,7 @@ const ActiveFilter: FC<Props> = ({
                         selectedTabId={selectedTabId}
                         onTabChange={setSelectedTabId}
                         field={field}
-                        tilesSavedQueryFilters={tilesSavedQueryFilters}
+                        availableTileFilters={availableTileFilters}
                         filterRule={filterRule}
                         onSave={onUpdate}
                     />

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,7 +1,7 @@
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesWithSavedQuery } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardTilesSavedQueryFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
@@ -30,12 +30,12 @@ const ActiveFilter: FC<Props> = ({
     onUpdate,
 }) => {
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesWithSavedQuery, isLoading } =
-        useDashboardTilesWithSavedQuery(dashboardTiles);
+    const { data: tilesSavedQueryFilters, isLoading } =
+        useDashboardTilesSavedQueryFilters(dashboardTiles);
 
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesWithSavedQuery) {
+    if (isLoading || !tilesSavedQueryFilters) {
         return null;
     }
 
@@ -53,10 +53,11 @@ const ActiveFilter: FC<Props> = ({
             content={
                 <FilterModalContainer $wide={selectedTabId === 'tiles'}>
                     <FilterConfiguration
+                        tiles={dashboardTiles}
                         selectedTabId={selectedTabId}
                         onTabChange={setSelectedTabId}
                         field={field}
-                        tilesWithSavedQuery={tilesWithSavedQuery}
+                        tilesSavedQueryFilters={tilesSavedQueryFilters}
                         filterRule={filterRule}
                         onSave={onUpdate}
                     />

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,7 +1,7 @@
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesWithFilters } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardTilesWithSavedQuery } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
@@ -30,12 +30,12 @@ const ActiveFilter: FC<Props> = ({
     onUpdate,
 }) => {
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesWithFilters, isLoading } =
-        useDashboardTilesWithFilters(dashboardTiles);
+    const { data: tilesWithSavedQuery, isLoading } =
+        useDashboardTilesWithSavedQuery(dashboardTiles);
 
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesWithFilters) {
+    if (isLoading || !tilesWithSavedQuery) {
         return null;
     }
 
@@ -56,7 +56,7 @@ const ActiveFilter: FC<Props> = ({
                         selectedTabId={selectedTabId}
                         onTabChange={setSelectedTabId}
                         field={field}
-                        tilesWithFilters={tilesWithFilters}
+                        tilesWithSavedQuery={tilesWithSavedQuery}
                         filterRule={filterRule}
                         onSave={onUpdate}
                     />

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,10 +1,11 @@
-import { Classes, Popover2, Tooltip2 } from '@blueprintjs/popover2';
+import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
-import React, { FC } from 'react';
+import { FC, useState } from 'react';
 import { useDashboardTilesWithFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
-import FilterConfiguration from '../FilterConfiguration';
+import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
+import { FilterModalContainer } from '../FilterSearch/FilterSearch.styles';
 import {
     FilterValues,
     InvalidFilterTag,
@@ -32,6 +33,8 @@ const ActiveFilter: FC<Props> = ({
     const { data: tilesWithFilters, isLoading } =
         useDashboardTilesWithFilters(dashboardTiles);
 
+    const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
+
     if (isLoading || !tilesWithFilters) {
         return null;
     }
@@ -47,14 +50,17 @@ const ActiveFilter: FC<Props> = ({
     return (
         <Popover2
             content={
-                <FilterConfiguration
-                    field={field}
-                    tilesWithFilters={tilesWithFilters}
-                    filterRule={filterRule}
-                    onSave={onUpdate}
-                />
+                <FilterModalContainer $wide={selectedTabId === 'tiles'}>
+                    <FilterConfiguration
+                        selectedTabId={selectedTabId}
+                        onTabChange={setSelectedTabId}
+                        field={field}
+                        tilesWithFilters={tilesWithFilters}
+                        filterRule={filterRule}
+                        onSave={onUpdate}
+                    />
+                </FilterModalContainer>
             }
-            popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
             position="bottom"
         >
             <TagContainer interactive onRemove={onRemove} onClick={onClick}>

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,6 +1,8 @@
 import { Classes, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
 import React, { FC } from 'react';
+import { useDashboardTilesWithFilters } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { getFilterRuleLabel } from '../../common/Filters/configs';
 import FilterConfiguration from '../FilterConfiguration';
 import {
@@ -26,6 +28,14 @@ const ActiveFilter: FC<Props> = ({
     onRemove,
     onUpdate,
 }) => {
+    const { dashboardTiles } = useDashboardContext();
+    const { data: tilesWithFilters, isLoading } =
+        useDashboardTilesWithFilters(dashboardTiles);
+
+    if (!isLoading || !tilesWithFilters) {
+        return null;
+    }
+
     if (!field) {
         return (
             <InvalidFilterTag onRemove={onRemove}>
@@ -39,6 +49,7 @@ const ActiveFilter: FC<Props> = ({
             content={
                 <FilterConfiguration
                     field={field}
+                    tilesWithFilters={tilesWithFilters}
                     filterRule={filterRule}
                     onSave={onUpdate}
                 />

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -32,7 +32,7 @@ const ActiveFilter: FC<Props> = ({
     const { data: tilesWithFilters, isLoading } =
         useDashboardTilesWithFilters(dashboardTiles);
 
-    if (!isLoading || !tilesWithFilters) {
+    if (isLoading || !tilesWithFilters) {
         return null;
     }
 

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -49,6 +49,7 @@ const ActiveFilter: FC<Props> = ({
     const filterRuleLabels = getFilterRuleLabel(filterRule, field);
     return (
         <Popover2
+            placement="bottom-start"
             content={
                 <FilterModalContainer $wide={selectedTabId === 'tiles'}>
                     <FilterConfiguration
@@ -61,13 +62,12 @@ const ActiveFilter: FC<Props> = ({
                     />
                 </FilterModalContainer>
             }
-            position="bottom"
         >
             <TagContainer interactive onRemove={onRemove} onClick={onClick}>
                 <Tooltip2
-                    content={`Table: ${field.tableLabel}`}
                     interactionKind="hover"
-                    placement={'bottom-start'}
+                    placement="bottom-start"
+                    content={`Table: ${field.tableLabel}`}
                 >
                     <>
                         {`${filterRuleLabels.field}: ${filterRuleLabels.operator} `}

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
@@ -25,14 +25,6 @@ export const InvalidFilterTag = styled(TagContainer)`
     }
 `;
 
-export const TagsWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 0.5em;
-    padding-top: 0.2em;
-`;
-
 export const FilterValues = styled.span`
     font-weight: 700;
 `;

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -1,5 +1,5 @@
 import { FieldId, fieldId, FilterableField } from '@lightdash/common';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useAvailableDashboardFilterTargets } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import ActiveFilter from './ActiveFilter';

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -3,7 +3,6 @@ import { FC } from 'react';
 import { useAvailableDashboardFilterTargets } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import ActiveFilter from './ActiveFilter';
-import { TagsWrapper } from './ActiveFilters.styles';
 
 const ActiveFilters: FC = () => {
     const {
@@ -24,7 +23,7 @@ const ActiveFilters: FC = () => {
     );
 
     return (
-        <TagsWrapper>
+        <>
             {dashboardFilters.dimensions.map((item, index) => (
                 <ActiveFilter
                     key={item.id}
@@ -51,7 +50,7 @@ const ActiveFilters: FC = () => {
                     }
                 />
             ))}
-        </TagsWrapper>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -7,15 +7,16 @@ import { TagsWrapper } from './ActiveFilters.styles';
 
 const ActiveFilters: FC = () => {
     const {
-        dashboard,
         dashboardFilters,
         dashboardTemporaryFilters,
         updateDimensionDashboardFilter,
         removeDimensionDashboardFilter,
         dashboardTiles,
     } = useDashboardContext();
-    const { data: filterableFields } =
+    const { isLoading, data: filterableFields } =
         useAvailableDashboardFilterTargets(dashboardTiles);
+
+    if (isLoading || !filterableFields) return null;
 
     const fieldMap = filterableFields.reduce<Record<FieldId, FilterableField>>(
         (acc, field) => ({ ...acc, [fieldId(field)]: field }),

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -38,8 +38,3 @@ export const DashboardFilterWrapper = styled.div`
     gap: 8px;
     align-items: center;
 `;
-
-export const Tooltip = styled.p`
-    padding: 0;
-    margin: 0;
-`;

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -34,10 +34,9 @@ export const FilterTrigger = styled(AnchorButton)`
 `;
 
 export const DashboardFilterWrapper = styled.div`
-    display: grid;
+    display: flex;
+    gap: 8px;
     align-items: center;
-    grid-template-columns: 7.3em auto;
-    margin-bottom: 0.5em;
 `;
 
 export const Tooltip = styled.p`

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -1,11 +1,5 @@
 import { AnchorButton, Colors } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
-
-export const TriggerWrapper = styled(Popover2)`
-    width: fit-content;
-    align-self: baseline;
-`;
 
 export const FilterTrigger = styled(AnchorButton)`
     color: ${Colors.BLUE3} !important;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -1,9 +1,11 @@
+import { Button } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const ConfigureFilterWrapper = styled.div`
     height: 100%;
     display: flex;
     flex-direction: column;
+    gap: 15px;
 `;
 
 export const Title = styled.div`
@@ -13,10 +15,15 @@ export const Title = styled.div`
 
 export const InputsWrapper = styled.div`
     display: flex;
-    gap: 1.071em;
     flex-direction: column;
+    gap: 10px;
+`;
 
-    select {
-        width: 100% !important;
-    }
+export const ActionsWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+export const ApplyButton = styled(Button)`
+    margin-left: auto;
 `;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -1,43 +1,21 @@
-import { AnchorButton, Button, Colors } from '@blueprintjs/core';
 import styled from 'styled-components';
-import LinkButton from '../../common/LinkButton';
-import SimpleButton from '../../common/SimpleButton';
 
 export const ConfigureFilterWrapper = styled.div`
-    width: 20.5em;
     height: 100%;
     display: flex;
     flex-direction: column;
 `;
 
-export const FieldTitle = styled.p`
+export const Title = styled.span`
     font-weight: bold;
-    margin-bottom: 10px;
-`;
-
-export const Title = styled.p`
-    font-weight: bold;
-    margin-bottom: 0px;
 `;
 
 export const InputsWrapper = styled.div`
     display: flex;
     gap: 1.071em;
-    width: 20.5em;
     flex-direction: column;
 
     select {
         width: 100% !important;
     }
-`;
-
-export const BackButton = styled(SimpleButton)`
-    align-self: flex-start;
-    font-size: 13px;
-    padding: 0 !important;
-`;
-
-export const ApplyFilterButton = styled(Button)`
-    margin: 1.714em 0 0 auto;
-    justify-self: flex-end;
 `;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -6,8 +6,9 @@ export const ConfigureFilterWrapper = styled.div`
     flex-direction: column;
 `;
 
-export const Title = styled.span`
-    font-weight: bold;
+export const Title = styled.div`
+    font-weight: 600;
+    margin-bottom: 10px;
 `;
 
 export const InputsWrapper = styled.div`

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -1,5 +1,7 @@
 import { AnchorButton, Button, Colors } from '@blueprintjs/core';
 import styled from 'styled-components';
+import LinkButton from '../../common/LinkButton';
+import SimpleButton from '../../common/SimpleButton';
 
 export const ConfigureFilterWrapper = styled.div`
     width: 20.5em;
@@ -10,6 +12,7 @@ export const ConfigureFilterWrapper = styled.div`
 
 export const Title = styled.p`
     font-weight: bold;
+    margin-bottom: 0;
 `;
 
 export const InputsWrapper = styled.div`
@@ -23,25 +26,10 @@ export const InputsWrapper = styled.div`
     }
 `;
 
-export const BackButton = styled(AnchorButton)`
-    color: ${Colors.BLUE3} !important;
-    padding: 0;
-    margin-bottom: 1.5em;
-    justify-content: flex-start;
-    font-size: 12px;
-    font-weight: 600;
-    :hover {
-        background: transparent !important;
-        span {
-            text-decoration: underline;
-        }
-    }
-    :focus {
-        outline: none;
-        span {
-            text-decoration: underline;
-        }
-    }
+export const BackButton = styled(SimpleButton)`
+    align-self: flex-start;
+    font-size: 13px;
+    padding: 0 !important;
 `;
 
 export const ApplyFilterButton = styled(Button)`

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -10,9 +10,14 @@ export const ConfigureFilterWrapper = styled.div`
     flex-direction: column;
 `;
 
+export const FieldTitle = styled.p`
+    font-weight: bold;
+    margin-bottom: 10px;
+`;
+
 export const Title = styled.p`
     font-weight: bold;
-    margin-bottom: 0;
+    margin-bottom: 0px;
 `;
 
 export const InputsWrapper = styled.div`

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -47,6 +47,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                 options={filterConfig.operatorOptions}
                 value={filterRule.operator}
             />
+
             <filterConfig.inputs
                 popoverProps={popoverProps}
                 filterType={filterType}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -1,0 +1,63 @@
+import { HTMLSelect } from '@blueprintjs/core';
+import { Popover2Props } from '@blueprintjs/popover2';
+import {
+    DashboardFilterRule,
+    FilterableField,
+    FilterRule,
+    FilterType,
+    getFilterTypeFromField,
+} from '@lightdash/common';
+import { FC, useMemo } from 'react';
+import { FilterTypeConfig } from '../../common/Filters/configs';
+import { InputsWrapper } from './FilterConfiguration.styled';
+
+interface FilterSettingsProps {
+    field: FilterableField;
+    filterRule: DashboardFilterRule;
+    popoverProps?: Popover2Props;
+    onChangeFilterOperator: (value: DashboardFilterRule['operator']) => void;
+    onChangeFilterRule: (value: DashboardFilterRule) => void;
+}
+
+const FilterSettings: FC<FilterSettingsProps> = ({
+    field,
+    filterRule,
+    popoverProps,
+    onChangeFilterOperator,
+    onChangeFilterRule,
+}) => {
+    const filterType = field
+        ? getFilterTypeFromField(field)
+        : FilterType.STRING;
+
+    const filterConfig = useMemo(
+        () => FilterTypeConfig[filterType],
+        [filterType],
+    );
+
+    return (
+        <InputsWrapper>
+            <HTMLSelect
+                fill
+                onChange={(e) =>
+                    onChangeFilterOperator(
+                        e.target.value as FilterRule['operator'],
+                    )
+                }
+                options={filterConfig.operatorOptions}
+                value={filterRule.operator}
+            />
+            <filterConfig.inputs
+                popoverProps={popoverProps}
+                filterType={filterType}
+                field={field}
+                filterRule={filterRule}
+                onChange={(newFilterRule) =>
+                    onChangeFilterRule(newFilterRule as DashboardFilterRule)
+                }
+            />
+        </InputsWrapper>
+    );
+};
+
+export default FilterSettings;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -75,7 +75,7 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
 
             {sortedTileEntries.map(([tileUuid, filters]) => {
                 const tile = tiles.find((t) => t.uuid === tileUuid);
-                const tileConfig = filterRule.tileTargetOverride?.[tileUuid];
+                const tileConfig = filterRule.tileTargets?.[tileUuid];
 
                 const isAvailable = filters.some(matchFieldByType(field));
                 const isChecked = isAvailable && !!tileConfig;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -3,7 +3,7 @@ import { Popover2Props } from '@blueprintjs/popover2';
 import {
     DashboardFilterRule,
     DashboardTile,
-    fieldId,
+    fieldId as getFieldId,
     FilterableField,
     matchFieldByType,
     matchFieldByTypeAndName,
@@ -23,7 +23,7 @@ interface TileFilterConfigurationProps {
     onChange: (
         action: FilterActions,
         tileUuid: string,
-        filterUuid?: FilterableField,
+        filter?: FilterableField,
     ) => void;
 }
 
@@ -73,24 +73,17 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                 Select tiles to apply filter to and which field to filter by
             </Title>
 
-            {sortedTileEntries.map(([tileUuid, savedQueryFilters]) => {
-                const tileConfig = filterRule.tileTargetOverride?.find(
-                    (t) => t.tileUuid === tileUuid,
-                );
+            {sortedTileEntries.map(([tileUuid, filters]) => {
+                const tile = tiles.find((t) => t.uuid === tileUuid);
+                const tileConfig = filterRule.tileTargetOverride?.[tileUuid];
 
-                const isAvailable = savedQueryFilters.some((t) =>
-                    matchFieldByType(field)(t),
-                );
+                const isAvailable = filters.some(matchFieldByType(field));
                 const isChecked = isAvailable && !!tileConfig;
 
-                const filterableFieldId = tileConfig?.fieldId;
-                const filterableField = savedQueryFilters.find(
-                    (f) => fieldId(f) === filterableFieldId,
-                );
+                const fieldId = tileConfig?.fieldId;
+                const filter = filters.find((f) => getFieldId(f) === fieldId);
 
-                const tile = tiles.find((t) => t.uuid === tileUuid);
-
-                const sortedItems = savedQueryFilters
+                const sortedFilters = filters
                     .filter(matchFieldByType(field))
                     .sort((a, b) => itemsSortBy(matchFieldByTypeAndName, a, b))
                     .sort((a, b) => itemsSortBy(matchFieldExact, a, b));
@@ -115,13 +108,13 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                             <FieldSelect
                                 available={isAvailable}
                                 disabled={!isAvailable || !isChecked}
-                                items={sortedItems}
-                                activeItem={filterableField}
-                                onItemSelect={(newFilterableField) => {
+                                items={sortedFilters}
+                                activeItem={filter}
+                                onItemSelect={(newFilter) => {
                                     onChange(
                                         FilterActions.ADD,
                                         tileUuid,
-                                        newFilterableField,
+                                        newFilter,
                                     );
                                 }}
                                 popoverProps={popoverProps}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -120,11 +120,7 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                                         newFilterableField,
                                     );
                                 }}
-                                popoverProps={{
-                                    captureDismiss: !popoverProps?.isOpen,
-                                    canEscapeKeyClose: !popoverProps?.isOpen,
-                                    ...popoverProps,
-                                }}
+                                popoverProps={popoverProps}
                             />
                         </div>
                     </FormGroup>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -11,11 +11,9 @@ import {
 } from '@lightdash/common';
 import { FC } from 'react';
 import { FilterActions } from '.';
-import {
-    FieldIcon,
-    FieldLabel,
-    renderItem,
-} from '../../common/Filters/FieldAutoComplete';
+import FieldIcon from '../../common/Filters/FieldIcon';
+import FieldLabel from '../../common/Filters/FieldLabel';
+import renderFilterItem from '../../common/Filters/renderFilterItem';
 import { Title } from './FilterConfiguration.styled';
 
 interface TileFilterConfigurationProps {
@@ -101,7 +99,7 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                                         fill
                                         filterable={false}
                                         items={sortedItems}
-                                        itemRenderer={renderItem}
+                                        itemRenderer={renderFilterItem}
                                         noResults={
                                             <MenuItem2
                                                 disabled

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -35,6 +35,23 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
     popoverProps,
     onChange,
 }) => {
+    // TODO enable sort.
+    const sortByAvailability = (
+        a: AvailableFiltersForSavedQuery,
+        b: AvailableFiltersForSavedQuery,
+    ) => {
+        const isAApplicable = availableFilters?.some((t) => t.uuid === a.uuid);
+        const isBApplicable = availableFilters?.some((t) => t.uuid === b.uuid);
+
+        if (isAApplicable && !isBApplicable) {
+            return -1;
+        } else if (!isAApplicable && isBApplicable) {
+            return 1;
+        } else {
+            return 0;
+        }
+    };
+
     return (
         <>
             <Title>
@@ -73,7 +90,6 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                             );
 
                         return (
-                            // TODO: extract to component
                             <FormGroup key={tileUuid}>
                                 <Checkbox
                                     label={savedQuery.name}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -16,9 +16,9 @@ import { Title } from './FilterConfiguration.styled';
 
 interface TileFilterConfigurationProps {
     tiles: DashboardTile[];
+    availableTileFilters: Record<string, FilterableField[]>;
     field: FilterableField;
     filterRule: DashboardFilterRule;
-    tilesSavedQueryFilters: Record<string, FilterableField[]>;
     popoverProps?: Popover2Props;
     onChange: (
         action: FilterActions,
@@ -31,7 +31,7 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
     tiles,
     field,
     filterRule,
-    tilesSavedQueryFilters,
+    availableTileFilters,
     popoverProps,
     onChange,
 }) => {
@@ -62,10 +62,10 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
     );
 
     const sortedTileEntries = useMemo(() => {
-        return Object.entries(tilesSavedQueryFilters)
+        return Object.entries(availableTileFilters)
             .sort(([, a], [, b]) => tilesSortBy(matchFieldByTypeAndName, a, b))
             .sort(([, a], [, b]) => tilesSortBy(matchFieldExact, a, b));
-    }, [tilesSortBy, tilesSavedQueryFilters]);
+    }, [tilesSortBy, availableTileFilters]);
 
     return (
         <>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -72,7 +72,7 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
             </Title>
 
             {sortedTileEntries.map(([tileUuid, savedQuery]) => {
-                const tileConfig = filterRule.tileConfigs?.find(
+                const tileConfig = filterRule.tileTargetOverride?.find(
                     (t) => t.tileUuid === tileUuid,
                 );
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -1,0 +1,171 @@
+import { Button, Checkbox, FormGroup } from '@blueprintjs/core';
+import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
+import { Select2 } from '@blueprintjs/select';
+import {
+    AvailableFiltersForSavedQuery,
+    byFieldExact,
+    byType,
+    DashboardFilterRule,
+    fieldId,
+    FilterableField,
+} from '@lightdash/common';
+import { FC } from 'react';
+import { FilterActions } from '.';
+import {
+    FieldIcon,
+    FieldLabel,
+    renderItem,
+} from '../../common/Filters/FieldAutoComplete';
+import { Title } from './FilterConfiguration.styled';
+
+interface TileFilterConfigurationProps {
+    field: FilterableField;
+    filterRule: DashboardFilterRule;
+    tilesWithSavedQuery: Record<string, AvailableFiltersForSavedQuery>;
+    popoverProps?: Popover2Props;
+    onChange: (
+        action: FilterActions,
+        tileUuid: string,
+        filterUuid?: FilterableField,
+    ) => void;
+}
+
+const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
+    field,
+    filterRule,
+    tilesWithSavedQuery,
+    popoverProps,
+    onChange,
+}) => {
+    return (
+        <>
+            <Title>
+                Select tiles to apply filter to and which field to filter by
+            </Title>
+
+            {tilesWithSavedQuery &&
+                Object.entries(tilesWithSavedQuery).map(
+                    ([tileUuid, savedQuery]) => {
+                        // TODO: fix sort
+                        // .sort(sortByAvailability)
+                        const isApplicable = true;
+                        // TODO: fix availability
+                        // availableFilters?.some(
+                        //     (t) => t.uuid === tileUuid,
+                        // );
+
+                        const tileConfig = filterRule.tileConfigs?.find(
+                            (t) => t.tileUuid === tileUuid,
+                        );
+
+                        const isChecked = isApplicable && !!tileConfig;
+
+                        const filterableFieldId = tileConfig?.fieldId;
+                        const filterableField = savedQuery.filters.find(
+                            (f) => fieldId(f) === filterableFieldId,
+                        );
+
+                        const sortedItems = savedQuery.filters
+                            .filter(byType(field))
+                            .sort((a, b) =>
+                                byFieldExact(a)(field) &&
+                                !byFieldExact(b)(field)
+                                    ? -1
+                                    : 1,
+                            );
+
+                        return (
+                            // TODO: extract to component
+                            <FormGroup key={tileUuid}>
+                                <Checkbox
+                                    label={savedQuery.name}
+                                    disabled={!isApplicable}
+                                    checked={isChecked}
+                                    onChange={() => {
+                                        onChange(
+                                            isChecked
+                                                ? FilterActions.REMOVE
+                                                : FilterActions.ADD,
+                                            tileUuid,
+                                        );
+                                    }}
+                                />
+
+                                <div
+                                    style={{
+                                        marginLeft: 24,
+                                    }}
+                                >
+                                    <Select2<FilterableField>
+                                        disabled={!isChecked}
+                                        fill
+                                        filterable={false}
+                                        items={sortedItems}
+                                        itemRenderer={renderItem}
+                                        noResults={
+                                            <MenuItem2
+                                                disabled
+                                                text="No results."
+                                            />
+                                        }
+                                        activeItem={filterableField}
+                                        onItemSelect={(newFilterableField) => {
+                                            onChange(
+                                                FilterActions.ADD,
+                                                tileUuid,
+                                                newFilterableField,
+                                            );
+                                        }}
+                                        popoverProps={{
+                                            lazy: true,
+                                            minimal: true,
+                                            matchTargetWidth: true,
+                                            captureDismiss:
+                                                !popoverProps?.isOpen,
+                                            canEscapeKeyClose:
+                                                !popoverProps?.isOpen,
+                                            ...popoverProps,
+                                        }}
+                                    >
+                                        <Button
+                                            minimal
+                                            alignText="left"
+                                            disabled={!isChecked}
+                                            outlined
+                                            fill
+                                            icon={
+                                                filterableField && (
+                                                    <FieldIcon
+                                                        item={filterableField}
+                                                    />
+                                                )
+                                            }
+                                            text={
+                                                isApplicable ? (
+                                                    filterableField ? (
+                                                        <FieldLabel
+                                                            item={
+                                                                filterableField
+                                                            }
+                                                        />
+                                                    ) : (
+                                                        'Select field'
+                                                    )
+                                                ) : (
+                                                    'Not applicable'
+                                                )
+                                            }
+                                            rightIcon="caret-down"
+                                            placeholder="Select a film"
+                                        />
+                                    </Select2>
+                                </div>
+                            </FormGroup>
+                        );
+                    },
+                )}
+        </>
+    );
+};
+
+export default TileFilterConfiguration;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -131,50 +131,44 @@ const FilterConfiguration: FC<Props> = ({
         [field, availableTileFilters],
     );
 
-    const filterSettings = (
-        <FilterSettings
-            field={field}
-            filterRule={internalFilterRule}
-            onChangeFilterOperator={handleChangeFilterOperator}
-            onChangeFilterRule={handleChangeFilterRule}
-            popoverProps={popoverProps}
-        />
-    );
-
     return (
         <ConfigureFilterWrapper>
             <FieldLabel item={field} />
 
-            {localStorage.getItem('dashboard_filters') ? (
-                <Tabs
-                    selectedTabId={selectedTabId}
-                    onChange={onTabChange}
-                    renderActiveTabPanelOnly
-                >
-                    <Tab
-                        id="settings"
-                        title="Settings"
-                        panel={filterSettings}
-                    />
+            <Tabs
+                selectedTabId={selectedTabId}
+                onChange={onTabChange}
+                renderActiveTabPanelOnly
+            >
+                <Tab
+                    id="settings"
+                    title="Settings"
+                    panel={
+                        <FilterSettings
+                            field={field}
+                            filterRule={internalFilterRule}
+                            onChangeFilterOperator={handleChangeFilterOperator}
+                            onChangeFilterRule={handleChangeFilterRule}
+                            popoverProps={popoverProps}
+                        />
+                    }
+                />
 
-                    <Tab
-                        id="tiles"
-                        title="Tiles"
-                        panel={
-                            <TileFilterConfiguration
-                                field={field}
-                                filterRule={internalFilterRule}
-                                popoverProps={popoverProps}
-                                tiles={tiles}
-                                availableTileFilters={availableTileFilters}
-                                onChange={handleChangeTileConfiguration}
-                            />
-                        }
-                    />
-                </Tabs>
-            ) : (
-                filterSettings
-            )}
+                <Tab
+                    id="tiles"
+                    title="Tiles"
+                    panel={
+                        <TileFilterConfiguration
+                            field={field}
+                            filterRule={internalFilterRule}
+                            popoverProps={popoverProps}
+                            tiles={tiles}
+                            availableTileFilters={availableTileFilters}
+                            onChange={handleChangeTileConfiguration}
+                        />
+                    }
+                />
+            </Tabs>
 
             <ActionsWrapper>
                 {onBack && (

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -4,9 +4,6 @@ import { Classes, Popover2Props } from '@blueprintjs/popover2';
 import {
     applyDefaultTileConfigToFilterRule,
     AvailableFiltersForSavedQuery,
-    byFieldExact,
-    byType,
-    byTypeAndName,
     createDashboardFilterRuleFromField,
     DashboardFilterRule,
     fieldId,
@@ -14,6 +11,9 @@ import {
     FilterOperator,
     FilterRule,
     getFilterRuleWithDefaultValue,
+    matchFieldByType,
+    matchFieldByTypeAndName,
+    matchFieldExact,
 } from '@lightdash/common';
 import produce from 'immer';
 import { FC, useCallback, useMemo, useState } from 'react';
@@ -108,12 +108,14 @@ const FilterConfiguration: FC<Props> = ({
                             return tileConfig.tileUuid !== tileUuid;
                         }) || [];
 
+                    const filters = savedQuery.filters;
+
                     if (action === FilterActions.ADD) {
                         const filterableField =
                             filterUuid ??
-                            savedQuery.filters.find(byFieldExact(field)) ??
-                            savedQuery.filters.find(byTypeAndName(field)) ??
-                            savedQuery.filters.find(byType(field));
+                            filters.find(matchFieldExact(field)) ??
+                            filters.find(matchFieldByTypeAndName(field)) ??
+                            filters.find(matchFieldByType(field));
 
                         if (!filterableField) return draftState;
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Intent, Tab, Tabs } from '@blueprintjs/core';
+import { Intent, Tab, Tabs } from '@blueprintjs/core';
 import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
@@ -19,7 +19,11 @@ import produce from 'immer';
 import { FC, useCallback, useMemo, useState } from 'react';
 import FieldLabel from '../../common/Filters/FieldLabel';
 import SimpleButton from '../../common/SimpleButton';
-import { ConfigureFilterWrapper } from './FilterConfiguration.styled';
+import {
+    ActionsWrapper,
+    ApplyButton,
+    ConfigureFilterWrapper,
+} from './FilterConfiguration.styled';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 
@@ -56,16 +60,6 @@ const FilterConfiguration: FC<Props> = ({
     onSave,
     onBack,
 }) => {
-    const availableFilters = useMemo(
-        () =>
-            Object.values(tilesWithSavedQuery).filter((tile) =>
-                tile.filters.some(byType(field)),
-            ),
-        [tilesWithSavedQuery, field],
-    );
-
-    console.log({ tilesWithSavedQuery });
-
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
             filterRule
@@ -134,29 +128,9 @@ const FilterConfiguration: FC<Props> = ({
         [field, tilesWithSavedQuery],
     );
 
-    // TODO move to tile filter config
-    const sortByAvailability = (
-        a: AvailableFiltersForSavedQuery,
-        b: AvailableFiltersForSavedQuery,
-    ) => {
-        const isAApplicable = availableFilters?.some((t) => t.uuid === a.uuid);
-        const isBApplicable = availableFilters?.some((t) => t.uuid === b.uuid);
-
-        if (isAApplicable && !isBApplicable) {
-            return -1;
-        } else if (!isAApplicable && isBApplicable) {
-            return 1;
-        } else {
-            return 0;
-        }
-    };
-
     return (
         <ConfigureFilterWrapper>
-            {/* TODO: styled? */}
-            <div style={{ marginBottom: 10 }}>
-                <FieldLabel item={field} />
-            </div>
+            <FieldLabel item={field} />
 
             <Tabs
                 selectedTabId={selectedTabId}
@@ -192,24 +166,14 @@ const FilterConfiguration: FC<Props> = ({
                 />
             </Tabs>
 
-            {/* TODO: style */}
-            <div
-                style={{
-                    display: 'flex',
-                    marginTop: 24,
-                }}
-            >
+            <ActionsWrapper>
                 {onBack && (
                     <SimpleButton small onClick={onBack}>
                         Back
                     </SimpleButton>
                 )}
 
-                {/* TODO: style */}
-                <Button
-                    style={{
-                        marginLeft: 'auto',
-                    }}
+                <ApplyButton
                     type="submit"
                     className={Classes.POPOVER2_DISMISS}
                     intent={Intent.PRIMARY}
@@ -224,7 +188,7 @@ const FilterConfiguration: FC<Props> = ({
                     }
                     onClick={() => onSave(internalFilterRule)}
                 />
-            </div>
+            </ActionsWrapper>
         </ConfigureFilterWrapper>
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -130,43 +130,49 @@ const FilterConfiguration: FC<Props> = ({
         [field, tilesWithSavedQuery],
     );
 
+    const filterSettings = (
+        <FilterSettings
+            field={field}
+            filterRule={internalFilterRule}
+            onChangeFilterOperator={handleChangeFilterOperator}
+            onChangeFilterRule={handleChangeFilterRule}
+            popoverProps={popoverProps}
+        />
+    );
+
     return (
         <ConfigureFilterWrapper>
             <FieldLabel item={field} />
 
-            <Tabs
-                selectedTabId={selectedTabId}
-                onChange={onTabChange}
-                renderActiveTabPanelOnly
-            >
-                <Tab
-                    id="settings"
-                    title="Settings"
-                    panel={
-                        <FilterSettings
-                            field={field}
-                            filterRule={internalFilterRule}
-                            onChangeFilterOperator={handleChangeFilterOperator}
-                            onChangeFilterRule={handleChangeFilterRule}
-                            popoverProps={popoverProps}
-                        />
-                    }
-                />
+            {localStorage.getItem('dashboard_filters') ? (
+                <Tabs
+                    selectedTabId={selectedTabId}
+                    onChange={onTabChange}
+                    renderActiveTabPanelOnly
+                >
+                    <Tab
+                        id="settings"
+                        title="Settings"
+                        panel={filterSettings}
+                    />
 
-                <Tab
-                    id="tiles"
-                    title="Tiles"
-                    panel={
-                        <TileFilterConfiguration
-                            field={field}
-                            filterRule={internalFilterRule}
-                            popoverProps={popoverProps}
-                            tilesWithSavedQuery={tilesWithSavedQuery}
-                            onChange={handleChangeTileConfiguration}
-                        />
-                    }
-                />
-            </Tabs>
+                    <Tab
+                        id="tiles"
+                        title="Tiles"
+                        panel={
+                            <TileFilterConfiguration
+                                field={field}
+                                filterRule={internalFilterRule}
+                                popoverProps={popoverProps}
+                                tilesWithSavedQuery={tilesWithSavedQuery}
+                                onChange={handleChangeTileConfiguration}
+                            />
+                        }
+                    />
+                </Tabs>
+            ) : (
+                filterSettings
+            )}
 
             <ActionsWrapper>
                 {onBack && (

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -34,24 +34,31 @@ import {
     Title,
 } from './FilterConfiguration.styled';
 
-interface Props {
-    field: FilterableField;
-    tilesWithFilters: Record<string, AvailableFiltersForSavedQuery>;
-    filterRule?: DashboardFilterRule;
-    popoverProps?: Popover2Props;
-    selectedTabId: string;
-    onTabChange: (tabId: string) => void;
-    onSave: (value: DashboardFilterRule) => void;
-    onBack?: () => void;
-}
-
 enum FilterActions {
     ADD = 'add',
     REMOVE = 'remove',
 }
 
+export enum FilterTabs {
+    SETTINGS = 'settings',
+    TILES = 'tiles',
+}
+
+const DEFAULT_TAB = FilterTabs.SETTINGS;
+
+interface Props {
+    field: FilterableField;
+    tilesWithFilters: Record<string, AvailableFiltersForSavedQuery>;
+    filterRule?: DashboardFilterRule;
+    popoverProps?: Popover2Props;
+    selectedTabId?: string;
+    onTabChange: (tabId: FilterTabs) => void;
+    onSave: (value: DashboardFilterRule) => void;
+    onBack?: () => void;
+}
+
 const FilterConfiguration: FC<Props> = ({
-    selectedTabId,
+    selectedTabId = DEFAULT_TAB,
     onTabChange,
     field,
     tilesWithFilters,
@@ -74,7 +81,7 @@ const FilterConfiguration: FC<Props> = ({
             Object.values(tilesWithFilters).filter((tile) =>
                 tile.filters.some(fieldMatchType(field)),
             ),
-        [tilesWithFilters, field.type],
+        [tilesWithFilters, field],
     );
 
     const [internalFilterRule, setInternalFilterRule] =
@@ -336,7 +343,7 @@ const FilterConfiguration: FC<Props> = ({
             <div
                 style={{
                     display: 'flex',
-                    justifyContent: 'space-between',
+                    justifyContent: 'flex-end',
                     marginTop: 24,
                 }}
             >
@@ -347,6 +354,9 @@ const FilterConfiguration: FC<Props> = ({
                 )}
 
                 <Button
+                    style={{
+                        alignSelf: 'flex-end',
+                    }}
                     type="submit"
                     className={Classes.POPOVER2_DISMISS}
                     intent={Intent.PRIMARY}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -2,7 +2,7 @@ import { Intent, Tab, Tabs } from '@blueprintjs/core';
 import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
-    applyDefaultTileFieldTargetOverride,
+    applyDefaultTileTargets,
     assertUnreachable,
     createDashboardFilterRuleFromField,
     DashboardFilterRule,
@@ -66,7 +66,7 @@ const FilterConfiguration: FC<Props> = ({
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
             filterRule
-                ? applyDefaultTileFieldTargetOverride(
+                ? applyDefaultTileTargets(
                       filterRule,
                       field,
                       tilesSavedQueryFilters,
@@ -102,8 +102,7 @@ const FilterConfiguration: FC<Props> = ({
 
             setInternalFilterRule((prevState) =>
                 produce(prevState, (draftState) => {
-                    draftState.tileTargetOverride =
-                        draftState.tileTargetOverride ?? {};
+                    draftState.tileTargets = draftState.tileTargets ?? {};
 
                     if (action === FilterActions.ADD) {
                         const filterableField =
@@ -114,12 +113,12 @@ const FilterConfiguration: FC<Props> = ({
 
                         if (!filterableField) return draftState;
 
-                        draftState.tileTargetOverride[tileUuid] = {
+                        draftState.tileTargets[tileUuid] = {
                             fieldId: fieldId(filterableField),
                             tableName: filterableField.table,
                         };
                     } else if (action === FilterActions.REMOVE) {
-                        delete draftState.tileTargetOverride[tileUuid];
+                        delete draftState.tileTargets[tileUuid];
                     } else {
                         return assertUnreachable(
                             action,

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -14,6 +14,7 @@ import {
     AvailableFiltersForSavedQuery,
     createDashboardFilterRuleFromField,
     DashboardFilterRule,
+    fieldId,
     fieldMatchExact,
     fieldMatchType,
     fieldMatchTypeAndName,
@@ -108,17 +109,17 @@ const FilterConfiguration: FC<Props> = ({
                     }) || [];
 
                 if (action === FilterActions.ADD) {
-                    const filter =
+                    const filterableField =
                         filterUuid ??
                         tile.filters.find(fieldMatchExact(field)) ??
                         tile.filters.find(fieldMatchTypeAndName(field)) ??
                         tile.filters.find(fieldMatchType(field));
 
-                    if (!filter) return draftState;
+                    if (!filterableField) return draftState;
 
                     draftState.tileConfigs.push({
                         tileUuid: tile.uuid,
-                        filter,
+                        fieldId: fieldId(filterableField),
                     });
                 }
             }),
@@ -232,7 +233,13 @@ const FilterConfiguration: FC<Props> = ({
                                         const isChecked =
                                             isApplicable && !!tileConfig;
 
-                                        const filter = tileConfig?.filter;
+                                        const filterableFieldId =
+                                            tileConfig?.fieldId;
+                                        const filter = tile.filters.find(
+                                            (f) =>
+                                                fieldId(f) ===
+                                                filterableFieldId,
+                                        );
 
                                         const sortedItems = tile.filters
                                             .filter(fieldMatchType(field))

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -77,8 +77,6 @@ const FilterConfiguration: FC<Props> = ({
         [tilesWithFilters, field.type],
     );
 
-    console.log({ filterConfig, filterType, field });
-
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
             filterRule

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import { Button, HTMLSelect, Intent, Tab, Tabs } from '@blueprintjs/core';
+import { Button, Intent, Tab, Tabs } from '@blueprintjs/core';
 import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
@@ -13,24 +13,14 @@ import {
     FilterableField,
     FilterOperator,
     FilterRule,
-    FilterType,
     getFilterRuleWithDefaultValue,
-    getFilterTypeFromField,
 } from '@lightdash/common';
 import produce from 'immer';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { FilterTypeConfig } from '../../common/Filters/configs';
-import {
-    FieldIcon,
-    FieldLabel,
-    renderItem,
-} from '../../common/Filters/FieldAutoComplete';
+import { FieldLabel } from '../../common/Filters/FieldAutoComplete';
 import SimpleButton from '../../common/SimpleButton';
-import {
-    ConfigureFilterWrapper,
-    InputsWrapper,
-    Title,
-} from './FilterConfiguration.styled';
+import { ConfigureFilterWrapper } from './FilterConfiguration.styled';
+import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 
 export enum FilterTabs {
@@ -66,15 +56,6 @@ const FilterConfiguration: FC<Props> = ({
     onSave,
     onBack,
 }) => {
-    const filterType = field
-        ? getFilterTypeFromField(field)
-        : FilterType.STRING;
-
-    const filterConfig = useMemo(
-        () => FilterTypeConfig[filterType],
-        [filterType],
-    );
-
     const availableFilters = useMemo(
         () =>
             Object.values(tilesWithSavedQuery).filter((tile) =>
@@ -99,7 +80,26 @@ const FilterConfiguration: FC<Props> = ({
                   ),
         );
 
-    const handleChange = useCallback(
+    const handleChangeFilterRule = useCallback(
+        (newFilterRule: DashboardFilterRule) => {
+            setInternalFilterRule(newFilterRule);
+        },
+        [],
+    );
+
+    const handleChangeFilterOperator = useCallback(
+        (operator: FilterRule['operator']) => {
+            setInternalFilterRule((prevState) =>
+                getFilterRuleWithDefaultValue(field, {
+                    ...prevState,
+                    operator: operator,
+                }),
+            );
+        },
+        [field],
+    );
+
+    const handleChangeTileConfiguration = useCallback(
         (
             action: FilterActions,
             tileUuid: string,
@@ -167,29 +167,13 @@ const FilterConfiguration: FC<Props> = ({
                     id="settings"
                     title="Settings"
                     panel={
-                        <InputsWrapper>
-                            <HTMLSelect
-                                fill
-                                onChange={(e) =>
-                                    setInternalFilterRule((prevState) =>
-                                        getFilterRuleWithDefaultValue(field, {
-                                            ...prevState,
-                                            operator: e.target
-                                                .value as FilterRule['operator'],
-                                        }),
-                                    )
-                                }
-                                options={filterConfig.operatorOptions}
-                                value={internalFilterRule.operator}
-                            />
-                            <filterConfig.inputs
-                                popoverProps={popoverProps}
-                                filterType={filterType}
-                                field={field}
-                                filterRule={internalFilterRule}
-                                onChange={setInternalFilterRule as any}
-                            />
-                        </InputsWrapper>
+                        <FilterSettings
+                            field={field}
+                            filterRule={internalFilterRule}
+                            onChangeFilterOperator={handleChangeFilterOperator}
+                            onChangeFilterRule={handleChangeFilterRule}
+                            popoverProps={popoverProps}
+                        />
                     }
                 />
 
@@ -202,7 +186,7 @@ const FilterConfiguration: FC<Props> = ({
                             filterRule={internalFilterRule}
                             popoverProps={popoverProps}
                             tilesWithSavedQuery={tilesWithSavedQuery}
-                            onChange={handleChange}
+                            onChange={handleChangeTileConfiguration}
                         />
                     }
                 />

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -8,7 +8,7 @@ import {
     Tabs,
 } from '@blueprintjs/core';
 import { Classes, MenuItem2, Popover2Props } from '@blueprintjs/popover2';
-import { ItemRenderer, Select2 } from '@blueprintjs/select';
+import { Select2 } from '@blueprintjs/select';
 import {
     applyDefaultTileConfigToFilterRule,
     AvailableFiltersForSavedQuery,
@@ -28,6 +28,11 @@ import {
 import produce from 'immer';
 import { FC, useMemo, useState } from 'react';
 import { FilterTypeConfig } from '../../common/Filters/configs';
+import {
+    FieldIcon,
+    FieldLabel,
+    renderItem,
+} from '../../common/Filters/FieldAutoComplete';
 import SimpleButton from '../../common/SimpleButton';
 import {
     ConfigureFilterWrapper,
@@ -142,36 +147,11 @@ const FilterConfiguration: FC<Props> = ({
         }
     };
 
-    const renderItem: ItemRenderer<FilterableField> = (
-        filter,
-        { handleClick, handleFocus, modifiers, query },
-    ) => {
-        if (!modifiers.matchesPredicate) {
-            return null;
-        }
-
-        return (
-            <MenuItem2
-                active={modifiers.active}
-                disabled={modifiers.disabled}
-                key={filter.name}
-                label={filter.type}
-                text={
-                    <>
-                        {filter.table} <b>{filter.name}</b>
-                    </>
-                }
-                onClick={handleClick}
-                onFocus={handleFocus}
-                roleStructure="listoption"
-            />
-        );
-    };
-
     return (
         <ConfigureFilterWrapper>
+            {/* TODO: styled? */}
             <div style={{ marginBottom: 10 }}>
-                {field.tableLabel} <Title>{field.label}</Title>
+                <FieldLabel item={field} />
             </div>
 
             <Tabs
@@ -235,11 +215,12 @@ const FilterConfiguration: FC<Props> = ({
 
                                         const filterableFieldId =
                                             tileConfig?.fieldId;
-                                        const filter = tile.filters.find(
-                                            (f) =>
-                                                fieldId(f) ===
-                                                filterableFieldId,
-                                        );
+                                        const filterableField =
+                                            tile.filters.find(
+                                                (f) =>
+                                                    fieldId(f) ===
+                                                    filterableFieldId,
+                                            );
 
                                         const sortedItems = tile.filters
                                             .filter(fieldMatchType(field))
@@ -285,14 +266,16 @@ const FilterConfiguration: FC<Props> = ({
                                                                 text="No results."
                                                             />
                                                         }
-                                                        activeItem={filter}
+                                                        activeItem={
+                                                            filterableField
+                                                        }
                                                         onItemSelect={(
-                                                            newFilter,
+                                                            newFilterableField,
                                                         ) => {
                                                             handleChange(
                                                                 FilterActions.ADD,
                                                                 tile,
-                                                                newFilter,
+                                                                newFilterableField,
                                                             );
                                                         }}
                                                         popoverProps={{
@@ -314,19 +297,23 @@ const FilterConfiguration: FC<Props> = ({
                                                             }
                                                             outlined
                                                             fill
+                                                            icon={
+                                                                filterableField && (
+                                                                    <FieldIcon
+                                                                        item={
+                                                                            filterableField
+                                                                        }
+                                                                    />
+                                                                )
+                                                            }
                                                             text={
                                                                 isApplicable ? (
-                                                                    filter ? (
-                                                                        <>
-                                                                            {
-                                                                                filter.table
-                                                                            }{' '}
-                                                                            <b>
-                                                                                {
-                                                                                    filter.name
-                                                                                }
-                                                                            </b>
-                                                                        </>
+                                                                    filterableField ? (
+                                                                        <FieldLabel
+                                                                            item={
+                                                                                filterableField
+                                                                            }
+                                                                        />
                                                                     ) : (
                                                                         'Select field'
                                                                     )

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -2,7 +2,7 @@ import { Intent, Tab, Tabs } from '@blueprintjs/core';
 import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
-    applyDefaultTileConfigToFilterRule,
+    applyDefaultTileFieldTargetOverride,
     AvailableFiltersForSavedQuery,
     createDashboardFilterRuleFromField,
     DashboardFilterRule,
@@ -63,7 +63,7 @@ const FilterConfiguration: FC<Props> = ({
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
             filterRule
-                ? applyDefaultTileConfigToFilterRule(
+                ? applyDefaultTileFieldTargetOverride(
                       filterRule,
                       field,
                       tilesWithSavedQuery,
@@ -103,8 +103,8 @@ const FilterConfiguration: FC<Props> = ({
 
             setInternalFilterRule((prevState) =>
                 produce(prevState, (draftState) => {
-                    draftState.tileConfigs =
-                        draftState.tileConfigs?.filter((tileConfig) => {
+                    draftState.tileTargetOverride =
+                        draftState.tileTargetOverride?.filter((tileConfig) => {
                             return tileConfig.tileUuid !== tileUuid;
                         }) || [];
 
@@ -119,9 +119,10 @@ const FilterConfiguration: FC<Props> = ({
 
                         if (!filterableField) return draftState;
 
-                        draftState.tileConfigs.push({
+                        draftState.tileTargetOverride.push({
                             tileUuid,
                             fieldId: fieldId(filterableField),
+                            tableName: filterableField.table,
                         });
                     }
                 }),

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -350,7 +350,7 @@ const FilterConfiguration: FC<Props> = ({
             <div
                 style={{
                     display: 'flex',
-                    justifyContent: 'flex-end',
+                    justifyContent: 'space-between',
                     marginTop: 24,
                 }}
             >

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -16,7 +16,7 @@ import {
     matchFieldExact,
 } from '@lightdash/common';
 import produce from 'immer';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import FieldLabel from '../../common/Filters/FieldLabel';
 import SimpleButton from '../../common/SimpleButton';
 import {

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -194,7 +194,10 @@ const FilterConfiguration: FC<Props> = ({
                     title="Tiles"
                     panel={
                         <>
-                            <Title>Select tiles to apply filter to</Title>
+                            <Title>
+                                Select tiles to apply filter to and which field
+                                to filter by
+                            </Title>
 
                             {tilesWithFilters &&
                                 Object.values(tilesWithFilters)
@@ -232,6 +235,7 @@ const FilterConfiguration: FC<Props> = ({
                                             );
 
                                         return (
+                                            // TODO: extract to component
                                             <FormGroup key={tile.uuid}>
                                                 <Checkbox
                                                     label={tile.name}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -3,9 +3,9 @@ import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
     applyDefaultTileFieldTargetOverride,
-    AvailableFiltersForSavedQuery,
     createDashboardFilterRuleFromField,
     DashboardFilterRule,
+    DashboardTile,
     fieldId,
     FilterableField,
     FilterOperator,
@@ -40,8 +40,9 @@ export enum FilterActions {
 }
 
 interface Props {
+    tiles: DashboardTile[];
     field: FilterableField;
-    tilesWithSavedQuery: Record<string, AvailableFiltersForSavedQuery>;
+    tilesSavedQueryFilters: Record<string, FilterableField[]>;
     filterRule?: DashboardFilterRule;
     popoverProps?: Popover2Props;
     selectedTabId?: string;
@@ -52,13 +53,14 @@ interface Props {
 
 const FilterConfiguration: FC<Props> = ({
     selectedTabId = DEFAULT_TAB,
-    onTabChange,
+    tiles,
     field,
-    tilesWithSavedQuery,
+    tilesSavedQueryFilters,
     filterRule,
     popoverProps,
     onSave,
     onBack,
+    onTabChange,
 }) => {
     const [internalFilterRule, setInternalFilterRule] =
         useState<DashboardFilterRule>(
@@ -66,11 +68,11 @@ const FilterConfiguration: FC<Props> = ({
                 ? applyDefaultTileFieldTargetOverride(
                       filterRule,
                       field,
-                      tilesWithSavedQuery,
+                      tilesSavedQueryFilters,
                   )
                 : createDashboardFilterRuleFromField(
                       field,
-                      tilesWithSavedQuery,
+                      tilesSavedQueryFilters,
                   ),
         );
 
@@ -99,7 +101,7 @@ const FilterConfiguration: FC<Props> = ({
             tileUuid: string,
             filterUuid?: FilterableField,
         ) => {
-            const savedQuery = tilesWithSavedQuery[tileUuid];
+            const savedQuery = tilesSavedQueryFilters[tileUuid];
 
             setInternalFilterRule((prevState) =>
                 produce(prevState, (draftState) => {
@@ -108,7 +110,7 @@ const FilterConfiguration: FC<Props> = ({
                             return tileConfig.tileUuid !== tileUuid;
                         }) || [];
 
-                    const filters = savedQuery.filters;
+                    const filters = savedQuery;
 
                     if (action === FilterActions.ADD) {
                         const filterableField =
@@ -128,7 +130,7 @@ const FilterConfiguration: FC<Props> = ({
                 }),
             );
         },
-        [field, tilesWithSavedQuery],
+        [field, tilesSavedQueryFilters],
     );
 
     const filterSettings = (
@@ -165,7 +167,8 @@ const FilterConfiguration: FC<Props> = ({
                                 field={field}
                                 filterRule={internalFilterRule}
                                 popoverProps={popoverProps}
-                                tilesWithSavedQuery={tilesWithSavedQuery}
+                                tiles={tiles}
+                                tilesSavedQueryFilters={tilesSavedQueryFilters}
                                 onChange={handleChangeTileConfiguration}
                             />
                         }

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -43,7 +43,7 @@ export enum FilterActions {
 interface Props {
     tiles: DashboardTile[];
     field: FilterableField;
-    tilesSavedQueryFilters: Record<string, FilterableField[]>;
+    availableTileFilters: Record<string, FilterableField[]>;
     filterRule?: DashboardFilterRule;
     popoverProps?: Popover2Props;
     selectedTabId?: string;
@@ -56,7 +56,7 @@ const FilterConfiguration: FC<Props> = ({
     selectedTabId = DEFAULT_TAB,
     tiles,
     field,
-    tilesSavedQueryFilters,
+    availableTileFilters,
     filterRule,
     popoverProps,
     onSave,
@@ -69,11 +69,11 @@ const FilterConfiguration: FC<Props> = ({
                 ? applyDefaultTileTargets(
                       filterRule,
                       field,
-                      tilesSavedQueryFilters,
+                      availableTileFilters,
                   )
                 : createDashboardFilterRuleFromField(
                       field,
-                      tilesSavedQueryFilters,
+                      availableTileFilters,
                   ),
         );
 
@@ -98,7 +98,7 @@ const FilterConfiguration: FC<Props> = ({
 
     const handleChangeTileConfiguration = useCallback(
         (action: FilterActions, tileUuid: string, filter?: FilterableField) => {
-            const filters = tilesSavedQueryFilters[tileUuid];
+            const filters = availableTileFilters[tileUuid];
 
             setInternalFilterRule((prevState) =>
                 produce(prevState, (draftState) => {
@@ -128,7 +128,7 @@ const FilterConfiguration: FC<Props> = ({
                 }),
             );
         },
-        [field, tilesSavedQueryFilters],
+        [field, availableTileFilters],
     );
 
     const filterSettings = (
@@ -166,7 +166,7 @@ const FilterConfiguration: FC<Props> = ({
                                 filterRule={internalFilterRule}
                                 popoverProps={popoverProps}
                                 tiles={tiles}
-                                tilesSavedQueryFilters={tilesSavedQueryFilters}
+                                availableTileFilters={availableTileFilters}
                                 onChange={handleChangeTileConfiguration}
                             />
                         }

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -334,10 +334,10 @@ const FilterConfiguration: FC<Props> = ({
                 />
             </Tabs>
 
+            {/* TODO: style */}
             <div
                 style={{
                     display: 'flex',
-                    justifyContent: 'space-between',
                     marginTop: 24,
                 }}
             >
@@ -347,9 +347,10 @@ const FilterConfiguration: FC<Props> = ({
                     </SimpleButton>
                 )}
 
+                {/* TODO: style */}
                 <Button
                     style={{
-                        alignSelf: 'flex-end',
+                        marginLeft: 'auto',
                     }}
                     type="submit"
                     className={Classes.POPOVER2_DISMISS}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@lightdash/common';
 import produce from 'immer';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { FieldLabel } from '../../common/Filters/FieldAutoComplete';
+import FieldLabel from '../../common/Filters/FieldLabel';
 import SimpleButton from '../../common/SimpleButton';
 import { ConfigureFilterWrapper } from './FilterConfiguration.styled';
 import FilterSettings from './FilterSettings';
@@ -200,7 +200,7 @@ const FilterConfiguration: FC<Props> = ({
                 }}
             >
                 {onBack && (
-                    <SimpleButton small fill={false} onClick={onBack}>
+                    <SimpleButton small onClick={onBack}>
                         Back
                     </SimpleButton>
                 )}

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/FilterSearch.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/FilterSearch.styles.tsx
@@ -2,21 +2,21 @@ import { Colors } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 
-export const FilterModalContainer = styled.div``;
+interface FilterModalContainerProps {
+    $wide?: boolean;
+}
 
-export const Title = styled.p`
-    font-weight: bold;
+export const FilterModalContainer = styled.div<FilterModalContainerProps>`
+    padding: 20px;
+    width: ${({ $wide }) => ($wide ? '500px' : '350px')};
+`;
+
+export const TileContainer = styled.div`
+    width: 500px;
 `;
 
 export const InputWrapper = styled.div`
     width: 20.5em;
-`;
-
-export const FilterFooter = styled.p`
-    color: ${Colors.GRAY2};
-    font-weight: 500;
-    font-size: 0.857em;
-    margin: 2.5em 0 0;
 `;
 
 export const DimensionLabel = styled(MenuItem2)`

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -14,7 +14,7 @@ import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import FieldAutoComplete from '../../common/Filters/FieldAutoComplete';
-import FilterConfiguration from '../FilterConfiguration';
+import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
 import { FilterModalContainer } from './FilterSearch.styles';
 
 type Props = {
@@ -24,8 +24,6 @@ type Props = {
     onClose: () => void;
     onSelectField: (field: FilterableField) => void;
 };
-
-const DEFAULT_TAB = 'settings';
 
 const FilterSearch: FC<Props> = ({
     fields,
@@ -41,7 +39,7 @@ const FilterSearch: FC<Props> = ({
     const { addDimensionDashboardFilter } = useDashboardContext();
 
     const [selectedField, setSelectedField] = useState<FilterableField>();
-    const [selectedTabId, setSelectedTabId] = useState(DEFAULT_TAB);
+    const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
     if (isLoading || !tilesWithFilters) {
         return null;
@@ -70,12 +68,12 @@ const FilterSearch: FC<Props> = ({
         });
         setSelectedField(undefined);
         addDimensionDashboardFilter(value, !isEditMode);
-        setSelectedTabId(DEFAULT_TAB);
+        setSelectedTabId(undefined);
         onClose();
     };
 
     const handleBack = () => {
-        setSelectedTabId(DEFAULT_TAB);
+        setSelectedTabId(undefined);
         setSelectedField(undefined);
     };
 

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -79,7 +79,7 @@ const FilterSearch: FC<Props> = ({
             {!selectedField ? (
                 <>
                     <FormGroup
-                        // TODO: stuff.
+                        // TODO: update styles.
                         label={<b>Select a dimension to filter</b>}
                         helperText="Filters set on individual charts will be overridden."
                     >

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -83,10 +83,7 @@ const FilterSearch: FC<Props> = ({
         >
             {!selectedField ? (
                 <FormGroup
-                    style={{
-                        marginBottom: 0,
-                    }}
-                    // TODO: update styles.
+                    style={{ marginBottom: 0 }}
                     label={<b>Select a dimension to filter</b>}
                     helperText="Filters set on individual charts will be overridden."
                 >
@@ -94,6 +91,7 @@ const FilterSearch: FC<Props> = ({
                         fields={fields}
                         onChange={handleChangeField}
                         popoverProps={{
+                            lazy: true,
                             matchTargetWidth: true,
                             captureDismiss: !popoverProps?.isOpen,
                             canEscapeKeyClose: !popoverProps?.isOpen,
@@ -108,8 +106,9 @@ const FilterSearch: FC<Props> = ({
                     field={selectedField}
                     tilesWithSavedQuery={tilesWithSavedQuery}
                     popoverProps={{
-                        captureDismiss: true,
-                        canEscapeKeyClose: true,
+                        lazy: true,
+                        captureDismiss: !popoverProps?.isOpen,
+                        canEscapeKeyClose: !popoverProps?.isOpen,
                         ...popoverProps,
                     }}
                     onSave={handleSave}

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -9,7 +9,7 @@ import {
     isFilterableField,
 } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesWithSavedQuery } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardTilesSavedQueryFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -34,14 +34,14 @@ const FilterSearch: FC<Props> = ({
 }) => {
     const { track } = useTracking();
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesWithSavedQuery, isLoading } =
-        useDashboardTilesWithSavedQuery(dashboardTiles);
+    const { data: tilesSavedQueryFilters, isLoading } =
+        useDashboardTilesSavedQueryFilters(dashboardTiles);
     const { addDimensionDashboardFilter } = useDashboardContext();
 
     const [selectedField, setSelectedField] = useState<FilterableField>();
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesWithSavedQuery) {
+    if (isLoading || !tilesSavedQueryFilters) {
         return null;
     }
 
@@ -103,8 +103,9 @@ const FilterSearch: FC<Props> = ({
                 <FilterConfiguration
                     selectedTabId={selectedTabId}
                     onTabChange={setSelectedTabId}
+                    tiles={dashboardTiles}
                     field={selectedField}
-                    tilesWithSavedQuery={tilesWithSavedQuery}
+                    tilesSavedQueryFilters={tilesSavedQueryFilters}
                     popoverProps={{
                         lazy: true,
                         captureDismiss: !popoverProps?.isOpen,

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -82,24 +82,25 @@ const FilterSearch: FC<Props> = ({
             $wide={!!selectedField && selectedTabId === 'tiles'}
         >
             {!selectedField ? (
-                <>
-                    <FormGroup
-                        // TODO: update styles.
-                        label={<b>Select a dimension to filter</b>}
-                        helperText="Filters set on individual charts will be overridden."
-                    >
-                        <FieldAutoComplete
-                            fields={fields}
-                            onChange={handleChangeField}
-                            popoverProps={{
-                                matchTargetWidth: true,
-                                captureDismiss: !popoverProps?.isOpen,
-                                canEscapeKeyClose: !popoverProps?.isOpen,
-                                ...popoverProps,
-                            }}
-                        />
-                    </FormGroup>
-                </>
+                <FormGroup
+                    style={{
+                        marginBottom: 0,
+                    }}
+                    // TODO: update styles.
+                    label={<b>Select a dimension to filter</b>}
+                    helperText="Filters set on individual charts will be overridden."
+                >
+                    <FieldAutoComplete
+                        fields={fields}
+                        onChange={handleChangeField}
+                        popoverProps={{
+                            matchTargetWidth: true,
+                            captureDismiss: !popoverProps?.isOpen,
+                            canEscapeKeyClose: !popoverProps?.isOpen,
+                            ...popoverProps,
+                        }}
+                    />
+                </FormGroup>
             ) : (
                 <FilterConfiguration
                     selectedTabId={selectedTabId}

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -1,6 +1,7 @@
 import { Popover2Props } from '@blueprintjs/popover2';
 import { FilterableField, isField, isFilterableField } from '@lightdash/common';
 import React, { FC, useState } from 'react';
+import { useDashboardTilesWithFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -27,9 +28,17 @@ const FilterSearch: FC<Props> = ({
     onSelectField,
     popoverProps,
 }) => {
-    const [selectedField, setSelectedField] = useState<FilterableField>();
-    const { addDimensionDashboardFilter } = useDashboardContext();
     const { track } = useTracking();
+    const { dashboardTiles } = useDashboardContext();
+    const { data: tilesWithFilters, isLoading } =
+        useDashboardTilesWithFilters(dashboardTiles);
+    const { addDimensionDashboardFilter } = useDashboardContext();
+
+    const [selectedField, setSelectedField] = useState<FilterableField>();
+
+    if (isLoading || !tilesWithFilters) {
+        return null;
+    }
 
     return (
         <FilterModalContainer>
@@ -59,6 +68,7 @@ const FilterSearch: FC<Props> = ({
             ) : (
                 <FilterConfiguration
                     field={selectedField}
+                    tilesWithFilters={tilesWithFilters}
                     popoverProps={{
                         captureDismiss: true,
                         canEscapeKeyClose: true,

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -85,7 +85,6 @@ const FilterSearch: FC<Props> = ({
                 <FormGroup
                     style={{ marginBottom: 0 }}
                     label={<b>Select a dimension to filter</b>}
-                    helperText="Filters set on individual charts will be overridden."
                 >
                     <FieldAutoComplete
                         fields={fields}

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -9,7 +9,7 @@ import {
     isFilterableField,
 } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesSavedQueryFilters } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardAvailableTileFilters } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -34,14 +34,14 @@ const FilterSearch: FC<Props> = ({
 }) => {
     const { track } = useTracking();
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesSavedQueryFilters, isLoading } =
-        useDashboardTilesSavedQueryFilters(dashboardTiles);
+    const { data: availableTileFilters, isLoading } =
+        useDashboardAvailableTileFilters(dashboardTiles);
     const { addDimensionDashboardFilter } = useDashboardContext();
 
     const [selectedField, setSelectedField] = useState<FilterableField>();
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesSavedQueryFilters) {
+    if (isLoading || !availableTileFilters) {
         return null;
     }
 
@@ -104,7 +104,7 @@ const FilterSearch: FC<Props> = ({
                     onTabChange={setSelectedTabId}
                     tiles={dashboardTiles}
                     field={selectedField}
-                    tilesSavedQueryFilters={tilesSavedQueryFilters}
+                    availableTileFilters={availableTileFilters}
                     popoverProps={{
                         lazy: true,
                         captureDismiss: !popoverProps?.isOpen,

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -83,7 +83,7 @@ const FilterSearch: FC<Props> = ({
         >
             {!selectedField ? (
                 <FormGroup
-                    style={{ marginBottom: 0 }}
+                    style={{ marginBottom: '5px' }}
                     label={<b>Select a dimension to filter</b>}
                 >
                     <FieldAutoComplete

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -9,7 +9,7 @@ import {
     isFilterableField,
 } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useDashboardTilesWithFilters } from '../../../hooks/dashboard/useDashboard';
+import { useDashboardTilesWithSavedQuery } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -34,14 +34,14 @@ const FilterSearch: FC<Props> = ({
 }) => {
     const { track } = useTracking();
     const { dashboardTiles } = useDashboardContext();
-    const { data: tilesWithFilters, isLoading } =
-        useDashboardTilesWithFilters(dashboardTiles);
+    const { data: tilesWithSavedQuery, isLoading } =
+        useDashboardTilesWithSavedQuery(dashboardTiles);
     const { addDimensionDashboardFilter } = useDashboardContext();
 
     const [selectedField, setSelectedField] = useState<FilterableField>();
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
-    if (isLoading || !tilesWithFilters) {
+    if (isLoading || !tilesWithSavedQuery) {
         return null;
     }
 
@@ -106,7 +106,7 @@ const FilterSearch: FC<Props> = ({
                     selectedTabId={selectedTabId}
                     onTabChange={setSelectedTabId}
                     field={selectedField}
-                    tilesWithFilters={tilesWithFilters}
+                    tilesWithSavedQuery={tilesWithSavedQuery}
                     popoverProps={{
                         captureDismiss: true,
                         canEscapeKeyClose: true,

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -47,6 +47,13 @@ const FilterSearch: FC<Props> = ({
         return null;
     }
 
+    const handleChangeField = (field: FilterableField) => {
+        if (isField(field) && isFilterableField(field)) {
+            setSelectedField(field);
+            onSelectField(field);
+        }
+    };
+
     const handleSave = (
         value: DashboardFilterRule<
             FilterOperator,
@@ -85,15 +92,7 @@ const FilterSearch: FC<Props> = ({
                     >
                         <FieldAutoComplete
                             fields={fields}
-                            onChange={(field) => {
-                                if (
-                                    isField(field) &&
-                                    isFilterableField(field)
-                                ) {
-                                    setSelectedField(field);
-                                    onSelectField(field);
-                                }
-                            }}
+                            onChange={handleChangeField}
                             popoverProps={{
                                 matchTargetWidth: true,
                                 captureDismiss: !popoverProps?.isOpen,

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -1,4 +1,4 @@
-import { Classes, Tooltip2 } from '@blueprintjs/popover2';
+import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardTileTypes } from '@lightdash/common';
 import React, { FC, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -11,7 +11,6 @@ import {
     DashboardFilterWrapper,
     FilterTrigger,
     Tooltip,
-    TriggerWrapper,
 } from './DashboardFilter.styles';
 import FilterSearch from './FilterSearch';
 
@@ -50,7 +49,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
             startOfWeek={project.data?.warehouseConnection?.startOfWeek}
         >
             <DashboardFilterWrapper>
-                <TriggerWrapper
+                <Popover2
                     content={
                         <FilterSearch
                             isEditMode={isEditMode}
@@ -65,7 +64,6 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     }
                     canEscapeKeyClose={isSubmenuOpen ? false : true}
                     interactionKind={isSubmenuOpen ? 'click-target' : 'click'}
-                    popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
                     onOpened={() => setIsOpen(true)}
                     onClose={handleClose}
                     position="bottom-right"
@@ -91,7 +89,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                             Add filter
                         </FilterTrigger>
                     </Tooltip2>
-                </TriggerWrapper>
+                </Popover2>
 
                 {!isLoading && dashboardFilters && <ActiveFilters />}
             </DashboardFilterWrapper>

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -22,13 +22,11 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [isOpen, setIsOpen] = useState(false);
     const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
+
     const project = useProject(projectUuid);
-    const {
-        dashboard,
-        fieldsWithSuggestions,
-        dashboardFilters,
-        dashboardTiles,
-    } = useDashboardContext();
+    const { dashboardFilters, fieldsWithSuggestions, dashboardTiles } =
+        useDashboardContext();
+
     const { isLoading, data: filterableFields } =
         useAvailableDashboardFilterTargets(dashboardTiles);
 

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -47,7 +47,6 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         >
             <DashboardFilterWrapper>
                 <Popover2
-                    lazy
                     disabled={!hasChartTiles || isLoading}
                     canEscapeKeyClose={isSubmenuOpen ? false : true}
                     interactionKind={isSubmenuOpen ? 'click-target' : 'click'}
@@ -70,7 +69,6 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     }
                 >
                     <Tooltip2
-                        lazy
                         disabled={isOpen || isEditMode}
                         placement="bottom-start"
                         interactionKind="hover"

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -48,6 +48,12 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         >
             <DashboardFilterWrapper>
                 <Popover2
+                    disabled={!hasChartTiles || isLoading}
+                    canEscapeKeyClose={isSubmenuOpen ? false : true}
+                    interactionKind={isSubmenuOpen ? 'click-target' : 'click'}
+                    placement="bottom-start"
+                    onOpened={() => setIsOpen(true)}
+                    onClose={handleClose}
                     content={
                         <FilterSearch
                             isEditMode={isEditMode}
@@ -60,23 +66,17 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                             onSelectField={handleClose}
                         />
                     }
-                    canEscapeKeyClose={isSubmenuOpen ? false : true}
-                    interactionKind={isSubmenuOpen ? 'click-target' : 'click'}
-                    onOpened={() => setIsOpen(true)}
-                    onClose={handleClose}
-                    position="bottom-right"
-                    disabled={!hasChartTiles || isLoading}
                 >
                     <Tooltip2
+                        disabled={isOpen || isEditMode}
+                        placement="bottom-start"
+                        interactionKind="hover"
                         content={
                             <Tooltip>
                                 Only filters added in <b>'edit'</b> mode will be
                                 saved
                             </Tooltip>
                         }
-                        placement="bottom"
-                        interactionKind="hover"
-                        disabled={isOpen || isEditMode}
                     >
                         <FilterTrigger
                             minimal

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -54,7 +54,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     content={
                         <FilterSearch
                             isEditMode={isEditMode}
-                            fields={filterableFields}
+                            fields={filterableFields || []}
                             popoverProps={{
                                 onOpened: () => setIsSubmenuOpen(true),
                                 onClose: () => setIsSubmenuOpen(false),

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -1,6 +1,6 @@
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardTileTypes } from '@lightdash/common';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAvailableDashboardFilterTargets } from '../../hooks/dashboard/useDashboard';
 import { useProject } from '../../hooks/useProject';
@@ -10,7 +10,6 @@ import ActiveFilters from './ActiveFilters';
 import {
     DashboardFilterWrapper,
     FilterTrigger,
-    Tooltip,
 } from './DashboardFilter.styles';
 import FilterSearch from './FilterSearch';
 
@@ -48,6 +47,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         >
             <DashboardFilterWrapper>
                 <Popover2
+                    lazy
                     disabled={!hasChartTiles || isLoading}
                     canEscapeKeyClose={isSubmenuOpen ? false : true}
                     interactionKind={isSubmenuOpen ? 'click-target' : 'click'}
@@ -60,7 +60,9 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                             fields={filterableFields || []}
                             popoverProps={{
                                 onOpened: () => setIsSubmenuOpen(true),
+                                onOpening: () => setIsSubmenuOpen(true),
                                 onClose: () => setIsSubmenuOpen(false),
+                                onClosing: () => setIsSubmenuOpen(false),
                             }}
                             onClose={handleClose}
                             onSelectField={handleClose}
@@ -68,14 +70,15 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     }
                 >
                     <Tooltip2
+                        lazy
                         disabled={isOpen || isEditMode}
                         placement="bottom-start"
                         interactionKind="hover"
                         content={
-                            <Tooltip>
+                            <>
                                 Only filters added in <b>'edit'</b> mode will be
                                 saved
-                            </Tooltip>
+                            </>
                         }
                     >
                         <FilterTrigger

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -60,6 +60,8 @@ const ValidDashboardChartTile: FC<{
         series: EChartSeries[],
     ) => void;
 }> = ({ data, project, onSeriesContextMenu }) => {
+    console.log({ data, project });
+
     const { data: resultData, isLoading } = useSavedChartResults(project, data);
     const { addSuggestions } = useDashboardContext();
     const { data: explore } = useExplore(data.tableName);

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -138,6 +138,7 @@ const DashboardChartTile: FC<Props> = (props) => {
     const { track } = useTracking();
     const {
         tile: {
+            uuid: tileUuid,
             properties: { savedChartUuid },
         },
         isEditMode,
@@ -261,8 +262,10 @@ const DashboardChartTile: FC<Props> = (props) => {
     // TODO: move this logic out of component
     let savedQueryWithDashboardFilters: SavedChart | undefined;
 
-    const dashboardFiltersThatApplyToChart =
-        useDashboardFiltersForExplore(explore);
+    const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
+        tileUuid,
+        explore,
+    );
 
     if (savedQuery) {
         const dimensionFilters: FilterGroup = {

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -41,7 +41,6 @@ import { getFilterRuleLabel } from '../common/Filters/configs';
 import { TableColumn } from '../common/Table/types';
 import CSVExporter from '../CSVExporter';
 import { FilterValues } from '../DashboardFilter/ActiveFilters/ActiveFilters.styles';
-import { Tooltip } from '../DashboardFilter/DashboardFilter.styles';
 import LightdashVisualization from '../LightdashVisualization';
 import VisualizationProvider from '../LightdashVisualization/VisualizationProvider';
 import { EchartSeriesClickEvent } from '../SimpleChart';
@@ -53,13 +52,14 @@ import TileBase from './TileBase/index';
 import { FilterLabel } from './TileBase/TileBase.styles';
 
 const ValidDashboardChartTile: FC<{
+    tileUuid: string;
     data: SavedChart;
     project: string;
     onSeriesContextMenu?: (
         e: EchartSeriesClickEvent,
         series: EChartSeries[],
     ) => void;
-}> = ({ data, project, onSeriesContextMenu }) => {
+}> = ({ tileUuid, data, project, onSeriesContextMenu }) => {
     const { data: resultData, isLoading } = useSavedChartResults(project, data);
     const { addSuggestions } = useDashboardContext();
     const { data: explore } = useExplore(data.tableName);
@@ -93,7 +93,11 @@ const ValidDashboardChartTile: FC<{
             onSeriesContextMenu={onSeriesContextMenu}
             columnOrder={data.tableConfig.columnOrder}
         >
-            <LightdashVisualization isDashboard $padding={0} />
+            <LightdashVisualization
+                isDashboard
+                tileUuid={tileUuid}
+                $padding={0}
+            />
         </VisualizationProvider>
     );
 };
@@ -313,10 +317,10 @@ const DashboardChartTile: FC<Props> = (props) => {
             if (field && isFilterableField(field)) {
                 const filterRuleLabels = getFilterRuleLabel(filterRule, field);
                 return (
-                    <Tooltip key={field.name}>
+                    <React.Fragment key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
                         <FilterValues>{filterRuleLabels.value}</FilterValues>
-                    </Tooltip>
+                    </React.Fragment>
                 );
             }
             return `Tried to reference field with unknown id: ${filterRule.target.fieldId}`;
@@ -494,6 +498,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                         transitionDuration={100}
                     />
                     <ValidDashboardChartTile
+                        tileUuid={tileUuid}
                         data={savedQueryWithDashboardFilters}
                         project={projectUuid}
                         onSeriesContextMenu={onSeriesContextMenu}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -60,8 +60,6 @@ const ValidDashboardChartTile: FC<{
         series: EChartSeries[],
     ) => void;
 }> = ({ data, project, onSeriesContextMenu }) => {
-    console.log({ data, project });
-
     const { data: resultData, isLoading } = useSavedChartResults(project, data);
     const { addSuggestions } = useDashboardContext();
     const { data: explore } = useExplore(data.tableName);

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -317,10 +317,10 @@ const DashboardChartTile: FC<Props> = (props) => {
             if (field && isFilterableField(field)) {
                 const filterRuleLabels = getFilterRuleLabel(filterRule, field);
                 return (
-                    <React.Fragment key={field.name}>
+                    <div key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
                         <FilterValues>{filterRuleLabels.value}</FilterValues>
-                    </React.Fragment>
+                    </div>
                 );
             }
             return `Tried to reference field with unknown id: ${filterRule.target.fieldId}`;
@@ -346,7 +346,15 @@ const DashboardChartTile: FC<Props> = (props) => {
                     <div>
                         <Tooltip2
                             content={
-                                <>{appliedFilterRules.map(renderFilterRule)}</>
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        gap: '4px',
+                                    }}
+                                >
+                                    {appliedFilterRules.map(renderFilterRule)}
+                                </div>
                             }
                             interactionKind="hover"
                             placement={'bottom-start'}

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -13,7 +13,14 @@ import {
     isFilterableField,
     Metric,
 } from '@lightdash/common';
-import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+    FC,
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { useParams } from 'react-router-dom';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
@@ -28,11 +35,7 @@ import {
     FieldsWithSuggestions,
     FiltersProvider,
 } from '../../common/Filters/FiltersProvider';
-import {
-    DisabledFilterHeader,
-    FilterValues,
-    Tooltip,
-} from './FiltersCard.styles';
+import { DisabledFilterHeader, FilterValues } from './FiltersCard.styles';
 
 const FiltersCard: FC = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -145,10 +148,10 @@ const FiltersCard: FC = memo(() => {
             if (field && isFilterableField(field)) {
                 const filterRuleLabels = getFilterRuleLabel(filterRule, field);
                 return (
-                    <Tooltip key={field.name}>
+                    <React.Fragment key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
                         <FilterValues>{filterRuleLabels.value}</FilterValues>
-                    </Tooltip>
+                    </React.Fragment>
                 );
             }
             return `Tried to reference field with unknown id: ${filterRule.target.fieldId}`;

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -148,10 +148,10 @@ const FiltersCard: FC = memo(() => {
             if (field && isFilterableField(field)) {
                 const filterRuleLabels = getFilterRuleLabel(filterRule, field);
                 return (
-                    <React.Fragment key={field.name}>
+                    <div key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
                         <FilterValues>{filterRuleLabels.value}</FilterValues>
-                    </React.Fragment>
+                    </div>
                 );
             }
             return `Tried to reference field with unknown id: ${filterRule.target.fieldId}`;
@@ -175,7 +175,15 @@ const FiltersCard: FC = memo(() => {
                     {totalActiveFilters > 0 && !filterIsOpen ? (
                         <Tooltip2
                             content={
-                                <>{allFilterRules.map(renderFilterRule)}</>
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        gap: '4px',
+                                    }}
+                                >
+                                    {allFilterRules.map(renderFilterRule)}
+                                </div>
                             }
                             interactionKind="hover"
                             placement={'bottom-start'}

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -7,13 +7,14 @@ import { useVisualizationContext } from './VisualizationProvider';
 
 interface LightdashVisualizationProps {
     isDashboard?: boolean;
+    tileUuid?: string;
     className?: string;
     $padding?: number;
     'data-testid'?: string;
 }
 
 const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
-    ({ isDashboard, className, ...props }) => {
+    ({ isDashboard, tileUuid, className, ...props }) => {
         const { chartType } = useVisualizationContext();
 
         switch (chartType) {
@@ -28,6 +29,7 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
             case ChartType.TABLE:
                 return (
                     <SimpleTable
+                        tileUuid={tileUuid}
                         isDashboard={!!isDashboard}
                         className={className}
                         $shouldExpand

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -21,13 +21,15 @@ import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
 const DashboardCellContextMenu: FC<
-    Pick<CellContextMenuProps, 'cell'> & { explore: Explore | undefined }
-> = ({ cell, explore }) => {
+    Pick<CellContextMenuProps, 'cell'> & {
+        explore: Explore | undefined;
+        tileUuid: string;
+    }
+> = ({ cell, explore, tileUuid }) => {
     const { viewData } = useUnderlyingDataContext();
     const { addDimensionDashboardFilter } = useDashboardContext();
     const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
-        // TODO: update here...
-        'needs tile uuid here',
+        tileUuid,
         explore,
     );
 

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -13,7 +13,7 @@ import {
     ResultRow,
 } from '@lightdash/common';
 import { uuid4 } from '@sentry/utils';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { CellContextMenuProps } from '../common/Table/types';
@@ -25,8 +25,12 @@ const DashboardCellContextMenu: FC<
 > = ({ cell, explore }) => {
     const { viewData } = useUnderlyingDataContext();
     const { addDimensionDashboardFilter } = useDashboardContext();
-    const dashboardFiltersThatApplyToChart =
-        useDashboardFiltersForExplore(explore);
+    const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
+        // TODO: update here...
+        'needs tile uuid here',
+        explore,
+    );
+
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -8,6 +8,7 @@ import DashboardCellContextMenu from './DashboardCellContextMenu';
 
 type SimpleTableProps = {
     isDashboard: boolean;
+    tileUuid?: string;
     className?: string;
     $padding?: number;
     $shouldExpand?: boolean;
@@ -15,6 +16,7 @@ type SimpleTableProps = {
 
 const SimpleTable: FC<SimpleTableProps> = ({
     isDashboard,
+    tileUuid,
     className,
     $shouldExpand,
     $padding,
@@ -62,10 +64,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
             }}
             cellContextMenu={(props) => {
                 if (isSqlRunner) return <>{props.children}</>;
-                if (isDashboard)
+                if (isDashboard && tileUuid)
                     return (
                         <DashboardCellContextMenu
                             {...props}
+                            tileUuid={tileUuid}
                             explore={explore}
                         />
                     );

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -1,23 +1,16 @@
-import { Icon } from '@blueprintjs/core';
 import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
-import { ItemRenderer, Suggest2 } from '@blueprintjs/select';
+import { Suggest2 } from '@blueprintjs/select';
 import {
     Field,
     FilterableField,
-    getItemColor,
-    getItemIcon,
+    FilterItem,
     getItemId,
     getItemLabel,
-    isDimension,
-    isField,
-    isMetric,
     TableCalculation,
 } from '@lightdash/common';
-import { FC } from 'react';
-import styled, { createGlobalStyle } from 'styled-components';
-import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
-
-type Item = Field | TableCalculation | FilterableField;
+import { createGlobalStyle } from 'styled-components';
+import FieldIcon from './FieldIcon';
+import renderFilterItem from './renderFilterItem';
 
 const AutocompleteMaxHeight = createGlobalStyle`
   .autocomplete-max-height {
@@ -25,62 +18,6 @@ const AutocompleteMaxHeight = createGlobalStyle`
     overflow-y: auto;
   }
 `;
-
-// TODO: extract
-const getFieldIcon = (field: Item) => {
-    if (isField(field) && (isDimension(field) || isMetric(field))) {
-        return getItemIconName(field.type);
-    }
-    return getItemIcon(field);
-};
-
-// TODO: extract
-interface FieldItemProps {
-    item: Item;
-}
-
-// TODO: extract
-const BolderText = styled.span`
-    font-weight: 600;
-`;
-
-export const FieldIcon: FC<FieldItemProps> = ({ item }) => {
-    return <Icon icon={getFieldIcon(item)} color={getItemColor(item)} />;
-};
-
-export const FieldLabel: FC<FieldItemProps> = ({ item }) => {
-    return (
-        <span>
-            {isField(item) ? `${item.tableLabel} ` : ''}
-            <BolderText>
-                {isField(item) ? item.label : item.displayName}
-            </BolderText>
-        </span>
-    );
-};
-
-// TODO: extract
-export const renderItem: ItemRenderer<Item> = (
-    item,
-    { modifiers, handleClick, handleFocus },
-) => {
-    if (!modifiers.matchesPredicate) {
-        return null;
-    }
-    return (
-        <MenuItem2
-            key={getItemId(item)}
-            roleStructure="listoption"
-            shouldDismissPopover={false}
-            active={modifiers.active}
-            disabled={modifiers.disabled}
-            icon={<FieldIcon item={item} />}
-            text={<FieldLabel item={item} />}
-            onClick={handleClick}
-            onFocus={handleFocus}
-        />
-    );
-};
 
 type FieldAutoCompleteProps<T> = {
     id?: string;
@@ -95,7 +32,7 @@ type FieldAutoCompleteProps<T> = {
     popoverProps?: Popover2Props;
 };
 
-const FieldAutoComplete = <T extends Item>({
+const FieldAutoComplete = <T extends FilterItem>({
     disabled,
     autoFocus,
     activeField,
@@ -118,18 +55,13 @@ const FieldAutoComplete = <T extends Item>({
                 name,
                 autoFocus,
                 placeholder: placeholder || 'Search field...',
-                leftIcon: activeField && (
-                    <Icon
-                        icon={getFieldIcon(activeField)}
-                        color={getItemColor(activeField)}
-                    />
-                ),
+                leftIcon: activeField && <FieldIcon item={activeField} />,
             }}
             items={fields}
             itemsEqual={(value, other) => {
                 return getItemId(value) === getItemId(other);
             }}
-            inputValueRenderer={(item: Item) => {
+            inputValueRenderer={(item: FilterItem) => {
                 if (!activeField) {
                     return '';
                 }
@@ -142,14 +74,14 @@ const FieldAutoComplete = <T extends Item>({
                 captureDismiss: true,
                 ...popoverProps,
             }}
-            itemRenderer={renderItem}
+            itemRenderer={renderFilterItem}
             activeItem={activeField}
             selectedItem={activeField}
             noResults={<MenuItem2 disabled text="No results." />}
             onItemSelect={onChange}
             itemPredicate={(
                 query: string,
-                item: Item,
+                item: FilterItem,
                 index?: undefined | number,
                 exactMatch?: undefined | false | true,
             ) => {

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -2,8 +2,6 @@ import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
 import { Suggest2 } from '@blueprintjs/select';
 import {
     Field,
-    FilterableField,
-    FilterItem,
     getItemId,
     getItemLabel,
     TableCalculation,
@@ -32,7 +30,7 @@ type FieldAutoCompleteProps<T> = {
     popoverProps?: Popover2Props;
 };
 
-const FieldAutoComplete = <T extends FilterItem>({
+const FieldAutoComplete = <T extends Field | TableCalculation>({
     disabled,
     autoFocus,
     activeField,
@@ -61,7 +59,7 @@ const FieldAutoComplete = <T extends FilterItem>({
             itemsEqual={(value, other) => {
                 return getItemId(value) === getItemId(other);
             }}
-            inputValueRenderer={(item: FilterItem) => {
+            inputValueRenderer={(item) => {
                 if (!activeField) {
                     return '';
                 }
@@ -79,12 +77,7 @@ const FieldAutoComplete = <T extends FilterItem>({
             selectedItem={activeField}
             noResults={<MenuItem2 disabled text="No results." />}
             onItemSelect={onChange}
-            itemPredicate={(
-                query: string,
-                item: FilterItem,
-                index?: undefined | number,
-                exactMatch?: undefined | false | true,
-            ) => {
+            itemPredicate={(query, item, index, exactMatch) => {
                 const label = getItemLabel(item);
                 if (exactMatch) {
                     return query.toLowerCase() === label.toLowerCase();

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -3,6 +3,7 @@ import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
 import { ItemRenderer, Suggest2 } from '@blueprintjs/select';
 import {
     Field,
+    FilterableField,
     getItemColor,
     getItemIcon,
     getItemId,
@@ -12,13 +13,10 @@ import {
     isMetric,
     TableCalculation,
 } from '@lightdash/common';
-import React, { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
 
-type Item = Field | TableCalculation;
-
-const FieldSuggest = Suggest2.ofType<Item>();
+type Item = Field | TableCalculation | FilterableField;
 
 const AutocompleteMaxHeight = createGlobalStyle`
   .autocomplete-max-height {
@@ -55,20 +53,20 @@ const renderItem: ItemRenderer<Item> = (item, { modifiers, handleClick }) => {
     );
 };
 
-type Props = {
+type FieldAutoCompleteProps<T> = {
     id?: string;
     name?: string;
     disabled?: boolean;
     autoFocus?: boolean;
-    activeField?: Item;
+    activeField?: T;
     placeholder?: string;
-    fields: Array<Item>;
-    onChange: (value: Item) => void;
+    fields: Array<T>;
+    onChange: (value: T) => void;
     onClosed?: () => void;
     popoverProps?: Popover2Props;
 };
 
-const FieldAutoComplete: FC<Props> = ({
+const FieldAutoComplete = <T extends Item>({
     disabled,
     autoFocus,
     activeField,
@@ -79,10 +77,10 @@ const FieldAutoComplete: FC<Props> = ({
     onClosed,
     placeholder,
     popoverProps,
-}) => (
+}: FieldAutoCompleteProps<T>) => (
     <>
         <AutocompleteMaxHeight />
-        <FieldSuggest
+        <Suggest2<T>
             fill
             className={disabled ? 'disabled-filter' : ''}
             disabled={disabled}

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -13,7 +13,8 @@ import {
     isMetric,
     TableCalculation,
 } from '@lightdash/common';
-import { createGlobalStyle } from 'styled-components';
+import { FC } from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
 import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
 
 type Item = Field | TableCalculation | FilterableField;
@@ -25,6 +26,7 @@ const AutocompleteMaxHeight = createGlobalStyle`
   }
 `;
 
+// TODO: extract
 const getFieldIcon = (field: Item) => {
     if (isField(field) && (isDimension(field) || isMetric(field))) {
         return getItemIconName(field.type);
@@ -32,23 +34,58 @@ const getFieldIcon = (field: Item) => {
     return getItemIcon(field);
 };
 
-const renderItem: ItemRenderer<Item> = (item, { modifiers, handleClick }) => {
+// TODO: extract
+interface FieldItemProps {
+    item: Item;
+}
+
+// TODO: extract
+const BolderText = styled.span`
+    font-weight: 600;
+`;
+
+export const FieldIcon: FC<FieldItemProps> = ({ item }) => {
+    return <Icon icon={getFieldIcon(item)} color={getItemColor(item)} />;
+};
+
+export const FieldLabel: FC<FieldItemProps> = ({ item }) => {
+    return (
+        <span>
+            {isField(item) ? `${item.tableLabel} ` : ''}
+            <BolderText>
+                {isField(item) ? item.label : item.displayName}
+            </BolderText>
+        </span>
+    );
+};
+
+// TODO: extract
+export const FieldItem: FC<FieldItemProps> = ({ item }) => (
+    <div>
+        <FieldIcon item={item} />
+        <FieldLabel item={item} />
+    </div>
+);
+
+// TODO: extract
+export const renderItem: ItemRenderer<Item> = (
+    item,
+    { modifiers, handleClick, handleFocus },
+) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
     return (
         <MenuItem2
-            active={modifiers.active}
             key={getItemId(item)}
-            icon={<Icon icon={getFieldIcon(item)} color={getItemColor(item)} />}
-            text={
-                <span>
-                    {isField(item) ? `${item.tableLabel} ` : ''}
-                    <b>{isField(item) ? item.label : item.displayName}</b>
-                </span>
-            }
-            onClick={handleClick}
+            roleStructure="listoption"
             shouldDismissPopover={false}
+            active={modifiers.active}
+            disabled={modifiers.disabled}
+            icon={<FieldIcon item={item} />}
+            text={<FieldLabel item={item} />}
+            onClick={handleClick}
+            onFocus={handleFocus}
         />
     );
 };

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -60,14 +60,6 @@ export const FieldLabel: FC<FieldItemProps> = ({ item }) => {
 };
 
 // TODO: extract
-export const FieldItem: FC<FieldItemProps> = ({ item }) => (
-    <div>
-        <FieldIcon item={item} />
-        <FieldLabel item={item} />
-    </div>
-);
-
-// TODO: extract
 export const renderItem: ItemRenderer<Item> = (
     item,
     { modifiers, handleClick, handleFocus },

--- a/packages/frontend/src/components/common/Filters/FieldIcon.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldIcon.tsx
@@ -1,17 +1,18 @@
 import { Icon } from '@blueprintjs/core';
 import {
-    FilterableField,
-    FilterItem,
+    AdditionalMetric,
+    Field,
     getItemColor,
     getItemIcon,
     isDimension,
     isField,
     isMetric,
+    TableCalculation,
 } from '@lightdash/common';
 import { FC } from 'react';
 import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
 
-const getFieldIcon = (field: FilterItem) => {
+const getFieldIcon = (field: Field | TableCalculation | AdditionalMetric) => {
     if (isField(field) && (isDimension(field) || isMetric(field))) {
         return getItemIconName(field.type);
     }
@@ -19,7 +20,7 @@ const getFieldIcon = (field: FilterItem) => {
 };
 
 interface FieldIconProps {
-    item: FilterItem;
+    item: Field | TableCalculation | AdditionalMetric;
 }
 
 const FieldIcon: FC<FieldIconProps> = ({ item }) => {

--- a/packages/frontend/src/components/common/Filters/FieldIcon.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldIcon.tsx
@@ -1,0 +1,29 @@
+import { Icon } from '@blueprintjs/core';
+import {
+    FilterableField,
+    FilterItem,
+    getItemColor,
+    getItemIcon,
+    isDimension,
+    isField,
+    isMetric,
+} from '@lightdash/common';
+import { FC } from 'react';
+import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
+
+const getFieldIcon = (field: FilterItem) => {
+    if (isField(field) && (isDimension(field) || isMetric(field))) {
+        return getItemIconName(field.type);
+    }
+    return getItemIcon(field);
+};
+
+interface FieldIconProps {
+    item: FilterItem;
+}
+
+const FieldIcon: FC<FieldIconProps> = ({ item }) => {
+    return <Icon icon={getFieldIcon(item)} color={getItemColor(item)} />;
+};
+
+export default FieldIcon;

--- a/packages/frontend/src/components/common/Filters/FieldLabel.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldLabel.tsx
@@ -1,0 +1,24 @@
+import { FilterItem, isField } from '@lightdash/common';
+import { FC } from 'react';
+import styled from 'styled-components';
+
+interface FieldLabelProps {
+    item: FilterItem;
+}
+
+const BolderText = styled.span`
+    font-weight: 600;
+`;
+
+const FieldLabel: FC<FieldLabelProps> = ({ item }) => {
+    return (
+        <span>
+            {isField(item) ? `${item.tableLabel} ` : ''}
+            <BolderText>
+                {isField(item) ? item.label : item.displayName}
+            </BolderText>
+        </span>
+    );
+};
+
+export default FieldLabel;

--- a/packages/frontend/src/components/common/Filters/FieldLabel.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldLabel.tsx
@@ -1,9 +1,15 @@
-import { FilterItem, isField } from '@lightdash/common';
+import {
+    AdditionalMetric,
+    Field,
+    isAdditionalMetric,
+    isField,
+    TableCalculation,
+} from '@lightdash/common';
 import { FC } from 'react';
 import styled from 'styled-components';
 
 interface FieldLabelProps {
-    item: FilterItem;
+    item: Field | TableCalculation | AdditionalMetric;
 }
 
 const BolderText = styled.span`
@@ -15,7 +21,9 @@ const FieldLabel: FC<FieldLabelProps> = ({ item }) => {
         <span>
             {isField(item) ? `${item.tableLabel} ` : ''}
             <BolderText>
-                {isField(item) ? item.label : item.displayName}
+                {isField(item) || isAdditionalMetric(item)
+                    ? item.label
+                    : item.displayName}
             </BolderText>
         </span>
     );

--- a/packages/frontend/src/components/common/Filters/FieldSelect.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldSelect.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@blueprintjs/core';
+import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
+import { Select2 } from '@blueprintjs/select';
+import { FilterableField } from '@lightdash/common';
+import { FC } from 'react';
+import FieldIcon from './FieldIcon';
+import FieldLabel from './FieldLabel';
+import renderFilterItem from './renderFilterItem';
+
+interface FieldSelectProps {
+    available: boolean;
+    disabled: boolean;
+    items: FilterableField[];
+    activeItem?: FilterableField;
+    onItemSelect: (newItem: FilterableField) => void;
+    popoverProps?: Popover2Props;
+}
+
+const FieldSelect: FC<FieldSelectProps> = ({
+    available,
+    disabled,
+    items,
+    activeItem,
+    onItemSelect,
+    popoverProps,
+}) => {
+    return (
+        <Select2<FilterableField>
+            disabled={disabled}
+            fill
+            filterable={false}
+            items={items}
+            itemRenderer={renderFilterItem}
+            noResults={<MenuItem2 disabled text="No results." />}
+            activeItem={activeItem}
+            onItemSelect={onItemSelect}
+            popoverProps={{
+                lazy: true,
+                minimal: true,
+                matchTargetWidth: true,
+                ...popoverProps,
+            }}
+        >
+            <Button
+                minimal
+                alignText="left"
+                disabled={disabled}
+                outlined
+                fill
+                icon={activeItem && <FieldIcon item={activeItem} />}
+                text={
+                    available ? (
+                        activeItem ? (
+                            <FieldLabel item={activeItem} />
+                        ) : (
+                            'Select field'
+                        )
+                    ) : (
+                        'Not applicable'
+                    )
+                }
+                rightIcon="caret-down"
+                placeholder="Select a film"
+            />
+        </Select2>
+    );
+};
+
+export default FieldSelect;

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -9,7 +9,7 @@ import {
     getFilterTypeFromField,
     isField,
 } from '@lightdash/common';
-import React, { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { FilterTypeConfig } from './configs';
 import FieldAutoComplete from './FieldAutoComplete';
 

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -15,7 +15,7 @@ import {
     Metric,
     TableCalculation,
 } from '@lightdash/common';
-import React, { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { useToggle } from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 import FieldAutoComplete from './FieldAutoComplete';

--- a/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
@@ -1,0 +1,29 @@
+import { MenuItem2 } from '@blueprintjs/popover2';
+import { ItemRenderer } from '@blueprintjs/select';
+import { FilterItem, getItemId } from '@lightdash/common';
+import FieldIcon from './FieldIcon';
+import FieldLabel from './FieldLabel';
+
+const renderFilterItem: ItemRenderer<FilterItem> = (
+    item,
+    { modifiers, handleClick, handleFocus },
+) => {
+    if (!modifiers.matchesPredicate) {
+        return null;
+    }
+    return (
+        <MenuItem2
+            key={getItemId(item)}
+            roleStructure="listoption"
+            shouldDismissPopover={false}
+            active={modifiers.active}
+            disabled={modifiers.disabled}
+            icon={<FieldIcon item={item} />}
+            text={<FieldLabel item={item} />}
+            onClick={handleClick}
+            onFocus={handleFocus}
+        />
+    );
+};
+
+export default renderFilterItem;

--- a/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
@@ -1,13 +1,17 @@
 import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemRenderer } from '@blueprintjs/select';
-import { FilterItem, getItemId } from '@lightdash/common';
+import {
+    AdditionalMetric,
+    Field,
+    getItemId,
+    TableCalculation,
+} from '@lightdash/common';
 import FieldIcon from './FieldIcon';
 import FieldLabel from './FieldLabel';
 
-const renderFilterItem: ItemRenderer<FilterItem> = (
-    item,
-    { modifiers, handleClick, handleFocus },
-) => {
+const renderFilterItem: ItemRenderer<
+    Field | TableCalculation | AdditionalMetric
+> = (item, { modifiers, handleClick, handleFocus }) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -69,7 +69,7 @@ export const getQueryConfig = (savedChartUuid: string) => {
     };
 };
 
-export const useDashboardTilesSavedQueryFilters = (
+export const useDashboardAvailableTileFilters = (
     tiles: DashboardTile[] = [],
 ) => {
     const savedChartUuids = useMemo(() => {
@@ -115,7 +115,7 @@ export const useDashboardTilesSavedQueryFilters = (
 export const useAvailableDashboardFilterTargets = (
     tiles: DashboardTile[] = [],
 ) => {
-    const { isLoading, data } = useDashboardTilesSavedQueryFilters(tiles);
+    const { isLoading, data } = useDashboardAvailableTileFilters(tiles);
 
     const availableFilters = useMemo(() => {
         if (isLoading || !data) return;

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -2,6 +2,8 @@ import {
     ApiError,
     CreateDashboard,
     Dashboard,
+    DashboardChartTile,
+    DashboardTile,
     DashboardTileTypes,
     FilterableField,
     UpdateDashboard,
@@ -61,48 +63,74 @@ export const getChartAvailableFilters = async (savedChartUuid: string) =>
         body: undefined,
     });
 
-export const useAvailableDashboardFilterTargets = (
-    availableTilesToFilter: Dashboard['tiles'],
-): { isLoading: boolean; data: FilterableField[] } => {
-    const queries = useMemo(() => {
-        const savedChartUuids = (availableTilesToFilter || [])
-            .map((tile) =>
-                tile.type === DashboardTileTypes.SAVED_CHART
-                    ? tile.properties.savedChartUuid
-                    : null,
-            )
-            .filter((id) => id !== null) as string[];
-        return savedChartUuids.map((savedChartUuid) => ({
-            queryKey: ['available_filters', savedChartUuid],
-            queryFn: () => getChartAvailableFilters(savedChartUuid),
-        }));
-    }, [availableTilesToFilter]);
-    const results = useQueries(queries) as UseQueryResult<
-        FilterableField[],
-        ApiError
-    >[]; // useQueries doesn't allow us to specify TError
+export const getQueryConfig = (savedChartUuid: string) => {
+    return {
+        queryKey: ['available_filters', savedChartUuid],
+        queryFn: () => getChartAvailableFilters(savedChartUuid),
+    };
+};
 
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [availableFilters, setAvailableFilters] = useState<FilterableField[]>(
-        [],
-    );
+// TODO: remove if not used
+const useAvailableChartFilters = (savedChartUuid: string) => {
+    return useQuery(getQueryConfig(savedChartUuid));
+};
+
+export const useDashboardFiltersByTiles = (tiles: DashboardTile[] = []) => {
+    const tileUuids = useMemo(() => {
+        return tiles
+            .filter(
+                (tile): tile is DashboardChartTile =>
+                    tile.type === DashboardTileTypes.SAVED_CHART,
+            )
+            .map((tile) => tile.properties.savedChartUuid)
+            .filter((uuid): uuid is string => !!uuid);
+    }, [tiles]);
+
+    const queries = useQueries(
+        tileUuids.map((uuid) => getQueryConfig(uuid)),
+    ) as UseQueryResult<FilterableField[], ApiError>[]; // useQueries doesn't allow us to specify TError
+
+    const isLoading = queries.some((query) => query.isLoading);
+    const queryResults = queries.map((query) => query.data!);
+
+    const [data, setData] = useState<Record<string, FilterableField[]>>();
 
     useDeepCompareEffect(() => {
-        setIsLoading(results.some((q) => q.isLoading));
-        setAvailableFilters(
-            results
-                .flatMap((q) => q.data || [])
-                .filter(
-                    (field, index, allFields) =>
-                        index ===
-                        allFields.findIndex(
-                            (f) =>
-                                f.table === field.table &&
-                                f.name === field.name,
-                        ),
+        if (isLoading || queryResults.length === 0) return;
+
+        const results = queryResults.reduce<Record<string, FilterableField[]>>(
+            (acc, result, index) => ({ ...acc, [tileUuids[index]]: result }),
+            {},
+        );
+
+        setData(results);
+    }, [isLoading, tileUuids, queryResults]);
+
+    return {
+        isLoading,
+        data,
+    };
+};
+
+export const useAvailableDashboardFilterTargets = (
+    tiles: DashboardTile[] = [],
+) => {
+    const { isLoading, data } = useDashboardFiltersByTiles(tiles);
+
+    const availableFilters = useMemo(() => {
+        if (isLoading || !data) return;
+
+        const allFilters = Object.values(data).flat();
+        if (allFilters.length === 0) return;
+
+        return allFilters.filter(
+            (field, index, allFields) =>
+                index ===
+                allFields.findIndex(
+                    (f) => f.table === field.table && f.name === field.name,
                 ),
         );
-    }, [results]);
+    }, [isLoading, data]);
 
     return {
         isLoading,
@@ -337,9 +365,9 @@ export const useDeleteMutation = () => {
 };
 
 export const appendNewTilesToBottom = (
-    existingTiles: Dashboard['tiles'] | [],
-    newTiles: Dashboard['tiles'],
-): Dashboard['tiles'] => {
+    existingTiles: DashboardTile[] | [],
+    newTiles: DashboardTile[],
+): DashboardTile[] => {
     const tilesY =
         existingTiles &&
         existingTiles.map(function (tile) {

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -4,9 +4,7 @@ import {
     byDashbordChartTileType,
     CreateDashboard,
     Dashboard,
-    DashboardChartTile,
     DashboardTile,
-    DashboardTileTypes,
     UpdateDashboard,
     UpdateDashboardDetails,
 } from '@lightdash/common';

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -1,10 +1,10 @@
 import {
     ApiError,
-    byDashbordChartTileType,
     CreateDashboard,
     Dashboard,
     DashboardTile,
     FilterableField,
+    isDashboardChartTileType,
     UpdateDashboard,
     UpdateDashboardDetails,
 } from '@lightdash/common';
@@ -74,7 +74,7 @@ export const useDashboardTilesSavedQueryFilters = (
 ) => {
     const savedChartUuids = useMemo(() => {
         return tiles
-            .filter(byDashbordChartTileType)
+            .filter(isDashboardChartTileType)
             .map((tile) => tile.properties.savedChartUuid)
             .filter((uuid): uuid is string => !!uuid);
     }, [tiles]);

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -18,7 +18,7 @@ const useDashboardFiltersForExplore = (
         [explore],
     );
 
-    const aggregateFilters = useCallback(
+    const overrideTileFilters = useCallback(
         (rules: DashboardFilterRule[]) =>
             rules
                 .filter((f) => {
@@ -37,7 +37,7 @@ const useDashboardFiltersForExplore = (
                         ...f,
                         target: {
                             fieldId: tileConfig.fieldId,
-                            tableName: tileConfig.fieldId.split('_')[0],
+                            tableName: tileConfig.fieldId.split('_')[0], // TODO: use a better way to get a table name
                         },
                     };
                 })
@@ -47,16 +47,16 @@ const useDashboardFiltersForExplore = (
 
     return useMemo(() => {
         return {
-            dimensions: aggregateFilters([
+            dimensions: overrideTileFilters([
                 ...dashboardFilters.dimensions,
                 ...dashboardTemporaryFilters.dimensions,
             ]),
-            metrics: aggregateFilters([
+            metrics: overrideTileFilters([
                 ...dashboardFilters.metrics,
                 ...dashboardTemporaryFilters.metrics,
             ]),
         };
-    }, [dashboardFilters, dashboardTemporaryFilters, aggregateFilters]);
+    }, [dashboardFilters, dashboardTemporaryFilters, overrideTileFilters]);
 };
 
 export default useDashboardFiltersForExplore;

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -21,21 +21,13 @@ const useDashboardFiltersForExplore = (
     const overrideTileFilters = useCallback(
         (rules: DashboardFilterRule[]) =>
             rules
-                .filter((f) => {
-                    return (
-                        f.tileTargetOverride?.some(
-                            (t) => t.tileUuid === tileUuid,
-                        ) ?? true
-                    );
-                })
-                .map((f) => {
-                    const tileConfig = f.tileTargetOverride?.find(
-                        (t) => t.tileUuid === tileUuid,
-                    );
-                    if (!tileConfig) return f;
+                .filter((f) => f.tileTargetOverride?.[tileUuid] ?? true)
+                .map((filter) => {
+                    const tileConfig = filter.tileTargetOverride?.[tileUuid];
+                    if (!tileConfig) return filter;
 
                     return {
-                        ...f,
+                        ...filter,
                         target: {
                             fieldId: tileConfig.fieldId,
                             tableName: tileConfig.tableName,

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -21,13 +21,14 @@ const useDashboardFiltersForExplore = (
     const overrideTileFilters = useCallback(
         (rules: DashboardFilterRule[]) =>
             rules
-                .filter((f) => f.tileTargetOverride?.[tileUuid] ?? true)
+                .filter((f) => f.tileTargets?.[tileUuid] ?? true)
                 .map((filter) => {
-                    const tileConfig = filter.tileTargetOverride?.[tileUuid];
+                    const { tileTargets, ...rest } = filter;
+                    const tileConfig = tileTargets?.[tileUuid];
                     if (!tileConfig) return filter;
 
                     return {
-                        ...filter,
+                        ...rest,
                         target: {
                             fieldId: tileConfig.fieldId,
                             tableName: tileConfig.tableName,

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -23,12 +23,13 @@ const useDashboardFiltersForExplore = (
             rules
                 .filter((f) => {
                     return (
-                        f.tileConfigs?.some((t) => t.tileUuid === tileUuid) ??
-                        true
+                        f.tileTargetOverride?.some(
+                            (t) => t.tileUuid === tileUuid,
+                        ) ?? true
                     );
                 })
                 .map((f) => {
-                    const tileConfig = f.tileConfigs?.find(
+                    const tileConfig = f.tileTargetOverride?.find(
                         (t) => t.tileUuid === tileUuid,
                     );
                     if (!tileConfig) return f;
@@ -37,7 +38,7 @@ const useDashboardFiltersForExplore = (
                         ...f,
                         target: {
                             fieldId: tileConfig.fieldId,
-                            tableName: tileConfig.fieldId.split('_')[0], // TODO: use a better way to get a table name
+                            tableName: tileConfig.tableName,
                         },
                     };
                 })

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -149,7 +149,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
     );
 
     useEffect(() => {
-        if (filterableFields.length > 0) {
+        if (filterableFields && filterableFields.length > 0) {
             setFieldsWithSuggestions((prev) =>
                 filterableFields.reduce<FieldsWithSuggestions>(
                     (sum, field) => ({

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -206,6 +206,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         } else {
             newParams.set('filters', JSON.stringify(dashboardTemporaryFilters));
         }
+
         history.replace({
             pathname,
             search: newParams.toString(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,6 +1938,84 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@slack/bolt@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@slack/bolt/-/bolt-3.12.2.tgz#8fff81816af16409ec84a9af5e456a44b2e041b8"
+  integrity sha512-Rv5apx14Nx25ho7MHigZcmYG+P/TzKB4MEdY/UDM7ntCCmTBdRd5d+teERmGPNalFjz/tEfQ5bw+Z8zZjHIOXA==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/oauth" "^2.5.1"
+    "@slack/socket-mode" "^1.3.0"
+    "@slack/types" "^2.7.0"
+    "@slack/web-api" "^6.7.1"
+    "@types/express" "^4.16.1"
+    "@types/node" "18.11.8"
+    "@types/promise.allsettled" "^1.0.3"
+    "@types/tsscmp" "^1.0.0"
+    axios "^0.26.1"
+    express "^4.16.4"
+    please-upgrade-node "^3.2.0"
+    promise.allsettled "^1.0.2"
+    raw-body "^2.3.3"
+    tsscmp "^1.0.6"
+
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/oauth@^2.5.1":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@slack/oauth/-/oauth-2.5.4.tgz#94882a57068ae837720291ab875fe08d276ace77"
+  integrity sha512-NjkJBNSHw2edpSe4bPMO0DvGR2Hl9J37kYjopH06LXFEvh+ucxrds9VUnPNj3t0n32zVo/f7iniGdDl0Zk+t+g==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/web-api" "^6.3.0"
+    "@types/jsonwebtoken" "^8.3.7"
+    "@types/node" ">=12"
+    jsonwebtoken "^8.5.1"
+    lodash.isstring "^4.0.1"
+
+"@slack/socket-mode@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@slack/socket-mode/-/socket-mode-1.3.2.tgz#b3c4db146779cb63ec240a10de722deadd907305"
+  integrity sha512-6LiwYE6k4DNbnctZZSLfERiOzWngAvXogxQEYzUkxeZgh2GC6EdmRq6OEbZXOBe71/K66YVx05VfR7B4b1ScTQ==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/web-api" "^6.2.3"
+    "@types/node" ">=12.0.0"
+    "@types/p-queue" "^2.3.2"
+    "@types/ws" "^7.4.7"
+    eventemitter3 "^3.1.0"
+    finity "^0.5.4"
+    p-cancelable "^1.1.0"
+    p-queue "^2.4.2"
+    ws "^7.5.3"
+
+"@slack/types@^2.0.0", "@slack/types@^2.7.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.8.0.tgz#11ea10872262a7e6f86f54e5bcd4f91e3a41fe91"
+  integrity sha512-ghdfZSF0b4NC9ckBA8QnQgC9DJw2ZceDq0BIjjRSv6XAZBXJdWgxIsYz0TYnWSiqsKZGH2ZXbj9jYABZdH3OSQ==
+
+"@slack/web-api@^6.2.3", "@slack/web-api@^6.3.0", "@slack/web-api@^6.7.1":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.8.0.tgz#6ef0ca7e3ff432ba0b7871b0d2939ef3d75f2a7f"
+  integrity sha512-DI0T7pQy2SM14s+zJKlarzkyOqhpu2Qk3rL19g+3m7VDZ+lSMB/dt9nwf3BZIIp49/CoLlBjEmKMoakm69OD4Q==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.0.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=12.0.0"
+    axios "^0.27.2"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-electron "2.2.0"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@svgr/babel-plugin-add-jsx-attribute@^6.3.1":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz#b9a5d84902be75a05ede92e70b338d28ab63fa74"
@@ -2279,6 +2357,16 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/express@^4.16.1":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/express@^4.17.11":
   version "4.17.12"
   resolved "https://registry.npmjs.org/@types/express/-/express-4.17.12.tgz"
@@ -2350,6 +2438,13 @@
   dependencies:
     "@types/through" "*"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz"
@@ -2414,6 +2509,13 @@
   version "0.0.29"
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/jsonwebtoken@^8.3.7":
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz#2c064ecb0b3128d837d2764aa0b117b0ff6e4586"
+  integrity sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/lodash-es@^4.17.6":
   version "4.17.6"
@@ -2489,6 +2591,16 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz"
   integrity sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==
 
+"@types/node@18.11.8":
+  version "18.11.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.8.tgz#16d222a58d4363a2a359656dd20b28414de5d265"
+  integrity sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==
+
+"@types/node@>=12", "@types/node@>=12.0.0":
+  version "18.11.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.10.tgz#4c64759f3c2343b7e6c4b9caf761c7a3a05cee34"
+  integrity sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==
+
 "@types/node@^14.11.8":
   version "14.17.9"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz"
@@ -2528,6 +2640,11 @@
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.2.1.tgz#02a3ade3dc4d3950029c6466a4034565dba7cf8c"
   integrity sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==
+
+"@types/p-queue@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
+  integrity sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2588,6 +2705,11 @@
   version "2.3.1"
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz"
   integrity sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==
+
+"@types/promise.allsettled@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/promise.allsettled/-/promise.allsettled-1.0.3.tgz#6f3166618226a570b98c8250fc78687a912e56d5"
+  integrity sha512-b/IFHHTkYkTqu41IH9UtpICwqrpKj2oNlb4KHPzFQDMiz+h1BgAeATeO0/XTph4+UkH9W2U0E4B4j64KWOovag==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -2718,6 +2840,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
 "@types/scheduler@*":
   version "0.16.1"
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz"
@@ -2776,6 +2903,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tsscmp@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tsscmp/-/tsscmp-1.0.0.tgz#761c885a530f9673ae6fda0cae38253ffd46cba6"
+  integrity sha512-rj18XR6c4Ohds86Lq8MI1NMRrXes4eLo4H06e5bJyKucE1rXGsfBBbFGD2oDC+DSufQCpnU3TTW7QAiwLx+7Yw==
+
 "@types/tunnel@^0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz"
@@ -2797,6 +2929,13 @@
   version "8.3.4"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
+"@types/ws@^7.4.7":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -3006,6 +3145,14 @@ accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 ace-builds@^1.4.13, ace-builds@^1.4.14:
   version "1.4.14"
@@ -3329,6 +3476,17 @@ array.prototype.flatmap@^1.3.0:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
+array.prototype.map@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.5.tgz#6e43c2fee6c0fb5e4806da2dc92eb00970809e55"
+  integrity sha512-gfaKntvwqYIuC7mLLyv2wzZIJqrRhn5PZ9EfFejSx6a78sV7iDsGpG9P+3oUPtm1Rerqm6nrKS4FYuTIvWfo3g==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.7"
+
 arrify@^2.0.0, arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz"
@@ -3514,6 +3672,21 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -3710,7 +3883,7 @@ binascii@0.0.2:
   resolved "https://registry.npmjs.org/binascii/-/binascii-0.0.2.tgz"
   integrity sha1-p/iogB28z4sXVrdD2qD+6eLZ4O4=
 
-bl@^4.1.0:
+bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -3749,6 +3922,24 @@ body-parser@1.19.0, body-parser@^1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+body-parser@1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
+  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -3913,7 +4104,7 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -3953,6 +4144,11 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -4225,6 +4421,11 @@ chokidar@^3.5.2, chokidar@^3.5.3:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -4634,6 +4835,13 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
 content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
@@ -4668,6 +4876,11 @@ cookie@0.4.1, cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookie@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -4751,7 +4964,7 @@ cron-parser@^4.2.1:
   dependencies:
     luxon "^2.4.0"
 
-cross-fetch@^3.0.4, cross-fetch@^3.1.5:
+cross-fetch@3.1.5, cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -4970,7 +5183,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -5123,15 +5336,15 @@ denque@^1.1.0:
   resolved "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz"
   integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
+depd@2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
-depd@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 dependency-graph@^0.11.0:
   version "0.11.0"
@@ -5142,6 +5355,11 @@ dequal@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz"
   integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
+destroy@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -5172,6 +5390,11 @@ detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
+devtools-protocol@0.0.1045489:
+  version "0.0.1045489"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz#f959ad560b05acd72d55644bc3fb8168a83abf28"
+  integrity sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ==
 
 dicer@0.2.5:
   version "0.2.5"
@@ -5556,6 +5779,55 @@ es-abstract@^1.19.5:
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
+
+es-abstract@^1.20.4:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
+  integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.3"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.2"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-get-iterator@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
+  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.0"
+    has-symbols "^1.0.1"
+    is-arguments "^1.1.0"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.5"
+    isarray "^2.0.5"
 
 es-module-lexer@^1.0.3:
   version "1.0.5"
@@ -6054,7 +6326,12 @@ eventemitter2@^6.4.3:
   resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz"
   integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
 
-eventemitter3@^4.0.0:
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -6200,6 +6477,43 @@ express-session@^1.17.2:
     parseurl "~1.3.3"
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
+
+express@^4.16.4:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
+  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.20.1"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.5.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.2.0"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.11.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.18.0"
+    serve-static "1.15.0"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 express@^4.17.1:
   version "4.17.1"
@@ -6437,6 +6751,19 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+finalhandler@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
+  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    statuses "2.0.1"
+    unpipe "~1.0.0"
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz"
@@ -6494,6 +6821,11 @@ fined@^1.0.1:
     object.pick "^1.2.0"
     parse-filepath "^1.0.1"
 
+finity@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/finity/-/finity-0.5.4.tgz#f2a8a9198e8286467328ec32c8bfcc19a2229c11"
+  integrity sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA==
+
 flagged-respawn@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz"
@@ -6532,6 +6864,11 @@ follow-redirects@^1.14.8:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
+follow-redirects@^1.14.9:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
@@ -6548,6 +6885,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -6597,6 +6943,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -6754,7 +7105,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
   integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
@@ -7547,6 +7898,17 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz"
@@ -7604,6 +7966,14 @@ http-signature@~1.3.6:
     assert-plus "^1.0.0"
     jsprim "^2.0.2"
     sshpk "^1.14.1"
+
+https-proxy-agent@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 https-proxy-agent@^3.0.0:
   version "3.0.1"
@@ -7878,7 +8248,7 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
-is-arguments@^1.0.4:
+is-arguments@^1.0.4, is-arguments@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
   integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
@@ -7934,6 +8304,11 @@ is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
+is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -8036,6 +8411,11 @@ is-docker@^2.0.0:
   resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-electron@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
@@ -8132,6 +8512,11 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -8252,6 +8637,11 @@ is-retry-allowed@^2.2.0:
   resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz"
   integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
+is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
 is-shared-array-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz"
@@ -8349,6 +8739,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
@@ -8422,6 +8817,19 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterate-iterator@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.2.tgz#551b804c9eaa15b847ea6a7cdc2f5bf1ec150f91"
+  integrity sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==
+
+iterate-value@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
+  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
+  dependencies:
+    es-get-iterator "^1.0.2"
+    iterate-iterator "^1.0.1"
 
 jest-changed-files@^29.0.0:
   version "29.0.0"
@@ -9111,10 +9519,10 @@ kleur@^4.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz"
   integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
-knex-mock-client@^1.6.0:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/knex-mock-client/-/knex-mock-client-1.6.1.tgz"
-  integrity sha512-BmP+3zGmgGEllTigslK+vtfMbCOFZP47X7DLVbWkDMsr0WXA7+/VM9z07U/fQEmQTlBiQQRQNAeZl7k82zO1ag==
+knex-mock-client@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/knex-mock-client/-/knex-mock-client-1.11.0.tgz#356513462d19cf769ca2e92e4be033ff244b2238"
+  integrity sha512-6Mf2jscz6XMVfk7Jhp7pnRe37HsupVfScPf8pyiL6X51B7sporDVQPra4oyj7Ea5ssuqE3XnVhRgUeP50+Yrog==
   dependencies:
     lodash.clonedeep "^4.5.0"
 
@@ -10127,6 +10535,11 @@ mime-db@1.50.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.31"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz"
@@ -10140,6 +10553,13 @@ mime-types@^2.1.29:
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
   dependencies:
     mime-db "1.50.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -10215,6 +10635,11 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^0.5.4, mkdirp@^0.5.5:
   version "0.5.5"
@@ -10328,7 +10753,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1, ms@^2.1.3:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -10430,6 +10855,11 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -10810,6 +11240,13 @@ ocsp@^1.2.0:
     async "^1.5.2"
     simple-lru-cache "0.0.2"
 
+on-finished@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
+
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
@@ -10908,7 +11345,7 @@ ospath@^1.2.2:
   resolved "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz"
   integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
 
-p-cancelable@^1.0.0:
+p-cancelable@^1.0.0, p-cancelable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
@@ -10971,6 +11408,27 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-queue@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.4.2.tgz#03609826682b743be9a22dba25051bd46724fc34"
+  integrity sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==
+
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
 
 p-timeout@^3.1.0, p-timeout@^3.2.0:
   version "3.2.0"
@@ -11365,6 +11823,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
+
 popper.js@^1.14.4, popper.js@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
@@ -11519,10 +11984,27 @@ process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-polyfill@^8.1.3:
   version "8.2.0"
   resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz"
   integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
+
+promise.allsettled@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.6.tgz#8dc8ba8edf429feb60f8e81335b920e109c94b6e"
+  integrity sha512-22wJUOD3zswWFqgwjNHa1965LvqTX87WPu/lreY2KSd7SVcERfuZ4GfUaOnJNnvtoIv2yXT/W00YIGMetXtFXg==
+  dependencies:
+    array.prototype.map "^1.0.5"
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    iterate-value "^1.0.2"
 
 prompts@^2.0.1:
   version "2.4.1"
@@ -11569,7 +12051,7 @@ property-information@^6.0.0:
   resolved "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz"
   integrity sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==
 
-proxy-addr@~2.0.5:
+proxy-addr@~2.0.5, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
@@ -11581,6 +12063,11 @@ proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+
+proxy-from-env@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -11622,6 +12109,32 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+puppeteer-core@18.2.1:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-18.2.1.tgz#9b7827bb2bf478bb615e2c21425e4659555dc1fe"
+  integrity sha512-MRtTAZfQTluz3U2oU/X2VqVWPcR1+94nbA2V6ZrSZRVEwLqZ8eclZ551qGFQD/vD2PYqHJwWOW/fpC721uznVw==
+  dependencies:
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.1045489"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.9.0"
+
+puppeteer@^18.0.5:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-18.2.1.tgz#08967cd423efe511ee4c6e3a5c882ffaf2e6bbf3"
+  integrity sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==
+  dependencies:
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    puppeteer-core "18.2.1"
+
 python-struct@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/python-struct/-/python-struct-1.1.3.tgz"
@@ -11633,6 +12146,13 @@ q@^1.5.0:
   version "1.5.1"
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qs@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@6.7.0:
   version "6.7.0"
@@ -11690,6 +12210,16 @@ raw-body@2.4.0:
   dependencies:
     bytes "3.1.0"
     http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.5.1, raw-body@^2.3.3:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
@@ -12517,6 +13047,11 @@ retry-request@^4.2.2:
     debug "^4.1.1"
     extend "^3.0.2"
 
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
@@ -12622,6 +13157,15 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, s
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
@@ -12673,6 +13217,11 @@ screenfull@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/screenfull/-/screenfull-5.1.0.tgz"
   integrity sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA==
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -12741,6 +13290,25 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+send@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
+  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
 sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
@@ -12767,6 +13335,16 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
+serve-static@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
+  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.18.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
@@ -12791,6 +13369,11 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shallowequal@^1.1.0:
   version "1.1.0"
@@ -13219,6 +13802,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
@@ -13562,6 +14150,27 @@ svg-pathdata@^5.0.5:
   resolved "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz"
   integrity sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==
 
+tar-fs@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar@^6.1.0:
   version "6.1.11"
   resolved "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz"
@@ -13785,6 +14394,11 @@ toidentifier@1.0.0:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 totalist@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz"
@@ -13910,6 +14524,11 @@ tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tsscmp@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -14047,6 +14666,14 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unbzip2-stream@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -14807,6 +15434,11 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
+ws@8.9.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.9.0.tgz#2a994bb67144be1b53fe2d23c53c028adeb7f45e"
+  integrity sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==
+
 ws@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
@@ -14818,6 +15450,11 @@ ws@^7.4.2:
   version "7.5.3"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+
+ws@^7.5.3:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
closes: https://github.com/lightdash/lightdash/issues/3657
closes: https://github.com/lightdash/lightdash/issues/2346
closes: https://github.com/lightdash/lightdash/issues/1617

### Description:

⚠️ before testing in staging: open console, run `localStorage.setItem('dashboard_filters', true)` and refresh the browser.

- [x] You should be able to select/deselect the tiles that you would like to apply your chosen filter to. You should only be able to choose from tiles that include the relevant field type. Eg. if I choose a date filter but Tile E is made from a model that doesn’t have date fields, it should not appear as a selectable option.
- [x] You should be able to choose which column you want to filter by per tile. You should only be able to choose from the same column type. eg dates!
- [x] You should be able to access the ‘tiles’ tab in view mode as well as edit mode.

video demo:


https://user-images.githubusercontent.com/962095/203396228-7ff85ecd-121d-40de-ac46-3ff33a746fb0.mp4


