### PR TITLE
fix: remove pivot when changing to table vizualisation

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -204,6 +204,7 @@ const VisualizationCardOptions: FC = memo(() => {
                         icon="panel-table"
                         onClick={() => {
                             setChartType(ChartType.TABLE);
+                            setPivotDimensions(undefined);
                             setIsOpen(false);
                         }}
                         disabled={disabled}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3886 <!-- reference the related issue e.g. #150 -->

### Description:

Changes: 
- we always remove the pivot value when changing to table visualization

Changing from chart to table:

![Dec-08-2022 10-49-11](https://user-images.githubusercontent.com/9117144/206428778-df52cca0-5900-4064-aaf2-f34a2796e424.gif)

Defining a pivot in table and then changing to chart and back to table ( resets pivot ) 

![tableviz pivot](https://user-images.githubusercontent.com/9117144/206428789-c64efa65-b369-4a36-ad93-dd1f061f5384.gif)



