### PR TITLE
fix: script bash preinstall script if fails on windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
         "fix-lint": "yarn run linter ./src --fix",
         "format": "yarn run formatter ./src --check",
         "fix-format": "yarn run formatter ./src --write",
-        "preinstall": "bash track.sh started || true",
-        "postinstall": "bash track.sh completed || true"
+        "preinstall": "bash track.sh started || echo 'skipping preinstall'",
+        "postinstall": "bash track.sh completed || echo 'skipping postinstall'"
     }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
         "fix-lint": "yarn run linter ./src --fix",
         "format": "yarn run formatter ./src --check",
         "fix-format": "yarn run formatter ./src --write",
-        "preinstall": "bash track.sh started",
-        "postinstall": "bash track.sh completed"
+        "preinstall": "bash track.sh started || true",
+        "postinstall": "bash track.sh completed || true"
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [3813](https://github.com/lightdash/lightdash/issues/3813)

### Description:

Before:

![Screenshot from 2022-12-16 15-51-34](https://user-images.githubusercontent.com/1983672/208125157-c7a4fb86-883d-431b-b08b-0d3f5faae0d9.png)

After:

Published and tested with `npm i -g @lightdash/cli@0.346.1-rc1`
![Screenshot from 2022-12-16 15-53-01](https://user-images.githubusercontent.com/1983672/208125183-71059f65-b65c-4133-8951-a252a0baab3d.png)
![Screenshot from 2022-12-16 15-54-13](https://user-images.githubusercontent.com/1983672/208125186-c98274b0-41a9-48b3-aab6-213f90f3a2e6.png)



<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
