### PR TITLE
feat: add schema validation to CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
         "@lightdash/common": "^0.346.1",
         "@lightdash/warehouses": "^0.346.1",
         "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
         "better-ajv-errors": "^1.2.0",
         "chalk": "4.1.2",
         "chokidar": "^3.5.3",

--- a/packages/cli/src/dbt/manifestv7.json
+++ b/packages/cli/src/dbt/manifestv7.json
@@ -1,0 +1,6481 @@
+{
+    "type": "object",
+    "required": [
+        "metadata",
+        "nodes",
+        "sources",
+        "macros",
+        "docs",
+        "exposures",
+        "metrics",
+        "selectors"
+    ],
+    "properties": {
+        "metadata": {
+            "$ref": "#/definitions/ManifestMetadata",
+            "description": "Metadata about the manifest"
+        },
+        "nodes": {
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/CompiledAnalysisNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledSingularTestNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledModelNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledHookNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledRPCNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledSqlNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledGenericTestNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledSeedNode"
+                    },
+                    {
+                        "$ref": "#/definitions/CompiledSnapshotNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedAnalysisNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedSingularTestNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedHookNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedModelNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedRPCNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedSqlNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedGenericTestNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedSeedNode"
+                    },
+                    {
+                        "$ref": "#/definitions/ParsedSnapshotNode"
+                    }
+                ]
+            },
+            "description": "The nodes defined in the dbt project and its dependencies"
+        },
+        "sources": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/ParsedSourceDefinition"
+            },
+            "description": "The sources defined in the dbt project and its dependencies"
+        },
+        "macros": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/ParsedMacro"
+            },
+            "description": "The macros defined in the dbt project and its dependencies"
+        },
+        "docs": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/ParsedDocumentation"
+            },
+            "description": "The docs defined in the dbt project and its dependencies"
+        },
+        "exposures": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/ParsedExposure"
+            },
+            "description": "The exposures defined in the dbt project and its dependencies"
+        },
+        "metrics": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/ParsedMetric"
+            },
+            "description": "The metrics defined in the dbt project and its dependencies"
+        },
+        "selectors": {
+            "type": "object",
+            "description": "The selectors defined in selectors.yml"
+        },
+        "disabled": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/CompiledAnalysisNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledSingularTestNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledModelNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledHookNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledRPCNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledSqlNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledGenericTestNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledSeedNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/CompiledSnapshotNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedAnalysisNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedSingularTestNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedHookNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedModelNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedRPCNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedSqlNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedGenericTestNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedSeedNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedSnapshotNode"
+                                },
+                                {
+                                    "$ref": "#/definitions/ParsedSourceDefinition"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "A mapping of the disabled nodes in the target"
+        },
+        "parent_map": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "A mapping from\u00a0child nodes to their dependencies"
+        },
+        "child_map": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "A mapping from parent nodes to their dependents"
+        }
+    },
+    "additionalProperties": false,
+    "description": "WritableManifest(metadata: dbt.contracts.graph.manifest.ManifestMetadata, nodes: Mapping[str, Union[dbt.contracts.graph.compiled.CompiledAnalysisNode, dbt.contracts.graph.compiled.CompiledSingularTestNode, dbt.contracts.graph.compiled.CompiledModelNode, dbt.contracts.graph.compiled.CompiledHookNode, dbt.contracts.graph.compiled.CompiledRPCNode, dbt.contracts.graph.compiled.CompiledSqlNode, dbt.contracts.graph.compiled.CompiledGenericTestNode, dbt.contracts.graph.compiled.CompiledSeedNode, dbt.contracts.graph.compiled.CompiledSnapshotNode, dbt.contracts.graph.parsed.ParsedAnalysisNode, dbt.contracts.graph.parsed.ParsedSingularTestNode, dbt.contracts.graph.parsed.ParsedHookNode, dbt.contracts.graph.parsed.ParsedModelNode, dbt.contracts.graph.parsed.ParsedRPCNode, dbt.contracts.graph.parsed.ParsedSqlNode, dbt.contracts.graph.parsed.ParsedGenericTestNode, dbt.contracts.graph.parsed.ParsedSeedNode, dbt.contracts.graph.parsed.ParsedSnapshotNode]], sources: Mapping[str, dbt.contracts.graph.parsed.ParsedSourceDefinition], macros: Mapping[str, dbt.contracts.graph.parsed.ParsedMacro], docs: Mapping[str, dbt.contracts.graph.parsed.ParsedDocumentation], exposures: Mapping[str, dbt.contracts.graph.parsed.ParsedExposure], metrics: Mapping[str, dbt.contracts.graph.parsed.ParsedMetric], selectors: Mapping[str, Any], disabled: Optional[Mapping[str, List[Union[dbt.contracts.graph.compiled.CompiledAnalysisNode, dbt.contracts.graph.compiled.CompiledSingularTestNode, dbt.contracts.graph.compiled.CompiledModelNode, dbt.contracts.graph.compiled.CompiledHookNode, dbt.contracts.graph.compiled.CompiledRPCNode, dbt.contracts.graph.compiled.CompiledSqlNode, dbt.contracts.graph.compiled.CompiledGenericTestNode, dbt.contracts.graph.compiled.CompiledSeedNode, dbt.contracts.graph.compiled.CompiledSnapshotNode, dbt.contracts.graph.parsed.ParsedAnalysisNode, dbt.contracts.graph.parsed.ParsedSingularTestNode, dbt.contracts.graph.parsed.ParsedHookNode, dbt.contracts.graph.parsed.ParsedModelNode, dbt.contracts.graph.parsed.ParsedRPCNode, dbt.contracts.graph.parsed.ParsedSqlNode, dbt.contracts.graph.parsed.ParsedGenericTestNode, dbt.contracts.graph.parsed.ParsedSeedNode, dbt.contracts.graph.parsed.ParsedSnapshotNode, dbt.contracts.graph.parsed.ParsedSourceDefinition]]]], parent_map: Optional[Dict[str, List[str]]], child_map: Optional[Dict[str, List[str]]])",
+    "definitions": {
+        "ManifestMetadata": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "dbt_schema_version": {
+                    "type": "string",
+                    "default": "https://schemas.getdbt.com/dbt/manifest/v7.json"
+                },
+                "dbt_version": {
+                    "type": "string",
+                    "default": "1.3.0b2"
+                },
+                "generated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "default": "2022-10-05T17:41:25.798224Z"
+                },
+                "invocation_id": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "020388aa-c5cf-4e92-9391-497c583ddc54"
+                },
+                "env": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "project_id": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A unique identifier for the project"
+                },
+                "user_id": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A unique identifier for the user"
+                },
+                "send_anonymous_usage_stats": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Whether dbt is configured to send anonymous usage statistics"
+                },
+                "adapter_type": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type name of the adapter"
+                }
+            },
+            "additionalProperties": false,
+            "description": "Metadata for the manifest."
+        },
+        "CompiledAnalysisNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["analysis"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.801986
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledAnalysisNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "FileHash": {
+            "type": "object",
+            "required": ["name", "checksum"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "description": "FileHash(name: str, checksum: str)"
+        },
+        "NodeConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "alias": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tags": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "default": []
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "view"
+                },
+                "incremental_strategy": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
+                "full_refresh": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "unique_key": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
+                },
+                "grants": {
+                    "type": "object",
+                    "default": {}
+                },
+                "packages": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                }
+            },
+            "additionalProperties": true,
+            "description": "NodeConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Optional[str] = None, schema: Optional[str] = None, database: Optional[str] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'view', incremental_strategy: Optional[str] = None, persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Optional[bool] = None, unique_key: Union[str, List[str], NoneType] = None, on_schema_change: Optional[str] = 'ignore', grants: Dict[str, Any] = <factory>, packages: List[str] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>)"
+        },
+        "Hook": {
+            "type": "object",
+            "required": ["sql"],
+            "properties": {
+                "sql": {
+                    "type": "string"
+                },
+                "transaction": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "index": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "Hook(sql: str, transaction: bool = True, index: Optional[int] = None)"
+        },
+        "Docs": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "show": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "node_color": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "Docs(show: bool = True, node_color: Optional[str] = None)"
+        },
+        "DependsOn": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "macros": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": false,
+            "description": "DependsOn(macros: List[str] = <factory>, nodes: List[str] = <factory>)"
+        },
+        "ColumnInfo": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "data_type": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "quote": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": true,
+            "description": "ColumnInfo(name: str, description: str = '', meta: Dict[str, Any] = <factory>, data_type: Optional[str] = None, quote: Optional[bool] = None, tags: List[str] = <factory>, _extra: Dict[str, Any] = <factory>)"
+        },
+        "InjectedCTE": {
+            "type": "object",
+            "required": ["id", "sql"],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "sql": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "description": "InjectedCTE(id: str, sql: str)"
+        },
+        "CompiledSingularTestNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["test"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/TestConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": "dbt_test__audit",
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "test",
+                        "severity": "ERROR",
+                        "store_failures": null,
+                        "where": null,
+                        "limit": null,
+                        "fail_calc": "count(*)",
+                        "warn_if": "!= 0",
+                        "error_if": "!= 0"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.803982
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledSingularTestNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "TestConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "alias": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "dbt_test__audit"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tags": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "default": []
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "test"
+                },
+                "severity": {
+                    "type": "string",
+                    "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$",
+                    "default": "ERROR"
+                },
+                "store_failures": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "where": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "limit": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "fail_calc": {
+                    "type": "string",
+                    "default": "count(*)"
+                },
+                "warn_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                },
+                "error_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                }
+            },
+            "additionalProperties": true,
+            "description": "TestConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Optional[str] = None, schema: Optional[str] = 'dbt_test__audit', database: Optional[str] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'test', severity: dbt.contracts.graph.model_config.Severity = 'ERROR', store_failures: Optional[bool] = None, where: Optional[str] = None, limit: Optional[int] = None, fail_calc: str = 'count(*)', warn_if: str = '!= 0', error_if: str = '!= 0')"
+        },
+        "CompiledModelNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["model"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.806056
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledModelNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "CompiledHookNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["operation"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.807287
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "index": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledHookNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None, index: Optional[int] = None)"
+        },
+        "CompiledRPCNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["rpc"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.808457
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledRPCNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "CompiledSqlNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["sql operation"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8095949
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledSqlNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "CompiledGenericTestNode": {
+            "type": "object",
+            "required": [
+                "test_metadata",
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "test_metadata": {
+                    "$ref": "#/definitions/TestMetadata"
+                },
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["test"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/TestConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": "dbt_test__audit",
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "test",
+                        "severity": "ERROR",
+                        "store_failures": null,
+                        "where": null,
+                        "limit": null,
+                        "fail_calc": "count(*)",
+                        "warn_if": "!= 0",
+                        "error_if": "!= 0"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.81105
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "column_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "file_key_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledGenericTestNode(test_metadata: dbt.contracts.graph.parsed.TestMetadata, compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None, column_name: Optional[str] = None, file_key_name: Optional[str] = None)"
+        },
+        "TestMetadata": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "kwargs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "namespace": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "TestMetadata(name: str, kwargs: Dict[str, Any] = <factory>, namespace: Optional[str] = None)"
+        },
+        "CompiledSeedNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["seed"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/SeedConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "seed",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "quote_columns": null,
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.813088
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledSeedNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "SeedConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "alias": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tags": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "default": []
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "seed"
+                },
+                "incremental_strategy": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
+                "full_refresh": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "unique_key": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
+                },
+                "grants": {
+                    "type": "object",
+                    "default": {}
+                },
+                "packages": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "quote_columns": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "description": "SeedConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Optional[str] = None, schema: Optional[str] = None, database: Optional[str] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'seed', incremental_strategy: Optional[str] = None, persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Optional[bool] = None, unique_key: Union[str, List[str], NoneType] = None, on_schema_change: Optional[str] = 'ignore', grants: Dict[str, Any] = <factory>, packages: List[str] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, quote_columns: Optional[bool] = None)"
+        },
+        "CompiledSnapshotNode": {
+            "type": "object",
+            "required": [
+                "compiled",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "compiled": {
+                    "type": "boolean"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["snapshot"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.814346
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "compiled_code": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "extra_ctes_injected": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "extra_ctes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InjectedCTE"
+                    },
+                    "default": []
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "CompiledSnapshotNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
+        },
+        "ParsedAnalysisNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["analysis"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8153868
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedAnalysisNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedSingularTestNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["test"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/TestConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": "dbt_test__audit",
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "test",
+                        "severity": "ERROR",
+                        "store_failures": null,
+                        "where": null,
+                        "limit": null,
+                        "fail_calc": "count(*)",
+                        "warn_if": "!= 0",
+                        "error_if": "!= 0"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.81637
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedSingularTestNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedHookNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["operation"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.817323
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "index": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedHookNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, index: Optional[int] = None)"
+        },
+        "ParsedModelNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["model"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8182888
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedModelNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedRPCNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["rpc"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.819205
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedRPCNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedSqlNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["sql operation"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/NodeConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "view",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8202639
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedSqlNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedGenericTestNode": {
+            "type": "object",
+            "required": [
+                "test_metadata",
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "test_metadata": {
+                    "$ref": "#/definitions/TestMetadata"
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["test"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/TestConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": "dbt_test__audit",
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "test",
+                        "severity": "ERROR",
+                        "store_failures": null,
+                        "where": null,
+                        "limit": null,
+                        "fail_calc": "count(*)",
+                        "warn_if": "!= 0",
+                        "error_if": "!= 0"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.821276
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "file_key_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedGenericTestNode(test_metadata: dbt.contracts.graph.parsed.TestMetadata, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.TestConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, column_name: Optional[str] = None, file_key_name: Optional[str] = None)"
+        },
+        "ParsedSeedNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["seed"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/SeedConfig",
+                    "default": {
+                        "enabled": true,
+                        "alias": null,
+                        "schema": null,
+                        "database": null,
+                        "tags": [],
+                        "meta": {},
+                        "materialized": "seed",
+                        "incremental_strategy": null,
+                        "persist_docs": {},
+                        "quoting": {},
+                        "column_types": {},
+                        "full_refresh": null,
+                        "unique_key": null,
+                        "on_schema_change": "ignore",
+                        "grants": {},
+                        "packages": [],
+                        "docs": {
+                            "show": true,
+                            "node_color": null
+                        },
+                        "quote_columns": null,
+                        "post-hook": [],
+                        "pre-hook": []
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.822274
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedSeedNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SeedConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "ParsedSnapshotNode": {
+            "type": "object",
+            "required": [
+                "schema",
+                "fqn",
+                "unique_id",
+                "raw_code",
+                "language",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "resource_type",
+                "alias",
+                "checksum",
+                "config"
+            ],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "raw_code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["snapshot"]
+                },
+                "alias": {
+                    "type": "string"
+                },
+                "checksum": {
+                    "$ref": "#/definitions/FileHash"
+                },
+                "config": {
+                    "$ref": "#/definitions/SnapshotConfig"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "compiled_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "build_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "deferred": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8241339
+                },
+                "config_call_dict": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedSnapshotNode(database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.SnapshotConfig, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>)"
+        },
+        "SnapshotConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "alias": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tags": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "default": []
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "materialized": {
+                    "type": "string",
+                    "default": "snapshot"
+                },
+                "incremental_strategy": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "persist_docs": {
+                    "type": "object",
+                    "default": {}
+                },
+                "post-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "pre-hook": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Hook"
+                    },
+                    "default": []
+                },
+                "quoting": {
+                    "type": "object",
+                    "default": {}
+                },
+                "column_types": {
+                    "type": "object",
+                    "default": {}
+                },
+                "full_refresh": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "unique_key": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "on_schema_change": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "ignore"
+                },
+                "grants": {
+                    "type": "object",
+                    "default": {}
+                },
+                "packages": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "strategy": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "target_schema": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "target_database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "updated_at": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "check_cols": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "description": "SnapshotConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True, alias: Optional[str] = None, schema: Optional[str] = None, database: Optional[str] = None, tags: Union[List[str], str] = <factory>, meta: Dict[str, Any] = <factory>, materialized: str = 'snapshot', incremental_strategy: Optional[str] = None, persist_docs: Dict[str, Any] = <factory>, post_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, pre_hook: List[dbt.contracts.graph.model_config.Hook] = <factory>, quoting: Dict[str, Any] = <factory>, column_types: Dict[str, Any] = <factory>, full_refresh: Optional[bool] = None, unique_key: Optional[str] = None, on_schema_change: Optional[str] = 'ignore', grants: Dict[str, Any] = <factory>, packages: List[str] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, strategy: Optional[str] = None, target_schema: Optional[str] = None, target_database: Optional[str] = None, updated_at: Optional[str] = None, check_cols: Union[str, List[str], NoneType] = None)"
+        },
+        "ParsedSourceDefinition": {
+            "type": "object",
+            "required": [
+                "fqn",
+                "schema",
+                "unique_id",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "source_name",
+                "source_description",
+                "loader",
+                "identifier",
+                "resource_type"
+            ],
+            "properties": {
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "source_description": {
+                    "type": "string"
+                },
+                "loader": {
+                    "type": "string"
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["source"]
+                },
+                "quoting": {
+                    "$ref": "#/definitions/Quoting",
+                    "default": {
+                        "database": null,
+                        "schema": null,
+                        "identifier": null,
+                        "column": null
+                    }
+                },
+                "loaded_at_field": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "freshness": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/FreshnessThreshold"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "external": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/ExternalTable"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ColumnInfo"
+                    },
+                    "default": {}
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "source_meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "config": {
+                    "$ref": "#/definitions/SourceConfig",
+                    "default": {
+                        "enabled": true
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "relation_name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.825852
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedSourceDefinition(fqn: List[str], database: Optional[str], schema: str, unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, source_name: str, source_description: str, loader: str, identifier: str, resource_type: dbt.node_types.NodeType, _event_status: Dict[str, Any] = <factory>, quoting: dbt.contracts.graph.unparsed.Quoting = <factory>, loaded_at_field: Optional[str] = None, freshness: Optional[dbt.contracts.graph.unparsed.FreshnessThreshold] = None, external: Optional[dbt.contracts.graph.unparsed.ExternalTable] = None, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, source_meta: Dict[str, Any] = <factory>, tags: List[str] = <factory>, config: dbt.contracts.graph.model_config.SourceConfig = <factory>, patch_path: Optional[pathlib.Path] = None, unrendered_config: Dict[str, Any] = <factory>, relation_name: Optional[str] = None, created_at: float = <factory>)"
+        },
+        "Quoting": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "database": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "identifier": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "column": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "Quoting(database: Optional[bool] = None, schema: Optional[bool] = None, identifier: Optional[bool] = None, column: Optional[bool] = None)"
+        },
+        "FreshnessThreshold": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "warn_after": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": {
+                        "count": null,
+                        "period": null
+                    }
+                },
+                "error_after": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": {
+                        "count": null,
+                        "period": null
+                    }
+                },
+                "filter": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "FreshnessThreshold(warn_after: Optional[dbt.contracts.graph.unparsed.Time] = <factory>, error_after: Optional[dbt.contracts.graph.unparsed.Time] = <factory>, filter: Optional[str] = None)"
+        },
+        "FreshnessMetadata": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "dbt_schema_version": {
+                    "type": "string",
+                    "default": "https://schemas.getdbt.com/dbt/sources/v3.json"
+                },
+                "dbt_version": {
+                    "type": "string",
+                    "default": "1.3.0b2"
+                },
+                "generated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "default": "2022-10-05T17:41:25.794018Z"
+                },
+                "invocation_id": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "020388aa-c5cf-4e92-9391-497c583ddc54"
+                },
+                "env": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "description": "FreshnessMetadata(dbt_schema_version: str = <factory>, dbt_version: str = '1.3.0b2', generated_at: datetime.datetime = <factory>, invocation_id: Optional[str] = <factory>, env: Dict[str, str] = <factory>)"
+        },
+        "SourceFreshnessRuntimeError": {
+            "type": "object",
+            "required": ["unique_id", "status"],
+            "properties": {
+                "unique_id": {
+                    "type": "string"
+                },
+                "error": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["runtime error"]
+                }
+            },
+            "additionalProperties": false,
+            "description": "SourceFreshnessRuntimeError(unique_id: str, error: Union[str, int, NoneType], status: dbt.contracts.results.FreshnessErrorEnum)"
+        },
+        "SourceFreshnessOutput": {
+            "type": "object",
+            "required": [
+                "unique_id",
+                "max_loaded_at",
+                "snapshotted_at",
+                "max_loaded_at_time_ago_in_s",
+                "status",
+                "criteria",
+                "adapter_response",
+                "timing",
+                "thread_id",
+                "execution_time"
+            ],
+            "properties": {
+                "unique_id": {
+                    "type": "string"
+                },
+                "max_loaded_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "snapshotted_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "max_loaded_at_time_ago_in_s": {
+                    "type": "number"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pass", "warn", "error", "runtime error"]
+                },
+                "criteria": {
+                    "$ref": "#/definitions/FreshnessThreshold"
+                },
+                "adapter_response": {
+                    "type": "object"
+                },
+                "timing": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimingInfo"
+                    }
+                },
+                "thread_id": {
+                    "type": "string"
+                },
+                "execution_time": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "description": "SourceFreshnessOutput(unique_id: str, max_loaded_at: datetime.datetime, snapshotted_at: datetime.datetime, max_loaded_at_time_ago_in_s: float, status: dbt.contracts.results.FreshnessStatus, criteria: dbt.contracts.graph.unparsed.FreshnessThreshold, adapter_response: Dict[str, Any], timing: List[dbt.contracts.results.TimingInfo], thread_id: str, execution_time: float)"
+        },
+        "Time": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "count": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "period": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["minute", "hour", "day"]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "Time(count: Optional[int] = None, period: Optional[dbt.contracts.graph.unparsed.TimePeriod] = None)"
+        },
+        "TimingInfo": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "completed_at": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "TimingInfo(name: str, started_at: Optional[datetime.datetime] = None, completed_at: Optional[datetime.datetime] = None)"
+        },
+        "ExternalTable": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "location": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "file_format": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "row_format": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "tbl_properties": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "partitions": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ExternalPartition"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "description": "ExternalTable(_extra: Dict[str, Any] = <factory>, location: Optional[str] = None, file_format: Optional[str] = None, row_format: Optional[str] = None, tbl_properties: Optional[str] = None, partitions: Optional[List[dbt.contracts.graph.unparsed.ExternalPartition]] = None)"
+        },
+        "ExternalPartition": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": ""
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "data_type": {
+                    "type": "string",
+                    "default": ""
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                }
+            },
+            "additionalProperties": true,
+            "description": "ExternalPartition(_extra: Dict[str, Any] = <factory>, name: str = '', description: str = '', data_type: str = '', meta: Dict[str, Any] = <factory>)"
+        },
+        "SourceConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "additionalProperties": true,
+            "description": "SourceConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True)"
+        },
+        "ParsedMacro": {
+            "type": "object",
+            "required": [
+                "unique_id",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "macro_sql",
+                "resource_type"
+            ],
+            "properties": {
+                "unique_id": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "macro_sql": {
+                    "type": "string"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": ["macro"]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/MacroDependsOn",
+                    "default": {
+                        "macros": []
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "docs": {
+                    "$ref": "#/definitions/Docs",
+                    "default": {
+                        "show": true,
+                        "node_color": null
+                    }
+                },
+                "patch_path": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MacroArgument"
+                    },
+                    "default": []
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8266501
+                },
+                "supported_languages": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["python", "sql"]
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedMacro(unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, macro_sql: str, resource_type: dbt.node_types.NodeType, tags: List[str] = <factory>, depends_on: dbt.contracts.graph.parsed.MacroDependsOn = <factory>, description: str = '', meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, arguments: List[dbt.contracts.graph.unparsed.MacroArgument] = <factory>, created_at: float = <factory>, supported_languages: Optional[List[dbt.node_types.ModelLanguage]] = None)"
+        },
+        "MacroDependsOn": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "macros": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": false,
+            "description": "MacroDependsOn(macros: List[str] = <factory>)"
+        },
+        "MacroArgument": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": false,
+            "description": "MacroArgument(name: str, type: Optional[str] = None, description: str = '')"
+        },
+        "ParsedDocumentation": {
+            "type": "object",
+            "required": [
+                "unique_id",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "block_contents"
+            ],
+            "properties": {
+                "unique_id": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "block_contents": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedDocumentation(unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, block_contents: str)"
+        },
+        "ParsedExposure": {
+            "type": "object",
+            "required": [
+                "fqn",
+                "unique_id",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "type",
+                "owner"
+            ],
+            "properties": {
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "dashboard",
+                        "notebook",
+                        "analysis",
+                        "ml",
+                        "application"
+                    ]
+                },
+                "owner": {
+                    "$ref": "#/definitions/ExposureOwner"
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": [
+                        "model",
+                        "analysis",
+                        "test",
+                        "snapshot",
+                        "operation",
+                        "seed",
+                        "rpc",
+                        "sql operation",
+                        "docs block",
+                        "source",
+                        "macro",
+                        "exposure",
+                        "metric"
+                    ],
+                    "default": "exposure"
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "label": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "maturity": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["low", "medium", "high"]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "config": {
+                    "$ref": "#/definitions/ExposureConfig",
+                    "default": {
+                        "enabled": true
+                    }
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "url": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.828064
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedExposure(fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, type: dbt.contracts.graph.unparsed.ExposureType, owner: dbt.contracts.graph.unparsed.ExposureOwner, resource_type: dbt.node_types.NodeType = <NodeType.Exposure: 'exposure'>, description: str = '', label: Optional[str] = None, maturity: Optional[dbt.contracts.graph.unparsed.MaturityType] = None, meta: Dict[str, Any] = <factory>, tags: List[str] = <factory>, config: dbt.contracts.graph.model_config.ExposureConfig = <factory>, unrendered_config: Dict[str, Any] = <factory>, url: Optional[str] = None, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, created_at: float = <factory>)"
+        },
+        "ExposureOwner": {
+            "type": "object",
+            "required": ["email"],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "ExposureOwner(email: str, name: Optional[str] = None)"
+        },
+        "ExposureConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "additionalProperties": true,
+            "description": "ExposureConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True)"
+        },
+        "ParsedMetric": {
+            "type": "object",
+            "required": [
+                "fqn",
+                "unique_id",
+                "package_name",
+                "root_path",
+                "path",
+                "original_file_path",
+                "name",
+                "description",
+                "label",
+                "calculation_method",
+                "expression",
+                "timestamp",
+                "filters",
+                "time_grains",
+                "dimensions"
+            ],
+            "properties": {
+                "fqn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unique_id": {
+                    "type": "string"
+                },
+                "package_name": {
+                    "type": "string"
+                },
+                "root_path": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "original_file_path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "calculation_method": {
+                    "type": "string"
+                },
+                "expression": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MetricFilter"
+                    }
+                },
+                "time_grains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "window": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/MetricTime"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "model": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "model_unique_id": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "resource_type": {
+                    "type": "string",
+                    "enum": [
+                        "model",
+                        "analysis",
+                        "test",
+                        "snapshot",
+                        "operation",
+                        "seed",
+                        "rpc",
+                        "sql operation",
+                        "docs block",
+                        "source",
+                        "macro",
+                        "exposure",
+                        "metric"
+                    ],
+                    "default": "metric"
+                },
+                "meta": {
+                    "type": "object",
+                    "default": {}
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "config": {
+                    "$ref": "#/definitions/MetricConfig",
+                    "default": {
+                        "enabled": true
+                    }
+                },
+                "unrendered_config": {
+                    "type": "object",
+                    "default": {}
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "depends_on": {
+                    "$ref": "#/definitions/DependsOn",
+                    "default": {
+                        "macros": [],
+                        "nodes": []
+                    }
+                },
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "default": []
+                },
+                "created_at": {
+                    "type": "number",
+                    "default": 1664991685.8293078
+                }
+            },
+            "additionalProperties": false,
+            "description": "ParsedMetric(fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, description: str, label: str, calculation_method: str, expression: str, timestamp: str, filters: List[dbt.contracts.graph.unparsed.MetricFilter], time_grains: List[str], dimensions: List[str], window: Optional[dbt.contracts.graph.unparsed.MetricTime] = None, model: Optional[str] = None, model_unique_id: Optional[str] = None, resource_type: dbt.node_types.NodeType = <NodeType.Metric: 'metric'>, meta: Dict[str, Any] = <factory>, tags: List[str] = <factory>, config: dbt.contracts.graph.model_config.MetricConfig = <factory>, unrendered_config: Dict[str, Any] = <factory>, sources: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, refs: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, created_at: float = <factory>)"
+        },
+        "MetricFilter": {
+            "type": "object",
+            "required": ["field", "operator", "value"],
+            "properties": {
+                "field": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "description": "MetricFilter(field: str, operator: str, value: str)"
+        },
+        "MetricTime": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "count": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "period": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["day", "week", "month", "year"]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "description": "MetricTime(count: Optional[int] = None, period: Optional[dbt.contracts.graph.unparsed.MetricTimePeriod] = None)"
+        },
+        "MetricConfig": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "additionalProperties": true,
+            "description": "MetricConfig(_extra: Dict[str, Any] = <factory>, enabled: bool = True)"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.getdbt.com/dbt/manifest/v7.json"
+}

