### PR TITLE
style: dashboard filters popover

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -8,12 +8,6 @@ export const ConfigureFilterWrapper = styled.div`
     gap: 15px;
 `;
 
-export const InputsWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-`;
-
 export const ActionsWrapper = styled.div`
     display: flex;
     justify-content: space-between;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -8,11 +8,6 @@ export const ConfigureFilterWrapper = styled.div`
     gap: 15px;
 `;
 
-export const Title = styled.div`
-    font-weight: 600;
-    margin-bottom: 10px;
-`;
-
 export const InputsWrapper = styled.div`
     display: flex;
     flex-direction: column;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -8,6 +8,12 @@ export const ConfigureFilterWrapper = styled.div`
     gap: 15px;
 `;
 
+export const FieldLabelAndIconWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
 export const ActionsWrapper = styled.div`
     display: flex;
     justify-content: space-between;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -1,4 +1,4 @@
-import { HTMLSelect } from '@blueprintjs/core';
+import { FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
 import { Popover2Props } from '@blueprintjs/popover2';
 import {
     DashboardFilterRule,
@@ -9,7 +9,6 @@ import {
 } from '@lightdash/common';
 import { FC, useMemo } from 'react';
 import { FilterTypeConfig } from '../../common/Filters/configs';
-import { InputsWrapper } from './FilterConfiguration.styled';
 
 interface FilterSettingsProps {
     field: FilterableField;
@@ -36,28 +35,32 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     );
 
     return (
-        <InputsWrapper>
-            <HTMLSelect
-                fill
-                onChange={(e) =>
-                    onChangeFilterOperator(
-                        e.target.value as FilterRule['operator'],
-                    )
-                }
-                options={filterConfig.operatorOptions}
-                value={filterRule.operator}
-            />
+        <>
+            <FormGroup label="Value">
+                <HTMLSelect
+                    fill
+                    onChange={(e) =>
+                        onChangeFilterOperator(
+                            e.target.value as FilterRule['operator'],
+                        )
+                    }
+                    options={filterConfig.operatorOptions}
+                    value={filterRule.operator}
+                />
+            </FormGroup>
 
-            <filterConfig.inputs
-                popoverProps={popoverProps}
-                filterType={filterType}
-                field={field}
-                filterRule={filterRule}
-                onChange={(newFilterRule) =>
-                    onChangeFilterRule(newFilterRule as DashboardFilterRule)
-                }
-            />
-        </InputsWrapper>
+            <FormGroup>
+                <filterConfig.inputs
+                    popoverProps={popoverProps}
+                    filterType={filterType}
+                    field={field}
+                    filterRule={filterRule}
+                    onChange={(newFilterRule) =>
+                        onChangeFilterRule(newFilterRule as DashboardFilterRule)
+                    }
+                />
+            </FormGroup>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -9,6 +9,7 @@ import {
 } from '@lightdash/common';
 import { FC, useMemo } from 'react';
 import { FilterTypeConfig } from '../../common/Filters/configs';
+import { BolderLabel } from '../FilterSearch/FilterSearch.styles';
 
 interface FilterSettingsProps {
     field: FilterableField;
@@ -36,7 +37,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
 
     return (
         <>
-            <FormGroup label="Value">
+            <FormGroup label={<BolderLabel>Value</BolderLabel>}>
                 <HTMLSelect
                     fill
                     onChange={(e) =>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -12,7 +12,6 @@ import {
 import { FC, useCallback, useMemo } from 'react';
 import { FilterActions } from '.';
 import FieldSelect from '../../common/Filters/FieldSelect';
-import { Title } from './FilterConfiguration.styled';
 
 interface TileFilterConfigurationProps {
     tiles: DashboardTile[];
@@ -71,10 +70,6 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
 
     return (
         <>
-            <Title>
-                Select tiles to apply filter to and which field to filter by
-            </Title>
-
             {sortedTileEntries.map(([tileUuid, filters]) => {
                 if (!filters) return null;
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -18,12 +18,14 @@ import {
 } from '@lightdash/common';
 import produce from 'immer';
 import { FC, useCallback, useState } from 'react';
+import FieldIcon from '../../common/Filters/FieldIcon';
 import FieldLabel from '../../common/Filters/FieldLabel';
 import SimpleButton from '../../common/SimpleButton';
 import {
     ActionsWrapper,
     ApplyButton,
     ConfigureFilterWrapper,
+    FieldLabelAndIconWrapper,
 } from './FilterConfiguration.styled';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
@@ -134,7 +136,10 @@ const FilterConfiguration: FC<Props> = ({
 
     return (
         <ConfigureFilterWrapper>
-            <FieldLabel item={field} />
+            <FieldLabelAndIconWrapper>
+                <FieldIcon item={field} />
+                <FieldLabel item={field} />
+            </FieldLabelAndIconWrapper>
 
             <Tabs
                 selectedTabId={selectedTabId}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,5 +1,5 @@
 import { Intent, Tab, Tabs } from '@blueprintjs/core';
-import { Classes, Popover2Props } from '@blueprintjs/popover2';
+import { Classes, Popover2Props, Tooltip2 } from '@blueprintjs/popover2';
 
 import {
     applyDefaultTileTargets,
@@ -143,7 +143,14 @@ const FilterConfiguration: FC<Props> = ({
             >
                 <Tab
                     id="settings"
-                    title="Settings"
+                    title={
+                        <Tooltip2
+                            content="Select the value you want to filter your dimension by"
+                            position="bottom"
+                        >
+                            Settings
+                        </Tooltip2>
+                    }
                     panel={
                         <FilterSettings
                             field={field}
@@ -157,7 +164,14 @@ const FilterConfiguration: FC<Props> = ({
 
                 <Tab
                     id="tiles"
-                    title="Tiles"
+                    title={
+                        <Tooltip2
+                            content="Select tiles to apply filter to and which field to filter by"
+                            position="bottom"
+                        >
+                            Tiles
+                        </Tooltip2>
+                    }
                     panel={
                         <TileFilterConfiguration
                             field={field}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/4008

### Description:

**Settings tab**
- [x] Add field type icon to the field name (this makes it easier to identify the field type when you're in the 'Tiles' tab)
- [x] Add a label above the 'Value' inputs 
- [ ] ~~Add a "Label" input where the user can update the filter name  (this is once we have built the functionality)~~

**Tiles tab**
- [x] Get rid of the `Select tiles to apply filter to and which field to filter by` copy and instead, show it as a tooltip when you hover over the 'tiles' tab.

- [x] Add a tooltip when you hover over the 'settings' tab `Select the value you want to filter your dimension by`

https://user-images.githubusercontent.com/962095/208907180-c005a1c4-0cba-4754-a812-f622e17e7cfe.mp4

