### PR TITLE
fix: ">=" and "<=" metric number filters

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -1,6 +1,32 @@
 import { FilterOperator, UnitOfTime } from '../types/filter';
 
 export const DimensionSqlMock = 'customers.created';
+export const NumberDimensionMock = 'customers.age';
+
+export const NumberFilterBase = {
+    id: 'id',
+    target: {
+        fieldId: 'fieldId',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [1],
+};
+export const ExpectedNumberFilterSQL: Record<FilterOperator, string | null> = {
+    [FilterOperator.NULL]: '(customers.age) IS NULL',
+    [FilterOperator.NOT_NULL]: '(customers.age) IS NOT NULL',
+    [FilterOperator.EQUALS]: '(customers.age) IN (1)',
+    [FilterOperator.NOT_EQUALS]: '(customers.age) NOT IN (1)',
+    [FilterOperator.STARTS_WITH]: null,
+    [FilterOperator.INCLUDE]: null,
+    [FilterOperator.NOT_INCLUDE]: null,
+    [FilterOperator.LESS_THAN]: '(customers.age) < (1)',
+    [FilterOperator.LESS_THAN_OR_EQUAL]: '(customers.age) <= (1)',
+    [FilterOperator.GREATER_THAN]: '(customers.age) > (1)',
+    [FilterOperator.GREATER_THAN_OR_EQUAL]: '(customers.age) >= (1)',
+    [FilterOperator.IN_THE_PAST]: null,
+    [FilterOperator.IN_THE_CURRENT]: null,
+    [FilterOperator.IN_THE_NEXT]: null,
+};
 
 export const InTheCurrentFilterBase = {
     id: 'id',

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1,11 +1,16 @@
 import moment from 'moment/moment';
-import { UnitOfTime } from '../types/filter';
-import { renderDateFilterSql, renderStringFilterSql } from './filtersCompiler';
+import { FilterOperator, UnitOfTime } from '../types/filter';
+import {
+    renderDateFilterSql,
+    renderNumberFilterSql,
+    renderStringFilterSql,
+} from './filtersCompiler';
 import {
     DimensionSqlMock,
     ExpectedInTheCurrentFilterSQL,
     ExpectedInTheNextCompleteFilterSQL,
     ExpectedInTheNextFilterSQL,
+    ExpectedNumberFilterSQL,
     InTheCurrentFilterBase,
     InTheLast1CompletedDayFilter,
     InTheLast1CompletedDayFilterSQL,
@@ -32,6 +37,8 @@ import {
     InTheLast1YearFilter,
     InTheLast1YearFilterSQL,
     InTheNextFilterBase,
+    NumberDimensionMock,
+    NumberFilterBase,
     stringFilterDimension,
     stringFilterRuleMocks,
 } from './filtersCompiler.mock';
@@ -47,6 +54,26 @@ describe('Filter SQL', () => {
     afterAll(() => {
         jest.useFakeTimers();
     });
+    test.each(Object.values(FilterOperator))(
+        'should return number filter sql for operator %s',
+        (operator) => {
+            if (ExpectedNumberFilterSQL[operator]) {
+                expect(
+                    renderNumberFilterSql(NumberDimensionMock, {
+                        ...NumberFilterBase,
+                        operator,
+                    }),
+                ).toStrictEqual(ExpectedNumberFilterSQL[operator]);
+            } else {
+                expect(() => {
+                    renderNumberFilterSql(NumberDimensionMock, {
+                        ...NumberFilterBase,
+                        operator,
+                    });
+                }).toThrow();
+            }
+        },
+    );
     test.each(Object.values(UnitOfTime))(
         'should return in the current %s filter sql',
         (unitOfTime) => {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -64,7 +64,7 @@ export const renderStringFilterSql = (
     }
 };
 
-const renderNumberFilterSql = (
+export const renderNumberFilterSql = (
     dimensionSql: string,
     filter: FilterRule,
 ): string => {
@@ -84,8 +84,12 @@ const renderNumberFilterSql = (
             return `(${dimensionSql}) IS NOT NULL`;
         case FilterOperator.GREATER_THAN:
             return `(${dimensionSql}) > (${filter.values?.[0] || 0})`;
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+            return `(${dimensionSql}) >= (${filter.values?.[0] || 0})`;
         case FilterOperator.LESS_THAN:
             return `(${dimensionSql}) < (${filter.values?.[0] || 0})`;
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+            return `(${dimensionSql}) <= (${filter.values?.[0] || 0})`;
         default:
             throw Error(
                 `No function implemented to render sql for filter type ${filterType} on dimension of number type`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4092 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


```
          metrics:
            in_gbp:
              type: sum
              format: 'gbp'
              filters:
                - event_id: '>= 4'
```
<img width="1188" alt="Screenshot 2023-01-09 at 10 09 55" src="https://user-images.githubusercontent.com/9117144/211289773-902d834b-c155-4e76-bbdc-73623b9cd7f4.png">

