### PR TITLE
chore: add svgr type ref

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,3 +1,5 @@
+/// <reference types="vite-plugin-svgr/client" />
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';


### PR DESCRIPTION
### Description:

fixes types for SVG imports:

<img width="496" alt="CleanShot 2022-12-05 at 10 39 26@2x" src="https://user-images.githubusercontent.com/962095/205566052-ffa63c20-ea8a-47b3-bfa5-7cb04d0128db.png">
