### PR TITLE
chore: show generic footer message when space has full access

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -84,7 +84,8 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                 </DialogBody>
 
                 <DialogFooter>
-                    {sessionUser.data?.ability?.can('create', 'InviteLink') ? (
+                    {selectedAccess.value === SpaceAccessType.PRIVATE &&
+                    sessionUser.data?.ability?.can('create', 'InviteLink') ? (
                         <>
                             Can’t find a user? Spaces can only be shared with{' '}
                             <Link


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3865 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Show generic footer message if "Full access" is selected

![footer message](https://user-images.githubusercontent.com/9117144/210339994-4a9cf795-7017-4b12-9b6b-e8138ea1856d.gif)
