### PR TITLE
style: permissions modal

### DIFF
--- a/packages/frontend/src/App.styles.tsx
+++ b/packages/frontend/src/App.styles.tsx
@@ -6,6 +6,11 @@ const AppStyle = createGlobalStyle`
         color: ${Colors.GRAY3};
     }
 
+    .bp4-dialog-container {
+        padding-top: 110px; !important;
+        align-items: flex-start !important;
+    }
+
     .ace_editor.ace_autocomplete {
         width: 500px;
     }

--- a/packages/frontend/src/App.styles.tsx
+++ b/packages/frontend/src/App.styles.tsx
@@ -1,6 +1,11 @@
+import { Colors } from '@blueprintjs/core';
 import { createGlobalStyle } from 'styled-components';
 
 const AppStyle = createGlobalStyle`
+    .bp4-multi-select-tag-input-input::placeholder {
+        color: ${Colors.GRAY3};
+    }
+
     .ace_editor.ace_autocomplete {
         width: 500px;
     }

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@blueprintjs/core';
 import { Select2 } from '@blueprintjs/select';
 import { Space } from '@lightdash/common';
 import { FC } from 'react';
@@ -11,6 +12,7 @@ import {
     ChangeAccessButton,
     MemberAccess,
     ShareTag,
+    UserRole,
 } from './ShareSpaceModal.style';
 import {
     AccessOption,
@@ -40,21 +42,23 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
     );
     return (
         <AccessWrapper>
-            <ShareTag
-                round
-                large
-                icon={
-                    selectedAccess.value === SpaceAccessType.PRIVATE
-                        ? 'lock'
-                        : 'people'
-                }
-            />
+            <ShareTag>
+                <Icon
+                    icon={
+                        selectedAccess.value === SpaceAccessType.PRIVATE
+                            ? 'lock'
+                            : 'people'
+                    }
+                />
+            </ShareTag>
+
             <MemberAccess>
                 <AccessName>Members of {project?.name}</AccessName>
                 <AccessDescription>
                     {selectedAccess.description}
                 </AccessDescription>
             </MemberAccess>
+
             <AccessRole>
                 <Select2<AccessOption>
                     filterable={false}
@@ -76,14 +80,13 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
                         }
                     }}
                     popoverProps={{
-                        placement: 'bottom-end',
+                        minimal: true,
+                        position: 'bottom-right',
                     }}
                 >
-                    <ChangeAccessButton
-                        minimal
-                        text={selectedAccess.title}
-                        rightIcon="caret-down"
-                    />
+                    <ChangeAccessButton minimal rightIcon="caret-down">
+                        <UserRole>{selectedAccess.title}</UserRole>
+                    </ChangeAccessButton>
                 </Select2>
             </AccessRole>
         </AccessWrapper>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
