### PR TITLE
fix: referenceline flipped chart

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -24,12 +24,11 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 import SeriesColorPicker from '../Series/SeriesColorPicker';
 import { GridSettings, SectionTitle } from './Legend.styles';
 import { CollapseWrapper, DeleteButtonTooltip } from './ReferenceLine.styles';
-import { ReferenceLineField } from './ReferenceLines';
 
 type Props = {
     index: number;
     items: (Field | TableCalculation | CompiledDimension)[];
-    referenceLine: ReferenceLineField;
+    referenceLine: MarkLineData;
     updateReferenceLine: (
         value: string,
         field: Field | TableCalculation | CompiledDimension,
@@ -72,23 +71,21 @@ export const ReferenceLine: FC<Props> = ({
         selectedMarklineLabel,
         selectedColor,
     ] = useMemo(() => {
-        /*const serieWithMarkLine = dirtyEchartsConfig?.series?.find(
+        const serieWithMarkLine = dirtyEchartsConfig?.series?.find(
             (serie) =>
                 serie.markLine?.data.find(
-                    (data) => data.name === referenceLine.data.name,
+                    (data) => data.name === referenceLine.name,
                 ) !== undefined,
         );
 
+        const markLineKey = 'xAxis' in referenceLine ? 'xAxis' : 'yAxis';
+        const markLineValue = referenceLine[markLineKey];
         const fieldId =
             markLineKey === 'xAxis'
                 ? serieWithMarkLine?.encode.xRef.field
-                : serieWithMarkLine?.encode.yRef.field;*/
-        const markLineKey = 'xAxis' in referenceLine ? 'xAxis' : 'yAxis';
-        const markLineValue = referenceLine.data[markLineKey];
-
-        const fieldId = referenceLine.fieldId;
-        const label = referenceLine.data.label?.formatter;
-        const color = referenceLine.data.lineStyle?.color;
+                : serieWithMarkLine?.encode.yRef.field;
+        const label = referenceLine.label?.formatter;
+        const color = referenceLine.lineStyle?.color;
         return [markLineKey, markLineValue, fieldId, label, color];
     }, [dirtyEchartsConfig?.series, referenceLine]);
 
@@ -124,7 +121,7 @@ export const ReferenceLine: FC<Props> = ({
                     selectedField,
                     updatedLabel,
                     lineColor,
-                    referenceLine.data.name,
+                    referenceLine.name,
                 );
         }, 500),
         [value, selectedField, updateReferenceLine],
@@ -145,9 +142,7 @@ export const ReferenceLine: FC<Props> = ({
                         small
                         minimal
                         icon="cross"
-                        onClick={() =>
-                            removeReferenceLine(referenceLine.data.name)
-                        }
+                        onClick={() => removeReferenceLine(referenceLine.name)}
                     />
                 </DeleteButtonTooltip>
             </Flex>
@@ -165,7 +160,7 @@ export const ReferenceLine: FC<Props> = ({
                                     item,
                                     label,
                                     lineColor,
-                                    referenceLine.data.name,
+                                    referenceLine.name,
                                 );
                         }}
                     />
@@ -188,7 +183,7 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     lineColor,
-                                    referenceLine.data.name,
+                                    referenceLine.name,
                                 );
                         }}
                         placeholder="Add value for the reference line"
@@ -222,7 +217,7 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     color,
-                                    referenceLine.data.name,
+                                    referenceLine.name,
                                 );
                         }}
                     />

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -24,11 +24,12 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 import SeriesColorPicker from '../Series/SeriesColorPicker';
 import { GridSettings, SectionTitle } from './Legend.styles';
 import { CollapseWrapper, DeleteButtonTooltip } from './ReferenceLine.styles';
