### PR TITLE
fix: browse menu items should not be underlined

### DIFF
--- a/packages/frontend/src/components/NavLink.styles.tsx
+++ b/packages/frontend/src/components/NavLink.styles.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const StyledNavLink = styled(Link)`
+    &:hover {
+        text-decoration: none;
+    }
+
+    li {
+        color: white;
+    }
+`;

--- a/packages/frontend/src/components/NavLink.tsx
+++ b/packages/frontend/src/components/NavLink.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, FC } from 'react';
-import { Link, Route } from 'react-router-dom';
+import { Route } from 'react-router-dom';
+import { StyledNavLink } from './NavLink.styles';
 
 interface Props {
     to: string;
@@ -16,7 +17,7 @@ const NavLink: FC<Props> = ({ to, style, exact, children }) => (
             const isActive = match?.isExact;
 
             return (
-                <Link to={to} style={{ color: 'inherit', ...style }}>
+                <StyledNavLink to={to} style={style}>
                     {typeof children === 'function'
                         ? children(isActive)
                         : React.Children.map(children, (child) => {
@@ -30,7 +31,7 @@ const NavLink: FC<Props> = ({ to, style, exact, children }) => (
                               }
                               return child;
                           })}
-                </Link>
+                </StyledNavLink>
             );
         }}
     />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  [3966](https://github.com/lightdash/lightdash/issues/3966)

### Description:
![image](https://user-images.githubusercontent.com/67699259/208422589-a0623ee3-3d51-4efb-b73b-757316238e0a.png)
All items under the `Browse` menu are underlined. They shouldn't be (for consistency!)
