### PR TITLE
feat: pinning `charts` and `dashboards` to homepage

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -249,6 +249,17 @@ type DashboardEvent = BaseTrack & {
     };
 };
 
+type HomepagePinningEvent = BaseTrack & {
+    event: 'homepage_pinning.updated';
+    userId: string;
+    properties: {
+        projectId: string;
+        dashboardId?: string;
+        savedQueryId?: string;
+        isPinned: boolean;
+    };
+};
+
 export type CreateDashboardOrVersionEvent = BaseTrack & {
     event: 'dashboard.created' | 'dashboard_version.created';
     properties: {
@@ -436,7 +447,8 @@ type Track =
     | FieldValueSearch
     | PermissionsUpdated
     | ShareUrl
-    | ShareSlack;
+    | ShareSlack
+    | HomepagePinningEvent;
 
 export class LightdashAnalytics extends Analytics {
     static lightdashContext = {

--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -57,7 +57,7 @@ type DbDashboardTileChart = {
 export type DashboardTable = Knex.CompositeTableType<
     DbDashboard,
     Pick<DbDashboard, 'name' | 'description' | 'space_id'>,
-    Pick<DbDashboard, 'name' | 'description' | 'is_pinned'>
+    Partial<Pick<DbDashboard, 'name' | 'description' | 'is_pinned'>>
 >;
 
 export type DashboardVersionTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -17,6 +17,7 @@ type DbDashboard = {
     description?: string;
     space_id: number;
     created_at: Date;
+    is_pinned: boolean;
 };
 
 type DbDashboardVersion = {
@@ -56,7 +57,7 @@ type DbDashboardTileChart = {
 export type DashboardTable = Knex.CompositeTableType<
     DbDashboard,
     Pick<DbDashboard, 'name' | 'description' | 'space_id'>,
-    Pick<DbDashboard, 'name' | 'description'>
+    Pick<DbDashboard, 'name' | 'description' | 'is_pinned'>
 >;
 
 export type DashboardVersionTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -11,12 +11,13 @@ type DbSavedChart = {
     name: string;
     created_at: Date;
     description: string | undefined;
+    is_pinned: boolean;
 };
 
 export type SavedChartTable = Knex.CompositeTableType<
     DbSavedChart,
     Pick<DbSavedChart, 'name' | 'space_id' | 'description'>,
-    Pick<DbSavedChart, 'name' | 'description'>
+    Pick<DbSavedChart, 'name' | 'description' | 'is_pinned'>
 >;
 
 export type DbSavedChartVersion = {

--- a/packages/backend/src/database/migrations/20230111155548_add_is_pinned_column.ts
+++ b/packages/backend/src/database/migrations/20230111155548_add_is_pinned_column.ts
@@ -1,0 +1,26 @@
+import { Knex } from 'knex';
+
+const DashboardsTableName = 'dashboards';
+const SavedChartsTableName = 'saved_queries';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardsTableName, (tableBuilder) => {
+        tableBuilder.boolean('is_pinned').notNullable().defaultTo(false);
+    });
+    await knex.schema.alterTable(SavedChartsTableName, (tableBuilder) => {
+        tableBuilder.boolean('is_pinned').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(DashboardsTableName, 'is_pinned')) {
+        await knex.schema.alterTable(DashboardsTableName, (tableBuilder) => {
+            tableBuilder.dropColumn('is_pinned');
+        });
+    }
+    if (await knex.schema.hasColumn(SavedChartsTableName, 'is_pinned')) {
+        await knex.schema.alterTable(SavedChartsTableName, (tableBuilder) => {
+            tableBuilder.dropColumn('is_pinned');
+        });
+    }
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -49,7 +49,7 @@ export const createDashboard: CreateDashboard = {
         dimensions: [],
         metrics: [],
     },
-    isPinned: false,
+    is_pinned: false,
 };
 
 export const createDashboardWithTileIds: CreateDashboard = {
@@ -106,7 +106,7 @@ export const addDashboardVersionWithoutChart: DashboardVersionedFields = {
 export const updateDashboard: DashboardUnversionedFields = {
     name: 'my updated dashboard',
     description: 'updated description',
-    isPinned: false,
+    is_pinned: false,
 };
 
 // Select mocks

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -49,6 +49,7 @@ export const createDashboard: CreateDashboard = {
         dimensions: [],
         metrics: [],
     },
+    isPinned: false,
 };
 
 export const createDashboardWithTileIds: CreateDashboard = {
@@ -105,6 +106,7 @@ export const addDashboardVersionWithoutChart: DashboardVersionedFields = {
 export const updateDashboard: DashboardUnversionedFields = {
     name: 'my updated dashboard',
     description: 'updated description',
+    isPinned: false,
 };
 
 // Select mocks
@@ -132,6 +134,7 @@ export const savedChartEntry: SavedChartTable['base'] = {
     name: 'chart name',
     description: 'My description',
     created_at: new Date(),
+    is_pinned: false,
 };
 
 export const dashboardEntry: DashboardTable['base'] = {
@@ -141,6 +144,7 @@ export const dashboardEntry: DashboardTable['base'] = {
     description: 'description',
     space_id: 0,
     created_at: new Date(),
+    is_pinned: false,
 };
 
 export const dashboardVersionEntry: DashboardVersionTable['base'] = {
@@ -173,6 +177,7 @@ export const dashboardWithVersionEntry: GetDashboardQuery = {
     user_uuid: 'userUuid',
     first_name: 'firstName',
     last_name: 'lastName',
+    is_pinned: dashboardEntry.is_pinned,
 };
 
 export const dashboardTileEntry: DashboardTileTable['base'] = {
@@ -218,6 +223,7 @@ export const expectedDashboard: Dashboard = {
     name: dashboardEntry.name,
     description: dashboardEntry.description,
     updatedAt: dashboardVersionEntry.created_at,
+    isPinned: dashboardEntry.is_pinned,
     tiles: [
         {
             uuid: dashboardTileEntry.dashboard_tile_uuid,
@@ -280,6 +286,7 @@ export const expectedAllDashboards: DashboardBasicDetails[] = [
         name: dashboardEntry.name,
         description: dashboardEntry.description,
         updatedAt: dashboardVersionEntry.created_at,
+        isPinned: dashboardEntry.is_pinned,
         updatedByUser: {
             firstName: 'firstName',
             lastName: 'lastName',

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -106,7 +106,6 @@ export const addDashboardVersionWithoutChart: DashboardVersionedFields = {
 export const updateDashboard: DashboardUnversionedFields = {
     name: 'my updated dashboard',
     description: 'updated description',
-    is_pinned: false,
 };
 
 // Select mocks

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -244,7 +244,6 @@ describe('DashboardModel', () => {
                 queryMatcher(DashboardsTableName, [
                     updateDashboard.name,
                     updateDashboard.description,
-                    updateDashboard.is_pinned,
                     dashboardUuid,
                 ]),
             )

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -244,6 +244,7 @@ describe('DashboardModel', () => {
                 queryMatcher(DashboardsTableName, [
                     updateDashboard.name,
                     updateDashboard.description,
+                    updateDashboard.isPinned,
                     dashboardUuid,
                 ]),
             )

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -244,7 +244,7 @@ describe('DashboardModel', () => {
                 queryMatcher(DashboardsTableName, [
                     updateDashboard.name,
                     updateDashboard.description,
-                    updateDashboard.isPinned,
+                    updateDashboard.is_pinned,
                     dashboardUuid,
                 ]),
             )

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -45,7 +45,7 @@ import Transaction = Knex.Transaction;
 
 export type GetDashboardQuery = Pick<
     DashboardTable['base'],
-    'dashboard_id' | 'dashboard_uuid' | 'name' | 'description'
+    'dashboard_id' | 'dashboard_uuid' | 'name' | 'description' | 'is_pinned'
 > &
     Pick<DashboardVersionTable['base'], 'dashboard_version_id' | 'created_at'> &
     Pick<ProjectTable['base'], 'project_uuid'> &
@@ -54,7 +54,7 @@ export type GetDashboardQuery = Pick<
 
 export type GetDashboardDetailsQuery = Pick<
     DashboardTable['base'],
-    'dashboard_uuid' | 'name' | 'description'
+    'dashboard_uuid' | 'name' | 'description' | 'is_pinned'
 > &
     Pick<DashboardVersionTable['base'], 'created_at'> &
     Pick<ProjectTable['base'], 'project_uuid'> &
@@ -297,6 +297,7 @@ export class DashboardModel {
                 last_name,
                 organization_uuid,
                 space_uuid,
+                is_pinned,
             }) => ({
                 organizationUuid: organization_uuid,
                 name,
@@ -310,6 +311,7 @@ export class DashboardModel {
                     lastName: last_name,
                 },
                 spaceUuid: space_uuid,
+                isPinned: is_pinned,
             }),
         );
     }
@@ -466,6 +468,7 @@ export class DashboardModel {
             name: dashboard.name,
             description: dashboard.description,
             updatedAt: dashboard.created_at,
+            isPinned: dashboard.is_pinned,
             tiles: tiles.map(
                 ({
                     type,
@@ -591,6 +594,7 @@ export class DashboardModel {
             .update({
                 name: dashboard.name,
                 description: dashboard.description,
+                is_pinned: dashboard.isPinned,
                 ...withSpaceId,
             })
             .where('dashboard_uuid', dashboardUuid);
@@ -617,6 +621,7 @@ export class DashboardModel {
                             .update({
                                 name: dashboard.name,
                                 description: dashboard.description,
+                                is_pinned: dashboard.isPinned,
                                 ...withSpaceId,
                             })
                             .where('dashboard_uuid', dashboard.uuid);

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -602,15 +602,11 @@ export class DashboardModel {
 
     async updatePinning(
         dashboardUuid: string,
-        dashboard: DashboardUnversionedFields,
+        isPinned: DashboardUnversionedFields['is_pinned'],
     ): Promise<Dashboard> {
-        const withSpaceId = dashboard.spaceUuid
-            ? { space_id: await getSpaceId(this.database, dashboard.spaceUuid) }
-            : {};
         await this.database(DashboardsTableName)
             .update({
-                is_pinned: dashboard.isPinned,
-                ...withSpaceId,
+                is_pinned: isPinned,
             })
             .where('dashboard_uuid', dashboardUuid);
         return this.getById(dashboardUuid);

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -594,6 +594,21 @@ export class DashboardModel {
             .update({
                 name: dashboard.name,
                 description: dashboard.description,
+                ...withSpaceId,
+            })
+            .where('dashboard_uuid', dashboardUuid);
+        return this.getById(dashboardUuid);
+    }
+
+    async updatePinning(
+        dashboardUuid: string,
+        dashboard: DashboardUnversionedFields,
+    ): Promise<Dashboard> {
+        const withSpaceId = dashboard.spaceUuid
+            ? { space_id: await getSpaceId(this.database, dashboard.spaceUuid) }
+            : {};
+        await this.database(DashboardsTableName)
+            .update({
                 is_pinned: dashboard.isPinned,
                 ...withSpaceId,
             })

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -286,7 +286,19 @@ export class SavedChartModel {
                 name: data.name,
                 description: data.description,
                 space_id: await getSpaceId(this.database, data.spaceUuid),
+            })
+            .where('saved_query_uuid', savedChartUuid);
+        return this.get(savedChartUuid);
+    }
+
+    async updatePinning(
+        savedChartUuid: string,
+        data: UpdateSavedChart,
+    ): Promise<SavedChart> {
+        await this.database('saved_queries')
+            .update({
                 is_pinned: data.is_pinned,
+                space_id: await getSpaceId(this.database, data.spaceUuid),
             })
             .where('saved_query_uuid', savedChartUuid);
         return this.get(savedChartUuid);

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -293,12 +293,11 @@ export class SavedChartModel {
 
     async updatePinning(
         savedChartUuid: string,
-        data: UpdateSavedChart,
+        isPinned: UpdateSavedChart['is_pinned'],
     ): Promise<SavedChart> {
         await this.database('saved_queries')
             .update({
-                is_pinned: data.is_pinned,
-                space_id: await getSpaceId(this.database, data.spaceUuid),
+                is_pinned: isPinned,
             })
             .where('saved_query_uuid', savedChartUuid);
         return this.get(savedChartUuid);

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -32,6 +32,7 @@ import { GetDashboardDetailsQuery } from './DashboardModel/DashboardModel';
 type Dependencies = {
     database: Knex;
 };
+
 export class SpaceModel {
     private database: Knex;
 
@@ -135,6 +136,7 @@ export class SpaceModel {
                 first_name,
                 last_name,
                 organization_uuid,
+                is_pinned,
             }) => ({
                 organizationUuid: organization_uuid,
                 name,
@@ -148,6 +150,7 @@ export class SpaceModel {
                     lastName: last_name,
                 },
                 spaceUuid,
+                isPinned: is_pinned,
             }),
         );
     }

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -47,6 +47,26 @@ dashboardRouter.patch(
     },
 );
 
+dashboardRouter.patch(
+    '/pinning',
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        try {
+            res.json({
+                status: 'ok',
+                results: await dashboardService.updatePinning(
+                    req.user!,
+                    req.params.dashboardUuid,
+                    req.body,
+                ),
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
 dashboardRouter.delete(
     '/',
     isAuthenticated,

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -77,6 +77,23 @@ savedChartRouter.patch(
     },
 );
 
+savedChartRouter.patch(
+    '/:savedQueryUuid/pinning',
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        savedChartsService
+            .updatePinning(req.user!, req.params.savedQueryUuid, req.body)
+            .then((results) => {
+                res.json({
+                    status: 'ok',
+                    results,
+                });
+            })
+            .catch(next);
+    },
+);
+
 savedChartRouter.post(
     '/:savedQueryUuid/version',
     isAuthenticated,

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -87,6 +87,7 @@ export const dashboard: Dashboard = {
     },
     spaceUuid: 'spaceUuid',
     spaceName: 'space name',
+    isPinned: false,
 };
 
 export const dashboardsDetails: DashboardBasicDetails[] = [
@@ -98,6 +99,7 @@ export const dashboardsDetails: DashboardBasicDetails[] = [
         description: dashboard.description,
         updatedAt: dashboard.updatedAt,
         spaceUuid: 'spaceUuid',
+        isPinned: dashboard.isPinned,
     },
 ];
 
@@ -126,6 +128,7 @@ export const createDashboard: CreateDashboard = {
         dimensions: [],
         metrics: [],
     },
+    is_pinned: false,
 };
 
 export const createDashboardWithTileIds: CreateDashboard = {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -322,7 +322,7 @@ export class DashboardService {
         );
 
         analytics.track({
-            event: 'dashboard.updated',
+            event: 'homepage_pinning.updated',
             userId: user.userUuid,
             properties: {
                 dashboardId: updatedDashboard.uuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -149,7 +149,7 @@ export class SavedChartService {
     async updatePinning(
         user: SessionUser,
         savedChartUuid: string,
-        data: UpdateSavedChart,
+        isPinned: UpdateSavedChart['is_pinned'],
     ): Promise<SavedChart> {
         const { organizationUuid, projectUuid } =
             await this.savedChartModel.get(savedChartUuid);
@@ -164,7 +164,7 @@ export class SavedChartService {
         }
         const savedChart = await this.savedChartModel.updatePinning(
             savedChartUuid,
-            data,
+            isPinned,
         );
         analytics.track({
             event: 'saved_chart.updated',
@@ -172,6 +172,7 @@ export class SavedChartService {
             properties: {
                 projectId: savedChart.projectUuid,
                 savedQueryId: savedChartUuid,
+                isPinned: savedChart.is_pinned,
             },
         });
         return savedChart;

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -167,7 +167,7 @@ export class SavedChartService {
             isPinned,
         );
         analytics.track({
-            event: 'saved_chart.updated',
+            event: 'homepage_pinning.updated',
             userId: user.userUuid,
             properties: {
                 projectId: savedChart.projectUuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -146,6 +146,37 @@ export class SavedChartService {
         return savedChart;
     }
 
+    async updatePinning(
+        user: SessionUser,
+        savedChartUuid: string,
+        data: UpdateSavedChart,
+    ): Promise<SavedChart> {
+        const { organizationUuid, projectUuid } =
+            await this.savedChartModel.get(savedChartUuid);
+
+        if (
+            user.ability.cannot(
+                'update',
+                subject('SavedChart', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const savedChart = await this.savedChartModel.updatePinning(
+            savedChartUuid,
+            data,
+        );
+        analytics.track({
+            event: 'saved_chart.updated',
+            userId: user.userUuid,
+            properties: {
+                projectId: savedChart.projectUuid,
+                savedQueryId: savedChartUuid,
+            },
+        });
+        return savedChart;
+    }
+
     async updateMultiple(
         user: SessionUser,
         projectUuid: string,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -70,7 +70,7 @@ export type CreateDashboard = {
     filters?: DashboardFilters;
     updatedByUser?: Pick<UpdatedByUser, 'userUuid'>;
     spaceUuid?: string;
-    isPinned: boolean;
+    is_pinned: boolean;
 };
 
 export type DashboardTile =
@@ -111,7 +111,7 @@ export type DashboardBasicDetails = Pick<
 >;
 
 export type DashboardUnversionedFields = Partial<
-    Pick<CreateDashboard, 'name' | 'description' | 'spaceUuid' | 'isPinned'>
+    Pick<CreateDashboard, 'name' | 'description' | 'spaceUuid' | 'is_pinned'>
 >;
 export type DashboardVersionedFields = Pick<
     CreateDashboard,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -70,6 +70,7 @@ export type CreateDashboard = {
     filters?: DashboardFilters;
     updatedByUser?: Pick<UpdatedByUser, 'userUuid'>;
     spaceUuid?: string;
+    isPinned: boolean;
 };
 
 export type DashboardTile =
@@ -93,6 +94,7 @@ export type Dashboard = {
     updatedByUser?: UpdatedByUser;
     spaceUuid: string;
     spaceName: string;
+    isPinned: boolean;
 };
 
 export type DashboardBasicDetails = Pick<
@@ -105,11 +107,12 @@ export type DashboardBasicDetails = Pick<
     | 'updatedByUser'
     | 'organizationUuid'
     | 'spaceUuid'
+    | 'isPinned'
 >;
 
 export type DashboardUnversionedFields = Pick<
     CreateDashboard,
-    'name' | 'description' | 'spaceUuid'
+    'name' | 'description' | 'spaceUuid' | 'isPinned'
 >;
 export type DashboardVersionedFields = Pick<
     CreateDashboard,
@@ -125,7 +128,7 @@ export type UpdateDashboard =
 
 export type UpdateMultipleDashboards = Pick<
     Dashboard,
-    'uuid' | 'name' | 'description' | 'spaceUuid'
+    'uuid' | 'name' | 'description' | 'spaceUuid' | 'isPinned'
 >;
 
 export const isDashboardUnversionedFields = (

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -110,9 +110,8 @@ export type DashboardBasicDetails = Pick<
     | 'isPinned'
 >;
 
-export type DashboardUnversionedFields = Pick<
-    CreateDashboard,
-    'name' | 'description' | 'spaceUuid' | 'isPinned'
+export type DashboardUnversionedFields = Partial<
+    Pick<CreateDashboard, 'name' | 'description' | 'spaceUuid' | 'isPinned'>
 >;
 export type DashboardVersionedFields = Pick<
     CreateDashboard,

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -8,6 +8,7 @@ export enum ChartType {
     TABLE = 'table',
     BIG_NUMBER = 'big_number',
 }
+
 export type BigNumber = {
     label?: string;
     style?: CompactOrAlias;
@@ -199,6 +200,7 @@ export type SavedChart = {
     organizationUuid: string;
     spaceUuid: string;
     spaceName: string;
+    is_pinned: boolean;
 };
 
 export type CreateSavedChart = Omit<
@@ -224,7 +226,7 @@ export type CreateSavedChartVersion = Omit<
 
 export type UpdateSavedChart = Pick<
     SavedChart,
-    'name' | 'description' | 'spaceUuid'
+    'name' | 'description' | 'spaceUuid' | 'is_pinned'
 >;
 
 export type UpdateMultipleSavedChart = Pick<

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -241,6 +241,7 @@ export type SpaceQuery = Pick<
     | 'updatedByUser'
     | 'description'
     | 'spaceUuid'
+    | 'is_pinned'
 >;
 
 export const isCompleteLayout = (

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -224,9 +224,8 @@ export type CreateSavedChartVersion = Omit<
     | 'spaceName'
 >;
 
-export type UpdateSavedChart = Pick<
-    SavedChart,
-    'name' | 'description' | 'spaceUuid' | 'is_pinned'
+export type UpdateSavedChart = Partial<
+    Pick<SavedChart, 'name' | 'description' | 'spaceUuid' | 'is_pinned'>
 >;
 
 export type UpdateMultipleSavedChart = Pick<


### PR DESCRIPTION
Closes:  (#3043)[https://github.com/lightdash/lightdash/issues/3043]

### Description:
MVP for pinning - This ticket covers the basic functionality. The rest in this milestone will cover a better user experience and frontend improvements. 


**You can pin **charts** and **dashboards** to your homepage.** (no limit) 
- [ ] If there are 1+ pinned items, a new panel appears on top of the homepage. (use the same component as the other panels on the page). **If there are no pinned items, there is no panel.** 
- [ ] Pinned items will appear in a list format, reusing existing components.
<img width="737" alt="Screenshot 2023-01-04 at 09 58 17" src="https://user-images.githubusercontent.com/12776522/210529587-03d12fbc-ab5e-43e5-892d-19c84c5b8516.png">




**Where can you pin from?**

- [ ] Add an item `Pin to homepage` to the dashboard and charts context menus. (the context menus appear on the homepage/space pages).
- [ ] If an item is pinned, the action should turn into `Unpin from homepage`
<img width="311" alt="Screenshot 2023-01-04 at 10 05 57" src="https://user-images.githubusercontent.com/12776522/210530869-d64f64ad-0a97-4b8c-9145-d5df39966389.png">



**Permissions**
- [ ]  Pinned items are public, and affect everyone in the project.  (if you have access to it and its pinned, you should see it. You should not be able to see anything you don't have access to) 
- [ ] - Only admins/editors can pin/unpin items.
- [ ] - Viewers can see the pinned items panels, but not add/remove anything from it.