--- a/packages/cli/src/dbt/schema.json
+++ b/packages/cli/src/dbt/schema.json
@@ -1,0 +1,161 @@
+{
+    "definitions": {
+        "LightdashDimension": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9_]+$"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["string", "number", "boolean", "date", "timestamp"]
+                },
+                "dimension": {
+                    "type": "string"
+                },
+                "sql": {
+                    "type": "string"
+                },
+                "time_intervals": {
+                    "oneOf": [
+                        {
+                            "const": "default"
+                        },
+                        {
+                            "const": "OFF"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "hidden": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "LightdashMetric": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "average",
+                        "count",
+                        "count_distinct",
+                        "sum",
+                        "min",
+                        "max",
+                        "number",
+                        "string",
+                        "date",
+                        "boolean"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "sql": {
+                    "type": "string"
+                },
+                "hidden": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "LightdashColumnMetadata": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "dimension": {
+                    "$ref": "#/definitions/LightdashDimension"
+                },
+                "metrics": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/LightdashMetric"
+                    },
+                    "default": {}
+                }
+            }
+        },
+        "LightdashModelMetadata": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "joins": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["join", "sql_on"],
+                        "properties": {
+                            "join": {
+                                "type": "string"
+                            },
+                            "sql_on": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "default": {}
+        },
+        "LightdashNodeConfig": {
+            "allOf": [
+                {
+                    "$ref": "https://schemas.getdbt.com/dbt/manifest/v7.json#/definitions/NodeConfig"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "$ref": "#/definitions/LightdashModelMetadata"
+                        }
+                    }
+                }
+            ]
+        },
+        "LightdashColumnInfo": {
+            "allOf": [
+                {
+                    "$ref": "https://schemas.getdbt.com/dbt/manifest/v7.json#/definitions/ColumnInfo"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "$ref": "#/definitions/LightdashColumnMetadata"
+                        }
+                    }
+                }
+            ]
+        },
+        "LightdashCompiledModelNode": {
+            "allOf": [
+                {
+                    "$ref": "https://schemas.getdbt.com/dbt/manifest/v7.json#/definitions/CompiledModelNode"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "$ref": "#/definitions/LightdashModelMetadata"
+                        },
+                        "config": {
+                            "$ref": "#/definitions/LightdashNodeConfig"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.lightdash.com/dbt/manifest/v7.json"
+}

--- a/packages/cli/src/dbt/validation.ts
+++ b/packages/cli/src/dbt/validation.ts
@@ -1,0 +1,101 @@
+import {
+    DbtMetric,
+    DbtModelNode,
+    DbtRawModelNode,
+    ExploreError,
+    friendlyName,
+    InlineError,
+    InlineErrorType,
+    normaliseModelDatabase,
+    ParseError,
+    SupportedDbtAdapter,
+} from '@lightdash/common';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { AnyValidateFunction } from 'ajv/dist/types';
+import dbtManifestSchema from './manifestv7.json';
+import lightdashDbtSchema from './schema.json';
+
+const ajv = new Ajv({ schemas: [lightdashDbtSchema, dbtManifestSchema] });
+addFormats(ajv);
+
+const getMetricValidator = () => {
+    const metricValidator = ajv.getSchema<DbtMetric>(
+        'https://schemas.getdbt.com/dbt/manifest/v7.json#/definitions/ParsedMetric',
+    );
+    if (metricValidator === undefined) {
+        throw new ParseError('Could not parse dbt schema.');
+    }
+    return metricValidator;
+};
+
+const getModelValidator = () => {
+    const modelValidator = ajv.getSchema<DbtRawModelNode>(
+        'https://schemas.lightdash.com/dbt/manifest/v7.json#/definitions/LightdashCompiledModelNode',
+    );
+    if (modelValidator === undefined) {
+        throw new ParseError('Could not parse Lightdash schema.');
+    }
+    return modelValidator;
+};
+
+const formatAjvErrors = (validator: AnyValidateFunction): string =>
+    (validator.errors || [])
+        .map((err) => `Field at "${err.instancePath}" ${err.message}`)
+        .join('\n');
+
+export const validateDbtModel = (
+    adapterType: string,
+    models: DbtRawModelNode[],
+): [DbtModelNode[], ExploreError[]] => {
+    const validator = getModelValidator();
+    return models.reduce(
+        ([validModels, invalidModels], model) => {
+            let error: InlineError | undefined;
+            // Match against json schema
+            const isValid = validator(model);
+            if (!isValid) {
+                error = {
+                    type: InlineErrorType.METADATA_PARSE_ERROR,
+                    message: formatAjvErrors(validator),
+                };
+            } else if (isValid && Object.values(model.columns).length <= 0) {
+                error = {
+                    type: InlineErrorType.NO_DIMENSIONS_FOUND,
+                    message: 'No dimensions available',
+                };
+            }
+            if (error) {
+                const exploreError: ExploreError = {
+                    name: model.name,
+                    label: model.meta.label || friendlyName(model.name),
+                    errors: [error],
+                };
+                return [validModels, [...invalidModels, exploreError]];
+            }
+            // Fix null databases
+            const validatedModel = normaliseModelDatabase(
+                model,
+                adapterType as SupportedDbtAdapter,
+            );
+            return [[...validModels, validatedModel], invalidModels];
+        },
+        [[] as DbtModelNode[], [] as ExploreError[]],
+    );
+};
+
+export const validateDbtMetrics = (metrics: DbtMetric[]): DbtMetric[] => {
+    const validator = getMetricValidator();
+    metrics.forEach((metric) => {
+        const isValid = validator(metric);
+        if (isValid !== true) {
+            throw new ParseError(
+                `Could not parse dbt metric with id ${
+                    metric.unique_id
+                }: ${formatAjvErrors(validator)}`,
+                {},
+            );
+        }
+    });
+    return metrics;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #3846

### Description:

We still need to do dbt build before checkin schema, because we use the manifest. Which means some schema issues will be captured on dbt. 

Our lightdash validation is a bit out of date (just copied it from backend) (for example, it does not contain info about metric filters). So right now, we only catch a few issues with schema. Maybe something to do on a separate PR ? 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2022-12-16 11-20-22](https://user-images.githubusercontent.com/1983672/208077766-b74e5164-fec2-44d3-86c9-b7b49818921c.png)
