### PR TITLE
feat: add Proxy-Authorization header support

### DIFF
--- a/docs/docs/guides/cli/cli-authentication.mdx
+++ b/docs/docs/guides/cli/cli-authentication.mdx
@@ -44,11 +44,12 @@ You can use the following environment variables to authenticate yourself on each
 
 - **LIGHTDASH_API_KEY** a personal access token you can generate in the app under the user settings
 - **LIGHTDASH_URL** address for your running Lightdash instance
+- **LIGHTDASH_PROXY_AUTHENTICATION** if your Lightdash instance is behind a proxy like (Cloud IAP)[https://cloud.google.com/iap] you can set here `Proxy-Authentication` header value
 
 Example:
 
   ```shell
-  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://app.lightdash.cloud" lightdash preview
+  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://app.lightdash.cloud" LIGHTDASH_PROXY_AUTHENTICATION="Bearer <JWT_TOKEN>" lightdash preview
   ```
 
 </details>

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -17,6 +17,7 @@ export type Config = {
         serverUrl?: string;
         project?: string;
         apiKey?: string;
+        proxyAuthorization?: string;
     };
     answers?: {
         permissionToStoreWarehouseCredentials?: boolean;
@@ -67,6 +68,9 @@ export const getConfig = async (): Promise<Config> => {
                 process.env.LIGHTDASH_PROJECT || rawConfig.context?.project,
             serverUrl:
                 process.env.LIGHTDASH_URL || rawConfig.context?.serverUrl,
+            proxyAuthorization:
+                process.env.LIGHTDASH_PROXY_AUTHORIZATION ||
+                rawConfig.context?.proxyAuthorization,
         },
     };
 };

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -31,7 +31,9 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             `Not logged in. Run 'lightdash login --help'`,
         );
     }
-
+    const proxyAuthorizationHeader = config.context.proxyAuthorization
+        ? { 'Proxy-Authorization': config.context.proxyAuthorization }
+        : undefined;
     const headers = {
         'Content-Type': 'application/json',
         Authorization: `ApiKey ${config.context.apiKey}`,
@@ -39,6 +41,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             process.env.CI === 'true'
                 ? RequestMethod.CLI_CI
                 : RequestMethod.CLI,
+        ...proxyAuthorizationHeader,
     };
     const fullUrl = new URL(url, config.context.serverUrl).href;
     GlobalState.debug(`> Making HTTP query to: ${fullUrl}`);

--- a/packages/cli/src/handlers/login.ts
+++ b/packages/cli/src/handlers/login.ts
@@ -15,14 +15,23 @@ type LoginOptions = {
     verbose: boolean;
 };
 
-const loginWithToken = async (url: string, token: string) => {
+const loginWithToken = async (
+    url: string,
+    token: string,
+    proxyAuthorization?: string,
+) => {
     const userInfoUrl = new URL(`/api/v1/user`, url).href;
+    const proxyAuthorizationHeader = proxyAuthorization
+        ? { 'Proxy-Authorization': proxyAuthorization }
+        : undefined;
+    const headers = {
+        Authorization: `ApiKey ${token}`,
+        'Content-Type': 'application/json',
+        ...proxyAuthorizationHeader,
+    };
     const response = await fetch(userInfoUrl, {
         method: 'GET',
-        headers: {
-            Authorization: `ApiKey ${token}`,
-            'Content-Type': 'application/json',
-        },
+        headers,
     });
 
     if (response.status !== 200) {
@@ -114,8 +123,9 @@ export const login = async (url: string, options: LoginOptions) => {
             )} ?\n`,
         );
     }
+    const proxyAuthorization = process.env.LIGHTDASH_PROXY_AUTHORIZATION;
     const { userUuid, token } = options.token
-        ? await loginWithToken(url, options.token)
+        ? await loginWithToken(url, options.token, proxyAuthorization)
         : await loginWithPassword(url);
 
     GlobalState.debug(`> Logged in with userUuid: ${userUuid}`);


### PR DESCRIPTION
Closes: #3580 

### Description:

I'm adding support for the [`Proxy-Authorization`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization) header. In many production deployments, we want to hide Lightdash behind an authorization proxy like: [Cloud IAP](https://cloud.google.com/iap). Now, you can easily authorize by setting `LIGHTDASH_PROXY_AUTHORIZATION` environment variable. It enable scenarios, when we want to deploy changes to secured Lightdash instance using CLI or generating previews of local changes on remote, secured Lightdash instance

