### PR TITLE
fix: legend align left

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/index.tsx
@@ -100,7 +100,11 @@ const LegendPanel: FC<Props> = ({ items }) => {
                                 label={startCase(position)}
                                 name={position}
                                 units={units}
-                                defaultValue="auto"
+                                defaultValue={
+                                    position === Positions.Left
+                                        ? 'center'
+                                        : 'auto'
+                                }
                             />
                         ))}
                     </SectionRow>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4116

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Problem: We've recently made a change to legends and now we add positions (with auto) instead of leaving those properties undefined. 

![Screenshot from 2023-01-10 10-45-50](https://user-images.githubusercontent.com/1983672/211517866-f04f7ed2-6b0f-40ae-9da2-ba371b449456.png)

For some reason, despite default on echarts being `auto` it doesn't seem to be a valid value for `left`, the right default value should be `center`


![Screenshot from 2023-01-10 10-45-28](https://user-images.githubusercontent.com/1983672/211517897-09dcaf84-2840-41d8-b8cd-e863266dc644.png)


Solution: replace default `auto` on left with `center` , other positions can still be auto

![Screenshot from 2023-01-10 10-45-41](https://user-images.githubusercontent.com/1983672/211517939-ef961ad0-a358-40e9-b4f1-a686002b9332.png)


