### PR TITLE
feat: update drill down  copy

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -2,6 +2,7 @@ import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     DashboardFilters,
     Field,
+    fieldId as getFieldId,
     isField,
     isMetric,
     PivotReference,
@@ -19,6 +20,7 @@ export const DrillDownMenuItem: FC<{
 }> = ({ row, selectedItem, dashboardFilters, pivotReference }) => {
     const { explore, metricQuery, openDrillDownModel } =
         useMetricQueryDataContext();
+
     if (
         selectedItem &&
         isField(selectedItem) &&
@@ -27,9 +29,11 @@ export const DrillDownMenuItem: FC<{
         row &&
         metricQuery
     ) {
+        const value = row[getFieldId(selectedItem)]?.value.formatted;
+
         return (
             <MenuItem2
-                text="Drill by"
+                text={`Drill into "${value}"`}
                 icon="path"
                 onClick={() =>
                     openDrillDownModel({

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -12,6 +12,7 @@ import {
     CreateSavedChartVersion,
     DashboardFilters,
     FieldId,
+    fieldId as getFieldId,
     FilterGroupItem,
     FilterOperator,
     FilterRule,
@@ -19,6 +20,7 @@ import {
     getDimensions,
     getItemId,
     isField,
+    isMetric,
     MetricQuery,
     PivotReference,
     ResultRow,
@@ -175,6 +177,13 @@ const DrillDownModal: FC = () => {
         }
         return [];
     }, [explore]);
+
+    const value = useMemo(() => {
+        if (drillDownConfig && isField(drillDownConfig.selectedItem))
+            return drillDownConfig.row[getFieldId(drillDownConfig.selectedItem)]
+                ?.value.formatted;
+    }, [drillDownConfig]);
+
     const url = useMemo(() => {
         if (selectedDimension && metricQuery && explore && drillDownConfig) {
             return drillDownExploreUrl({
@@ -199,12 +208,12 @@ const DrillDownModal: FC = () => {
             isOpen={isDrillDownModalOpen}
             onClose={closeDrillDownModal}
             lazy
-            title={`Drill by dimension`}
+            title={`Drill into "${value}"`}
         >
             <form>
                 <div className={Classes.DIALOG_BODY}>
                     <FormGroup
-                        label="Pick a dimension to drill by"
+                        label="Pick a dimension to segment your metric by"
                         labelFor="chart-name"
                     >
                         <FieldAutoComplete


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #4034

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
- [x] The sub-menu should say drill into "___". For example, here, it would say drill into "924"
![Screenshot from 2022-12-23 10-22-41](https://user-images.githubusercontent.com/1983672/209309888-45cf12c0-7527-4b7b-98cf-0284b2908f7d.png)

The modal that pops up should say
- [x] Drill by dimension --> Drill into "924"
- [x] pick dimension to drill by --> pick a dimension to segment your metric by

![Screenshot from 2022-12-23 10-22-53](https://user-images.githubusercontent.com/1983672/209309880-df4fb5ac-2b19-49f9-b96a-efb94f762440.png)
