### PR TITLE
feat: dashboard filters should be an icon and description should appear on title hover

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1,4 +1,11 @@
-import { Menu, NonIdealState, Portal } from '@blueprintjs/core';
+import {
+    Colors,
+    Icon,
+    Menu,
+    NonIdealState,
+    Portal,
+    Tag,
+} from '@blueprintjs/core';
 import {
     MenuItem2,
     Popover2,
@@ -50,7 +57,12 @@ import {
 } from '../MetricQueryData/MetricQueryDataProvider';
 import { EchartSeriesClickEvent } from '../SimpleChart';
 import TileBase from './TileBase/index';
-import { FilterLabel, GlobalTileStyles } from './TileBase/TileBase.styles';
+import {
+    FilterIcon,
+    FilterLabel,
+    FilterWrapper,
+    GlobalTileStyles,
+} from './TileBase/TileBase.styles';
 
 const ValidDashboardChartTile: FC<{
     tileUuid: string;
@@ -318,8 +330,13 @@ const DashboardChartTile: FC<Props> = (props) => {
                 const filterRuleLabels = getFilterRuleLabel(filterRule, field);
                 return (
                     <div key={field.name}>
-                        {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
-                        <FilterValues>{filterRuleLabels.value}</FilterValues>
+                        <Tag minimal style={{ color: 'white' }}>
+                            {filterRuleLabels.field}:{' '}
+                            {filterRuleLabels.operator}{' '}
+                            <FilterValues>
+                                {filterRuleLabels.value}
+                            </FilterValues>
+                        </Tag>
                     </div>
                 );
             }
@@ -349,28 +366,25 @@ const DashboardChartTile: FC<Props> = (props) => {
                         <div>
                             <Tooltip2
                                 content={
-                                    <div
-                                        style={{
-                                            display: 'flex',
-                                            flexDirection: 'column',
-                                            gap: '4px',
-                                        }}
-                                    >
+                                    <FilterWrapper>
+                                        <FilterLabel>
+                                            Dashboard filter
+                                            {appliedFilterRules.length > 1
+                                                ? 's'
+                                                : ''}{' '}
+                                            applied:
+                                        </FilterLabel>
                                         {appliedFilterRules.map(
                                             renderFilterRule,
                                         )}
-                                    </div>
+                                    </FilterWrapper>
                                 }
                                 interactionKind="hover"
-                                placement={'bottom-start'}
+                                placement="bottom-end"
                             >
-                                <FilterLabel>
-                                    Dashboard filter
-                                    {appliedFilterRules.length > 1
-                                        ? 's'
-                                        : ''}{' '}
-                                    applied
-                                </FilterLabel>
+                                <FilterIcon>
+                                    <Icon icon="filter" />
+                                </FilterIcon>
                             </Tooltip2>
                         </div>
                     )

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -6,6 +6,10 @@ interface HeaderContainerProps {
     isHovering?: boolean;
 }
 
+interface TitleWrapperProps {
+    hasDescription: boolean;
+}
+
 export const TileBaseWrapper = styled(Card)<HeaderContainerProps>`
     height: 100%;
     display: flex;
@@ -24,7 +28,7 @@ export const HeaderContainer = styled.div<HeaderContainerProps>`
     flex-direction: row;
     justify-content: space-between;
     align-items: baseline;
-    min-height: 80px;
+    margin-bottom: 15px;
     flex-wrap: wrap;
 
     ${(props) =>
@@ -46,10 +50,17 @@ export const GlobalTileStyles = createGlobalStyle`
   }
 `;
 
-export const TitleWrapper = styled.div`
+export const TitleWrapper = styled.div<TitleWrapperProps>`
     display: flex;
     flex-direction: row;
     align-items: center;
+
+    ${(props) =>
+        props.hasDescription
+            ? `
+                &:hover { cursor: pointer }
+            `
+            : ''}
 `;
 
 export const Title = styled(H5)`
@@ -68,16 +79,39 @@ export const ButtonsWrapper = styled.div`
     justify-content: flex-end;
 `;
 
-export const FilterLabel = styled.span`
-    color: ${Colors.GRAY2};
-    font-weight: 500;
-    font-size: 0.857em;
-    line-height: 1.583em;
-    margin: 0.5em 0 1em;
-`;
-
 export const ChartContainer = styled.div`
     flex: 1;
     overflow: hidden;
     display: flex;
+`;
+
+export const TooltipContent = styled.p`
+    max-width: 400px;
+    margin: 0;
+`;
+
+export const FilterIcon = styled.div`
+    border-radius: 2px;
+    box-sizing: border-box;
+    position: relative;
+    color: ${Colors.GRAY1} !important;
+    padding: 6px 7px;
+
+    :hover {
+        cursor: pointer;
+        background: rgba(143, 153, 168, 0.15) !important;
+    }
+`;
+
+export const FilterWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+export const FilterLabel = styled.p`
+    margin-bottom: 5px;
+    color: ${Colors.GRAY5};
+    font-size: 12px;
+    font-weight: 500;
 `;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -17,12 +17,14 @@ import {
     TileBaseWrapper,
     Title,
     TitleWrapper,
+    TooltipContent,
 } from './TileBase.styles';
 
 type Props<T> = {
     isEditMode: boolean;
     title: string;
     description?: string;
+    hasDescription: boolean;
     tile: T;
     isLoading?: boolean;
     extraMenuItems?: React.ReactNode;
@@ -43,6 +45,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     onEdit,
     children,
     extraHeaderElement,
+    hasDescription,
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
     const [isHovering, setIsHovering] = useState(false);
@@ -63,19 +66,25 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 onMouseLeave={() => setIsHovering(false)}
             >
                 <HeaderWrapper>
-                    {!hideTitle && (
-                        <TitleWrapper>
+                    {!hideTitle && description ? (
+                        <Tooltip2
+                            content={
+                                <TooltipContent>{description}</TooltipContent>
+                            }
+                            position="bottom-left"
+                        >
+                            <TitleWrapper hasDescription={true}>
+                                <Title className="non-draggable">{title}</Title>
+                            </TitleWrapper>
+                        </Tooltip2>
+                    ) : !hideTitle ? (
+                        <TitleWrapper hasDescription={hasDescription}>
                             <Title className="non-draggable">{title}</Title>
                         </TitleWrapper>
-                    )}
-                    {extraHeaderElement}
+                    ) : null}
                 </HeaderWrapper>
                 <ButtonsWrapper>
-                    {description && (
-                        <Tooltip2 content={description} position="bottom">
-                            <Button icon="info-sign" minimal />
-                        </Tooltip2>
-                    )}
+                    {extraHeaderElement}
                     {(isEditMode || (!isEditMode && extraMenuItems)) && (
                         <Popover2
                             className="non-draggable"
@@ -156,6 +165,7 @@ TileBase.defaultProps = {
     isLoading: false,
     extraMenuItems: null,
     description: null,
+    hasDescription: false,
     hasFilters: false,
 };
 


### PR DESCRIPTION
Closes: [#3986](https://github.com/lightdash/lightdash/issues/3986)

### Description:

- [x] filters should appear on hover of a filter icon, replacing the information icon
- [x] description (if any) should appear on title hover

### Before
<img width="591" alt="image" src="https://user-images.githubusercontent.com/67699259/209114509-bb29584a-4fc9-4b9d-b34d-059218ef32b1.png">

### After
<img width="596" alt="image" src="https://user-images.githubusercontent.com/67699259/209171510-4878324d-3168-4259-8797-8bb50f786329.png">
