### PR TITLE
feat: date picker use start of week configuration

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -3,6 +3,7 @@ import { DashboardTileTypes } from '@lightdash/common';
 import React, { FC, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAvailableDashboardFilterTargets } from '../../hooks/dashboard/useDashboard';
+import { useProject } from '../../hooks/useProject';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { FiltersProvider } from '../common/Filters/FiltersProvider';
 import ActiveFilters from './ActiveFilters';
@@ -22,7 +23,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [isOpen, setIsOpen] = useState(false);
     const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
-
+    const project = useProject(projectUuid);
     const {
         dashboard,
         fieldsWithSuggestions,
@@ -46,6 +47,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         <FiltersProvider
             projectUuid={projectUuid}
             fieldsMap={fieldsWithSuggestions}
+            startOfWeek={project.data?.warehouseConnection?.startOfWeek}
         >
             <DashboardFilterWrapper>
                 <TriggerWrapper

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -16,6 +16,7 @@ import {
 import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useExplore } from '../../../hooks/useExplore';
+import { useProject } from '../../../hooks/useProject';
 import {
     ExplorerSection,
     useExplorerContext,
@@ -35,6 +36,7 @@ import {
 
 const FiltersCard: FC = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const project = useProject(projectUuid);
     const expandedSections = useExplorerContext(
         (context) => context.state.expandedSections,
     );
@@ -193,6 +195,7 @@ const FiltersCard: FC = memo(() => {
             <FiltersProvider
                 projectUuid={projectUuid}
                 fieldsMap={fieldsWithSuggestions}
+                startOfWeek={project.data?.warehouseConnection?.startOfWeek}
             >
                 <FiltersForm
                     isEditMode={isEditMode}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -15,12 +15,14 @@ import React, { FC } from 'react';
 import MonthAndYearInput from '../../MonthAndYearInput';
 import WeekPicker from '../../WeekPicker';
 import YearInput from '../../YearInput';
+import { useFiltersContext } from '../FiltersProvider';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 import { MultipleInputsWrapper } from './FilterInputs.styles';
 import UnitOfTimeAutoComplete from './UnitOfTimeAutoComplete';
 
 const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
     const { field, filterRule, onChange, popoverProps, disabled } = props;
+    const { startOfWeek } = useFiltersContext();
     const isTimestamp = field.type === DimensionType.TIMESTAMP;
 
     switch (filterRule.operator) {
@@ -42,6 +44,7 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                                     disabled={disabled}
                                     value={filterRule.values?.[0] || new Date()}
                                     popoverProps={popoverProps}
+                                    startOfWeek={startOfWeek}
                                     onChange={(value: Date) => {
                                         onChange({
                                             ...filterRule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -6,6 +6,7 @@ import {
     FilterOperator,
     formatDate,
     isDimension,
+    isWeekDay,
     parseDate,
     TimeFrames,
     UnitOfTime,
@@ -13,7 +14,7 @@ import {
 import moment from 'moment';
 import React, { FC } from 'react';
 import MonthAndYearInput from '../../MonthAndYearInput';
-import WeekPicker from '../../WeekPicker';
+import WeekPicker, { convertWeekDayToDayPickerWeekDay } from '../../WeekPicker';
 import YearInput from '../../YearInput';
 import { useFiltersContext } from '../FiltersProvider';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
@@ -126,6 +127,11 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                             placement: 'bottom',
                             ...popoverProps,
                         }}
+                        dayPickerProps={{
+                            firstDayOfWeek: isWeekDay(startOfWeek)
+                                ? convertWeekDayToDayPickerWeekDay(startOfWeek)
+                                : undefined,
+                        }}
                     />
                 );
             }
@@ -159,6 +165,11 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                     popoverProps={{
                         placement: 'bottom',
                         ...popoverProps,
+                    }}
+                    dayPickerProps={{
+                        firstDayOfWeek: isWeekDay(startOfWeek)
+                            ? convertWeekDayToDayPickerWeekDay(startOfWeek)
+                            : undefined,
                     }}
                 />
             );

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -1,4 +1,4 @@
-import { FilterableField, FilterRule } from '@lightdash/common';
+import { FilterableField, FilterRule, WeekDay } from '@lightdash/common';
 import React, { createContext, FC, useCallback, useContext } from 'react';
 
 export type FieldWithSuggestions = FilterableField & {
@@ -10,6 +10,7 @@ export type FieldsWithSuggestions = Record<string, FieldWithSuggestions>;
 type FiltersContext = {
     projectUuid: string;
     fieldsMap: FieldsWithSuggestions;
+    startOfWeek?: WeekDay | null;
     getField: (filterRule: FilterRule) => FieldWithSuggestions | undefined;
 };
 
@@ -18,11 +19,13 @@ const Context = createContext<FiltersContext | undefined>(undefined);
 type Props = {
     projectUuid: string;
     fieldsMap: Record<string, FieldWithSuggestions>;
+    startOfWeek?: WeekDay | null;
 };
 
 export const FiltersProvider: FC<Props> = ({
     projectUuid,
     fieldsMap,
+    startOfWeek,
     children,
 }) => {
     const getField = useCallback(
@@ -34,7 +37,9 @@ export const FiltersProvider: FC<Props> = ({
         [fieldsMap],
     );
     return (
-        <Context.Provider value={{ projectUuid, fieldsMap, getField }}>
+        <Context.Provider
+            value={{ projectUuid, fieldsMap, startOfWeek, getField }}
+        >
             {children}
         </Context.Provider>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3804<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- day picker 
- week picker 

Note that when a user picks a week from the week picker we only store the starting day of that week. This might cause problems when the user changes the start of the week configuration.

<a href="https://www.loom.com/share/ddcfc6a2ada346b99804c3b87c50e032">
    <p>Lightdash - date picker start of week - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/ddcfc6a2ada346b99804c3b87c50e032-with-play.gif">
  </a>
