### PR TITLE
feat: chart config unit input improvements

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -21,16 +21,7 @@ enum Units {
     Percentage = '%',
 }
 
-const getValueAndUnit = (valueWithUnit?: string): [string?, Units?] => {
-    if (!valueWithUnit || valueWithUnit === '') return [];
-
-    const unit =
-        Object.values(Units).find((u) => valueWithUnit.endsWith(u)) ||
-        Units.Pixels;
-
-    const value = valueWithUnit.replace(unit, '');
-    return [value, unit];
-};
+const units = Object.values(Units);
 
 const GridPanel: FC = () => {
     const {
@@ -57,26 +48,9 @@ const GridPanel: FC = () => {
         return newState;
     };
 
-    const handleUpdateUnit = (
-        key: typeof positions[number],
-        nextUnit: Units = Units.Pixels,
-    ) => {
-        const originalValue = config[key];
-        const [value] = getValueAndUnit(originalValue);
-
-        if (!value || value === '') return;
-
-        handleUpdate(key, value, nextUnit);
-    };
-
     return (
         <SectionRow>
             {positions.map((position) => {
-                const [value, unit] = getValueAndUnit(config[position]);
-                const [placeholder, placeholderUnit] = getValueAndUnit(
-                    defaultGrid[position],
-                );
-
                 return (
                     <FormGroup
                         key={position}
@@ -84,17 +58,12 @@ const GridPanel: FC = () => {
                         labelFor={`${position}-input`}
                     >
                         <UnitInput
+                            units={units}
                             name={position}
-                            value={value || ''}
-                            placeholder={placeholder}
-                            placeholderUnit={placeholderUnit}
-                            unit={unit}
-                            units={Object.values(Units)}
-                            onChange={(newValue, newUnit) =>
-                                handleUpdate(position, newValue, newUnit)
-                            }
-                            onUnitChange={(newUnit) =>
-                                handleUpdateUnit(position, newUnit)
+                            value={config[position] || ''}
+                            defaultValue={defaultGrid[position]}
+                            onChange={(value, unit) =>
+                                handleUpdate(position, value, unit)
                             }
                         />
                     </FormGroup>

--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormGroup, InputGroup } from '@blueprintjs/core';
+import { FormGroup } from '@blueprintjs/core';
 import { EchartsGrid } from '@lightdash/common';
 import startCase from 'lodash/startCase';
 import { FC, useMemo } from 'react';
@@ -14,7 +14,12 @@ export const defaultGrid = {
     bottom: '30px', // pixels from bottom (makes room for x-axis)
 };
 
-const positions = ['top', 'bottom', 'left', 'right'] as const;
+enum Positions {
+    Left = 'left',
+    Right = 'right',
+    Top = 'top',
+    Bottom = 'bottom',
+}
 
 enum Units {
     Pixels = 'px',
@@ -37,7 +42,7 @@ const GridPanel: FC = () => {
     );
 
     const handleUpdate = (
-        position: typeof positions[number],
+        position: Positions,
         value: string,
         unit: Units = Units.Pixels,
     ) => {
@@ -49,27 +54,34 @@ const GridPanel: FC = () => {
     };
 
     return (
-        <SectionRow>
-            {positions.map((position) => {
-                return (
-                    <FormGroup
-                        key={position}
-                        label={startCase(position)}
-                        labelFor={`${position}-input`}
-                    >
-                        <UnitInput
-                            units={units}
-                            name={position}
-                            value={config[position] || ''}
-                            defaultValue={defaultGrid[position]}
-                            onChange={(value, unit) =>
-                                handleUpdate(position, value, unit)
-                            }
-                        />
-                    </FormGroup>
-                );
-            })}
-        </SectionRow>
+        <>
+            {[
+                [Positions.Left, Positions.Right],
+                [Positions.Top, Positions.Bottom],
+            ].map((positionGroup) => (
+                <SectionRow key={positionGroup.join(',')}>
+                    {positionGroup.map((position) => {
+                        return (
+                            <FormGroup
+                                key={position}
+                                label={startCase(position)}
+                                labelFor={`${position}-input`}
+                            >
+                                <UnitInput
+                                    units={units}
+                                    name={position}
+                                    value={config[position] || ''}
+                                    defaultValue={defaultGrid[position]}
+                                    onChange={(value, unit) =>
+                                        handleUpdate(position, value, unit)
+                                    }
+                                />
+                            </FormGroup>
+                        );
+                    })}
+                </SectionRow>
+            ))}
+        </>
     );
 };
 

--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -64,8 +64,8 @@ const GridPanel: FC = () => {
                             labelFor={`${position}-input`}
                         >
                             <UnitInput
-                                units={units}
                                 name={position}
+                                units={units}
                                 value={config[position] || ''}
                                 defaultValue={defaultGrid[position]}
                                 onChange={(value) =>

--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -21,14 +21,6 @@ enum Units {
     Percentage = '%',
 }
 
-const getNextUnit = (current?: Units): Units | undefined => {
-    if (!current) return;
-
-    const units = Object.values(Units);
-    const currentIndex = units.indexOf(current);
-    return units.concat(units[0])[currentIndex + 1];
-};
-
 const getValueAndUnit = (valueWithUnit?: string): [string?, Units?] => {
     if (!valueWithUnit || valueWithUnit === '') return [];
 
@@ -85,8 +77,6 @@ const GridPanel: FC = () => {
                     defaultGrid[position],
                 );
 
-                const nextUnit = getNextUnit(unit);
-
                 return (
                     <FormGroup
                         key={position}
@@ -97,7 +87,6 @@ const GridPanel: FC = () => {
                             name={position}
                             value={value || ''}
                             placeholder={placeholder}
-                            nextUnit={nextUnit}
                             placeholderUnit={placeholderUnit}
                             unit={unit}
                             units={Object.values(Units)}

--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -43,11 +43,8 @@ const GridPanel: FC = () => {
 
     const handleUpdate = (
         position: Positions,
-        value: string,
-        unit: Units = Units.Pixels,
+        newValue: string | undefined,
     ) => {
-        const newValue = value && value !== '' ? `${value}${unit}` : undefined;
-
         const newState = { ...config, [position]: newValue };
         setGrid(newState);
         return newState;
@@ -60,25 +57,23 @@ const GridPanel: FC = () => {
                 [Positions.Top, Positions.Bottom],
             ].map((positionGroup) => (
                 <SectionRow key={positionGroup.join(',')}>
-                    {positionGroup.map((position) => {
-                        return (
-                            <FormGroup
-                                key={position}
-                                label={startCase(position)}
-                                labelFor={`${position}-input`}
-                            >
-                                <UnitInput
-                                    units={units}
-                                    name={position}
-                                    value={config[position] || ''}
-                                    defaultValue={defaultGrid[position]}
-                                    onChange={(value, unit) =>
-                                        handleUpdate(position, value, unit)
-                                    }
-                                />
-                            </FormGroup>
-                        );
-                    })}
+                    {positionGroup.map((position) => (
+                        <FormGroup
+                            key={position}
+                            label={startCase(position)}
+                            labelFor={`${position}-input`}
+                        >
+                            <UnitInput
+                                units={units}
+                                name={position}
+                                value={config[position] || ''}
+                                defaultValue={defaultGrid[position]}
+                                onChange={(value) =>
+                                    handleUpdate(position, value)
+                                }
+                            />
+                        </FormGroup>
+                    ))}
                 </SectionRow>
             ))}
         </>

--- a/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Grid/index.tsx
@@ -2,6 +2,7 @@ import { Button, FormGroup, InputGroup } from '@blueprintjs/core';
 import { EchartsGrid } from '@lightdash/common';
 import startCase from 'lodash/startCase';
 import { FC, useMemo } from 'react';
+import UnitInput from '../../common/UnitInput';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import { SectionRow } from './Grid.styles';
 
@@ -92,33 +93,19 @@ const GridPanel: FC = () => {
                         label={startCase(position)}
                         labelFor={`${position}-input`}
                     >
-                        <InputGroup
-                            type="number"
-                            id={`${position}-input`}
+                        <UnitInput
                             name={position}
-                            placeholder={placeholder}
                             value={value || ''}
-                            onChange={(e) =>
-                                handleUpdate(
-                                    position,
-                                    e.target.value,
-                                    value ? unit : placeholderUnit,
-                                )
+                            placeholder={placeholder}
+                            nextUnit={nextUnit}
+                            placeholderUnit={placeholderUnit}
+                            unit={unit}
+                            units={Object.values(Units)}
+                            onChange={(newValue, newUnit) =>
+                                handleUpdate(position, newValue, newUnit)
                             }
-                            rightElement={
-                                <Button
-                                    minimal
-                                    small
-                                    disabled={!value}
-                                    onClick={() =>
-                                        handleUpdateUnit(
-                                            position,
-                                            value ? nextUnit : placeholderUnit,
-                                        )
-                                    }
-                                >
-                                    {unit || placeholderUnit}
-                                </Button>
+                            onUnitChange={(newUnit) =>
+                                handleUpdateUnit(position, newUnit)
                             }
                         />
                     </FormGroup>

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
@@ -7,11 +7,6 @@ export const SectionTitle = styled.p`
     margin-bottom: 0.286em;
 `;
 
-export const InputTitle = styled.p`
-    font-weight: 500;
-    gap: 3px;
-}
-`;
 export const SectionRow = styled.div`
     display: inline-flex;
     gap: 10px;

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -1,15 +1,30 @@
 import { Collapse, Switch } from '@blueprintjs/core';
 import { EchartsLegend, friendlyName } from '@lightdash/common';
+import startCase from 'lodash-es/startCase';
 import React, { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import Checkbox from '../../ReactHookForm/Checkbox';
 import Form from '../../ReactHookForm/Form';
-import Input from '../../ReactHookForm/Input';
 import Select from '../../ReactHookForm/Select';
-import { InputTitle, SectionRow, SectionTitle } from './Legend.styles';
+import UnitInput from '../../ReactHookForm/UnitInput';
+import { SectionRow, SectionTitle } from './Legend.styles';
 
 const triggerSubmitFields = ['show', 'orient'];
+
+enum Positions {
+    Left = 'left',
+    Right = 'right',
+    Top = 'top',
+    Bottom = 'bottom',
+}
+
+enum Units {
+    Pixels = 'px',
+    Percentage = '%',
+}
+
+const units = Object.values(Units);
 
 const LegendPanel: FC = () => {
     const {
@@ -51,7 +66,7 @@ const LegendPanel: FC = () => {
                         : showDefault
                 }
             >
-                <InputTitle>Scroll</InputTitle>
+                <SectionTitle>Scroll</SectionTitle>
                 <Switch
                     large
                     checked={dirtyEchartsConfig?.legend?.type !== 'plain'}
@@ -65,17 +80,28 @@ const LegendPanel: FC = () => {
                     }}
                 />
                 <SectionTitle>Position</SectionTitle>
-                <SectionRow>
-                    <Input name="top" label="Top" placeholder={'auto'} />
-                    <Input name="bottom" label="Bottom" placeholder={'auto'} />
-                    <Input name="left" label="Left" placeholder={'auto'} />
-                    <Input name="right" label="Right" placeholder={'auto'} />
-                </SectionRow>
-                <SectionTitle>Appearance</SectionTitle>
+
+                {[
+                    [Positions.Left, Positions.Right],
+                    [Positions.Top, Positions.Bottom],
+                ].map((positionGroup) => (
+                    <SectionRow key={positionGroup.join(',')}>
+                        {positionGroup.map((position) => (
+                            <UnitInput
+                                key={position}
+                                label={startCase(position)}
+                                name={position}
+                                units={units}
+                                defaultValue="auto"
+                            />
+                        ))}
+                    </SectionRow>
+                ))}
+
+                <SectionTitle>Orientation</SectionTitle>
                 <SectionRow>
                     <Select
                         name="orient"
-                        label="Orientation"
                         options={['horizontal', 'vertical'].map((x) => ({
                             value: x,
                             label: friendlyName(x),

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ProjectConnectFlow.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ProjectConnectFlow.styles.tsx
@@ -58,6 +58,10 @@ export const StyledNonIdealState = styled(NonIdealState)`
 
     svg {
         fill-opacity: unset !important;
+        stroke-width: 0 !important;
+        // path: {
+        //     stroke-width: 0 !important;
+        // }
     }
 `;
 

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ProjectConnectFlow.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ProjectConnectFlow.styles.tsx
@@ -58,10 +58,6 @@ export const StyledNonIdealState = styled(NonIdealState)`
 
     svg {
         fill-opacity: unset !important;
-        stroke-width: 0 !important;
-        // path: {
-        //     stroke-width: 0 !important;
-        // }
     }
 `;
 

--- a/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
@@ -8,11 +8,9 @@ type UnitInputWrapperProps = Omit<UnitInputProps, 'value' | 'onChange'> &
 const UnitInput: FC<UnitInputWrapperProps> = ({ ...unitInputProps }) => (
     <InputWrapper
         {...unitInputProps}
-        render={(props, { field }) =>
-            console.log(unitInputProps.defaultValue, field, props) || (
-                <UnitInputOriginal {...unitInputProps} {...field} {...props} />
-            )
-        }
+        render={(props, { field }) => (
+            <UnitInputOriginal {...unitInputProps} {...field} {...props} />
+        )}
     />
 );
 export default UnitInput;

--- a/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
@@ -9,13 +9,7 @@ const UnitInput: FC<UnitInputWrapperProps> = ({ ...unitInputProps }) => (
     <InputWrapper
         {...unitInputProps}
         render={(props, { field }) => (
-            <UnitInputOriginal
-                {...unitInputProps}
-                {...field}
-                {...props}
-                value={field.value}
-                onChange={(value) => field.onChange(value)}
-            />
+            <UnitInputOriginal {...unitInputProps} {...field} {...props} />
         )}
     />
 );

--- a/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+import UnitInputOriginal, { UnitInputProps } from '../common/UnitInput';
+import InputWrapper, { InputWrapperProps } from './InputWrapper';
+
+type UnitInputWrapperProps = Omit<UnitInputProps, 'value' | 'onChange'> &
+    Omit<InputWrapperProps, 'render'>;
+
+const UnitInput: FC<UnitInputWrapperProps> = ({ ...unitInputProps }) => (
+    <InputWrapper
+        {...unitInputProps}
+        render={(props, { field }) => (
+            <UnitInputOriginal
+                {...unitInputProps}
+                {...field}
+                {...props}
+                value={field.value}
+                onChange={(value) => field.onChange(value)}
+            />
+        )}
+    />
+);
+export default UnitInput;

--- a/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/UnitInput.tsx
@@ -8,9 +8,11 @@ type UnitInputWrapperProps = Omit<UnitInputProps, 'value' | 'onChange'> &
 const UnitInput: FC<UnitInputWrapperProps> = ({ ...unitInputProps }) => (
     <InputWrapper
         {...unitInputProps}
-        render={(props, { field }) => (
-            <UnitInputOriginal {...unitInputProps} {...field} {...props} />
-        )}
+        render={(props, { field }) =>
+            console.log(unitInputProps.defaultValue, field, props) || (
+                <UnitInputOriginal {...unitInputProps} {...field} {...props} />
+            )
+        }
     />
 );
 export default UnitInput;

--- a/packages/frontend/src/components/common/UnitInput/UnitInput.style.ts
+++ b/packages/frontend/src/components/common/UnitInput/UnitInput.style.ts
@@ -1,0 +1,14 @@
+import { InputGroup } from '@blueprintjs/core';
+import styled from 'styled-components';
+
+export const StyledNumberInput = styled(InputGroup)`
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+        appearance: none;
+        margin: 0;
+    }
+
+    input[type='number'] {
+        appearance: textfield;
+    }
+`;

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -62,13 +62,13 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
                 onChange(
                     newValue && newValue !== '' && newUnit
                         ? `${newValue}${newUnit}`
-                        : undefined,
+                        : defaultValue,
                 );
                 if (trigger) {
                     inputRef.current?.focus();
                 }
             },
-            [onChange],
+            [onChange, defaultValue],
         );
 
         const isValueDefault =
@@ -76,6 +76,13 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
             valueWithUnit === '' ||
             valueWithUnit === defaultValue;
         const isValueNumeric = !!(value || defaultValue)?.match(/^[0-9]+$/);
+
+        console.log({
+            value,
+            defaultValue,
+            valueWithUnit,
+            defaultValueWithUnit,
+        });
 
         return (
             <StyledNumberInput
@@ -100,19 +107,20 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
                     handleChange(e.target.value, value ? unit : defaultUnit)
                 }
                 rightElement={
-                    isValueDefault && !isValueNumeric ? undefined : (
+                    !defaultUnit ||
+                    (isValueDefault && !isValueNumeric) ? undefined : (
                         <Button
                             minimal
                             small
                             onClick={() =>
                                 handleChange(
-                                    value,
-                                    value ? nextUnit : defaultUnit,
+                                    value || defaultValue,
+                                    nextUnit ?? defaultUnit,
                                     true,
                                 )
                             }
                         >
-                            {unit || defaultUnit}
+                            {unit ?? defaultUnit}
                         </Button>
                     )
                 }

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@blueprintjs/core';
+import { FC } from 'react';
+import { StyledNumberInput } from './UnitInput.style';
+
+type UnitInputProps<T> = {
+    name: string;
+    unit: T;
+    units: T[];
+    value: string;
+    nextUnit: T;
+    placeholder?: string;
+    placeholderUnit?: T;
+    onChange: (value: string, unit?: T) => void;
+    onUnitChange: (unit?: T) => void;
+};
+
+const UnitInput = <T,>({
+    name,
+    value,
+    units,
+    unit,
+    nextUnit,
+    placeholder,
+    placeholderUnit,
+    onChange,
+    onUnitChange,
+}: UnitInputProps<T>) => {
+    return (
+        <StyledNumberInput
+            type="number"
+            id={`${name}-input`}
+            name={name}
+            placeholder={placeholder}
+            value={value || ''}
+            onChange={(e) =>
+                onChange(e.target.value, value ? unit : placeholderUnit)
+            }
+            rightElement={
+                <Button
+                    minimal
+                    small
+                    disabled={!value}
+                    onClick={() =>
+                        onUnitChange(value ? nextUnit : placeholderUnit)
+                    }
+                >
+                    {unit || placeholderUnit}
+                </Button>
+            }
+        />
+    );
+};
+
+export default UnitInput;

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { StyledNumberInput } from './UnitInput.style';
 
 type UnitInputProps<T extends string> = {
@@ -7,7 +7,7 @@ type UnitInputProps<T extends string> = {
     units: T[];
     value: string;
     defaultValue: string;
-    onChange: (value: string, unit?: T) => void;
+    onChange: (value: string | undefined) => void;
 };
 
 export const getValueAndUnit = <T extends string>(
@@ -45,6 +45,16 @@ const UnitInput = <T extends string>({
         return units.concat(units[0])[currentIndex + 1];
     }, [unit, units]);
 
+    const handleChange = useCallback(
+        (newValue?: string, newUnit?: T) =>
+            onChange(
+                newValue && newValue !== '' && newUnit
+                    ? `${newValue}${newUnit}`
+                    : undefined,
+            ),
+        [onChange],
+    );
+
     return (
         <StyledNumberInput
             type="number"
@@ -53,7 +63,7 @@ const UnitInput = <T extends string>({
             placeholder={defaultValue}
             value={value || ''}
             onChange={(e) =>
-                onChange(e.target.value, value ? unit : defaultUnit)
+                handleChange(e.target.value, value ? unit : defaultUnit)
             }
             rightElement={
                 <Button
@@ -61,7 +71,7 @@ const UnitInput = <T extends string>({
                     small
                     disabled={!value}
                     onClick={() =>
-                        value && onChange(value, value ? nextUnit : defaultUnit)
+                        handleChange(value, value ? nextUnit : defaultUnit)
                     }
                 >
                     {unit || defaultUnit}

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -77,13 +77,6 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
             valueWithUnit === defaultValue;
         const isValueNumeric = !!(value || defaultValue)?.match(/^[0-9]+$/);
 
-        console.log({
-            value,
-            defaultValue,
-            valueWithUnit,
-            defaultValueWithUnit,
-        });
-
         return (
             <StyledNumberInput
                 inputRef={(input) => {

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@blueprintjs/core';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { StyledNumberInput } from './UnitInput.style';
 
 type UnitInputProps<T> = {
@@ -7,7 +7,6 @@ type UnitInputProps<T> = {
     unit: T;
     units: T[];
     value: string;
-    nextUnit: T;
     placeholder?: string;
     placeholderUnit?: T;
     onChange: (value: string, unit?: T) => void;
@@ -19,12 +18,18 @@ const UnitInput = <T,>({
     value,
     units,
     unit,
-    nextUnit,
     placeholder,
     placeholderUnit,
     onChange,
     onUnitChange,
 }: UnitInputProps<T>) => {
+    const nextUnit = useMemo(() => {
+        if (!unit) return;
+
+        const currentIndex = units.indexOf(unit);
+        return units.concat(units[0])[currentIndex + 1];
+    }, [unit, units]);
+
     return (
         <StyledNumberInput
             type="number"

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -1,28 +1,43 @@
 import { Button } from '@blueprintjs/core';
-import { FC, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { StyledNumberInput } from './UnitInput.style';
 
-type UnitInputProps<T> = {
+type UnitInputProps<T extends string> = {
     name: string;
-    unit: T;
     units: T[];
     value: string;
-    placeholder?: string;
-    placeholderUnit?: T;
+    defaultValue: string;
     onChange: (value: string, unit?: T) => void;
-    onUnitChange: (unit?: T) => void;
 };
 
-const UnitInput = <T,>({
+export const getValueAndUnit = <T extends string>(
+    valueWithUnit: string,
+    units: T[],
+): [string?, T?] => {
+    if (!valueWithUnit || valueWithUnit === '') return [];
+
+    const unit = units.find((u) => valueWithUnit.endsWith(u)) || units[0];
+    const value = valueWithUnit.replace(unit, '');
+    return [value, unit];
+};
+
+const UnitInput = <T extends string>({
     name,
-    value,
     units,
-    unit,
-    placeholder,
-    placeholderUnit,
+    value: valueWithUnit,
+    defaultValue: defaultValueWithUnit,
     onChange,
-    onUnitChange,
 }: UnitInputProps<T>) => {
+    const [value, unit] = useMemo(
+        () => getValueAndUnit(valueWithUnit, units),
+        [valueWithUnit, units],
+    );
+
+    const [defaultValue, defaultUnit] = useMemo(
+        () => getValueAndUnit(defaultValueWithUnit, units),
+        [defaultValueWithUnit, units],
+    );
+
     const nextUnit = useMemo(() => {
         if (!unit) return;
 
@@ -35,10 +50,10 @@ const UnitInput = <T,>({
             type="number"
             id={`${name}-input`}
             name={name}
-            placeholder={placeholder}
+            placeholder={defaultValue}
             value={value || ''}
             onChange={(e) =>
-                onChange(e.target.value, value ? unit : placeholderUnit)
+                onChange(e.target.value, value ? unit : defaultUnit)
             }
             rightElement={
                 <Button
@@ -46,10 +61,10 @@ const UnitInput = <T,>({
                     small
                     disabled={!value}
                     onClick={() =>
-                        onUnitChange(value ? nextUnit : placeholderUnit)
+                        value && onChange(value, value ? nextUnit : defaultUnit)
                     }
                 >
-                    {unit || placeholderUnit}
+                    {unit || defaultUnit}
                 </Button>
             }
         />

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -71,6 +71,12 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
             [onChange],
         );
 
+        const isValueDefault =
+            !valueWithUnit ||
+            valueWithUnit === '' ||
+            valueWithUnit === defaultValue;
+        const isValueNumeric = !!(value || defaultValue)?.match(/^[0-9]+$/);
+
         return (
             <StyledNumberInput
                 inputRef={(input) => {
@@ -89,25 +95,26 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
                 name={name}
                 {...rest}
                 placeholder={defaultValue}
-                value={value || ''}
+                value={!isValueDefault && isValueNumeric ? value : ''}
                 onChange={(e) =>
                     handleChange(e.target.value, value ? unit : defaultUnit)
                 }
                 rightElement={
-                    <Button
-                        minimal
-                        small
-                        disabled={!value || value === defaultValue}
-                        onClick={() =>
-                            handleChange(
-                                value,
-                                value ? nextUnit : defaultUnit,
-                                true,
-                            )
-                        }
-                    >
-                        {unit || defaultUnit}
-                    </Button>
+                    isValueDefault && !isValueNumeric ? undefined : (
+                        <Button
+                            minimal
+                            small
+                            onClick={() =>
+                                handleChange(
+                                    value,
+                                    value ? nextUnit : defaultUnit,
+                                    true,
+                                )
+                            }
+                        >
+                            {unit || defaultUnit}
+                        </Button>
+                    )
                 }
             />
         );

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -62,13 +62,13 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
                 onChange(
                     newValue && newValue !== '' && newUnit
                         ? `${newValue}${newUnit}`
-                        : defaultValue,
+                        : undefined,
                 );
                 if (trigger) {
                     inputRef.current?.focus();
                 }
             },
-            [onChange, defaultValue],
+            [onChange],
         );
 
         return (


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3871

### Description:

- [x] The `Position` inputs should match the ones we recently implemented in the `Margins` tab (pick between % and px) 

- [x] Rather than displayed as 1x4 inputs, we should display them as 2x2. This is because you can't see the full values. 

<img width="348" alt="CleanShot 2022-12-02 at 18 28 09@2x" src="https://user-images.githubusercontent.com/962095/205315314-950bdff8-d1a1-49b3-9073-d49d22e6c60c.png">

demo video / user testing:

https://cln.sh/wAlIMC

