### PR TITLE
feat: drill by dimension

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -16,6 +16,7 @@ import {
     friendlyName,
     getDimensions,
     getFields,
+    getItemId,
     getItemMap,
     getResultValues,
     getVisibleFields,
@@ -452,6 +453,10 @@ const DashboardChartTile: FC<Props> = (props) => {
                                                 metricQuery={
                                                     savedQuery?.metricQuery
                                                 }
+                                                drillByMetric={getItemId(
+                                                    viewUnderlyingDataOptions
+                                                        ?.meta?.item,
+                                                )}
                                                 pivotReference={
                                                     viewUnderlyingDataOptions?.pivotReference
                                                 }

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -16,13 +16,10 @@ import {
     friendlyName,
     getDimensions,
     getFields,
-    getItemId,
     getItemMap,
     getResultValues,
     getVisibleFields,
-    isField,
     isFilterableField,
-    isMetric,
     PivotReference,
     ResultRow,
     SavedChart,
@@ -435,36 +432,20 @@ const DashboardChartTile: FC<Props> = (props) => {
                                             }
                                         }}
                                     />
-                                    {viewUnderlyingDataOptions?.meta?.item &&
-                                        isField(
-                                            viewUnderlyingDataOptions.meta.item,
-                                        ) &&
-                                        isMetric(
-                                            viewUnderlyingDataOptions.meta
-                                                ?.item,
-                                        ) &&
-                                        explore &&
-                                        savedQuery?.metricQuery && (
-                                            <DrillDownMenuItem
-                                                row={
-                                                    viewUnderlyingDataOptions.row
-                                                }
-                                                explore={explore}
-                                                metricQuery={
-                                                    savedQuery?.metricQuery
-                                                }
-                                                drillByMetric={getItemId(
-                                                    viewUnderlyingDataOptions
-                                                        ?.meta?.item,
-                                                )}
-                                                pivotReference={
-                                                    viewUnderlyingDataOptions?.pivotReference
-                                                }
-                                                dashboardFilters={
-                                                    dashboardFiltersThatApplyToChart
-                                                }
-                                            />
-                                        )}
+                                    <DrillDownMenuItem
+                                        row={viewUnderlyingDataOptions?.row}
+                                        metricQuery={savedQuery?.metricQuery}
+                                        selectedItem={
+                                            viewUnderlyingDataOptions?.meta
+                                                ?.item
+                                        }
+                                        pivotReference={
+                                            viewUnderlyingDataOptions?.pivotReference
+                                        }
+                                        dashboardFilters={
+                                            dashboardFiltersThatApplyToChart
+                                        }
+                                    />
                                     <MenuItem2
                                         icon="filter"
                                         text="Filter dashboard to..."

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -19,7 +19,9 @@ import {
     getItemMap,
     getResultValues,
     getVisibleFields,
+    isField,
     isFilterableField,
+    isMetric,
     PivotReference,
     ResultRow,
     SavedChart,
@@ -41,6 +43,7 @@ import { getFilterRuleLabel } from '../common/Filters/configs';
 import { TableColumn } from '../common/Table/types';
 import CSVExporter from '../CSVExporter';
 import { FilterValues } from '../DashboardFilter/ActiveFilters/ActiveFilters.styles';
+import DrillDownMenuItem from '../DrillDownMenuItem';
 import LightdashVisualization from '../LightdashVisualization';
 import VisualizationProvider from '../LightdashVisualization/VisualizationProvider';
 import { EchartSeriesClickEvent } from '../SimpleChart';
@@ -431,7 +434,33 @@ const DashboardChartTile: FC<Props> = (props) => {
                                             }
                                         }}
                                     />
-
+                                    {viewUnderlyingDataOptions?.meta?.item &&
+                                        isField(
+                                            viewUnderlyingDataOptions.meta.item,
+                                        ) &&
+                                        isMetric(
+                                            viewUnderlyingDataOptions.meta
+                                                ?.item,
+                                        ) &&
+                                        explore &&
+                                        savedQuery?.metricQuery && (
+                                            <DrillDownMenuItem
+                                                projectUuid={projectUuid}
+                                                row={
+                                                    viewUnderlyingDataOptions.row
+                                                }
+                                                explore={explore}
+                                                metricQuery={
+                                                    savedQuery?.metricQuery
+                                                }
+                                                pivotReference={
+                                                    viewUnderlyingDataOptions?.pivotReference
+                                                }
+                                                dashboardFilters={
+                                                    dashboardFiltersThatApplyToChart
+                                                }
+                                            />
+                                        )}
                                     <MenuItem2
                                         icon="filter"
                                         text="Filter dashboard to..."

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -43,10 +43,10 @@ import { getFilterRuleLabel } from '../common/Filters/configs';
 import { TableColumn } from '../common/Table/types';
 import CSVExporter from '../CSVExporter';
 import { FilterValues } from '../DashboardFilter/ActiveFilters/ActiveFilters.styles';
