### PR TITLE
feat: configure start of week in CLI commands

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -143,6 +143,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 loadSources,
                 adapterType,
                 metrics,
+                this.warehouseClient.getStartOfWeek(),
             );
             return [...lazyExplores, ...failedExplores];
         } catch (e) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -4,6 +4,7 @@ import {
     getSchemaStructureFromDbtModels,
     isExploreError,
     isSupportedDbtAdapter,
+    isWeekDay,
     ParseError,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
@@ -26,6 +27,7 @@ type GenerateHandlerOptions = DbtCompileOptions & {
     target: string | undefined;
     profile: string | undefined;
     verbose: boolean;
+    startOfWeek?: number;
 };
 export const compile = async (options: GenerateHandlerOptions) => {
     await LightdashAnalytics.track({
@@ -84,6 +86,7 @@ export const compile = async (options: GenerateHandlerOptions) => {
         false,
         manifest.metadata.adapter_type,
         Object.values(manifest.metrics),
+        isWeekDay(options.startOfWeek) ? options.startOfWeek : undefined,
     );
     console.error('');
 

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -1,6 +1,7 @@
 import {
     CreateProject,
     DbtProjectType,
+    isWeekDay,
     Project,
     ProjectType,
     WarehouseTypes,
@@ -70,6 +71,7 @@ type CreateProjectOptions = {
     target: string | undefined;
     profile: string | undefined;
     type: ProjectType;
+    startOfWeek?: number;
 };
 export const createProject = async (
     options: CreateProjectOptions,
@@ -119,7 +121,12 @@ export const createProject = async (
     const project: CreateProject = {
         name: options.name,
         type: options.type,
-        warehouseConnection: credentials,
+        warehouseConnection: {
+            ...credentials,
+            startOfWeek: isWeekDay(options.startOfWeek)
+                ? options.startOfWeek
+                : undefined,
+        },
         dbtConnection: {
             type: DbtProjectType.NONE,
             target: targetName,

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -26,6 +26,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     create?: boolean;
     verbose: boolean;
     ignoreErrors: boolean;
+    startOfWeek?: number;
 };
 
 type DeployArgs = DeployHandlerOptions & {

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -25,6 +25,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     profile: string | undefined;
     name?: string;
     verbose: boolean;
+    startOfWeek?: number;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { LightdashError } from '@lightdash/common';
-import { program } from 'commander';
+import { InvalidArgumentError, program } from 'commander';
 import * as os from 'os';
 import * as path from 'path';
 import { compileHandler } from './handlers/compile';
@@ -22,6 +22,14 @@ const { version: VERSION } = require('../package.json');
 const defaultProjectDir = process.env.DBT_PROJECT_DIR || '.';
 const defaultProfilesDir =
     process.env.DBT_PROFILES_DIR || path.join(os.homedir(), '.dbt');
+
+function parseIntArgument(value: string) {
+    const parsedValue = parseInt(value, 10);
+    if (Number.isNaN(parsedValue)) {
+        throw new InvalidArgumentError('Not a number.');
+    }
+    return parsedValue;
+}
 
 program
     .version(VERSION)
@@ -277,7 +285,11 @@ program
     .option('--state <state>')
     .option('--full-refresh')
     .option('--verbose', undefined, false)
-
+    .option(
+        '--start-of-week <number>',
+        'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
+        parseIntArgument,
+    )
     .action(previewHandler);
 
 program
@@ -319,7 +331,11 @@ program
     .option('--state <state>')
     .option('--full-refresh')
     .option('--verbose', undefined, false)
-
+    .option(
+        '--start-of-week <number>',
+        'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
+        parseIntArgument,
+    )
     .action(startPreviewHandler);
 
 program
@@ -370,7 +386,11 @@ program
 
     .option('--create', 'Create a new project on your organization', false)
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
-
+    .option(
+        '--start-of-week <number>',
+        'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
+        parseIntArgument,
+    )
     .action(deployHandler);
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,16 @@ function parseIntArgument(value: string) {
     return parsedValue;
 }
 
+function parseStartOfWeekArgument(value: string) {
+    const number = parseIntArgument(value);
+    if (number <= 0 || number > 6) {
+        throw new InvalidArgumentError(
+            'Not a valid number. Please use a number from 0 (Monday) to 6 (Sunday)',
+        );
+    }
+    return number;
+}
+
 program
     .version(VERSION)
     .name(styles.title('⚡️lightdash'))
@@ -288,7 +298,7 @@ program
     .option(
         '--start-of-week <number>',
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
-        parseIntArgument,
+        parseStartOfWeekArgument,
     )
     .action(previewHandler);
 
@@ -334,7 +344,7 @@ program
     .option(
         '--start-of-week <number>',
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
-        parseIntArgument,
+        parseStartOfWeekArgument,
     )
     .action(startPreviewHandler);
 
@@ -389,7 +399,7 @@ program
     .option(
         '--start-of-week <number>',
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
-        parseIntArgument,
+        parseStartOfWeekArgument,
     )
     .action(deployHandler);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3803<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add `--start-of-week` option for commands `deploy` `preview` `start-preview` 

<a href="https://www.loom.com/share/68cdb585512445afb45b3d4e2ad622de">
    <p>Lightdash - start of week preview command - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/68cdb585512445afb45b3d4e2ad622de-with-play.gif">
  </a>

<a href="https://www.loom.com/share/563989d39ff54b2384ea588f36dba9e7">
    <p>Lightdash - start of week deploy command - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/563989d39ff54b2384ea588f36dba9e7-with-play.gif">
  </a>