@@ -8,7 +8,7 @@ import {
     AccessRole,
     ChangeAccessButton,
     FlexWrapper,
-    MemberAccess,
+    PrimaryAndSecondaryTextWrapper,
     PrimaryText,
     SecondaryText,
     ShareCircle,
@@ -52,10 +52,10 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
                 />
             </ShareCircle>
 
-            <MemberAccess>
+            <PrimaryAndSecondaryTextWrapper>
                 <PrimaryText>Members of {project?.name}</PrimaryText>
                 <SecondaryText>{selectedAccess.description}</SecondaryText>
-            </MemberAccess>
+            </PrimaryAndSecondaryTextWrapper>
 
             <AccessRole>
                 <Select2<AccessOption>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
@@ -5,13 +5,13 @@ import { FC } from 'react';
 import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSpaces';
 import {
-    AccessDescription,
-    AccessName,
     AccessRole,
     AccessWrapper,
     ChangeAccessButton,
     MemberAccess,
-    ShareTag,
+    PrimaryText,
+    SecondaryText,
+    ShareCircle,
     UserRole,
 } from './ShareSpaceModal.style';
 import {
@@ -42,7 +42,7 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
     );
     return (
         <AccessWrapper>
-            <ShareTag>
+            <ShareCircle>
                 <Icon
                     icon={
                         selectedAccess.value === SpaceAccessType.PRIVATE
@@ -50,13 +50,11 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
                             : 'people'
                     }
                 />
-            </ShareTag>
+            </ShareCircle>
 
             <MemberAccess>
-                <AccessName>Members of {project?.name}</AccessName>
-                <AccessDescription>
-                    {selectedAccess.description}
-                </AccessDescription>
+                <PrimaryText>Members of {project?.name}</PrimaryText>
+                <SecondaryText>{selectedAccess.description}</SecondaryText>
             </MemberAccess>
 
             <AccessRole>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAccessType.tsx
@@ -6,8 +6,8 @@ import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSpaces';
 import {
     AccessRole,
-    AccessWrapper,
     ChangeAccessButton,
+    FlexWrapper,
     MemberAccess,
     PrimaryText,
     SecondaryText,
@@ -41,7 +41,7 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
         space.uuid,
     );
     return (
-        <AccessWrapper>
+        <FlexWrapper>
             <ShareCircle>
                 <Icon
                     icon={
@@ -87,6 +87,6 @@ export const ShareSpaceAccessType: FC<ShareSpaceAccessTypeProps> = ({
                     </ChangeAccessButton>
                 </Select2>
             </AccessRole>
-        </AccessWrapper>
+        </FlexWrapper>
     );
 };

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -102,14 +102,17 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 <MenuItem2
                     active={modifiers.active}
                     icon={
-                        <SelectIcon
-                            icon={
-                                usersSelected.includes(user.userUuid) ||
-                                isDisabled
-                                    ? 'tick'
-                                    : 'blank'
-                            }
-                        />
+                        <UserTag large round>
+                            {getInitials(user.userUuid, organizationUsers)}
+                        </UserTag>
+                        // <SelectIcon
+                        //     icon={
+                        //         usersSelected.includes(user.userUuid) ||
+                        //         isDisabled
+                        //             ? 'tick'
+                        //             : 'blank'
+                        //     }
+                        // />
                     }
                     key={user.userUuid}
                     title={
@@ -119,10 +122,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                     }
                     disabled={isDisabled}
                     text={
-                        <FlexWrapper key={`render_${user.userUuid}`}>
-                            <UserTag large round>
-                                {getInitials(user.userUuid, organizationUsers)}
-                            </UserTag>
+                        <FlexWrapper key={user.userUuid}>
                             <MemberAccess>
                                 <AccessName>
                                     {user.firstName} {user.lastName}
@@ -171,8 +171,9 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 }
                 resetOnQuery={true}
                 popoverProps={{
+                    minimal: true,
+                    matchTargetWidth: true,
                     onClosing: () => setSearchQuery(''),
-                    placement: 'bottom-start',
                 }}
                 tagInputProps={{
                     placeholder: 'Start typing to search for users...',
@@ -187,6 +188,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 }}
                 selectedItems={usersSelected}
             />
+
             <ShareButton
                 text="Share"
                 intent="primary"

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -121,7 +121,6 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                                 <PrimaryText>
                                     {user.firstName} {user.lastName}
                                 </PrimaryText>
-
                                 <SecondaryText>{user.email}</SecondaryText>
                             </MemberAccess>
                         </FlexWrapper>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -1,3 +1,4 @@
+import { Classes } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemPredicate, ItemRenderer, MultiSelect2 } from '@blueprintjs/select';
 import {
@@ -10,7 +11,7 @@ import { useProjectAccess } from '../../../hooks/useProjectAccess';
 import { useAddSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
     FlexWrapper,
-    MemberAccess,
+    PrimaryAndSecondaryTextWrapper,
     PrimaryText,
     SecondaryText,
     ShareButton,
@@ -90,20 +91,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 .map((access) => access.userUuid)
                 .includes(user.userUuid);
 
+            const isSelected = usersSelected.includes(user.userUuid);
+
             return (
                 <MenuItem2
-                    active={modifiers.active}
-                    icon={
-                        null
-                        // <SelectIcon
-                        //     icon={
-                        //         usersSelected.includes(user.userUuid) ||
-                        //         isDisabled
-                        //             ? 'tick'
-                        //             : 'blank'
-                        //     }
-                        // />
-                    }
+                    className={isSelected ? Classes.SELECTED : ''}
                     key={user.userUuid}
                     title={
                         isDisabled
@@ -117,12 +109,14 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                                 {getInitials(user.userUuid, organizationUsers)}
                             </UserCircle>
 
-                            <MemberAccess>
-                                <PrimaryText>
+                            <PrimaryAndSecondaryTextWrapper
+                                $disabled={isDisabled}
+                            >
+                                <PrimaryText $selected={isSelected}>
                                     {user.firstName} {user.lastName}
                                 </PrimaryText>
                                 <SecondaryText>{user.email}</SecondaryText>
-                            </MemberAccess>
+                            </PrimaryAndSecondaryTextWrapper>
                         </FlexWrapper>
                     }
                     onClick={(e) => {

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -9,7 +9,6 @@ import { FC, useCallback, useMemo, useState } from 'react';
 import { useProjectAccess } from '../../../hooks/useProjectAccess';
 import { useAddSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
-    AddUsersWrapper,
     FlexWrapper,
     MemberAccess,
     PrimaryText,
@@ -143,11 +142,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 />
             );
         },
-        [usersSelected, space, organizationUsers, organizationUsers],
+        [usersSelected, space, organizationUsers],
     );
 
     return (
-        <AddUsersWrapper>
+        <FlexWrapper>
             <MultiSelect2
                 fill
                 itemPredicate={filterUser}
@@ -194,6 +193,6 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                     setUsersSelected([]);
                 }}
             />
-        </AddUsersWrapper>
+        </FlexWrapper>
     );
 };

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -38,6 +38,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         projectUuid,
         space.uuid,
     );
+
     const userUuids: string[] = useMemo(() => {
         if (organizationUsers === undefined) return [];
         const projectUserUuids =
@@ -64,6 +65,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         },
         [organizationUsers],
     );
+
     const handleRemove = useCallback(
         (selectedValue: React.ReactNode) => {
             setUsersSelected(
@@ -89,13 +91,13 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
 
             const isDisabled = space.access
                 .map((access) => access.userUuid)
-                .includes(user.userUuid);
+                .includes(userUuid);
 
-            const isSelected = usersSelected.includes(user.userUuid);
+            const isSelected = usersSelected.includes(userUuid) && !isDisabled;
 
             return (
                 <MenuItem2
-                    className={isSelected ? Classes.SELECTED : ''}
+                    className={isSelected ? Classes.SELECTED : undefined}
                     key={user.userUuid}
                     title={
                         isDisabled
@@ -112,10 +114,21 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                             <PrimaryAndSecondaryTextWrapper
                                 $disabled={isDisabled}
                             >
-                                <PrimaryText $selected={isSelected}>
-                                    {user.firstName} {user.lastName}
-                                </PrimaryText>
-                                <SecondaryText>{user.email}</SecondaryText>
+                                {user.firstName || user.lastName ? (
+                                    <>
+                                        <PrimaryText $selected={isSelected}>
+                                            {user.firstName} {user.lastName}
+                                        </PrimaryText>
+
+                                        <SecondaryText>
+                                            {user.email}
+                                        </SecondaryText>
+                                    </>
+                                ) : (
+                                    <PrimaryText $selected={isSelected}>
+                                        {user.email}
+                                    </PrimaryText>
+                                )}
                             </PrimaryAndSecondaryTextWrapper>
                         </FlexWrapper>
                     }

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemPredicate, ItemRenderer, MultiSelect2 } from '@blueprintjs/select';
 import {
@@ -7,23 +6,18 @@ import {
     Space,
 } from '@lightdash/common';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { useHistory } from 'react-router-dom';
-import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectAccess } from '../../../hooks/useProjectAccess';
 import { useAddSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
-    AccessDescription,
-    AccessName,
     AddUsersWrapper,
     FlexWrapper,
     MemberAccess,
-    SelectIcon,
+    PrimaryText,
+    SecondaryText,
     ShareButton,
-    UserTag,
+    UserCircle,
 } from './ShareSpaceModal.style';
 import { getInitials, getUserNameOrEmail } from './Utils';
-
-const StyledSpinner = () => <Spinner size={16} style={{ margin: 12 }} />;
 
 interface ShareSpaceAddUserProps {
     space: Space;
@@ -39,8 +33,6 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     const [usersSelected, setUsersSelected] = useState<string[]>([]);
     const [searchQuery, setSearchQuery] = useState<string>('');
     const { data: projectAccess } = useProjectAccess(projectUuid);
-    const { showToastError } = useToaster();
-    const history = useHistory();
 
     const { mutate: shareSpaceMutation } = useAddSpaceShareMutation(
         projectUuid,
@@ -96,15 +88,14 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
             if (!user) return null;
 
             const isDisabled = space.access
-                ?.map((access) => access.userUuid)
+                .map((access) => access.userUuid)
                 .includes(user.userUuid);
+
             return (
                 <MenuItem2
                     active={modifiers.active}
                     icon={
-                        <UserTag large round>
-                            {getInitials(user.userUuid, organizationUsers)}
-                        </UserTag>
+                        null
                         // <SelectIcon
                         //     icon={
                         //         usersSelected.includes(user.userUuid) ||
@@ -123,13 +114,16 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                     disabled={isDisabled}
                     text={
                         <FlexWrapper key={user.userUuid}>
+                            <UserCircle>
+                                {getInitials(user.userUuid, organizationUsers)}
+                            </UserCircle>
+
                             <MemberAccess>
-                                <AccessName>
+                                <PrimaryText>
                                     {user.firstName} {user.lastName}
-                                </AccessName>
-                                <AccessDescription>
-                                    {user.email}
-                                </AccessDescription>
+                                </PrimaryText>
+
+                                <SecondaryText>{user.email}</SecondaryText>
                             </MemberAccess>
                         </FlexWrapper>
                     }

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -63,7 +63,7 @@ export const PrimaryText = styled.div<PrimaryButtonProps>`
     flex: 1;
     font-weight: 600;
     font-size: 13px;
-    color: ${(props) => (props.$selected ? Colors.BLUE3 : Colors.DARK_GRAY1)};
+    color: ${(props) => (props.$selected ? Colors.BLUE2 : Colors.DARK_GRAY1)};
 `;
 
 PrimaryText.defaultProps = {

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -1,4 +1,12 @@
-import { AnchorButton, Button, Colors, Icon, Tag } from '@blueprintjs/core';
+import {
+    AnchorButton,
+    Button,
+    Classes,
+    Colors,
+    Icon,
+    Tag,
+} from '@blueprintjs/core';
+import { MultiSelect2 } from '@blueprintjs/select';
 import styled, { css } from 'styled-components';
 
 export const OpenShareModal = styled(Button)`
@@ -7,6 +15,7 @@ export const OpenShareModal = styled(Button)`
 
 export const AddUsersWrapper = styled.div`
     display: flex;
+    align-items: center;
     gap: 10px;
 `;
 
@@ -24,6 +33,8 @@ export const ListUserWrapper = styled.div`
 
 export const FlexWrapper = styled.div`
     display: flex;
+    align-items: center;
+    gap: 12px;
 `;
 
 export const ShareButton = styled(Button)`
@@ -47,57 +58,57 @@ const commonTagStyle = css`
     align-items: center;
 `;
 
-export const ShareTag = styled.div`
+export const ShareCircle = styled.div`
     ${commonTagStyle}
     background-color: ${Colors.LIGHT_GRAY4};
     color: ${Colors.GRAY1};
 `;
 
-export const UserTag = styled.div`
+export const UserCircle = styled.div`
     ${commonTagStyle}
     background-color: ${Colors.GRAY3};
     color: ${Colors.WHITE};
 `;
 
 export const MemberAccess = styled.div`
-    flex: auto;
+    flex-grow: 1;
+    overflow: hidden;
+    max-width: 100%;
 `;
 
-export const AccessSelectTitle = styled.div`
-    font-weight: 600;
-    font-size: 13px;
-
-    color: ${Colors.DARK_GRAY1};
-`;
-
-export const AccessSelectSubtitle = styled.div`
-    font-weight: 400;
-    font-size: 12px;
-    color: ${Colors.GRAY2};
-    width: 200px;
-`;
-
-export const AccessName = styled.div`
-    font-weight: 600;
-    font-size: 13px;
-`;
-
-export const AccessDescription = styled.div`
-    font-size: 12px;
-    font-weight: 400;
-    color: ${Colors.GRAY1};
-`;
-
-export const UserName = styled.div`
+export const PrimaryText = styled.div`
     flex: 1;
     font-weight: 600;
     font-size: 13px;
+    color: ${Colors.DARK_GRAY1};
+`;
+
+PrimaryText.defaultProps = {
+    className: Classes.TEXT_OVERFLOW_ELLIPSIS,
+};
+
+const secondaryTextStyles = css`
+    font-weight: 400;
+    font-size: 12px;
+    color: ${Colors.GRAY2};
+`;
+
+export const SecondaryText = styled.div`
+    ${secondaryTextStyles}
+`;
+
+SecondaryText.defaultProps = {
+    className: Classes.TEXT_OVERFLOW_ELLIPSIS,
+};
+
+export const SecondaryTextWithMaxWidth = styled.div`
+    ${secondaryTextStyles};
+    max-width: 200px;
 `;
 
 export const AccessRole = styled.div`
     flex-grow: 0;
     flex-shrink: 0;
-    text-align: right;
 `;
 
 export const DialogBody = styled.div`
@@ -116,7 +127,8 @@ export const DialogFooter = styled.div`
     font-size: 12px;
     font-weight: 400;
 
-    padding: 10px 20px;
+    padding: 10px 20px 12px 20px;
+    // 12px is intentional to fix optical alignment
 `;
 
 export const UserRole = styled.div`
@@ -129,4 +141,8 @@ export const YouLabel = styled.span`
     font-weight: 300;
 `;
 
-export const SelectIcon = styled(Icon)``;
+export const lighterPlaceholderTextStyle = css`
+    &::placeholder {
+        color: ${Colors.GRAY3};
+    }
+`;

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -62,6 +62,7 @@ PrimaryText.defaultProps = {
 };
 
 const secondaryTextStyles = css`
+    flex: 1;
     font-weight: 400;
     font-size: 12px;
     color: ${Colors.GRAY2};

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -44,17 +44,26 @@ export const UserCircle = styled.div`
     color: ${Colors.WHITE};
 `;
 
-export const MemberAccess = styled.div`
+interface PrimaryAndSecondaryTextWrapperProps {
+    $disabled?: boolean;
+}
+
+export const PrimaryAndSecondaryTextWrapper = styled.div<PrimaryAndSecondaryTextWrapperProps>`
     flex-grow: 1;
     overflow: hidden;
     max-width: 100%;
+    ${({ $disabled }) => ($disabled ? `opacity: 0.5;` : '')}
 `;
 
-export const PrimaryText = styled.div`
+interface PrimaryButtonProps {
+    $selected?: boolean;
+}
+
+export const PrimaryText = styled.div<PrimaryButtonProps>`
     flex: 1;
     font-weight: 600;
     font-size: 13px;
-    color: ${Colors.DARK_GRAY1};
+    color: ${(props) => (props.$selected ? Colors.BLUE3 : Colors.DARK_GRAY1)};
 `;
 
 PrimaryText.defaultProps = {

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -1,40 +1,14 @@
-import {
-    AnchorButton,
-    Button,
-    Classes,
-    Colors,
-    Icon,
-    Tag,
-} from '@blueprintjs/core';
-import { MultiSelect2 } from '@blueprintjs/select';
+import { AnchorButton, Button, Classes, Colors } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
 export const OpenShareModal = styled(Button)`
     margin-right: 10px;
 `;
 
-export const AddUsersWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 10px;
-`;
-
-export const AccessWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 10px;
-`;
-
-export const ListUserWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 10px;
-`;
-
 export const FlexWrapper = styled.div`
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
 `;
 
 export const ShareButton = styled(Button)`
@@ -139,10 +113,4 @@ export const UserRole = styled.div`
 
 export const YouLabel = styled.span`
     font-weight: 300;
-`;
-
-export const lighterPlaceholderTextStyle = css`
-    &::placeholder {
-        color: ${Colors.GRAY3};
-    }
 `;

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -1,5 +1,5 @@
-import { Button, Card, Colors, H5, Icon, Tag } from '@blueprintjs/core';
-import styled from 'styled-components';
+import { AnchorButton, Button, Colors, Icon, Tag } from '@blueprintjs/core';
+import styled, { css } from 'styled-components';
 
 export const OpenShareModal = styled(Button)`
     margin-right: 10px;
@@ -7,18 +7,19 @@ export const OpenShareModal = styled(Button)`
 
 export const AddUsersWrapper = styled.div`
     display: flex;
-    margin: 5px 5px 15px 5px;
+    gap: 10px;
 `;
 
 export const AccessWrapper = styled.div`
     display: flex;
-
-    margin: 5px 5px 5px 5px;
+    align-items: center;
+    gap: 10px;
 `;
 
 export const ListUserWrapper = styled.div`
     display: flex;
-    margin: 15px 5px 5px 5px;
+    align-items: center;
+    gap: 10px;
 `;
 
 export const FlexWrapper = styled.div`
@@ -28,109 +29,104 @@ export const FlexWrapper = styled.div`
 export const ShareButton = styled(Button)`
     width: 100px;
     text-align: center;
-    margin-left: 10px;
     border-radius: 3px;
 `;
 
-export const ChangeAccessButton = styled(Button)`
-    padding-right: 0;
-    font-weight: 500;
-    font-size: 13px;
-    text-align: right;
-    margin-top: 2px;
+export const ChangeAccessButton = styled(AnchorButton)`
+    height: 24px;
+    padding: 0 2px 0 5px;
 `;
-export const ShareTag = styled(Tag)`
+
+const commonTagStyle = css`
     width: 35px;
     height: 35px;
-    padding: 0 0 0 10px !important;
+    border-radius: 100%;
+    display: flex;
+    flex-shrink: 0;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const ShareTag = styled.div`
+    ${commonTagStyle}
     background-color: ${Colors.LIGHT_GRAY4};
     color: ${Colors.GRAY1};
-    margin-top: 4px;
 `;
-export const UserTag = styled(Tag)`
-    width: 35px;
-    height: 35px;
-    padding: 0 !important;
-    text-align: center;
-    background-color: #8f99a8;
-    margin-top: 4px;
+
+export const UserTag = styled.div`
+    ${commonTagStyle}
+    background-color: ${Colors.GRAY3};
     color: ${Colors.WHITE};
 `;
 
 export const MemberAccess = styled.div`
     flex: auto;
-    margin: 0px 0px 0 10px;
 `;
 
-export const AccessSelectTitle = styled.p`
+export const AccessSelectTitle = styled.div`
     font-weight: 600;
     font-size: 13px;
-    line-height: 20px;
-    margin-bottom: 0;
 
     color: ${Colors.DARK_GRAY1};
 `;
 
-export const AccessSelectSubtitle = styled.p`
+export const AccessSelectSubtitle = styled.div`
     font-weight: 400;
     font-size: 12px;
-    line-height: 18px;
     color: ${Colors.GRAY2};
     width: 200px;
-    margin-bottom: 0;
 `;
 
-export const AccessName = styled.p`
+export const AccessName = styled.div`
     font-weight: 600;
     font-size: 13px;
-    line-height: 20px;
-    margin-bottom: 0;
 `;
-export const AccessDescription = styled.p`
+
+export const AccessDescription = styled.div`
     font-size: 12px;
     font-weight: 400;
-    line-height: 20px;
     color: ${Colors.GRAY1};
-    margin-bottom: 0;
 `;
-export const UserName = styled.p`
-    flex: auto;
 
+export const UserName = styled.div`
+    flex: 1;
     font-weight: 600;
     font-size: 13px;
-    line-height: 20px;
-    margin: 10px 0px 0 10px;
 `;
+
 export const AccessRole = styled.div`
-    flex: 2;
+    flex-grow: 0;
+    flex-shrink: 0;
     text-align: right;
+`;
+
+export const DialogBody = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 20px;
 `;
 
 export const DialogFooter = styled.div`
-    height: 40px;
     background-color: ${Colors.LIGHT_GRAY5};
     border-top: 1px solid ${Colors.LIGHT_GRAY1};
-    border-radius: 2px;
+    border-radius: 0 0 2px 2px;
 
-    p {
-        color: ${Colors.GRAY1};
-        font-size: 12px;
-        line-height: 18px;
-        font-weight: 400;
-        margin: 11px 0 9px 21px;
-    }
+    color: ${Colors.GRAY1};
+    font-size: 12px;
+    font-weight: 400;
+
+    padding: 10px 20px;
 `;
 
 export const UserRole = styled.div`
-    flex: 2;
     text-align: right;
-    margin-top: 5px;
-    font-weight: 500;
-    font-size: 13px;
+    font-weight: 500 !important;
+    font-size: 13px !important;
 `;
+
 export const YouLabel = styled.span`
     font-weight: 300;
 `;
-export const SelectIcon = styled(Icon)`
-    margin-top: 24px;
-`;
+
+export const SelectIcon = styled(Icon)``;

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModal.style.ts
@@ -8,7 +8,7 @@ export const OpenShareModal = styled(Button)`
 export const FlexWrapper = styled.div`
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 12px;
 `;
 
 export const ShareButton = styled(Button)`

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceSelect.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceSelect.tsx
@@ -1,8 +1,8 @@
 import { MenuItem2 } from '@blueprintjs/popover2';
 import { ItemRenderer } from '@blueprintjs/select';
 import {
-    AccessSelectSubtitle,
-    AccessSelectTitle,
+    PrimaryText,
+    SecondaryTextWithMaxWidth,
 } from './ShareSpaceModal.style';
 
 export interface AccessOption {
@@ -14,25 +14,25 @@ export interface AccessOption {
 
 export const renderAccess: ItemRenderer<AccessOption> = (
     access,
-    { handleClick, handleFocus, modifiers, query },
+    { handleClick, handleFocus, modifiers },
 ) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
     return (
         <MenuItem2
+            key={access.value}
             multiline={true}
             active={modifiers.active}
             disabled={modifiers.disabled}
-            key={access.value}
             onClick={handleClick}
             onFocus={handleFocus}
             text={
                 <>
-                    <AccessSelectTitle>{access.title}</AccessSelectTitle>
-                    <AccessSelectSubtitle>
+                    <PrimaryText>{access.title}</PrimaryText>
+                    <SecondaryTextWithMaxWidth>
                         {access.selectDescription}
-                    </AccessSelectSubtitle>
+                    </SecondaryTextWithMaxWidth>
                 </>
             }
         />

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceSelect.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceSelect.tsx
@@ -43,6 +43,7 @@ export const enum SpaceAccessType {
     PRIVATE = 'private',
     PUBLIC = 'public',
 }
+
 export const SpaceAccessOptions: AccessOption[] = [
     {
         title: 'Restricted access',

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -8,7 +8,6 @@ import { upperFirst } from 'lodash-es';
 import { FC } from 'react';
 import { useDeleteSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
-    AddUsersWrapper,
     ChangeAccessButton,
     ListUserWrapper,
     UserName,
@@ -74,12 +73,13 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                     );
                     return (
                         <ListUserWrapper key={sharedUser.userUuid}>
-                            <UserTag round large>
+                            <UserTag>
                                 {getInitials(
                                     sharedUser.userUuid,
                                     organizationUsers,
                                 )}
                             </UserTag>
+
                             <UserName>
                                 {getUserNameOrEmail(
                                     sharedUser.userUuid,
@@ -87,6 +87,7 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                                 )}
                                 {isYou ? <YouLabel> (you)</YouLabel> : ''}
                             </UserName>
+
                             {isYou ? (
                                 <UserRole>{role}</UserRole>
                             ) : (
@@ -111,8 +112,9 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                                     <ChangeAccessButton
                                         minimal
                                         rightIcon="caret-down"
-                                        text={role}
-                                    />
+                                    >
+                                        <UserRole>{role}</UserRole>
+                                    </ChangeAccessButton>
                                 </Select2>
                             )}
                         </ListUserWrapper>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -3,6 +3,7 @@ import {
     LightdashUser,
     OrganizationMemberProfile,
     Space,
+    SpaceShare,
 } from '@lightdash/common';
 import { upperFirst } from 'lodash-es';
 import { FC } from 'react';
@@ -10,9 +11,9 @@ import { useDeleteSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
     ChangeAccessButton,
     ListUserWrapper,
-    UserName,
+    PrimaryText,
+    UserCircle,
     UserRole,
-    UserTag,
     YouLabel,
 } from './ShareSpaceModal.style';
 import { AccessOption, renderAccess } from './ShareSpaceSelect';
@@ -54,11 +55,20 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
         space.uuid,
     );
 
+    const userIsYou = (spaceShare: SpaceShare) =>
+        spaceShare.userUuid === sessionUser?.userUuid;
+
     return (
         <>
-            {space.access &&
-                space.access.map((sharedUser) => {
-                    const isYou = sessionUser?.userUuid === sharedUser.userUuid;
+            {space.access
+                .sort((a, b) => {
+                    if (userIsYou(a) && !userIsYou(b)) return -1;
+                    if (!userIsYou(a) && userIsYou(b)) return 1;
+                    return 0;
+                })
+
+                .map((sharedUser) => {
+                    const isYou = userIsYou(sharedUser);
                     const role = upperFirst(sharedUser.role?.toString() || '');
 
                     const userAccessTypes = UserAccessOptions.map(
@@ -71,22 +81,23 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                                 : accessType;
                         },
                     );
+
                     return (
                         <ListUserWrapper key={sharedUser.userUuid}>
-                            <UserTag>
+                            <UserCircle>
                                 {getInitials(
                                     sharedUser.userUuid,
                                     organizationUsers,
                                 )}
-                            </UserTag>
+                            </UserCircle>
 
-                            <UserName>
+                            <PrimaryText>
                                 {getUserNameOrEmail(
                                     sharedUser.userUuid,
                                     organizationUsers,
                                 )}
                                 {isYou ? <YouLabel> (you)</YouLabel> : ''}
-                            </UserName>
+                            </PrimaryText>
 
                             {isYou ? (
                                 <UserRole>{role}</UserRole>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -10,7 +10,7 @@ import { FC } from 'react';
 import { useDeleteSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
     ChangeAccessButton,
-    ListUserWrapper,
+    FlexWrapper,
     PrimaryText,
     UserCircle,
     UserRole,
@@ -83,7 +83,7 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                     );
 
                     return (
-                        <ListUserWrapper key={sharedUser.userUuid}>
+                        <FlexWrapper key={sharedUser.userUuid}>
                             <UserCircle>
                                 {getInitials(
                                     sharedUser.userUuid,
@@ -128,7 +128,7 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                                     </ChangeAccessButton>
                                 </Select2>
                             )}
-                        </ListUserWrapper>
+                        </FlexWrapper>
                     );
                 })}
         </>

--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -72,6 +72,7 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                         selectedAccess={selectedAccess}
                         setSelectedAccess={setSelectedAccess}
                     />
+
                     {selectedAccess.value === SpaceAccessType.PRIVATE && (
                         <ShareSpaceUserList
                             projectUuid={projectUuid}

--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -1,14 +1,16 @@
 import { Classes, Dialog } from '@blueprintjs/core';
-
 import { Space } from '@lightdash/common';
 import { FC, useState } from 'react';
-import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
-import { DialogFooter, OpenShareModal } from './ShareSpaceModal.style';
-
 import { Link } from 'react-router-dom';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useApp } from '../../../providers/AppProvider';
 import { ShareSpaceAccessType } from './ShareSpaceAccessType';
 import { ShareSpaceAddUser } from './ShareSpaceAddUser';
+import {
+    DialogBody,
+    DialogFooter,
+    OpenShareModal,
+} from './ShareSpaceModal.style';
 import {
     AccessOption,
     SpaceAccessOptions,
@@ -50,12 +52,12 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                     paddingBottom: 0,
                     backgroundColor: 'white',
                 }}
-                title={`Share '${space.name}'`}
+                title={`Share ’${space.name}’`}
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
                 lazy
             >
-                <div className={Classes.DIALOG_BODY}>
+                <DialogBody>
                     {selectedAccess.value === SpaceAccessType.PRIVATE ? (
                         <ShareSpaceAddUser
                             space={space}
@@ -63,6 +65,7 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                             organizationUsers={organizationUsers}
                         />
                     ) : null}
+
                     <ShareSpaceAccessType
                         projectUuid={projectUuid}
                         space={space}
@@ -77,20 +80,21 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                             organizationUsers={organizationUsers}
                         />
                     )}
-                </div>
+                </DialogBody>
+
                 <DialogFooter>
                     {sessionUser.data?.ability?.can('create', 'InviteLink') ? (
-                        <p>
-                            Can’t find a user? Spaces can only be shared with{' '}
+                        <>
+                            Can’t find a user? Saces can only be shared with{' '}
                             <Link
                                 to={`/generalSettings/projectManagement/${projectUuid}/projectAccess`}
                             >
                                 existing project members
                             </Link>
                             .
-                        </p>
+                        </>
                     ) : (
-                        <p>
+                        <>
                             Learn more about permissions in our{' '}
                             <a
                                 href="https://docs.lightdash.com/references/roles"
@@ -100,7 +104,7 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                                 docs
                             </a>
                             .
-                        </p>
+                        </>
                     )}
                 </DialogFooter>
             </Dialog>

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -4,8 +4,8 @@ import App from './App';
 import './index.css';
 
 ReactDOM.render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>,
+    // <React.StrictMode>
+    <App />,
+    // </React.StrictMode>,
     document.getElementById('root') as HTMLElement,
 );

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -4,8 +4,8 @@ import App from './App';
 import './index.css';
 
 ReactDOM.render(
-    // <React.StrictMode>
-    <App />,
-    // </React.StrictMode>,
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>,
     document.getElementById('root') as HTMLElement,
 );


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3817

### Description:

- [x] 1. "Full Access and "Admin" should have the same font-weight ( Admin is the correct one). This is my bad - figma error!
<img width="509" alt="CleanShot 2022-11-25 at 00 02 45@2x" src="https://user-images.githubusercontent.com/962095/203857332-2ae25a10-31e1-424f-8096-c2b04ef856c1.png">


- [x] 2. Members of Thyme to shine Market > Members of 'Thyme to shine Market' with an elipsis(...) if the text is too long (we have preview projects where the project names are really long)

<img width="522" alt="CleanShot 2022-11-25 at 00 18 24@2x" src="https://user-images.githubusercontent.com/962095/203858662-979a64b6-7af6-497f-ae16-feb7552a9ab1.png">

<img width="544" alt="CleanShot 2022-11-25 at 00 13 20@2x" src="https://user-images.githubusercontent.com/962095/203858229-dbca5561-95af-471d-abe7-ba9b76c8c76d.png">

<img width="545" alt="CleanShot 2022-11-25 at 00 17 20@2x" src="https://user-images.githubusercontent.com/962095/203858569-237742c5-aff5-4117-ac71-dce4cb242cad.png">

- [x] 3. Get rid of the tick on the left-hand-side of the user's name. If the user is selected, the background colour will be blue.

![CleanShot 2022-11-25 at 01 13 45@2x](https://user-images.githubusercontent.com/962095/203863964-793e09a2-64e1-4f7c-9418-9b027ca55635.png)


- [x] 4. Get rid of the popover arrow (the triangle). It can work like a normal dropdown, rather than a popover.

<img width="367" alt="CleanShot 2022-11-25 at 00 45 36@2x" src="https://user-images.githubusercontent.com/962095/203860786-03358045-3027-4938-95ba-f8d5fb2f8d5c.png">

<img width="278" alt="CleanShot 2022-11-25 at 00 45 39@2x" src="https://user-images.githubusercontent.com/962095/203860789-e75a1e0d-e702-4ec3-86c6-53b95aca4e31.png">


- [x] 5. The Share button should not increase in height when the input increases in height. It should either be pinned to the top, or remain in the middle. Check out Figma for inspo.

<img width="536" alt="CleanShot 2022-11-24 at 23 52 38@2x" src="https://user-images.githubusercontent.com/962095/203856408-c9b151bb-f504-4d37-91e3-179f4921239c.png">


- [x] 6. The modal should have a fixed position further up top on the page ( its position should not jump around on the page as it increases/decreases in height)

https://user-images.githubusercontent.com/962095/203865970-c7ef3836-531e-4c52-87ad-3f7688f0cdf2.mp4


- [x] 7.Bottom user's name is not aligned with role.

<img width="504" alt="CleanShot 2022-11-25 at 00 47 37@2x" src="https://user-images.githubusercontent.com/962095/203860925-dcb9b874-89dc-40eb-b9f5-960c3a3c39f9.png">


- [x] 8. Placeholder text colour in the input should be lighter (it should match the colour of the placeholder text in the 'create new space' modal

<img width="462" alt="CleanShot 2022-11-25 at 00 47 02@2x" src="https://user-images.githubusercontent.com/962095/203860873-bf491b78-0b84-4da2-9c2b-b251b70c50d0.png">

