### PR TITLE
fix: create dashboard flow same as create space flow

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_DASHBOARD_NAME } from '../../../pages/SavedDashboards';
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
 import SpaceActionModal, { ActionType } from '../../common/SpaceActionModal';
+import CreateSavedDashboardModal from '../../SavedDashboards/CreateSavedDashboardModal';
 import {
     ButtonWrapper,
     HelpItem,
@@ -32,6 +33,7 @@ interface ExploreItemProps {
     title: string;
     description: string;
 }
+
 const ExploreItem: FC<ExploreItemProps> = ({ icon, title, description }) => {
     return (
         <HelpItem>
@@ -57,6 +59,8 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
         reset,
     } = useCreateMutation(projectUuid);
     const [isCreateSpaceOpen, setIsCreateSpaceOpen] = useState<boolean>(false);
+    const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
+        useState<boolean>(false);
 
     if (!isCreatingDashboard && hasCreatedDashboard && newDashboard) {
         history.push(
@@ -116,10 +120,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             <ButtonWrapper
                                 onClick={() => {
                                     setIsOpen(false);
-                                    createDashboard({
-                                        name: DEFAULT_DASHBOARD_NAME,
-                                        tiles: [],
-                                    });
+                                    setIsCreateDashboardOpen(true);
                                 }}
                             >
                                 <ExploreItem
@@ -171,6 +172,13 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 `/projects/${projectUuid}/spaces/${space.uuid}`,
                             );
                     }}
+                />
+            )}
+            {isCreateDashboardOpen && (
+                <CreateSavedDashboardModal
+                    isOpen={true}
+                    showRedirectButton={false}
+                    onClose={() => setIsCreateDashboardOpen(false)}
                 />
             )}
         </>

--- a/packages/frontend/src/components/SavedDashboards/CreateSavedDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/CreateSavedDashboardModal.tsx
@@ -14,7 +14,6 @@ import { useApp } from '../../providers/AppProvider';
 
 interface CreateSavedDashboardModalProps {
     isOpen: boolean;
-
     tiles?: Dashboard['tiles'];
     showRedirectButton?: boolean;
     onClose?: () => void;
@@ -30,6 +29,7 @@ const CreateSavedDashboardModal: FC<CreateSavedDashboardModalProps> = ({
     const useCreate = useCreateMutation(projectUuid, showRedirectButton);
     const { mutate, isLoading: isCreating } = useCreate;
     const [name, setName] = useState<string>('');
+    const [description, setDescription] = useState<string>('');
 
     const { user } = useApp();
 
@@ -39,13 +39,30 @@ const CreateSavedDashboardModal: FC<CreateSavedDashboardModalProps> = ({
         <Dialog isOpen={isOpen} onClose={onClose} lazy title="Create dashboard">
             <form>
                 <div className={Classes.DIALOG_BODY}>
-                    <FormGroup label="Name" labelFor="chart-name">
+                    <FormGroup
+                        label="Name your dashboard"
+                        labelFor="chart-name"
+                    >
                         <InputGroup
                             id="chart-name"
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             placeholder="eg. KPI dashboard"
+                        />
+                    </FormGroup>
+                </div>
+                <div className={Classes.DIALOG_BODY}>
+                    <FormGroup
+                        label="Dashboard description"
+                        labelFor="chart-description"
+                    >
+                        <InputGroup
+                            id="chart-description"
+                            type="text"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="A few words to give your team some context"
                         />
                     </FormGroup>
                 </div>
@@ -58,8 +75,11 @@ const CreateSavedDashboardModal: FC<CreateSavedDashboardModalProps> = ({
                             text="Create"
                             type="submit"
                             onClick={(e) => {
-                                mutate({ tiles: tiles || [], name });
-
+                                mutate({
+                                    tiles: tiles || [],
+                                    name,
+                                    description,
+                                });
                                 if (onClose) onClose();
                                 e.preventDefault();
                             }}

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -17,7 +17,6 @@ import CreateSpaceModalContent, {
     CreateModalStep,
 } from './CreateSpaceModalContent';
 import DeleteSpaceModalContent from './DeleteSpaceModalContent';
-import { BackButton } from './SpaceActionModal.style';
 import UpdateSpaceModalContent from './UpdateSpaceModalContent';
 
 export enum ActionType {

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -304,6 +304,9 @@ export const useCreateMutation = (
                           }
                         : undefined,
                 });
+                history.push(
+                    `/projects/${projectUuid}/dashboards/${result.uuid}/edit`,
+                );
             },
             onError: (error) => {
                 showToastError({

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -2,6 +2,7 @@ import { Button, NonIdealState, Spinner } from '@blueprintjs/core';
 import { Breadcrumbs2, Tooltip2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
 import Page from '../components/common/Page/Page';
@@ -16,6 +17,7 @@ import {
     ResourceTag,
 } from '../components/common/ResourceList/ResourceList.styles';
 import { SortDirection } from '../components/common/ResourceList/ResourceTable';
+import CreateSavedDashboardModal from '../components/SavedDashboards/CreateSavedDashboardModal';
 import { useCreateMutation } from '../hooks/dashboard/useDashboard';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
 import { useSpaces } from '../hooks/useSpaces';
@@ -27,6 +29,8 @@ const SavedDashboards = () => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isLoading, data: dashboards = [] } = useDashboards(projectUuid);
+    const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
+        useState<boolean>(false);
 
     const {
         isLoading: isCreatingDashboard,
@@ -66,10 +70,11 @@ const SavedDashboards = () => {
     }
 
     const handleCreateDashboard = () => {
-        createDashboard({
-            name: DEFAULT_DASHBOARD_NAME,
-            tiles: [],
-        });
+        setIsCreateDashboardOpen(true);
+        // createDashboard({
+        //     name: DEFAULT_DASHBOARD_NAME,
+        //     tiles: [],
+        // });
     };
 
     return (
@@ -128,6 +133,13 @@ const SavedDashboards = () => {
                             </Tooltip2>
                         )}
                 </PageHeader>
+                {isCreateDashboardOpen && (
+                    <CreateSavedDashboardModal
+                        isOpen={true}
+                        showRedirectButton={false}
+                        onClose={() => setIsCreateDashboardOpen(false)}
+                    />
+                )}
 
                 <ResourceList
                     resourceType="dashboard"


### PR DESCRIPTION
Closes:  [#3964](https://github.com/lightdash/lightdash/issues/3964)

### Description:
When you `Create New Dashboard`, the dashboard is created right away and you're redirected immediately. This can be confusing and feels a lot more alarming now that you can create dashboards from the navbar! I also can't count the amount of times I have accidentally created an "Untitled" dashboard and forgotten to delete it.

![image](https://user-images.githubusercontent.com/67699259/210590361-904b9947-17a8-4667-a77c-f78143ab77c9.png)

- [x] When you 'Create a new dashboard', you should see a modal prompting you to name the dashboard (and give it a description, but this is optional). This is the same modal you see when you rename the dashboard, but instead, the title should say `Name your dashboard`. Instead of `Save`, it says `Create`.

- [x] Once you hit `Create` the dashboard is created, you are redirected and see the success toast. 

- [x] This should affect the `+Add Dashboard` button in the navbar, and the `+Create dashboard` button on the "`All dashboards`" page 