-import DrillDownMenuItem from '../DrillDownMenuItem';
 import LightdashVisualization from '../LightdashVisualization';
 import VisualizationProvider from '../LightdashVisualization/VisualizationProvider';
 import { EchartSeriesClickEvent } from '../SimpleChart';
+import DrillDownMenuItem from '../UnderlyingData/DrillDownMenuItem';
 import {
     getDataFromChartClick,
     useUnderlyingDataContext,
@@ -445,7 +445,6 @@ const DashboardChartTile: FC<Props> = (props) => {
                                         explore &&
                                         savedQuery?.metricQuery && (
                                             <DrillDownMenuItem
-                                                projectUuid={projectUuid}
                                                 row={
                                                     viewUnderlyingDataOptions.row
                                                 }

--- a/packages/frontend/src/components/DrillDownMenuItem/index.tsx
+++ b/packages/frontend/src/components/DrillDownMenuItem/index.tsx
@@ -1,0 +1,186 @@
+import { MenuItem2 } from '@blueprintjs/popover2';
+import {
+    ChartType,
+    CreateSavedChartVersion,
+    DashboardFilters,
+    Explore,
+    FieldId,
+    FilterGroupItem,
+    FilterOperator,
+    FilterRule,
+    Filters,
+    getItemId,
+    MetricQuery,
+    PivotReference,
+    ResultRow,
+} from '@lightdash/common';
+import { FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+
+type CombineFiltersArgs = {
+    metricQuery: MetricQuery;
+    row: ResultRow;
+    pivotReference?: PivotReference;
+    dashboardFilters?: DashboardFilters;
+    extraFilters?: Filters;
+};
+const combineFilters = ({
+    metricQuery,
+    row,
+    pivotReference,
+    dashboardFilters,
+    extraFilters,
+}: CombineFiltersArgs): Filters => {
+    const combinedDimensionFilters: Array<FilterGroupItem> = [];
+
+    if (metricQuery.filters.dimensions) {
+        combinedDimensionFilters.push(metricQuery.filters.dimensions);
+    }
+    if (dashboardFilters) {
+        combinedDimensionFilters.push(...dashboardFilters.dimensions);
+    }
+    if (pivotReference?.pivotValues) {
+        const pivotFilter: FilterRule[] = pivotReference.pivotValues.map(
+            (pivot) => ({
+                id: uuidv4(),
+                target: {
+                    fieldId: pivot.field,
+                },
+                operator: FilterOperator.EQUALS,
+                values: [pivot.value],
+            }),
+        );
+        combinedDimensionFilters.push(...pivotFilter);
+    }
+    if (extraFilters?.dimensions) {
+        combinedDimensionFilters.push(extraFilters.dimensions);
+    }
+
+    const dimensionFilters: FilterRule[] = metricQuery.dimensions.reduce<
+        FilterRule[]
+    >((acc, dimension) => {
+        const rowValue = row[dimension];
+        if (!rowValue) {
+            return acc;
+        }
+        const dimensionFilter: FilterRule = {
+            id: uuidv4(),
+            target: {
+                fieldId: dimension,
+            },
+            operator:
+                rowValue.value.raw === null
+                    ? FilterOperator.NULL
+                    : FilterOperator.EQUALS,
+            values:
+                rowValue.value.raw === null ? undefined : [rowValue.value.raw],
+        };
+        return [...acc, dimensionFilter];
+    }, []);
+    combinedDimensionFilters.push(...dimensionFilters);
+
+    return {
+        dimensions: {
+            id: uuidv4(),
+            and: combinedDimensionFilters,
+        },
+    };
+};
+
+type DrillDownExploreUrlArgs = {
+    projectUuid: string;
+    tableName: string;
+    metricQuery: MetricQuery;
+    row: ResultRow;
+    drillByDimension: FieldId;
+    dashboardFilters?: DashboardFilters;
+    extraFilters?: Filters;
+    pivotReference?: PivotReference;
+};
+
+export const drillDownExploreUrl = ({
+    projectUuid,
+    tableName,
+    metricQuery,
+    row,
+    drillByDimension,
+    dashboardFilters,
+    extraFilters,
+    pivotReference,
+}: DrillDownExploreUrlArgs) => {
+    const createSavedChartVersion: CreateSavedChartVersion = {
+        tableName,
+        metricQuery: {
+            ...metricQuery,
+            dimensions: [drillByDimension, ...metricQuery.dimensions],
+            filters: combineFilters({
+                metricQuery,
+                row,
+                dashboardFilters,
+                extraFilters,
+                pivotReference,
+            }),
+            limit: 500,
+        },
+        pivotConfig: undefined,
+        tableConfig: {
+            columnOrder: [],
+        },
+        chartConfig: {
+            type: ChartType.CARTESIAN,
+            config: { layout: {}, eChartsConfig: {} },
+        },
+    };
+    const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
+        projectUuid,
+        createSavedChartVersion,
+    );
+    return `${pathname}?${search}`;
+};
+
+export const DrillDownMenuItem: FC<{
+    projectUuid: string;
+    explore: Explore;
+    metricQuery: MetricQuery;
+    row: ResultRow;
+    dashboardFilters?: DashboardFilters;
+    pivotReference?: PivotReference;
+}> = ({
+    projectUuid,
+    explore,
+    metricQuery,
+    row,
+    dashboardFilters,
+    pivotReference,
+}) => {
+    return (
+        <MenuItem2 text="Drill by" icon="path">
+            {Object.values(explore.tables).map((table) => (
+                <MenuItem2 key={table.name} text={table.label}>
+                    {Object.values(table.dimensions)
+                        .filter((dimension) => !dimension.hidden)
+                        .sort((a, b) => a.label.localeCompare(b.label))
+                        .map((dimension) => (
+                            <MenuItem2
+                                key={getItemId(dimension)}
+                                text={dimension.label}
+                                href={drillDownExploreUrl({
+                                    projectUuid,
+                                    tableName: explore.name,
+                                    metricQuery,
+                                    row,
+                                    drillByDimension: getItemId(dimension),
+                                    dashboardFilters,
+                                    pivotReference,
+                                })}
+                                target="_blank"
+                            />
+                        ))}
+                </MenuItem2>
+            ))}
+        </MenuItem2>
+    );
+};
+
+export default DrillDownMenuItem;

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -2,16 +2,13 @@ import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
-    getItemId,
     isField,
     isFilterableField,
-    isMetric,
     MetricQuery,
     ResultRow,
     TableCalculation,
 } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useExplore } from '../../../hooks/useExplore';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -27,9 +24,8 @@ const CellContextMenu: FC<
     }
 > = ({ cell, isEditMode, itemsMap, metricQuery }) => {
     const { addFilter } = useFilters();
-    const { viewData, tableName } = useUnderlyingDataContext();
+    const { viewData } = useUnderlyingDataContext();
     const { track } = useTracking();
-    const { data: explore } = useExplore(tableName);
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
@@ -70,15 +66,11 @@ const CellContextMenu: FC<
                     }}
                 />
             )}
