### PR TITLE
feat: `is between` date filter

### DIFF
--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -47,15 +47,15 @@ To learn more about using filters, check out our docs on limiting data using fil
 
 ### Date filters
 
-| Filter          | logic                                                                                                     |
-|-----------------|-----------------------------------------------------------------------------------------------------------|
-| is null         | Only pulls in rows where the values are null for the field selected.                                      |
-| is not null     | Only pulls in rows where the values are not null for the field selected.                                  |
-| is equal to     | Only pulls in rows where the values are equal to the values listed.                                       |
-| is not equal to | Only pulls in rows where the values are not equal to the values listed.                                   |
-| in the last     | Only pulls in rows where the dates for the field selected are within the dynamic date range you selected. |
-| is before       | Only pulls in rows where the dates for the field selected are strictly before the date you entered.       |
-| is on or before | Only pulls in rows where the dates for the field selected are on or before the date you entered.          |
-| is after        | Only pulls in rows where the dates for the field selected are strictly after the date you entered.        |
-| is on or after  | Only pulls in rows where the dates for the field selected are on or after the date you entered.           |
-| is between      | Only pulls in rows where the dates for the field selected are on or between the dates you entered.        |
+| Filter          | logic                                                                                                                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| is null         | Only pulls in rows where the values are null for the field selected.                                                                                                                       |
+| is not null     | Only pulls in rows where the values are not null for the field selected.                                                                                                                   |
+| is equal to     | Only pulls in rows where the values are equal to the values listed.                                                                                                                        |
+| is not equal to | Only pulls in rows where the values are not equal to the values listed.                                                                                                                    |
+| in the last     | Only pulls in rows where the dates for the field selected are within the dynamic date range you selected.                                                                                  |
+| is before       | Only pulls in rows where the dates for the field selected are strictly before the date you entered.                                                                                        |
+| is on or before | Only pulls in rows where the dates for the field selected are on or before the date you entered.                                                                                           |
+| is after        | Only pulls in rows where the dates for the field selected are strictly after the date you entered.                                                                                         |
+| is on or after  | Only pulls in rows where the dates for the field selected are on or after the date you entered.                                                                                            |
+| custom range    | Only pulls in rows where the dates for the field selected are on or between the dates you entered. Some ranges are already provided: "Past 3 months", "Past 6 months", "Past 2 years" etc. |

--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -16,34 +16,34 @@ To learn more about using filters, check out our docs on limiting data using fil
 
 ### Numeric filters
 
-| Filter          | logic                                                                           |
-| --------------- | ------------------------------------------------------------------------------- |
-| is null         | Only pulls in rows where the values are null for the field selected.            |
-| is not null     | Only pulls in rows where the values are not null for the field selected.        |
-| is equal to     | Only pulls in rows where the values are equal to the values listed.             |
-| is not equal to | Only pulls in rows where the values are not equal to the values listed.         |
-| is less than    | Only pulls in rows where the values for the field selected are strictly less than the value listed.    |
+| Filter          | logic                                                                                                 |
+|-----------------|-------------------------------------------------------------------------------------------------------|
+| is null         | Only pulls in rows where the values are null for the field selected.                                  |
+| is not null     | Only pulls in rows where the values are not null for the field selected.                              |
+| is equal to     | Only pulls in rows where the values are equal to the values listed.                                   |
+| is not equal to | Only pulls in rows where the values are not equal to the values listed.                               |
+| is less than    | Only pulls in rows where the values for the field selected are strictly less than the value listed.   |
 | is greater than | Only pulls in rows where the values for the field selectedare strictly greater than the value listed. |
 
 ### String filters
 
-| Filter          | logic                                                                           |
-| --------------- | ------------------------------------------------------------------------------- |
-| is null         | Only pulls in rows where the values are null for the field selected.            |
-| is not null     | Only pulls in rows where the values are not null for the field selected.        |
-| is equal to     | Only pulls in rows where the values are equal to the values listed.             |
-| is not equal to | Only pulls in rows where the values are not equal to the values listed.         |
-| starts with     | Only pulls in rows where the values for the field selected start with characters you've entered. |
+| Filter          | logic                                                                                              |
+|-----------------|----------------------------------------------------------------------------------------------------|
+| is null         | Only pulls in rows where the values are null for the field selected.                               |
+| is not null     | Only pulls in rows where the values are not null for the field selected.                           |
+| is equal to     | Only pulls in rows where the values are equal to the values listed.                                |
+| is not equal to | Only pulls in rows where the values are not equal to the values listed.                            |
+| starts with     | Only pulls in rows where the values for the field selected start with characters you've entered.   |
 | includes        | Only pulls in rows where the values for the field selected includes the characters you've entered. |
 | ends with       | Only pulls in rows where the values for the field selected end with the characters you've entered. |
 
 ### Boolean filters
 
