### PR TITLE
feat: adjust axis limits when using reference lines outside of the chart

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -268,7 +268,8 @@ const getMinAndMaxReferenceLines = (
             const data = serie.markLine?.data;
             return data !== undefined && data.length > 0;
         }) !== undefined;
-    if (hasReferenceLines) return {};
+
+    if (!hasReferenceLines) return {};
 
     const getMinAndMaxValues = (axis: string | undefined): number[] => {
         if (!axis) return [];
@@ -329,7 +330,7 @@ const getMinAndMaxReferenceLines = (
                 ? minReferenceLineLeftY
                 : undefined,
         referenceLineMaxLeftY:
-            maxReferenceLineLeftY > maxValueRightY
+            maxReferenceLineLeftY > minValueLeftY
                 ? maxReferenceLineLeftY
                 : undefined,
         referenceLineMinRightY:
@@ -337,7 +338,7 @@ const getMinAndMaxReferenceLines = (
                 ? minReferenceLineRightY
                 : undefined,
         referenceLineMaxRightY:
-            maxReferenceLineRightY > maxValueLeftY
+            maxReferenceLineRightY > minValueRightY
                 ? maxReferenceLineRightY
                 : undefined,
     };

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -262,6 +262,13 @@ const getMinAndMaxReferenceLines = (
     series: Series[] | undefined,
 ) => {
     if (resultsData === undefined || series === undefined) return {};
+    // Skip method if there are no reference lines
+    const hasReferenceLines =
+        series.find((serie) => {
+            const data = serie.markLine?.data;
+            return data !== undefined && data.length > 0;
+        }) !== undefined;
+    if (hasReferenceLines) return {};
 
     const getMinAndMaxValues = (axis: string | undefined): number[] => {
         if (!axis) return [];

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -330,7 +330,7 @@ const getMinAndMaxReferenceLines = (
                 ? minReferenceLineLeftY
                 : undefined,
         referenceLineMaxLeftY:
-            maxReferenceLineLeftY > minValueLeftY
+            maxReferenceLineLeftY > maxValueLeftY
                 ? maxReferenceLineLeftY
                 : undefined,
         referenceLineMinRightY:
@@ -338,7 +338,7 @@ const getMinAndMaxReferenceLines = (
                 ? minReferenceLineRightY
                 : undefined,
         referenceLineMaxRightY:
-            maxReferenceLineRightY > minValueRightY
+            maxReferenceLineRightY > maxValueRightY
                 ? maxReferenceLineRightY
                 : undefined,
     };
@@ -746,16 +746,14 @@ const getEchartAxis = ({
                       })
                     : xAxisConfiguration?.[0]?.name ||
                       (xAxisItem ? getItemLabel(xAxisItem) : undefined),
-                min: !validCartesianConfig.layout.flipAxes
+                min: validCartesianConfig.layout.flipAxes
                     ? xAxisConfiguration?.[0]?.min ||
-                      referenceLineMinX ||
                       maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
-                    : undefined,
-                max: !validCartesianConfig.layout.flipAxes
+                    : referenceLineMinX,
+                max: validCartesianConfig.layout.flipAxes
                     ? xAxisConfiguration?.[0]?.max ||
-                      referenceLineMaxX ||
                       maybeGetAxisDefaultMaxValue(allowFirstAxisDefaultRange)
-                    : undefined,
+                    : referenceLineMaxX,
                 nameLocation: 'center',
                 nameGap: 30,
                 nameTextStyle: {

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -37,6 +37,7 @@ import groupBy from 'lodash-es/groupBy';
 import toNumber from 'lodash-es/toNumber';
 import { useMemo } from 'react';
 import { defaultGrid } from '../../components/ChartConfigPanel/Grid';
+import { SeriesExtraInputWrapper } from '../../components/ChartConfigPanel/Series/Series.styles';
 import { useVisualizationContext } from '../../components/LightdashVisualization/VisualizationProvider';
 import { useOrganisation } from '../organisation/useOrganisation';
 import usePlottedData from '../plottedData/usePlottedData';
@@ -251,6 +252,88 @@ const removeEmptyProperties = <T = Record<any, any>>(obj: T | undefined) => {
                 : sum,
         {},
     );
+};
+
+const getMinAndMaxReferenceLines = (
+    leftAxisYId: string | undefined,
+    rightAxisYId: string | undefined,
+    bottomAxisXId: string | undefined,
+    resultsData: ApiQueryResults | undefined,
+    series: Series[] | undefined,
+) => {
+    if (resultsData === undefined || series === undefined) return {};
+
+    const getMinAndMaxValues = (axis: string | undefined): number[] => {
+        if (!axis) return [];
+        return resultsData.rows
+            .map((row) => row[axis]?.value?.raw)
+            .reduce<number[]>(
+                (acc, p) => {
+                    if (isNaN(p)) return acc;
+                    const value = parseInt(p);
+                    const min = acc[0] < value ? acc[0] : value;
+                    const max = acc[1] > value ? acc[1] : value;
+                    return [min, max];
+                },
+                [0, 0],
+            );
+    };
+
+    const getMinAndMaxReferenceLineValues = (
+        axis: string,
+        fieldId: string | undefined,
+    ): number[] => {
+        const values = series.flatMap((serie) => {
+            const serieFieldId =
+                axis === 'yAxis' ? serie.encode.yRef : serie.encode.xRef;
+            if (serieFieldId.field !== fieldId) return [];
+
+            if (!serie.markLine) return [];
+            return serie.markLine?.data.reduce<number[]>((acc, data) => {
+                try {
+                    const value = parseInt(data[axis]);
+                    if (isNaN(value)) return acc;
+                    return [...acc, value];
+                } catch (e) {
+                    return acc;
+                }
+            }, []);
+        });
+        return [Math.min(...values), Math.max(...values)];
+    };
+    const [minValueLeftY, maxValueLeftY] = getMinAndMaxValues(leftAxisYId);
+    const [minValueRightY, maxValueRightY] = getMinAndMaxValues(rightAxisYId);
+    const [minValueX, maxValueX] = getMinAndMaxValues(bottomAxisXId);
+
+    const [minReferenceLineX, maxReferenceLineX] =
+        getMinAndMaxReferenceLineValues('xAxis', bottomAxisXId);
+    const [minReferenceLineLeftY, maxReferenceLineLeftY] =
+        getMinAndMaxReferenceLineValues('yAxis', leftAxisYId);
+    const [minReferenceLineRightY, maxReferenceLineRightY] =
+        getMinAndMaxReferenceLineValues('yAxis', rightAxisYId);
+
+    return {
+        referenceLineMinX:
+            minReferenceLineX < minValueX ? minReferenceLineX : undefined,
+        referenceLineMaxX:
+            maxReferenceLineX > maxValueX ? maxReferenceLineX : undefined,
+        referenceLineMinLeftY:
+            minReferenceLineLeftY < minValueLeftY
+                ? minReferenceLineLeftY
+                : undefined,
+        referenceLineMaxLeftY:
+            maxReferenceLineLeftY > maxValueRightY
+                ? maxReferenceLineLeftY
+                : undefined,
+        referenceLineMinRightY:
+            minReferenceLineRightY < minValueRightY
+                ? minReferenceLineRightY
+                : undefined,
+        referenceLineMaxRightY:
+            maxReferenceLineRightY > maxValueLeftY
+                ? maxReferenceLineRightY
+                : undefined,
+    };
 };
 type GetPivotSeriesArg = {
     series: Series;
@@ -624,6 +707,21 @@ const getEchartAxis = ({
             rightAxisYId,
         });
 
+    const {
+        referenceLineMinX,
+        referenceLineMaxX,
+        referenceLineMinLeftY,
+        referenceLineMaxLeftY,
+        referenceLineMinRightY,
+        referenceLineMaxRightY,
+    } = getMinAndMaxReferenceLines(
+        leftAxisYId,
+        rightAxisYId,
+        bottomAxisXId,
+        resultsData,
+        validCartesianConfig.eChartsConfig.series,
+    );
+
     return {
         xAxis: [
             {
@@ -640,12 +738,14 @@ const getEchartAxis = ({
                       })
                     : xAxisConfiguration?.[0]?.name ||
                       (xAxisItem ? getItemLabel(xAxisItem) : undefined),
-                min: validCartesianConfig.layout.flipAxes
+                min: !validCartesianConfig.layout.flipAxes
                     ? xAxisConfiguration?.[0]?.min ||
+                      referenceLineMinX ||
                       maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
                     : undefined,
-                max: validCartesianConfig.layout.flipAxes
+                max: !validCartesianConfig.layout.flipAxes
                     ? xAxisConfiguration?.[0]?.max ||
+                      referenceLineMaxX ||
                       maybeGetAxisDefaultMaxValue(allowFirstAxisDefaultRange)
                     : undefined,
                 nameLocation: 'center',
@@ -711,10 +811,12 @@ const getEchartAxis = ({
                       }),
                 min: !validCartesianConfig.layout.flipAxes
                     ? yAxisConfiguration?.[0]?.min ||
+                      referenceLineMinLeftY ||
                       maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
                     : undefined,
                 max: !validCartesianConfig.layout.flipAxes
                     ? yAxisConfiguration?.[0]?.max ||
+                      referenceLineMaxLeftY ||
                       maybeGetAxisDefaultMaxValue(allowFirstAxisDefaultRange)
                     : undefined,
                 nameTextStyle: {
@@ -746,10 +848,12 @@ const getEchartAxis = ({
                       }),
                 min: !validCartesianConfig.layout.flipAxes
                     ? yAxisConfiguration?.[1]?.min ||
+                      referenceLineMinRightY ||
                       maybeGetAxisDefaultMinValue(allowSecondAxisDefaultRange)
                     : undefined,
                 max: !validCartesianConfig.layout.flipAxes
                     ? yAxisConfiguration?.[1]?.max ||
+                      referenceLineMaxRightY ||
                       maybeGetAxisDefaultMaxValue(allowSecondAxisDefaultRange)
                     : undefined,
                 nameTextStyle: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4117

### Description:

Things in scope: 

- [x]  We can adjust axis on bottom (positive and negative) 
![image](https://user-images.githubusercontent.com/1983672/211779014-51961c6a-df52-4628-8f3a-cefac10b4347.png)

- [x] We can adjust axis on the left (postivie and negative) 

![image](https://user-images.githubusercontent.com/1983672/211779106-da6fba59-a679-40de-872f-ba4c49588506.png)

- [x] We can adjust a single axis on the right 

![image](https://user-images.githubusercontent.com/1983672/211779224-dea1ba90-c37b-48b9-91c4-268412c1d1f8.png)

- [x] If there is a custom min/max value, we don't adjust the axis 

![image](https://user-images.githubusercontent.com/1983672/211779925-9a8390b0-9e40-4d7b-85a7-2a43e5360225.png)



Things out of scope:

- [ ] Adjust axis when they are flipped. We need to fix this first: https://github.com/lightdash/lightdash/issues/4141
- [ ] Top axis . Same as before. 
- [ ] Having multiple axes (left and right) . it should be automatically fixed after this https://github.com/lightdash/lightdash/issues/4143
It kind of works despite of the bug, but it is not reliable 
![image](https://user-images.githubusercontent.com/1983672/211779493-ef52f8a5-a52b-4a31-863e-a67d2551a37d.png)



<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