-
-            {isField(item) && isMetric(item) && explore && (
-                <DrillDownMenuItem
-                    row={cell.row.original || {}}
-                    explore={explore}
-                    metricQuery={metricQuery}
-                    drillByMetric={getItemId(item)}
-                />
-            )}
+            <DrillDownMenuItem
+                row={cell.row.original || {}}
+                metricQuery={metricQuery}
+                selectedItem={item}
+            />
         </Menu>
     );
 };

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -10,13 +10,12 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useParams } from 'react-router-dom';
 import { useExplore } from '../../../hooks/useExplore';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { CellContextMenuProps } from '../../common/Table/types';
-import DrillDownMenuItem from '../../DrillDownMenuItem';
+import DrillDownMenuItem from '../../UnderlyingData/DrillDownMenuItem';
 import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataProvider';
 import UrlMenuItems from './UrlMenuItems';
 
@@ -26,7 +25,6 @@ const CellContextMenu: FC<
         metricQuery: MetricQuery;
     }
 > = ({ cell, isEditMode, itemsMap, metricQuery }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { addFilter } = useFilters();
     const { viewData, tableName } = useUnderlyingDataContext();
     const { track } = useTracking();
@@ -74,7 +72,6 @@ const CellContextMenu: FC<
 
             {isField(item) && isMetric(item) && explore && (
                 <DrillDownMenuItem
-                    projectUuid={projectUuid}
                     row={cell.row.original || {}}
                     explore={explore}
                     metricQuery={metricQuery}

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -4,26 +4,33 @@ import {
     Field,
     isField,
     isFilterableField,
+    isMetric,
+    MetricQuery,
     ResultRow,
     TableCalculation,
 } from '@lightdash/common';
 import React, { FC } from 'react';
+import { useParams } from 'react-router-dom';
+import { useExplore } from '../../../hooks/useExplore';
 import { useFilters } from '../../../hooks/useFilters';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { CellContextMenuProps } from '../../common/Table/types';
+import DrillDownMenuItem from '../../DrillDownMenuItem';
 import { useUnderlyingDataContext } from '../../UnderlyingData/UnderlyingDataProvider';
 import UrlMenuItems from './UrlMenuItems';
 
 const CellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell' | 'isEditMode'> & {
         itemsMap: Record<string, Field | TableCalculation>;
+        metricQuery: MetricQuery;
     }
-> = ({ cell, isEditMode, itemsMap }) => {
+> = ({ cell, isEditMode, itemsMap, metricQuery }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { addFilter } = useFilters();
-    const { viewData } = useUnderlyingDataContext();
+    const { viewData, tableName } = useUnderlyingDataContext();
     const { track } = useTracking();
-
+    const { data: explore } = useExplore(tableName);
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
@@ -62,6 +69,15 @@ const CellContextMenu: FC<
                             true,
                         );
                     }}
+                />
+            )}
+
+            {isField(item) && isMetric(item) && explore && (
+                <DrillDownMenuItem
+                    projectUuid={projectUuid}
+                    row={cell.row.original || {}}
+                    explore={explore}
+                    metricQuery={metricQuery}
                 />
             )}
         </Menu>

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
+    getItemId,
     isField,
     isFilterableField,
     isMetric,
