### PR TITLE
fix: remove livez,robots,favicon from sentry traces

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -61,7 +61,10 @@ const app = express();
 const tracesSampler = (context: SamplingContext): boolean | number => {
     if (
         context.request?.url?.endsWith('/status') ||
-        context.request?.url?.endsWith('/health')
+        context.request?.url?.endsWith('/health') ||
+        context.request?.url?.endsWith('/favicon.ico') ||
+        context.request?.url?.endsWith('/robots.txt') ||
+        context.request?.url?.endsWith('livez')
     ) {
         return 0.0;
     }


### PR DESCRIPTION
Removes three endpoints from sentry traces:

- /api/v1/livez
- /robots.txt
- /favicon.ico

The livez produces about 99% of traces in production (due to polling for live state), which contain no performance information. 