-| Filter          | logic                                                                           |
-| --------------- | ------------------------------------------------------------------------------- |
-| is null         | Only pulls in rows where the values are null for the field selected.            |
-| is not null     | Only pulls in rows where the values are not null for the field selected.        |
-| is equal to     | Only pulls in rows where the values are equal to the values listed.             |
+| Filter      | logic                                                                    |
+|-------------|--------------------------------------------------------------------------|
+| is null     | Only pulls in rows where the values are null for the field selected.     |
+| is not null | Only pulls in rows where the values are not null for the field selected. |
+| is equal to | Only pulls in rows where the values are equal to the values listed.      |
 
 ### Date filters
 
@@ -58,3 +58,4 @@ To learn more about using filters, check out our docs on limiting data using fil
 | is on or before       | Only pulls in rows where the dates for the field selected are on or before the date you entered. |
 | is after        | Only pulls in rows where the dates for the field selected are strictly after the date you entered. |
 | is on or after       | Only pulls in rows where the dates for the field selected are on or after the date you entered. |
+| is between      | Only pulls in rows where the dates for the field selected are on or between the dates you entered. |

--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -47,15 +47,15 @@ To learn more about using filters, check out our docs on limiting data using fil
 
 ### Date filters
 
-| Filter          | logic                                                                           |
-| --------------- | ------------------------------------------------------------------------------- |
-| is null         | Only pulls in rows where the values are null for the field selected.            |
-| is not null     | Only pulls in rows where the values are not null for the field selected.        |
-| is equal to     | Only pulls in rows where the values are equal to the values listed.             |
-| is not equal to | Only pulls in rows where the values are not equal to the values listed.         |
-| in the last     | Only pulls in rows where the dates for the field selected are within the dynamic date range you selected.  |
-| is before        | Only pulls in rows where the dates for the field selected are strictly before the date you entered. |
-| is on or before       | Only pulls in rows where the dates for the field selected are on or before the date you entered. |
-| is after        | Only pulls in rows where the dates for the field selected are strictly after the date you entered. |
-| is on or after       | Only pulls in rows where the dates for the field selected are on or after the date you entered. |
-| is between      | Only pulls in rows where the dates for the field selected are on or between the dates you entered. |
+| Filter          | logic                                                                                                     |
+|-----------------|-----------------------------------------------------------------------------------------------------------|
+| is null         | Only pulls in rows where the values are null for the field selected.                                      |
+| is not null     | Only pulls in rows where the values are not null for the field selected.                                  |
+| is equal to     | Only pulls in rows where the values are equal to the values listed.                                       |
+| is not equal to | Only pulls in rows where the values are not equal to the values listed.                                   |
+| in the last     | Only pulls in rows where the dates for the field selected are within the dynamic date range you selected. |
+| is before       | Only pulls in rows where the dates for the field selected are strictly before the date you entered.       |
+| is on or before | Only pulls in rows where the dates for the field selected are on or before the date you entered.          |
+| is after        | Only pulls in rows where the dates for the field selected are strictly after the date you entered.        |
+| is on or after  | Only pulls in rows where the dates for the field selected are on or after the date you entered.           |
+| is between      | Only pulls in rows where the dates for the field selected are on or between the dates you entered.        |