@@ -75,6 +76,7 @@ const CellContextMenu: FC<
                     row={cell.row.original || {}}
                     explore={explore}
                     metricQuery={metricQuery}
+                    drillByMetric={getItemId(item)}
                 />
             )}
         </Menu>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -24,6 +24,9 @@ export const ExplorerResults = memo(() => {
     const activeTableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );
+    const metricQuery = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery,
+    );
     const dimensions = useExplorerContext(
         (context) => context.state.unsavedChartVersion.metricQuery.dimensions,
     );
@@ -70,9 +73,10 @@ export const ExplorerResults = memo(() => {
                 isEditMode={isEditMode}
                 {...props}
                 itemsMap={itemsMap}
+                metricQuery={metricQuery}
             />
         ),
-        [isEditMode, itemsMap],
+        [isEditMode, itemsMap, metricQuery],
     );
 
     const IdleState: FC = useCallback(() => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -4,7 +4,7 @@ import {
     Popover2,
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
-import { getItemId, getItemMap, isField, isMetric } from '@lightdash/common';
+import { getItemMap } from '@lightdash/common';
 import React, {
     FC,
     memo,
@@ -72,7 +72,7 @@ export const SeriesContextMenu: FC<{
         }
     }, [echartSeriesClickEvent, explore, metricQuery, series]);
 
-    const viewUnderlyingData = useCallback(() => {
+    const onViewUnderlyingData = useCallback(() => {
         if (underlyingData !== undefined) {
             viewData(
                 underlyingData.value,
@@ -100,13 +100,6 @@ export const SeriesContextMenu: FC<{
         [],
     );
 
-    const onViewUnderlyingData = useCallback(
-        (e) => {
-            viewUnderlyingData();
-        },
-        [viewUnderlyingData],
-    );
-
     const onClose = useCallback(() => setContextMenuIsOpen(false), []);
 
     return (
@@ -119,23 +112,12 @@ export const SeriesContextMenu: FC<{
                             icon={'layers'}
                             onClick={onViewUnderlyingData}
                         />
-                        {underlyingData?.meta?.item &&
-                            isField(underlyingData.meta.item) &&
-                            isMetric(underlyingData.meta?.item) &&
-                            explore &&
-                            metricQuery && (
-                                <DrillDownMenuItem
-                                    row={underlyingData.row}
-                                    explore={explore}
-                                    metricQuery={metricQuery}
-                                    drillByMetric={getItemId(
-                                        underlyingData?.meta?.item,
-                                    )}
-                                    pivotReference={
-                                        underlyingData?.pivotReference
-                                    }
-                                />
-                            )}
+                        <DrillDownMenuItem
+                            row={underlyingData?.row}
+                            metricQuery={metricQuery}
+                            selectedItem={underlyingData?.meta?.item}
+                            pivotReference={underlyingData?.pivotReference}
+                        />
                     </Menu>
                 </div>
             }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -13,13 +13,12 @@ import React, {
     useMemo,
     useState,
 } from 'react';
-import { useParams } from 'react-router-dom';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
-import DrillDownMenuItem from '../../DrillDownMenuItem';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import { EchartSeriesClickEvent } from '../../SimpleChart';
+import DrillDownMenuItem from '../../UnderlyingData/DrillDownMenuItem';
 import {
     getDataFromChartClick,
     useUnderlyingDataContext,
@@ -30,7 +29,6 @@ export const SeriesContextMenu: FC<{
     dimensions: string[] | undefined;
     series: EChartSeries[] | undefined;
 }> = memo(({ echartSeriesClickEvent, dimensions, series }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const tableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );
@@ -127,7 +125,6 @@ export const SeriesContextMenu: FC<{
                             explore &&
                             metricQuery && (
                                 <DrillDownMenuItem
-                                    projectUuid={projectUuid}
                                     row={underlyingData.row}
                                     explore={explore}
                                     metricQuery={metricQuery}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -4,7 +4,7 @@ import {
     Popover2,
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
-import { getItemMap, isField, isMetric } from '@lightdash/common';
+import { getItemId, getItemMap, isField, isMetric } from '@lightdash/common';
 import React, {
     FC,
     memo,
@@ -128,6 +128,9 @@ export const SeriesContextMenu: FC<{
                                     row={underlyingData.row}
                                     explore={explore}
                                     metricQuery={metricQuery}
+                                    drillByMetric={getItemId(
+                                        underlyingData?.meta?.item,
+                                    )}
                                     pivotReference={
                                         underlyingData?.pivotReference
                                     }

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
-import { getItemId, isField, isMetric, ResultRow } from '@lightdash/common';
+import { ResultRow } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
 import { useExplore } from '../../hooks/useExplore';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
@@ -56,17 +56,11 @@ export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
                             viewUnderlyingData();
                         }}
                     />
-                    {isField(selectedItem) &&
-                        isMetric(selectedItem) &&
-                        explore &&
-                        resultsData && (
-                            <DrillDownMenuItem
-                                row={resultsData.rows[0]}
-                                explore={explore}
-                                metricQuery={resultsData.metricQuery}
-                                drillByMetric={getItemId(selectedItem)}
-                            />
-                        )}
+                    <DrillDownMenuItem
+                        row={resultsData?.rows[0]}
+                        metricQuery={resultsData?.metricQuery}
+                        selectedItem={selectedItem}
+                    />
                 </Menu>
             }
         />

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -2,10 +2,9 @@ import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
 import { isField, isMetric, ResultRow } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { useExplore } from '../../hooks/useExplore';
-import DrillDownMenuItem from '../DrillDownMenuItem';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
+import DrillDownMenuItem from '../UnderlyingData/DrillDownMenuItem';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
 interface BigNumberContextMenuProps {
@@ -15,7 +14,6 @@ interface BigNumberContextMenuProps {
 export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
     renderTarget,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { resultsData, bigNumberConfig } = useVisualizationContext();
     const { viewData, tableName } = useUnderlyingDataContext();
     const { data: explore } = useExplore(tableName);
@@ -63,7 +61,6 @@ export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
                         explore &&
                         resultsData && (
                             <DrillDownMenuItem
-                                projectUuid={projectUuid}
                                 row={resultsData.rows[0]}
                                 explore={explore}
                                 metricQuery={resultsData.metricQuery}

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
-import { isField, isMetric, ResultRow } from '@lightdash/common';
+import { getItemId, isField, isMetric, ResultRow } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
 import { useExplore } from '../../hooks/useExplore';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
@@ -64,6 +64,7 @@ export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
                                 row={resultsData.rows[0]}
                                 explore={explore}
                                 metricQuery={resultsData.metricQuery}
+                                drillByMetric={getItemId(selectedItem)}
                             />
                         )}
                 </Menu>

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,8 +1,10 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
-import { ResultRow } from '@lightdash/common';
-import { FC, useCallback } from 'react';
+import { isField, isMetric, ResultRow } from '@lightdash/common';
+import { FC, useCallback, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import { useExplore } from '../../hooks/useExplore';
+import DrillDownMenuItem from '../DrillDownMenuItem';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
@@ -13,9 +15,18 @@ interface BigNumberContextMenuProps {
 export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
     renderTarget,
 }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { resultsData, bigNumberConfig } = useVisualizationContext();
     const { viewData, tableName } = useUnderlyingDataContext();
     const { data: explore } = useExplore(tableName);
+
+    const selectedItem = useMemo(
+        () =>
+            bigNumberConfig?.selectedField
+                ? bigNumberConfig.getField(bigNumberConfig.selectedField)
+                : undefined,
+        [bigNumberConfig],
+    );
 
     const viewUnderlyingData = useCallback(() => {
         if (
@@ -47,6 +58,17 @@ export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
                             viewUnderlyingData();
                         }}
                     />
+                    {isField(selectedItem) &&
+                        isMetric(selectedItem) &&
+                        explore &&
+                        resultsData && (
+                            <DrillDownMenuItem
+                                projectUuid={projectUuid}
+                                row={resultsData.rows[0]}
+                                explore={explore}
+                                metricQuery={resultsData.metricQuery}
+                            />
+                        )}
                 </Menu>
             }
         />

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Explore,
+    getItemId,
     isField,
     isMetric,
     MetricQuery,
@@ -50,6 +51,7 @@ const CellContextMenu: FC<
                     explore={explore}
                     metricQuery={metricQuery}
                     pivotReference={meta?.pivotReference}
+                    drillByMetric={getItemId(item)}
                 />
             )}
         </Menu>

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -8,10 +8,9 @@ import {
     ResultRow,
 } from '@lightdash/common';
 import React, { FC } from 'react';
-import { useParams } from 'react-router-dom';
 import { CellContextMenuProps } from '../common/Table/types';
-import DrillDownMenuItem from '../DrillDownMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+import DrillDownMenuItem from '../UnderlyingData/DrillDownMenuItem';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
 const CellContextMenu: FC<
@@ -20,7 +19,6 @@ const CellContextMenu: FC<
         metricQuery?: MetricQuery;
     }
 > = ({ cell, explore, metricQuery }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { viewData } = useUnderlyingDataContext();
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
@@ -48,7 +46,6 @@ const CellContextMenu: FC<
             />
             {isField(item) && isMetric(item) && explore && metricQuery && (
                 <DrillDownMenuItem
-                    projectUuid={projectUuid}
                     row={cell.row.original || {}}
                     explore={explore}
                     metricQuery={metricQuery}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,14 +1,27 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import { isField, ResultRow } from '@lightdash/common';
+import {
+    Explore,
+    isField,
+    isMetric,
+    MetricQuery,
+    ResultRow,
+} from '@lightdash/common';
 import React, { FC } from 'react';
+import { useParams } from 'react-router-dom';
 import { CellContextMenuProps } from '../common/Table/types';
+import DrillDownMenuItem from '../DrillDownMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
-const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
+const CellContextMenu: FC<
+    Pick<CellContextMenuProps, 'cell'> & {
+        explore?: Explore;
+        metricQuery?: MetricQuery;
+    }
+> = ({ cell, explore, metricQuery }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { viewData } = useUnderlyingDataContext();
-
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
@@ -33,6 +46,15 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                     );
                 }}
             />
+            {isField(item) && isMetric(item) && explore && metricQuery && (
+                <DrillDownMenuItem
+                    projectUuid={projectUuid}
+                    row={cell.row.original || {}}
+                    explore={explore}
+                    metricQuery={metricQuery}
+                    pivotReference={meta?.pivotReference}
+                />
+            )}
         </Menu>
     );
 };

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,13 +1,6 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import {
-    Explore,
-    getItemId,
-    isField,
-    isMetric,
-    MetricQuery,
-    ResultRow,
-} from '@lightdash/common';
+import { isField, MetricQuery, ResultRow } from '@lightdash/common';
 import React, { FC } from 'react';
 import { CellContextMenuProps } from '../common/Table/types';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
@@ -16,10 +9,9 @@ import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvid
 
 const CellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell'> & {
-        explore?: Explore;
         metricQuery?: MetricQuery;
     }
-> = ({ cell, explore, metricQuery }) => {
+> = ({ cell, metricQuery }) => {
     const { viewData } = useUnderlyingDataContext();
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
@@ -45,15 +37,12 @@ const CellContextMenu: FC<
                     );
                 }}
             />
-            {isField(item) && isMetric(item) && explore && metricQuery && (
-                <DrillDownMenuItem
-                    row={cell.row.original || {}}
-                    explore={explore}
-                    metricQuery={metricQuery}
-                    pivotReference={meta?.pivotReference}
-                    drillByMetric={getItemId(item)}
-                />
-            )}
+            <DrillDownMenuItem
+                row={cell.row.original || {}}
+                metricQuery={metricQuery}
+                pivotReference={meta?.pivotReference}
+                selectedItem={item}
+            />
         </Menu>
     );
 };

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -107,6 +107,7 @@ const DashboardCellContextMenu: FC<
                     metricQuery={metricQuery}
                     dashboardFilters={dashboardFiltersThatApplyToChart}
                     pivotReference={meta?.pivotReference}
+                    drillByMetric={getItemId(item)}
                 />
             )}
             {filters.length > 0 && (

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -10,7 +10,6 @@ import {
     getItemId,
     isDimension,
     isField,
-    isMetric,
     MetricQuery,
     ResultRow,
 } from '@lightdash/common';
@@ -100,16 +99,13 @@ const DashboardCellContextMenu: FC<
                     );
                 }}
             />
-            {isField(item) && isMetric(item) && explore && metricQuery && (
-                <DrillDownMenuItem
-                    row={cell.row.original || {}}
-                    explore={explore}
-                    metricQuery={metricQuery}
-                    dashboardFilters={dashboardFiltersThatApplyToChart}
-                    pivotReference={meta?.pivotReference}
-                    drillByMetric={getItemId(item)}
-                />
-            )}
+            <DrillDownMenuItem
+                row={cell.row.original || {}}
+                metricQuery={metricQuery}
+                dashboardFilters={dashboardFiltersThatApplyToChart}
+                pivotReference={meta?.pivotReference}
+                selectedItem={item}
+            />
             {filters.length > 0 && (
                 <MenuItem2 icon="filter" text="Filter dashboard to...">
                     {filters.map((filter) => {

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -16,12 +16,11 @@ import {
 } from '@lightdash/common';
 import { uuid4 } from '@sentry/utils';
 import React, { FC } from 'react';
-import { useParams } from 'react-router-dom';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { CellContextMenuProps } from '../common/Table/types';
-import DrillDownMenuItem from '../DrillDownMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+import DrillDownMenuItem from '../UnderlyingData/DrillDownMenuItem';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
 const DashboardCellContextMenu: FC<
@@ -31,7 +30,6 @@ const DashboardCellContextMenu: FC<
         metricQuery?: MetricQuery;
     }
 > = ({ cell, explore, tileUuid, metricQuery }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { viewData } = useUnderlyingDataContext();
     const { addDimensionDashboardFilter } = useDashboardContext();
     const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
@@ -104,7 +102,6 @@ const DashboardCellContextMenu: FC<
             />
             {isField(item) && isMetric(item) && explore && metricQuery && (
                 <DrillDownMenuItem
-                    projectUuid={projectUuid}
                     row={cell.row.original || {}}
                     explore={explore}
                     metricQuery={metricQuery}

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -10,13 +10,17 @@ import {
     getItemId,
     isDimension,
     isField,
+    isMetric,
+    MetricQuery,
     ResultRow,
 } from '@lightdash/common';
 import { uuid4 } from '@sentry/utils';
-import { FC } from 'react';
+import React, { FC } from 'react';
+import { useParams } from 'react-router-dom';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { CellContextMenuProps } from '../common/Table/types';
+import DrillDownMenuItem from '../DrillDownMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import { useUnderlyingDataContext } from '../UnderlyingData/UnderlyingDataProvider';
 
@@ -24,8 +28,10 @@ const DashboardCellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell'> & {
         explore: Explore | undefined;
         tileUuid: string;
+        metricQuery?: MetricQuery;
     }
-> = ({ cell, explore, tileUuid }) => {
+> = ({ cell, explore, tileUuid, metricQuery }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const { viewData } = useUnderlyingDataContext();
     const { addDimensionDashboardFilter } = useDashboardContext();
     const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
@@ -96,6 +102,16 @@ const DashboardCellContextMenu: FC<
                     );
                 }}
             />
+            {isField(item) && isMetric(item) && explore && metricQuery && (
+                <DrillDownMenuItem
+                    projectUuid={projectUuid}
+                    row={cell.row.original || {}}
+                    explore={explore}
+                    metricQuery={metricQuery}
+                    dashboardFilters={dashboardFiltersThatApplyToChart}
+                    pivotReference={meta?.pivotReference}
+                />
+            )}
             {filters.length > 0 && (
                 <MenuItem2 icon="filter" text="Filter dashboard to...">
                     {filters.map((filter) => {

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -32,6 +32,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
             showColumnCalculation,
             hideRowNumbers,
         },
+        resultsData,
         isSqlRunner,
         explore,
     } = useVisualizationContext();
@@ -70,9 +71,16 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             {...props}
                             tileUuid={tileUuid}
                             explore={explore}
+                            metricQuery={resultsData?.metricQuery}
                         />
                     );
-                return <CellContextMenu {...props} />;
+                return (
+                    <CellContextMenu
+                        {...props}
+                        metricQuery={resultsData?.metricQuery}
+                        explore={explore}
+                    />
+                );
             }}
             {...rest}
         />

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -78,7 +78,6 @@ const SimpleTable: FC<SimpleTableProps> = ({
                     <CellContextMenu
                         {...props}
                         metricQuery={resultsData?.metricQuery}
-                        explore={explore}
                     />
                 );
             }}

--- a/packages/frontend/src/components/UnderlyingData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/UnderlyingData/DrillDownMenuItem.tsx
@@ -94,17 +94,19 @@ type DrillDownExploreUrlArgs = {
     tableName: string;
     metricQuery: MetricQuery;
     row: ResultRow;
+    drillByMetric: FieldId;
     drillByDimension: FieldId;
     dashboardFilters?: DashboardFilters;
     extraFilters?: Filters;
     pivotReference?: PivotReference;
 };
 
-export const drillDownExploreUrl = ({
+const drillDownExploreUrl = ({
     projectUuid,
     tableName,
     metricQuery,
     row,
+    drillByMetric,
     drillByDimension,
     dashboardFilters,
     extraFilters,
@@ -113,8 +115,9 @@ export const drillDownExploreUrl = ({
     const createSavedChartVersion: CreateSavedChartVersion = {
         tableName,
         metricQuery: {
-            ...metricQuery,
-            dimensions: [drillByDimension, ...metricQuery.dimensions],
+            tableCalculations: [],
+            dimensions: [drillByDimension],
+            metrics: [drillByMetric],
             filters: combineFilters({
                 metricQuery,
                 row,
@@ -123,6 +126,8 @@ export const drillDownExploreUrl = ({
                 pivotReference,
             }),
             limit: 500,
+            additionalMetrics: metricQuery.additionalMetrics,
+            sorts: [{ fieldId: drillByDimension, descending: false }],
         },
         pivotConfig: undefined,
         tableConfig: {
@@ -144,9 +149,17 @@ export const DrillDownMenuItem: FC<{
     explore: Explore;
     metricQuery: MetricQuery;
     row: ResultRow;
+    drillByMetric: FieldId;
     dashboardFilters?: DashboardFilters;
     pivotReference?: PivotReference;
-}> = ({ explore, metricQuery, row, dashboardFilters, pivotReference }) => {
+}> = ({
+    explore,
+    metricQuery,
+    row,
+    drillByMetric,
+    dashboardFilters,
+    pivotReference,
+}) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     return (
         <MenuItem2 text="Drill by" icon="path">
@@ -164,6 +177,7 @@ export const DrillDownMenuItem: FC<{
                                     tableName: explore.name,
                                     metricQuery,
                                     row,
+                                    drillByMetric,
                                     drillByDimension: getItemId(dimension),
                                     dashboardFilters,
                                     pivotReference,

--- a/packages/frontend/src/components/UnderlyingData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/UnderlyingData/DrillDownMenuItem.tsx
@@ -15,6 +15,7 @@ import {
     ResultRow,
 } from '@lightdash/common';
 import { FC } from 'react';
+import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 
@@ -140,20 +141,13 @@ export const drillDownExploreUrl = ({
 };
 
 export const DrillDownMenuItem: FC<{
-    projectUuid: string;
     explore: Explore;
     metricQuery: MetricQuery;
     row: ResultRow;
     dashboardFilters?: DashboardFilters;
     pivotReference?: PivotReference;
-}> = ({
-    projectUuid,
-    explore,
-    metricQuery,
-    row,
-    dashboardFilters,
-    pivotReference,
-}) => {
+}> = ({ explore, metricQuery, row, dashboardFilters, pivotReference }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     return (
         <MenuItem2 text="Drill by" icon="path">
             {Object.values(explore.tables).map((table) => (

--- a/packages/frontend/src/components/UnderlyingData/UnderlyingDataProvider.tsx
+++ b/packages/frontend/src/components/UnderlyingData/UnderlyingDataProvider.tsx
@@ -1,5 +1,6 @@
 import {
     DashboardFilters,
+    Explore,
     Field,
     Filters,
     getItemId,
@@ -17,6 +18,7 @@ import React, {
     useState,
 } from 'react';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
+import { useExplore } from '../../hooks/useExplore';
 import { TableColumn } from '../common/Table/types';
 import { EchartSeriesClickEvent } from '../SimpleChart';
 
@@ -31,6 +33,7 @@ type UnderlyingDataConfig = {
 
 type UnderlyingDataContext = {
     tableName: string;
+    explore: Explore | undefined;
     filters?: Filters;
     config: UnderlyingDataConfig | undefined;
     isModalOpen: boolean;
@@ -101,7 +104,7 @@ export const UnderlyingDataProvider: FC<Props> = ({
 }) => {
     const [config, setConfig] = useState<UnderlyingDataConfig>();
     const [isModalOpen, setModalOpen] = useState<boolean>(false);
-
+    const { data: explore } = useExplore(tableName);
     const closeModal = useCallback(() => {
         setModalOpen(false);
     }, []);
@@ -138,6 +141,7 @@ export const UnderlyingDataProvider: FC<Props> = ({
                 viewData,
                 isModalOpen,
                 closeModal,
+                explore,
             }}
         >
             {children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3891 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

This feature is available on both explore and dashboards:
- results table - only on metric cell
- charts - only on series with metric
- big number - only on metric values
- table viz - only on metric cell

When drilling down the query should contain:
- dimension selected in the menu
- metric clicked/selected
- explore filters + dashboard filters + one filter per pivot value + dimension value from selected chart series

<a href="https://www.loom.com/share/13ba56a4abc9475b9314684b86321d49">
    <p>Lightdash - drill by dimension ( chart ) - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/13ba56a4abc9475b9314684b86321d49-with-play.gif">
  </a>

<a href="https://www.loom.com/share/262ab30f65d9429698f9cb3bc90a6976">
    <p>Lightdash - drill by dimension ( big number ) - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/262ab30f65d9429698f9cb3bc90a6976-with-play.gif">
  </a>

<a href="https://www.loom.com/share/31cc8f25f0e7421b822b4de3272b9b8b">
    <p>Lightdash - drill by dimension ( table viz ) - Watch Video</p>
  </a>




### Following PRs

#### 1. Refactor underlying data provider 

- perhaps rename it to something generic that covers all data actions
- replace `filters` prop with `metricQuery` that will cover both underlying data and drill down 
- extract functions to utils and combine with drill down functions if possible

#### 2. Drill down should not be available for series using dimension vs dimension or metric vs metric

This was one of the acceptance criteria for this ticket but decided to leave it out of this PR since it involves refactor/abstraction of the underlying data util function `getDataFromChartClick`.

#### 3. Fix bug where selected cell is on top of the menu options

Fix might be unnecessary depending on solution for the next point.

![Screenshot 2022-12-09 at 16 06 54](https://user-images.githubusercontent.com/9117144/206754290-e4cd85c7-b3ef-446b-83b8-847bcdb7c93d.png)

#### 4. Have a better way to search the dimension to drill by

> There's a way to search for which dimension you want to add (similar to the filter selection component?)

This acceptance criteria was not included in this PR to keep it as simple as possible. There are a few design questions on how this would look and behave. Should we open a modal with an auto-complete input ? 