### PR TITLE
docs: add dev set up command to fix error when running build script

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -247,6 +247,9 @@ When ready, access the development container and run these commands:
 # Connect to container
 docker exec -it lightdash-app-lightdash-dev-1 bash
 
+# Skip puppeteer download
+PUPPETEER_SKIP_DOWNLOAD=true
+
 # Install dependencies & build common package
 ./scripts/build.sh
 


### PR DESCRIPTION
Closes: no related issue
### Description:
Added a command `PUPPETEER_SKIP_DOWNLOAD=true` before running build script to fix this error

<img width="1033" alt="Screenshot 2022-12-06 at 10 42 11" src="https://user-images.githubusercontent.com/67699259/205888644-fab1acdf-5294-4ec8-9c5f-2c6ebad09e28.png">
