### PR TITLE
fix: filter popover is on top of navigation on scroll

### DIFF
--- a/packages/frontend/src/components/NavBar/NavBar.styles.tsx
+++ b/packages/frontend/src/components/NavBar/NavBar.styles.tsx
@@ -9,6 +9,7 @@ export const NavBarWrapper = styled(Navbar)`
     position: sticky;
     top: 0;
     height: ${NAVBAR_HEIGHT}px;
+    z-index: 1000;
 `;
 
 export const ProjectDropdown = styled(HTMLSelect)`


### PR DESCRIPTION
Closes: [1347](https://github.com/lightdash/lightdash/issues/1347)

### Description:
When the filter popover is open and scroll down the page, it remains in front of the navbar. It makes things look broken.

![image](https://user-images.githubusercontent.com/67699259/208418720-8587a99c-7393-43ff-bd45-f55885b8f241.png)