### PR TITLE
fix: message on invite user success is confusing

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/InviteSuccess.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/InviteSuccess.tsx
@@ -23,9 +23,10 @@ const InviteSuccess: FC<{ invite: InviteLink; hasMarginTop?: boolean }> = ({
         if (health.data?.hasEmailClient) {
             return (
                 <>
-                    <b>{invite.email}</b> has been invited! You can also share
-                    this link with them and they can join your organization.
-                    This link will expire in {days} days.
+                    We've just sent <b>{invite.email}</b> an email with their
+                    invite! You can also share their invite link with them to
+                    join your organization. This link will expire in {days}{' '}
+                    days.
                 </>
             );
         }


### PR DESCRIPTION
Closes:  [3909](https://github.com/lightdash/lightdash/issues/3909)

### Description:
When I invite a new user, it says "invite successful" but then it also tells me to copy a link. 
This made me think that the user didn't get an email sent to them as well.

Instead, the copy should say:
`We've just sent xxxx an email with their invite! You can also share their invite link with them to join your organization. This link will expire in 3 days.`