--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -26,6 +26,7 @@ export const ExpectedNumberFilterSQL: Record<FilterOperator, string | null> = {
     [FilterOperator.IN_THE_PAST]: null,
     [FilterOperator.IN_THE_CURRENT]: null,
     [FilterOperator.IN_THE_NEXT]: null,
+    [FilterOperator.IN_BETWEEN]: null,
 };
 
 export const InTheCurrentFilterBase = {
@@ -214,6 +215,21 @@ export const InTheLast1CompletedMinuteFilter = {
 };
 
 export const InTheLast1CompletedMinuteFilterSQL = `((customers.created) >= ('2020-04-04 06:11:00') AND (customers.created) < ('2020-04-04 06:12:00'))`;
+
+export const InBetweenPastTwoYearsFilter = {
+    id: 'id',
+    target: {
+        fieldId: 'fieldId',
+    },
+    operator: FilterOperator.IN_BETWEEN,
+    values: [
+        new Date('04 Apr 2021 00:00:00 GMT'),
+        new Date('04 Apr 2023 00:00:00 GMT'),
+    ],
+};
+
+export const InBetweenPastTwoYearsFilterSQL = `((customers.created) >= ('2021-04-04') AND (customers.created) <= ('2023-04-04'))`;
+export const InBetweenPastTwoYearsTimestampFilterSQL = `((customers.created) >= ('2021-04-04 00:00:00') AND (customers.created) <= ('2023-04-04 00:00:00'))`;
 
 const stringSingleValueFilter = {
     id: '701b6520-1b19-4051-a553-7615aee0b03d',

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -11,6 +11,9 @@ import {
     ExpectedInTheNextCompleteFilterSQL,
     ExpectedInTheNextFilterSQL,
     ExpectedNumberFilterSQL,
+    InBetweenPastTwoYearsFilter,
+    InBetweenPastTwoYearsFilterSQL,
+    InBetweenPastTwoYearsTimestampFilterSQL,
     InTheCurrentFilterBase,
     InTheLast1CompletedDayFilter,
     InTheLast1CompletedDayFilterSQL,
@@ -191,6 +194,22 @@ describe('Filter SQL', () => {
                 formatTimestamp,
             ),
         ).toStrictEqual(InTheLast1CompletedMinuteFilterSQL);
+    });
+
+    test('should return in between date filter sql', () => {
+        expect(
+            renderDateFilterSql(DimensionSqlMock, InBetweenPastTwoYearsFilter),
+        ).toStrictEqual(InBetweenPastTwoYearsFilterSQL);
+    });
+
+    test('should return in between date filter sql for timestamps', () => {
+        expect(
+            renderDateFilterSql(
+                DimensionSqlMock,
+                InBetweenPastTwoYearsFilter,
+                formatTimestamp,
+            ),
+        ).toStrictEqual(InBetweenPastTwoYearsTimestampFilterSQL);
     });
 
     test('should return single value in includes filter sql', () => {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -192,6 +192,12 @@ export const renderDateFilterSql = (
             );
             return `((${dimensionSql}) >= ('${fromDate}') AND (${dimensionSql}) <= ('${untilDate}'))`;
         }
+        case FilterOperator.IN_BETWEEN: {
+            const startDate = dateFormatter(filter.values?.[0]);
+            const endDate = dateFormatter(filter.values?.[1]);
+
+            return `((${dimensionSql}) >= ('${startDate}') AND (${dimensionSql}) <= ('${endDate}'))`;
+        }
         default:
             throw Error(
                 `No function implemented to render sql for filter type ${filterType} on dimension of date type`,

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -21,6 +21,7 @@ export enum FilterOperator {
 
     IN_THE_NEXT = 'inTheNext',
     IN_THE_CURRENT = 'inTheCurrent',
+    IN_BETWEEN = 'inBetween',
 }
 
 export enum UnitOfTime {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -1,5 +1,5 @@
 import { NumericInput } from '@blueprintjs/core';
-import { DateInput2, DateRangeInput2 } from '@blueprintjs/datetime2';
+import { DateInput2 } from '@blueprintjs/datetime2';
 import {
     DateFilterRule,
     DimensionType,
@@ -240,7 +240,6 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                 </MultipleInputsWrapper>
             );
         case FilterOperator.IN_BETWEEN:
-            // const dateRange = filterRule.values ? filterRule.values?.map((value) => formatDate(value, undefined, false)) : [null, null];
             return (
                 <StyledDateRangeInput
                     className={disabled ? 'disabled-filter' : ''}
@@ -249,7 +248,14 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                         formatDate(value, undefined, false)
                     }
                     parseDate={parseDate}
-                    // value={dateRange}
+                    value={
+                        filterRule.values
+                            ? [
+                                  new Date(filterRule.values?.[0]),
+                                  new Date(filterRule.values?.[1]),
+                              ]
+                            : [null, null]
+                    }
                     onChange={(range: [Date | null, Date | null]) => {
                         if (range) {
                             onChange({

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -248,16 +248,16 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                         formatDate(value, undefined, false)
                     }
                     parseDate={parseDate}
-                    value={
-                        filterRule.values
-                            ? [
-                                  new Date(filterRule.values?.[0]),
-                                  new Date(filterRule.values?.[1]),
-                              ]
-                            : [null, null]
-                    }
-                    onChange={(range: [Date | null, Date | null]) => {
-                        if (range) {
+                    value={[
+                        filterRule.values?.[0]
+                            ? new Date(filterRule.values?.[0])
+                            : null,
+                        filterRule.values?.[1]
+                            ? new Date(filterRule.values?.[1])
+                            : null,
+                    ]}
+                    onChange={(range: [Date | null, Date | null] | null) => {
+                        if (range && range[0] && range[1]) {
                             onChange({
                                 ...filterRule,
                                 values: range.map((value) =>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -276,6 +276,7 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                             : undefined,
                     }}
                     closeOnSelection={true}
+                    shortcuts={false}
                 />
             );
         default: {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -1,5 +1,5 @@
 import { NumericInput } from '@blueprintjs/core';
-import { DateInput2 } from '@blueprintjs/datetime2';
+import { DateInput2, DateRangeInput2 } from '@blueprintjs/datetime2';
 import {
     DateFilterRule,
     DimensionType,
@@ -18,7 +18,10 @@ import WeekPicker, { convertWeekDayToDayPickerWeekDay } from '../../WeekPicker';
 import YearInput from '../../YearInput';
 import { useFiltersContext } from '../FiltersProvider';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
-import { MultipleInputsWrapper } from './FilterInputs.styles';
+import {
+    MultipleInputsWrapper,
+    StyledDateRangeInput,
+} from './FilterInputs.styles';
 import UnitOfTimeAutoComplete from './UnitOfTimeAutoComplete';
 
 const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
@@ -235,6 +238,39 @@ const DateFilterInputs: FC<FilterInputsProps<DateFilterRule>> = (props) => {
                         }
                     />
                 </MultipleInputsWrapper>
+            );
+        case FilterOperator.IN_BETWEEN:
+            // const dateRange = filterRule.values ? filterRule.values?.map((value) => formatDate(value, undefined, false)) : [null, null];
+            return (
+                <StyledDateRangeInput
+                    className={disabled ? 'disabled-filter' : ''}
+                    disabled={disabled}
+                    formatDate={(value: Date) =>
+                        formatDate(value, undefined, false)
+                    }
+                    parseDate={parseDate}
+                    // value={dateRange}
+                    onChange={(range: [Date | null, Date | null]) => {
+                        if (range) {
+                            onChange({
+                                ...filterRule,
+                                values: range.map((value) =>
+                                    formatDate(value, undefined, false),
+                                ),
+                            });
+                        }
+                    }}
+                    popoverProps={{
+                        placement: 'bottom',
+                        ...popoverProps,
+                    }}
+                    dayPickerProps={{
+                        firstDayOfWeek: isWeekDay(startOfWeek)
+                            ? convertWeekDayToDayPickerWeekDay(startOfWeek)
+                            : undefined,
+                    }}
+                    closeOnSelection={true}
+                />
             );
         default: {
             return <DefaultFilterInputs {...props} />;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterInputs.styles.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterInputs.styles.tsx
@@ -1,3 +1,4 @@
+import { DateRangeInput2 } from '@blueprintjs/datetime2';
 import styled from 'styled-components';
 
 export const MultipleInputsWrapper = styled.div`
@@ -5,4 +6,14 @@ export const MultipleInputsWrapper = styled.div`
     align-items: center;
     gap: 10px;
     width: 100%;
+`;
+
+export const StyledDateRangeInput = styled(DateRangeInput2)`
+    gap: 4px;
+
+    .bp4-input-group {
+        display: flex;
+        flex: 1 1 50%;
+        margin: 0 !important;
+    }
 `;

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -37,6 +37,7 @@ export const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.IN_THE_PAST]: 'in the last',
     [FilterOperator.IN_THE_NEXT]: 'in the next',
     [FilterOperator.IN_THE_CURRENT]: 'in the current',
+    [FilterOperator.IN_BETWEEN]: 'is between',
 };
 
 const getFilterOptions = <T extends FilterOperator>(
@@ -59,6 +60,7 @@ const timeFilterOptions: Array<{
         FilterOperator.IN_THE_PAST,
         FilterOperator.IN_THE_NEXT,
         FilterOperator.IN_THE_CURRENT,
+        FilterOperator.IN_BETWEEN,
     ]),
     { value: FilterOperator.LESS_THAN, label: 'is before' },
     { value: FilterOperator.LESS_THAN_OR_EQUAL, label: 'is on or before' },
@@ -145,6 +147,9 @@ export const getFilterRuleLabel = (
                 valuesText = `${filterRule.values?.[0]} ${
                     filterRule.settings.completed ? 'completed ' : ''
                 }${filterRule.settings.unitOfTime}`;
+            }
+            if (filterRule.operator === FilterOperator.IN_BETWEEN) {
+                valuesText = `${filterRule.values?.[0]} and ${filterRule.values?.[1]}`;
             } else {
                 valuesText = filterRule.values
                     ?.map((value) => {

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -37,7 +37,7 @@ export const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.IN_THE_PAST]: 'in the last',
     [FilterOperator.IN_THE_NEXT]: 'in the next',
     [FilterOperator.IN_THE_CURRENT]: 'in the current',
-    [FilterOperator.IN_BETWEEN]: 'Custom range',
+    [FilterOperator.IN_BETWEEN]: 'is between',
 };
 
 const getFilterOptions = <T extends FilterOperator>(
@@ -65,7 +65,7 @@ const timeFilterOptions: Array<{
     { value: FilterOperator.LESS_THAN_OR_EQUAL, label: 'is on or before' },
     { value: FilterOperator.GREATER_THAN, label: 'is after' },
     { value: FilterOperator.GREATER_THAN_OR_EQUAL, label: 'is on or after' },
-    { value: FilterOperator.IN_BETWEEN, label: 'Custom range' },
+    { value: FilterOperator.IN_BETWEEN, label: 'is between' },
 ];
 
 export const FilterTypeConfig: Record<
@@ -140,15 +140,16 @@ export const getFilterRuleLabel = (
             valuesText = filterRule.values?.map(formatBoolean).join(', ');
             break;
         case FilterType.DATE: {
-            if (filterRule.operator === FilterOperator.IN_BETWEEN) {
-                valuesText = `${filterRule.values?.[0]} to ${filterRule.values?.[1]}`;
-            } else if (
+            if (
                 filterRule.operator === FilterOperator.IN_THE_PAST ||
-                filterRule.operator === FilterOperator.IN_THE_NEXT
+                filterRule.operator === FilterOperator.IN_THE_NEXT ||
+                filterRule.operator === FilterOperator.IN_THE_CURRENT
             ) {
                 valuesText = `${filterRule.values?.[0]} ${
                     filterRule.settings.completed ? 'completed ' : ''
                 }${filterRule.settings.unitOfTime}`;
+            } else if (filterRule.operator === FilterOperator.IN_BETWEEN) {
+                valuesText = `${filterRule.values?.[0]} and ${filterRule.values?.[1]}`;
             } else {
                 valuesText = filterRule.values
                     ?.map((value) => {

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -142,8 +142,7 @@ export const getFilterRuleLabel = (
         case FilterType.DATE: {
             if (
                 filterRule.operator === FilterOperator.IN_THE_PAST ||
-                filterRule.operator === FilterOperator.IN_THE_NEXT ||
-                filterRule.operator === FilterOperator.IN_THE_CURRENT
+                filterRule.operator === FilterOperator.IN_THE_NEXT
             ) {
                 valuesText = `${filterRule.values?.[0]} ${
                     filterRule.settings.completed ? 'completed ' : ''

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -37,7 +37,7 @@ export const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.IN_THE_PAST]: 'in the last',
     [FilterOperator.IN_THE_NEXT]: 'in the next',
     [FilterOperator.IN_THE_CURRENT]: 'in the current',
-    [FilterOperator.IN_BETWEEN]: 'custom range',
+    [FilterOperator.IN_BETWEEN]: 'Custom range',
 };
 
 const getFilterOptions = <T extends FilterOperator>(
@@ -65,7 +65,7 @@ const timeFilterOptions: Array<{
     { value: FilterOperator.LESS_THAN_OR_EQUAL, label: 'is on or before' },
     { value: FilterOperator.GREATER_THAN, label: 'is after' },
     { value: FilterOperator.GREATER_THAN_OR_EQUAL, label: 'is on or after' },
-    { value: FilterOperator.IN_BETWEEN, label: 'custom range' },
+    { value: FilterOperator.IN_BETWEEN, label: 'Custom range' },
 ];
 
 export const FilterTypeConfig: Record<
@@ -140,16 +140,15 @@ export const getFilterRuleLabel = (
             valuesText = filterRule.values?.map(formatBoolean).join(', ');
             break;
         case FilterType.DATE: {
-            if (
+            if (filterRule.operator === FilterOperator.IN_BETWEEN) {
+                valuesText = `${filterRule.values?.[0]} to ${filterRule.values?.[1]}`;
+            } else if (
                 filterRule.operator === FilterOperator.IN_THE_PAST ||
                 filterRule.operator === FilterOperator.IN_THE_NEXT
             ) {
                 valuesText = `${filterRule.values?.[0]} ${
                     filterRule.settings.completed ? 'completed ' : ''
                 }${filterRule.settings.unitOfTime}`;
-            }
-            if (filterRule.operator === FilterOperator.IN_BETWEEN) {
-                valuesText = `${filterRule.values?.[0]} and ${filterRule.values?.[1]}`;
             } else {
                 valuesText = filterRule.values
                     ?.map((value) => {

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -37,7 +37,7 @@ export const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.IN_THE_PAST]: 'in the last',
     [FilterOperator.IN_THE_NEXT]: 'in the next',
     [FilterOperator.IN_THE_CURRENT]: 'in the current',
-    [FilterOperator.IN_BETWEEN]: 'is between',
+    [FilterOperator.IN_BETWEEN]: 'custom range',
 };
 
 const getFilterOptions = <T extends FilterOperator>(
@@ -60,12 +60,12 @@ const timeFilterOptions: Array<{
         FilterOperator.IN_THE_PAST,
         FilterOperator.IN_THE_NEXT,
         FilterOperator.IN_THE_CURRENT,
-        FilterOperator.IN_BETWEEN,
     ]),
     { value: FilterOperator.LESS_THAN, label: 'is before' },
     { value: FilterOperator.LESS_THAN_OR_EQUAL, label: 'is on or before' },
     { value: FilterOperator.GREATER_THAN, label: 'is after' },
     { value: FilterOperator.GREATER_THAN_OR_EQUAL, label: 'is on or after' },
+    { value: FilterOperator.IN_BETWEEN, label: 'custom range' },
 ];
 
 export const FilterTypeConfig: Record<


### PR DESCRIPTION
Closes: [#3599](https://github.com/lightdash/lightdash/issues/3599)

### Description

We have the option to filter `is on or after` and then include `is on or before`, but right now, because we don't have nested filtering options, this means I'm forced to have any other filters I might choose have the `all filters apply` logic to them. 

Also, it's a bit annoying that I need to apply `is on or after` and `is on or before` as two separate filters (a user actually didn't know how to do this...they were looking for a `range` option - that's how unintuitive it was)

We should add an option for `is between` for date + timestamp filters. 

<img width="175" alt="image" src="https://user-images.githubusercontent.com/31848148/198223075-07392b06-afcc-49c9-9b00-db63aabb3bcc.png">

- [x] selecting the options should be the exact same behaviour as when you're filtering using `is on or before`
<img width="623" alt="image" src="https://user-images.githubusercontent.com/31848148/198223331-bdc82839-b284-450e-a610-bf4dbd652fc2.png">

- [x] except now, you'll have two boxes to fill in. They should be joined with `and` like this:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/31848148/198224037-6a942e39-f102-4116-b9ac-1468842a60d4.png">

- [x]  the filter logic will be `is on or after` _xxx_ AND `is on or before` _yyyy_ (i.e. we include the ranges like this [date1, date2] not like this (date1, date2))

- [x] we need to update the docs to include these changes (and add details about how it _**includes**_ the boundary dates)