### PR TITLE
fix: clean up dashboard tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -50,7 +50,7 @@ import {
     useUnderlyingDataContext,
 } from '../UnderlyingData/UnderlyingDataProvider';
 import TileBase from './TileBase/index';
-import { FilterLabel } from './TileBase/TileBase.styles';
+import { FilterLabel, GlobalTileStyles } from './TileBase/TileBase.styles';
 
 const ValidDashboardChartTile: FC<{
     tileUuid: string;
@@ -341,195 +341,212 @@ const DashboardChartTile: FC<Props> = (props) => {
     }, [savedQueryWithDashboardFilters]);
 
     return (
-        <TileBase
-            extraHeaderElement={
-                appliedFilterRules.length > 0 && (
-                    <div>
-                        <Tooltip2
-                            content={
-                                <div
-                                    style={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        gap: '4px',
-                                    }}
-                                >
-                                    {appliedFilterRules.map(renderFilterRule)}
-                                </div>
-                            }
-                            interactionKind="hover"
-                            placement={'bottom-start'}
-                        >
-                            <FilterLabel>
-                                Dashboard filter
-                                {appliedFilterRules.length > 1 ? 's' : ''}{' '}
-                                applied
-                            </FilterLabel>
-                        </Tooltip2>
-                    </div>
-                )
-            }
-            title={savedQueryWithDashboardFilters?.name || ''}
-            description={savedQueryWithDashboardFilters?.description}
-            isLoading={isLoading}
-            extraMenuItems={
-                savedChartUuid !== null && (
-                    <>
-                        {user.data?.ability?.can('manage', 'SavedChart') && (
-                            <MenuItem2
-                                icon="document-open"
-                                text="Edit chart"
-                                href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
-                            />
-                        )}
-                        <MenuItem2
-                            icon="series-search"
-                            text="Explore from here"
-                            href={exploreFromHereUrl}
-                        />
-                        {savedQueryWithDashboardFilters &&
-                            savedQueryWithDashboardFilters.chartConfig.type ===
-                                ChartType.TABLE && (
-                                <DownloadCSV
-                                    data={savedQueryWithDashboardFilters}
-                                    project={projectUuid}
+        <>
+            <GlobalTileStyles />
+
+            <TileBase
+                extraHeaderElement={
+                    appliedFilterRules.length > 0 && (
+                        <div>
+                            <Tooltip2
+                                content={
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            gap: '4px',
+                                        }}
+                                    >
+                                        {appliedFilterRules.map(
+                                            renderFilterRule,
+                                        )}
+                                    </div>
+                                }
+                                interactionKind="hover"
+                                placement={'bottom-start'}
+                            >
+                                <FilterLabel>
+                                    Dashboard filter
+                                    {appliedFilterRules.length > 1
+                                        ? 's'
+                                        : ''}{' '}
+                                    applied
+                                </FilterLabel>
+                            </Tooltip2>
+                        </div>
+                    )
+                }
+                title={savedQueryWithDashboardFilters?.name || ''}
+                description={savedQueryWithDashboardFilters?.description}
+                isLoading={isLoading}
+                extraMenuItems={
+                    savedChartUuid !== null && (
+                        <>
+                            {user.data?.ability?.can(
+                                'manage',
+                                'SavedChart',
+                            ) && (
+                                <MenuItem2
+                                    icon="document-open"
+                                    text="Edit chart"
+                                    href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
                                 />
                             )}
-                    </>
-                )
-            }
-            {...props}
-        >
-            {savedQueryWithDashboardFilters ? (
-                <>
-                    <Popover2
-                        content={
-                            <div onContextMenu={cancelContextMenu}>
-                                <Menu>
-                                    <MenuItem2
-                                        text={`View underlying data`}
-                                        icon={'layers'}
-                                        onClick={(e) => {
-                                            if (
-                                                viewUnderlyingDataOptions !==
-                                                undefined
-                                            ) {
-                                                const {
-                                                    value,
-                                                    meta,
-                                                    row,
-                                                    dimensions,
-                                                    pivotReference,
-                                                } = viewUnderlyingDataOptions;
-                                                viewData(
-                                                    value,
-                                                    meta,
-                                                    row,
-                                                    dimensions,
-                                                    pivotReference,
-                                                    dashboardFiltersThatApplyToChart,
-                                                );
+                            <MenuItem2
+                                icon="series-search"
+                                text="Explore from here"
+                                href={exploreFromHereUrl}
+                            />
+                            {savedQueryWithDashboardFilters &&
+                                savedQueryWithDashboardFilters.chartConfig
+                                    .type === ChartType.TABLE && (
+                                    <DownloadCSV
+                                        data={savedQueryWithDashboardFilters}
+                                        project={projectUuid}
+                                    />
+                                )}
+                        </>
+                    )
+                }
+                {...props}
+            >
+                {savedQueryWithDashboardFilters ? (
+                    <>
+                        <Popover2
+                            content={
+                                <div onContextMenu={cancelContextMenu}>
+                                    <Menu>
+                                        <MenuItem2
+                                            text={`View underlying data`}
+                                            icon={'layers'}
+                                            onClick={(e) => {
+                                                if (
+                                                    viewUnderlyingDataOptions !==
+                                                    undefined
+                                                ) {
+                                                    const {
+                                                        value,
+                                                        meta,
+                                                        row,
+                                                        dimensions,
+                                                        pivotReference,
+                                                    } = viewUnderlyingDataOptions;
+                                                    viewData(
+                                                        value,
+                                                        meta,
+                                                        row,
+                                                        dimensions,
+                                                        pivotReference,
+                                                        dashboardFiltersThatApplyToChart,
+                                                    );
+                                                }
+                                            }}
+                                        />
+                                        <DrillDownMenuItem
+                                            row={viewUnderlyingDataOptions?.row}
+                                            metricQuery={
+                                                savedQuery?.metricQuery
                                             }
-                                        }}
-                                    />
-                                    <DrillDownMenuItem
-                                        row={viewUnderlyingDataOptions?.row}
-                                        metricQuery={savedQuery?.metricQuery}
-                                        selectedItem={
-                                            viewUnderlyingDataOptions?.meta
-                                                ?.item
-                                        }
-                                        pivotReference={
-                                            viewUnderlyingDataOptions?.pivotReference
-                                        }
-                                        dashboardFilters={
-                                            dashboardFiltersThatApplyToChart
-                                        }
-                                    />
-                                    <MenuItem2
-                                        icon="filter"
-                                        text="Filter dashboard to..."
-                                    >
-                                        {dashboardTileFilterOptions.map(
-                                            (filter) => (
-                                                <MenuItem2
-                                                    key={filter.id}
-                                                    text={`${friendlyName(
-                                                        filter.target.fieldId,
-                                                    )} is ${
-                                                        filter.values &&
-                                                        filter.values[0]
-                                                    }`}
-                                                    onClick={() => {
-                                                        track({
-                                                            name: EventName.ADD_FILTER_CLICKED,
-                                                            properties: {
-                                                                mode: isEditMode
-                                                                    ? 'edit'
-                                                                    : 'viewer',
-                                                            },
-                                                        });
+                                            selectedItem={
+                                                viewUnderlyingDataOptions?.meta
+                                                    ?.item
+                                            }
+                                            pivotReference={
+                                                viewUnderlyingDataOptions?.pivotReference
+                                            }
+                                            dashboardFilters={
+                                                dashboardFiltersThatApplyToChart
+                                            }
+                                        />
+                                        <MenuItem2
+                                            icon="filter"
+                                            text="Filter dashboard to..."
+                                        >
+                                            {dashboardTileFilterOptions.map(
+                                                (filter) => (
+                                                    <MenuItem2
+                                                        key={filter.id}
+                                                        text={`${friendlyName(
+                                                            filter.target
+                                                                .fieldId,
+                                                        )} is ${
+                                                            filter.values &&
+                                                            filter.values[0]
+                                                        }`}
+                                                        onClick={() => {
+                                                            track({
+                                                                name: EventName.ADD_FILTER_CLICKED,
+                                                                properties: {
+                                                                    mode: isEditMode
+                                                                        ? 'edit'
+                                                                        : 'viewer',
+                                                                },
+                                                            });
 
-                                                        const fields = explore
-                                                            ? getFields(explore)
-                                                            : [];
-                                                        const field =
-                                                            fields.find(
-                                                                (f) =>
-                                                                    fieldId(
-                                                                        f,
-                                                                    ) ===
-                                                                    filter
-                                                                        .target
-                                                                        .fieldId,
+                                                            const fields =
+                                                                explore
+                                                                    ? getFields(
+                                                                          explore,
+                                                                      )
+                                                                    : [];
+                                                            const field =
+                                                                fields.find(
+                                                                    (f) =>
+                                                                        fieldId(
+                                                                            f,
+                                                                        ) ===
+                                                                        filter
+                                                                            .target
+                                                                            .fieldId,
+                                                                );
+
+                                                            track({
+                                                                name: EventName.CROSS_FILTER_DASHBOARD_APPLIED,
+                                                                properties: {
+                                                                    fieldType:
+                                                                        field?.type,
+                                                                    projectId:
+                                                                        projectUuid,
+                                                                    dashboardId:
+                                                                        dashboardUuid,
+                                                                },
+                                                            });
+
+                                                            addDimensionDashboardFilter(
+                                                                filter,
+                                                                !isEditMode,
                                                             );
-
-                                                        track({
-                                                            name: EventName.CROSS_FILTER_DASHBOARD_APPLIED,
-                                                            properties: {
-                                                                fieldType:
-                                                                    field?.type,
-                                                                projectId:
-                                                                    projectUuid,
-                                                                dashboardId:
-                                                                    dashboardUuid,
-                                                            },
-                                                        });
-
-                                                        addDimensionDashboardFilter(
-                                                            filter,
-                                                            !isEditMode,
-                                                        );
-                                                    }}
-                                                />
-                                            ),
-                                        )}
-                                    </MenuItem2>
-                                </Menu>
-                            </div>
-                        }
-                        enforceFocus={false}
-                        hasBackdrop={true}
-                        isOpen={contextMenuIsOpen}
-                        minimal={true}
-                        onClose={() => setContextMenuIsOpen(false)}
-                        placement="right-start"
-                        positioningStrategy="fixed"
-                        rootBoundary={'viewport'}
-                        renderTarget={contextMenuRenderTarget}
-                        transitionDuration={100}
-                    />
-                    <ValidDashboardChartTile
-                        tileUuid={tileUuid}
-                        data={savedQueryWithDashboardFilters}
-                        project={projectUuid}
-                        onSeriesContextMenu={onSeriesContextMenu}
-                    />
-                </>
-            ) : (
-                <InvalidDashboardChartTile />
-            )}
-        </TileBase>
+                                                        }}
+                                                    />
+                                                ),
+                                            )}
+                                        </MenuItem2>
+                                    </Menu>
+                                </div>
+                            }
+                            enforceFocus={false}
+                            hasBackdrop={true}
+                            isOpen={contextMenuIsOpen}
+                            minimal={true}
+                            onClose={() => setContextMenuIsOpen(false)}
+                            placement="right-start"
+                            positioningStrategy="fixed"
+                            rootBoundary={'viewport'}
+                            renderTarget={contextMenuRenderTarget}
+                            transitionDuration={100}
+                        />
+                        <ValidDashboardChartTile
+                            tileUuid={tileUuid}
+                            data={savedQueryWithDashboardFilters}
+                            project={projectUuid}
+                            onSeriesContextMenu={onSeriesContextMenu}
+                        />
+                    </>
+                ) : (
+                    <InvalidDashboardChartTile />
+                )}
+            </TileBase>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -1,9 +1,23 @@
 import { Card, Colors, H5 } from '@blueprintjs/core';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 interface HeaderContainerProps {
     isEditMode: boolean;
+    isHovering?: boolean;
 }
+
+export const TileBaseWrapper = styled(Card)<HeaderContainerProps>`
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    ${(props) =>
+        props.isEditMode && props.isHovering
+            ? `
+                box-shadow: 0 0 0 1px ${Colors.GRAY4};
+            `
+            : ''}
+`;
 
 export const HeaderContainer = styled.div<HeaderContainerProps>`
     display: flex;
@@ -16,37 +30,22 @@ export const HeaderContainer = styled.div<HeaderContainerProps>`
     ${(props) =>
         props.isEditMode
             ? `
-      &:hover {
-          cursor: grab;
-         
-      }
-      &:active, &:focus {
-        cursor: grabbing;
-      }
-    `
+                &:hover {
+                    cursor: grab;
+                }
+                &:active, &:focus {
+                    cursor: grabbing;
+                }
+            `
             : ''}
 `;
-export const TileBaseWrapper = styled(Card)<HeaderContainerProps>`
-    height: 100%;
-    display: flex;
-    flex-direction: column;
 
-    ${(props) =>
-        props.isEditMode
-            ? `
-    ${HeaderContainer}:hover {
-        box-shadow: 0 0 0 1px ${Colors.GRAY4};
-    }
-
-    ${HeaderContainer}:focus {
-        box-shadow: 0 0 0 1px ${Colors.BLUE4};
-    }
-
-    ${HeaderContainer}:active {
-        box-shadow: 0 0 0 1px ${Colors.BLUE4};
-    }`
-            : ``}
+export const GlobalTileStyles = createGlobalStyle`
+  .react-draggable.react-draggable-dragging ${TileBaseWrapper} {
+    box-shadow: 0 0 0 1px ${Colors.BLUE4};
+  }
 `;
+
 export const TitleWrapper = styled.div`
     display: flex;
     flex-direction: row;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -1,20 +1,52 @@
 import { Card, Colors, H5 } from '@blueprintjs/core';
 import styled from 'styled-components';
 
-export const TileBaseWrapper = styled(Card)`
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-`;
+interface HeaderContainerProps {
+    isEditMode: boolean;
+}
 
-export const HeaderContainer = styled.div`
+export const HeaderContainer = styled.div<HeaderContainerProps>`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: baseline;
-    gap: 20px;
-`;
+    min-height: 80px;
+    flex-wrap: wrap;
 
+    ${(props) =>
+        props.isEditMode
+            ? `
+      &:hover {
+          cursor: grab;
+         
+      }
+      &:active, &:focus {
+        cursor: grabbing;
+      }
+    `
+            : ''}
+`;
+export const TileBaseWrapper = styled(Card)<HeaderContainerProps>`
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    ${(props) =>
+        props.isEditMode
+            ? `
+    ${HeaderContainer}:hover {
+        box-shadow: 0 0 0 1px ${Colors.GRAY4};
+    }
+
+    ${HeaderContainer}:focus {
+        box-shadow: 0 0 0 1px ${Colors.BLUE4};
+    }
+
+    ${HeaderContainer}:active {
+        box-shadow: 0 0 0 1px ${Colors.BLUE4};
+    }`
+            : ``}
+`;
 export const TitleWrapper = styled.div`
     display: flex;
     flex-direction: row;
@@ -28,7 +60,13 @@ export const Title = styled(H5)`
 export const HeaderWrapper = styled.div`
     display: flex;
     flex-direction: column;
-    margin-bottom: 15px;
+    padding-top: 5px;
+`;
+
+export const ButtonsWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
 `;
 
 export const FilterLabel = styled.span`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -10,6 +10,7 @@ import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import React, { ReactNode, useState } from 'react';
 import { TileModal } from '../TileForms/TileModal';
 import {
+    ButtonsWrapper,
     ChartContainer,
     HeaderContainer,
     HeaderWrapper,
@@ -50,86 +51,87 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             ? tile.properties.hideTitle
             : false;
     return (
-        <TileBaseWrapper className={isLoading ? Classes.SKELETON : undefined}>
-            <HeaderContainer>
+        <TileBaseWrapper
+            className={isLoading ? Classes.SKELETON : undefined}
+            isEditMode={isEditMode}
+        >
+            <HeaderContainer isEditMode={isEditMode}>
                 <HeaderWrapper>
                     {!hideTitle && (
                         <TitleWrapper>
                             <Title className="non-draggable">{title}</Title>
-                            {description && (
-                                <Tooltip2
-                                    content={description}
-                                    position="bottom"
-                                >
-                                    <Button icon="info-sign" minimal />
-                                </Tooltip2>
-                            )}
                         </TitleWrapper>
                     )}
                     {extraHeaderElement}
                 </HeaderWrapper>
-                {(isEditMode || (!isEditMode && extraMenuItems)) && (
-                    <Popover2
-                        className="non-draggable"
-                        content={
-                            <Menu>
-                                {extraMenuItems}
-                                {isEditMode && extraMenuItems && (
-                                    <MenuDivider />
-                                )}
-                                {isEditMode && (
-                                    <>
-                                        <MenuItem2
-                                            icon="edit"
-                                            text="Edit tile"
-                                            onClick={() => setIsEditing(true)}
-                                        />
-                                        {tile.type !==
-                                            DashboardTileTypes.MARKDOWN && (
+                <ButtonsWrapper>
+                    {description && (
+                        <Tooltip2 content={description} position="bottom">
+                            <Button icon="info-sign" minimal />
+                        </Tooltip2>
+                    )}
+                    {(isEditMode || (!isEditMode && extraMenuItems)) && (
+                        <Popover2
+                            className="non-draggable"
+                            content={
+                                <Menu>
+                                    {extraMenuItems}
+                                    {isEditMode && extraMenuItems && (
+                                        <MenuDivider />
+                                    )}
+                                    {isEditMode && (
+                                        <>
                                             <MenuItem2
-                                                icon={
-                                                    hideTitle
-                                                        ? 'eye-open'
-                                                        : 'eye-off'
-                                                }
-                                                text={`${
-                                                    hideTitle ? 'Show' : 'Hide'
-                                                } title`}
+                                                icon="edit"
+                                                text="Edit tile"
                                                 onClick={() =>
-                                                    onEdit({
-                                                        ...tile,
-                                                        properties: {
-                                                            ...tile.properties,
-                                                            hideTitle:
-                                                                !hideTitle,
-                                                        },
-                                                    })
+                                                    setIsEditing(true)
                                                 }
                                             />
-                                        )}
-
-                                        <MenuDivider />
-
-                                        <MenuItem2
-                                            icon="delete"
-                                            intent="danger"
-                                            text="Remove tile"
-                                            onClick={() => onDelete(tile)}
-                                        />
-                                    </>
-                                )}
-                            </Menu>
-                        }
-                        position={PopoverPosition.BOTTOM_RIGHT}
-                        lazy
-                    >
-                        <Tooltip2 content="Tile configuration">
+                                            {tile.type !==
+                                                DashboardTileTypes.MARKDOWN && (
+                                                <MenuItem2
+                                                    icon={
+                                                        hideTitle
+                                                            ? 'eye-open'
+                                                            : 'eye-off'
+                                                    }
+                                                    text={`${
+                                                        hideTitle
+                                                            ? 'Show'
+                                                            : 'Hide'
+                                                    } title`}
+                                                    onClick={() =>
+                                                        onEdit({
+                                                            ...tile,
+                                                            properties: {
+                                                                ...tile.properties,
+                                                                hideTitle:
+                                                                    !hideTitle,
+                                                            },
+                                                        })
+                                                    }
+                                                />
+                                            )}
+                                            <MenuDivider />
+                                            <MenuItem2
+                                                icon="delete"
+                                                intent="danger"
+                                                text="Remove tile"
+                                                onClick={() => onDelete(tile)}
+                                            />
+                                        </>
+                                    )}
+                                </Menu>
+                            }
+                            position={PopoverPosition.BOTTOM_RIGHT}
+                            lazy
+                        >
                             <Button minimal icon="more" />
-                        </Tooltip2>
-                    </Popover2>
-                )}
+                        </Popover2>
+                    )}
+                </ButtonsWrapper>
             </HeaderContainer>
-
             <ChartContainer className="non-draggable cohere-block">
                 {children}
             </ChartContainer>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -45,6 +45,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     extraHeaderElement,
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
+    const [isHovering, setIsHovering] = useState(false);
 
     const hideTitle =
         tile.type !== DashboardTileTypes.MARKDOWN
@@ -54,8 +55,13 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         <TileBaseWrapper
             className={isLoading ? Classes.SKELETON : undefined}
             isEditMode={isEditMode}
+            isHovering={isHovering}
         >
-            <HeaderContainer isEditMode={isEditMode}>
+            <HeaderContainer
+                isEditMode={isEditMode}
+                onMouseEnter={() => setIsHovering(true)}
+                onMouseLeave={() => setIsHovering(false)}
+            >
                 <HeaderWrapper>
                     {!hideTitle && (
                         <TitleWrapper>


### PR DESCRIPTION
Closes:  #3696

### Description:
**In edit mode**

- Add hover state to dashboard tile (suggestion : drop shadow)
- Add selected state to dashboard tile (suggestion : blue border)
- Grab cursor when hovering over tile header
- Grabbing cursor when selecting tile to drag

**In view mode**

- The context menu and info icon should only show on hover.