### PR TITLE
fix: add filter input width

### DIFF
--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.styles.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.styles.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const FieldAutoCompleteWrapper = styled.div`
+    display: flex;
+    padding-left: 60px;
+    input {
+        max-width: 42%;
+    }
+`;

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -19,6 +19,7 @@ import { FC, useCallback, useMemo } from 'react';
 import { useToggle } from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 import FieldAutoComplete from './FieldAutoComplete';
+import { FieldAutoCompleteWrapper } from './FieldAutoComplete.styles';
 import FilterGroupForm from './FilterGroupForm';
 import { FieldWithSuggestions, useFiltersContext } from './FiltersProvider';
 import SimplifiedFilterGroupForm from './SimplifiedFilterGroupForm';
@@ -198,7 +199,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                 }}
             >
                 {isOpen && (
-                    <>
+                    <FieldAutoCompleteWrapper>
                         <FieldAutoComplete
                             autoFocus
                             fields={fields}
@@ -211,7 +212,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                             icon="cross"
                             onClick={toggleFieldInput}
                         />
-                    </>
+                    </FieldAutoCompleteWrapper>
                 )}
                 {isEditMode && !isOpen && (
                     <Button


### PR DESCRIPTION
Closes: #4003

#### Description
Added a styles file that exports a wrapper to limit the width of the input field in addition to aligning the input filed with the close button.

[Loom Demo](https://www.loom.com/share/a4edee9b79014b79921981aa48ef043c)

