### PR TITLE
fix: notifications icon styles

### DIFF
--- a/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
@@ -77,7 +77,7 @@ export const NotificationWrapper = styled.div`
     padding: 0.357em 0.571em;
     border-radius: 0.214em;
     position: relative;
-    color: ${Colors.GRAY5} !important;
+    color: ${Colors.GRAY4} !important;
 
     :hover {
         cursor: pointer;

--- a/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/HelpMenu.styles.tsx
@@ -74,14 +74,15 @@ export const ItemDescription = styled.p`
 `;
 
 export const NotificationWrapper = styled.div`
-    padding: 0.357em 0.571em;
-    border-radius: 0.214em;
+    border-radius: 2px;
+    box-sizing: border-box;
     position: relative;
     color: ${Colors.GRAY4} !important;
+    padding: 6px 7px;
 
     :hover {
         cursor: pointer;
-        background: rgba(138, 155, 168, 0.15) !important;
+        background: rgba(143, 153, 168, 0.15) !important;
     }
 `;
 export const NotificationWidget = styled.div`

--- a/packages/frontend/src/components/NavBar/HelpMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu/index.tsx
@@ -70,7 +70,7 @@ const HelpMenu: FC = () => {
         <>
             <NotificationWrapper>
                 <Icon icon="notifications" />
-                <NotificationWidget id="headway-badge"></NotificationWidget>
+                <NotificationWidget id="headway-badge" />
             </NotificationWrapper>
             <Popover2
                 interactionKind={PopoverInteractionKind.CLICK}


### PR DESCRIPTION
Closes:  [3918](https://github.com/lightdash/lightdash/issues/3918)

### Description:
![image](https://user-images.githubusercontent.com/67699259/208731948-15293cdf-1a9b-4370-b3a8-b740ea559d5a.png)
The bell is a different colour compared to the help and settings icon. It should match them!
#abb3bf