### PR TITLE
fix: remove extra fields from ShareModel

### DIFF
--- a/packages/backend/src/models/ShareModel.ts
+++ b/packages/backend/src/models/ShareModel.ts
@@ -23,17 +23,14 @@ export class ShareModel {
             .select('organization_id')
             .where('organization_uuid', shareUrl.organizationUuid);
 
-        const [share] = await this.database(ShareTableName)
-            .insert({
-                nanoid: shareUrl.nanoid,
-                path: shareUrl.path,
-                params: shareUrl.params,
-                organization_id: organization.organization_id,
-                created_by_user_id: user.user_id,
-            })
-            .returning('*');
-
-        return share;
+        await this.database(ShareTableName).insert({
+            nanoid: shareUrl.nanoid,
+            path: shareUrl.path,
+            params: shareUrl.params,
+            organization_id: organization.organization_id,
+            created_by_user_id: user.user_id,
+        });
+        return shareUrl;
     }
 
     async getSharedUrl(nanoid: string): Promise<ShareUrl> {


### PR DESCRIPTION
Remove accidental database fields returned during creation of share links.

(orginally part of https://github.com/lightdash/lightdash/pull/3937)