### PR TITLE
docs: amend CLI login example 

### DIFF
--- a/docs/docs/guides/cli/cli-authentication.mdx
+++ b/docs/docs/guides/cli/cli-authentication.mdx
@@ -33,7 +33,7 @@ cloud users in the US would type `lightdash login https://app.lightdash.cloud` i
 
 where `https://my-lightdash.domain.com` is the address for your running Lightdash instance. For example Lightdash
 cloud users in the US would type `lightdash login https://app.lightdash.cloud` if you're in Europe you'd type
-`lightdash login https://eu1.lightdash.com`.
+`lightdash login https://eu1.lightdash.cloud`.
 
 </details>
 


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
I was trying to authenticate lightdash, but the link is wrong for Europe. I get this error:
```
FetchError: request to https://eu1.lightdash.com/api/v1/login failed, reason: getaddrinfo ENOTFOUND eu1.lightdash.com
    at ClientRequest.<anonymous> (/Users/annebelleolminkhof/.nvm/versions/node/v18.12.1/lib/node_modules/@lightdash/cli/node_modules/node-fetch/lib/index.js:1491:11)
    at ClientRequest.emit (node:events:513:28)
    at ClientRequest.emit (node:domain:489:12)
    at TLSSocket.socketErrorListener (node:_http_client:494:9)
    at TLSSocket.emit (node:events:513:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  type: 'system',
  errno: 'ENOTFOUND',
  code: 'ENOTFOUND'
}
FetchError: request to https://eu1.lightdash.com/api/v1/login failed, reason: getaddrinfo ENOTFOUND eu1.lightdash.com
    at ClientRequest.<anonymous> (/Users/annebelleolminkhof/.nvm/versions/node/v18.12.1/lib/node_modules/@lightdash/cli/node_modules/node-fetch/lib/index.js:1491:11)
    at ClientRequest.emit (node:events:513:28)
    at ClientRequest.emit (node:domain:489:12)
    at TLSSocket.socketErrorListener (node:_http_client:494:9)
    at TLSSocket.emit (node:events:513:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)

Report this issue with 1-click:

  🐛 https://github.com/lightdash/lightdash/issues/new?assignees=&labels=🐛+bug&template=bug_report.md&title=request%20to%20https%3A%2F%2Feu1.lightdash.com%2Fapi%2Fv1%2Flogin%20failed%2C%20reason%3A%20getaddrinfo%20ENOTFOUND%20eu1.lightdash.com
```

I updated it with the correct one.