+import { ReferenceLineField } from './ReferenceLines';
 
 type Props = {
     index: number;
     items: (Field | TableCalculation | CompiledDimension)[];
-    referenceLine: MarkLineData;
+    referenceLine: ReferenceLineField;
     updateReferenceLine: (
         value: string,
         field: Field | TableCalculation | CompiledDimension,
@@ -71,21 +72,23 @@ export const ReferenceLine: FC<Props> = ({
         selectedMarklineLabel,
         selectedColor,
     ] = useMemo(() => {
-        const serieWithMarkLine = dirtyEchartsConfig?.series?.find(
+        /*const serieWithMarkLine = dirtyEchartsConfig?.series?.find(
             (serie) =>
                 serie.markLine?.data.find(
-                    (data) => data.name === referenceLine.name,
+                    (data) => data.name === referenceLine.data.name,
                 ) !== undefined,
         );
 
-        const markLineKey = 'xAxis' in referenceLine ? 'xAxis' : 'yAxis';
-        const markLineValue = referenceLine[markLineKey];
         const fieldId =
             markLineKey === 'xAxis'
                 ? serieWithMarkLine?.encode.xRef.field
-                : serieWithMarkLine?.encode.yRef.field;
-        const label = referenceLine.label?.formatter;
-        const color = referenceLine.lineStyle?.color;
+                : serieWithMarkLine?.encode.yRef.field;*/
+        const markLineKey = 'xAxis' in referenceLine ? 'xAxis' : 'yAxis';
+        const markLineValue = referenceLine.data[markLineKey];
+
+        const fieldId = referenceLine.fieldId;
+        const label = referenceLine.data.label?.formatter;
+        const color = referenceLine.data.lineStyle?.color;
         return [markLineKey, markLineValue, fieldId, label, color];
     }, [dirtyEchartsConfig?.series, referenceLine]);
 
@@ -121,7 +124,7 @@ export const ReferenceLine: FC<Props> = ({
                     selectedField,
                     updatedLabel,
                     lineColor,
-                    referenceLine.name,
+                    referenceLine.data.name,
                 );
         }, 500),
         [value, selectedField, updateReferenceLine],
@@ -142,7 +145,9 @@ export const ReferenceLine: FC<Props> = ({
                         small
                         minimal
                         icon="cross"
-                        onClick={() => removeReferenceLine(referenceLine.name)}
+                        onClick={() =>
+                            removeReferenceLine(referenceLine.data.name)
+                        }
                     />
                 </DeleteButtonTooltip>
             </Flex>
@@ -160,7 +165,7 @@ export const ReferenceLine: FC<Props> = ({
                                     item,
                                     label,
                                     lineColor,
-                                    referenceLine.name,
+                                    referenceLine.data.name,
                                 );
                         }}
                     />
@@ -183,7 +188,7 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     lineColor,
-                                    referenceLine.name,
+                                    referenceLine.data.name,
                                 );
                         }}
                         placeholder="Add value for the reference line"
@@ -217,7 +222,7 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     color,
-                                    referenceLine.name,
+                                    referenceLine.data.name,
                                 );
                         }}
                     />

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -18,10 +18,6 @@ type Props = {
     items: (Field | TableCalculation | CompiledDimension)[];
 };
 
-export type ReferenceLineField = {
-    fieldId?: string;
-    data: MarkLineData;
-};
 export const ReferenceLines: FC<Props> = ({ items }) => {
     const {
         cartesianConfig: {
@@ -32,20 +28,17 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
         },
     } = useVisualizationContext();
 
-    const selectedReferenceLines: ReferenceLineField[] = useMemo(() => {
+    const selectedReferenceLines: MarkLineData[] = useMemo(() => {
         if (dirtyEchartsConfig?.series === undefined) return [];
-        return dirtyEchartsConfig.series.reduce<ReferenceLineField[]>(
+        return dirtyEchartsConfig.series.reduce<MarkLineData[]>(
             (acc, serie) => {
                 const data = serie.markLine?.data;
                 if (data !== undefined) {
                     const fullData = data.map((markData) => {
                         return {
-                            fieldId: '',
-                            data: {
-                                label: serie.markLine?.label,
-                                lineStyle: serie.markLine?.lineStyle,
-                                ...markData,
-                            },
+                            label: serie.markLine?.label,
+                            lineStyle: serie.markLine?.lineStyle,
+                            ...markData,
                         };
                     });
 
@@ -57,7 +50,7 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
         );
     }, [dirtyEchartsConfig?.series]);
 
-    const [referenceLines, setReferenceLines] = useState<ReferenceLineField[]>(
+    const [referenceLines, setReferenceLines] = useState<MarkLineData[]>(
         selectedReferenceLines,
     );
 
@@ -124,10 +117,9 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
                             data: updatedData,
                         },
                     };
-                    const updatedReferenceLines: ReferenceLineField[] =
+                    const updatedReferenceLines: MarkLineData[] =
                         referenceLines.map((line) => {
-                            if (line.data.name === lineId)
-                                return { fieldId: fieldId, data: newData };
+                            if (line.name === lineId) return newData;
                             else return line;
                         });
 
@@ -143,12 +135,9 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
             referenceLines,
         ],
     );
-
     const addReferenceLine = useCallback(() => {
-        const newReferenceLine: ReferenceLineField = {
-            data: {
-                name: uuidv4(),
-            },
+        const newReferenceLine: MarkLineData = {
+            name: uuidv4(),
         };
         setReferenceLines([...referenceLines, newReferenceLine]);
     }, [referenceLines]);
@@ -172,7 +161,7 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
             updateSeries(series);
 
             setReferenceLines(
-                referenceLines.filter((line) => line.data.name !== markLineId),
+                referenceLines.filter((line) => line.name !== markLineId),
             );
         },
         [updateSeries, dirtyEchartsConfig?.series, referenceLines],
@@ -185,7 +174,7 @@ export const ReferenceLines: FC<Props> = ({ items }) => {
                 referenceLines.map((line, index) => {
                     return (
                         <ReferenceLine
-                            key={line.data.name}
+                            key={line.name}
                             index={index + 1}
                             isDefaultOpen={referenceLines.length <= 1}
                             items={items}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4141

### Description:

- [x] This PR will add the right reference line to a flipped chart. 

![Screenshot from 2023-01-12 09-00-19](https://user-images.githubusercontent.com/1983672/212011517-b902aef3-1d1d-4d86-9a17-24ea0847c7f8.png)



But it will NOT 

- [ ] Keep an existing reference line if you click `flip axes` . This is because we need to update the markline data on chart changes  which is a bigger change (similar to  https://github.com/lightdash/lightdash/issues/4133) , so I think it makes more sense to do it on a separate PR that fixes all those issues 

- [ ] Apply new limits when chart is flipped (still in progress... I'll have to fix it once this is merged ) https://github.com/lightdash/lightdash/pull/4144