### PR TITLE
fix: dashboard filters wrapping

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
@@ -2,13 +2,7 @@ import { Colors, Tag } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const TagContainer = styled(Tag)`
-    width: fit-content;
-    padding: 0 0.5em;
-    border-radius: 0.214em;
-
-    & span {
-        color: ${Colors.WHITE};
-    }
+    flex-shrink: 0;
 `;
 
 export const InvalidFilterTag = styled(TagContainer)`

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -2,6 +2,7 @@ import { FieldId, fieldId, FilterableField } from '@lightdash/common';
 import { FC } from 'react';
 import { useAvailableDashboardFilterTargets } from '../../../hooks/dashboard/useDashboard';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
+import { ActiveDashboardFiltersWrapper } from '../DashboardFilter.styles';
 import ActiveFilter from './ActiveFilter';
 
 const ActiveFilters: FC = () => {
@@ -23,7 +24,7 @@ const ActiveFilters: FC = () => {
     );
 
     return (
-        <>
+        <ActiveDashboardFiltersWrapper>
             {dashboardFilters.dimensions.map((item, index) => (
                 <ActiveFilter
                     key={item.id}
@@ -50,7 +51,7 @@ const ActiveFilters: FC = () => {
                     }
                 />
             ))}
-        </>
+        </ActiveDashboardFiltersWrapper>
     );
 };
 

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -35,6 +35,7 @@ export const FilterTrigger = styled(AnchorButton)`
 
 export const DashboardFilterWrapper = styled.div`
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
     align-items: center;
     margin-bottom: 10px;

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -35,8 +35,13 @@ export const FilterTrigger = styled(AnchorButton)`
 
 export const DashboardFilterWrapper = styled.div`
     display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
+    gap: 12px;
     align-items: center;
     margin-bottom: 10px;
+`;
+
+export const ActiveDashboardFiltersWrapper = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
 `;

--- a/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
+++ b/packages/frontend/src/components/DashboardFilter/DashboardFilter.styles.tsx
@@ -36,7 +36,7 @@ export const FilterTrigger = styled(AnchorButton)`
 export const DashboardFilterWrapper = styled.div`
     display: flex;
     gap: 12px;
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: 10px;
 `;
 
@@ -44,4 +44,5 @@ export const ActiveDashboardFiltersWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+    padding: 5px 0;
 `;


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3980

### Description:

- [x] fixes wrapping for dashboard filters

<img width="1507" alt="CleanShot 2022-12-15 at 16 56 54@2x" src="https://user-images.githubusercontent.com/962095/207893584-168bd598-c51f-40a3-90a4-e8ec4da3ad08.png">

<img width="1505" alt="CleanShot 2022-12-15 at 16 57 57@2x" src="https://user-images.githubusercontent.com/962095/207893594-b7a91163-3205-416f-8b47-c97893529e49.png">
