### PR TITLE
feat: hide share space button if user does not have space permissions

### DIFF
--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -78,7 +78,18 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                 </PageBreadcrumbsWrapper>
 
                 <div>
-                    <ShareSpaceModal space={space} projectUuid={projectUuid} />
+                    <Can
+                        I="manage"
+                        this={subject('Space', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid,
+                        })}
+                    >
+                        <ShareSpaceModal
+                            space={space}
+                            projectUuid={projectUuid}
+                        />
+                    </Can>
 
                     <SpaceBrowserMenu
                         onRename={() => setUpdateSpace(true)}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3825

### Description:
Without  `manage` space permissions
![Screenshot from 2022-11-23 11-16-17](https://user-images.githubusercontent.com/1983672/203522177-fb653b01-fe32-4917-b93f-3fd03afe36b6.png)


With `manage` space permissions
![Screenshot from 2022-11-23 11-16-21](https://user-images.githubusercontent.com/1983672/203522170-b2ba0e8b-32d0-4337-ab36-89d492b7a1af.png)

