### PR TITLE
chore: add headless browser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - ALLOW_MULTIPLE_ORGS=${ALLOW_MULTIPLE_ORGS:-false}
       - LIGHTDASH_QUERY_MAX_LIMIT=${LIGHTDASH_QUERY_MAX_LIMIT}
       - LIGHTDASH_MAX_PAYLOAD=${LIGHTDASH_MAX_PAYLOAD:-5mb}
+      - HEADLESS_BROWSER_HOST=headless-browser
+      - HEADLESS_BROWSER_PORT=3000
     volumes:
       - "${DBT_PROJECT_DIR}:/usr/app/dbt"
     ports:
@@ -46,6 +48,12 @@ services:
       POSTGRES_DB: ${PGDATABASE:-postgres}
     volumes:
       - db-data:/var/lib/postgresql/data
+
+  headless-browser:
+    image: browserless/chrome
+    restart: always
+    ports:
+      - "3001:3000"
 
 volumes:
   db-data:

--- a/docker/Dockerfile.headless-browser
+++ b/docker/Dockerfile.headless-browser
@@ -1,0 +1,1 @@
+FROM browserless/chrome:latest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -39,6 +39,8 @@ services:
       - EMAIL_SMTP_SENDER_EMAIL=${EMAIL_SMTP_SENDER_EMAIL}
       - ALLOW_MULTIPLE_ORGS=${ALLOW_MULTIPLE_ORGS}
       - LIGHTDASH_QUERY_MAX_LIMIT=${LIGHTDASH_QUERY_MAX_LIMIT}
+      - HEADLESS_BROWSER_HOST=headless-browser
+      - HEADLESS_BROWSER_PORT=3000
     volumes:
       - "../:/usr/app"
       - "../examples/full-jaffle-shop-demo/dbt:/usr/app/dbt"
@@ -56,3 +58,9 @@ services:
       POSTGRES_PASSWORD: ${PGPASSWORD}
     ports:
       - "5432:${PGPORT}"
+
+  headless-browser:
+    image: browserless/chrome
+    restart: always
+    ports:
+      - "3001:3000"

--- a/render.yaml
+++ b/render.yaml
@@ -4,8 +4,11 @@ databases:
   - name: jaffle_db
     ipAllowList: []
 
-
 services:
+  - type: pserv
+    env: docker
+    name: headless-browser
+    dockerfilePath: docker/Dockerfile.headless-browser
   - type: web
     env: docker
     name: lightdash
@@ -40,6 +43,16 @@ services:
         value: true
       - key: TRUST_PROXY
         value: true
+      - key: HEADLESS_BROWSER_PORT
+        fromService:
+          type: pserv
+          name: headless-browser
+          property: host
+      - key: HEADLESS_BROWSER_HOST
+        fromService:
+          type: pserv
+          name: headless-browser
+          property: port
 
 envVarGroups:
   - name: rudder-settings


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3823 

### Description:

Adds a new microservice running a headless chrome browser. Microservice runs in docker-compose and render environments (used for previews).

Separate updates needed:
- [ ] private helm charts
- [ ] public helm charts
- [ ] demo environment
- [ ] 1-click heroku
- [ ] 1-click render

We can merge those separately, I want to be sure this works in render first. 
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
