### PR TITLE
fix: override default props for blueprint dialog - do not close on es…

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,10 +1,4 @@
-import { Colors, FocusStyleManager, HotkeysProvider } from '@blueprintjs/core';
-import '@blueprintjs/core/lib/css/blueprint.css';
-import '@blueprintjs/datetime/lib/css/blueprint-datetime.css'; // We need to import the datetime css until this bug is fixed: https://github.com/palantir/blueprint/issues/5388
-import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
-import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
-import '@blueprintjs/select/lib/css/blueprint-select.css';
-import '@blueprintjs/table/lib/css/table.css';
+import { Colors } from '@blueprintjs/core';
 import { Helmet } from 'react-helmet';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -44,6 +38,7 @@ import Signup from './pages/Signup';
 import Space from './pages/Space';
 import SqlRunner from './pages/SqlRunner';
 import { AppProvider } from './providers/AppProvider';
+import { BlueprintProvider } from './providers/BlueprintProvider';
 import { DashboardProvider } from './providers/DashboardProvider';
 import { TrackingProvider, TrackPage } from './providers/TrackingProvider';
 import { PageName } from './types/Events';
@@ -68,8 +63,6 @@ const isMobile =
         navigator.userAgent,
     ) || window.innerWidth < 768;
 
-FocusStyleManager.onlyShowFocusOnTabs();
-
 const App = () => (
     <>
         <Helmet>
@@ -77,7 +70,7 @@ const App = () => (
         </Helmet>
         <AppStyle />
         <QueryClientProvider client={queryClient}>
-            <HotkeysProvider>
+            <BlueprintProvider>
                 <AppProvider>
                     <TrackingProvider>
                         {isMobile ? (
@@ -303,7 +296,7 @@ const App = () => (
                         )}
                     </TrackingProvider>
                 </AppProvider>
-            </HotkeysProvider>
+            </BlueprintProvider>
             <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
     </>

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -120,7 +120,6 @@ const UserListItem: FC<{
                 onClose={() => setIsDeleteDialogOpen(false)}
                 title="Revoke project access"
                 lazy
-                canOutsideClickClose={false}
             >
                 <div className={Classes.DIALOG_BODY}>
                     <p>

--- a/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/DeleteTableCalculationModal.tsx
@@ -35,7 +35,6 @@ const DeleteTableCalculationModal: FC<DeleteTableCalculationModalProps> = ({
             onClose={onClose}
             title="Settings"
             lazy
-            canOutsideClickClose={false}
         >
             <div className={Classes.DIALOG_BODY}>
                 <p>Are you sure you want to delete this table calculation ?</p>

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -101,7 +101,6 @@ const TableCalculationModal: FC<Props> = ({
                     : 'Add table calculation'
             }
             lazy
-            canOutsideClickClose
             style={
                 isFullscreen
                     ? {

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -65,7 +65,6 @@ const TokenListItem: FC<{
                 }
                 title={`Delete token ${description}`}
                 lazy
-                canOutsideClickClose={false}
             >
                 <div className={Classes.DIALOG_BODY}>
                     <p>

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -91,7 +91,6 @@ const ProjectListItem: FC<{
                 }
                 title={'Delete project ' + name}
                 lazy
-                canOutsideClickClose={false}
             >
                 <div className={Classes.DIALOG_BODY}>
                     <p>

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -158,7 +158,6 @@ const UserListItem: FC<{
                 }
                 title="Delete user"
                 lazy
-                canOutsideClickClose={false}
             >
                 <div className={Classes.DIALOG_BODY}>
                     <p>Are you sure you want to delete this user ?</p>

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -89,7 +89,6 @@ const SpaceModal: FC<ActionModalProps> = ({
     return (
         <BaseModal
             isOpen
-            canOutsideClickClose
             title={title}
             icon={icon}
             onClose={onClose}

--- a/packages/frontend/src/components/common/modal/ActionModal.tsx
+++ b/packages/frontend/src/components/common/modal/ActionModal.tsx
@@ -103,7 +103,6 @@ const ActionModal = <T extends State>(props: ActionModalProps<T>) => {
 
     return (
         <BaseModal
-            canOutsideClickClose={!(actionType === ActionTypeModal.DELETE)}
             title={title}
             isOpen={actionType !== ActionTypeModal.CLOSE}
             icon={icon}

--- a/packages/frontend/src/components/common/modal/BaseModal.tsx
+++ b/packages/frontend/src/components/common/modal/BaseModal.tsx
@@ -1,28 +1,24 @@
-import { Classes, Dialog, IconName, MaybeElement } from '@blueprintjs/core';
+import { Classes, Dialog, DialogProps } from '@blueprintjs/core';
 import React, { ReactNode } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import Form from '../../ReactHookForm/Form';
 import Wrap from '../Wrap';
 
-interface BaseModalProps<T> {
-    onClose: () => void;
-    isOpen: boolean;
+interface BaseModalProps extends DialogProps {
     title: string;
-    icon: IconName | MaybeElement;
     renderBody: (props?: any) => ReactNode;
     renderFooter: (props?: any) => ReactNode;
-    canOutsideClickClose?: boolean;
     methods?: UseFormReturn<any, object>;
     handleSubmit?: (data: any) => void;
 }
 
-const BaseModal = ({
+const BaseModal: React.FC<BaseModalProps> = ({
     renderBody,
     renderFooter,
     methods,
     handleSubmit,
     ...modalProps
-}: BaseModalProps<any>) => (
+}) => (
     <Dialog lazy {...modalProps} className="non-draggable">
         <Wrap
             wrap={(children) => {
@@ -49,11 +45,5 @@ const BaseModal = ({
         </Wrap>
     </Dialog>
 );
-
-BaseModal.defaultProps = {
-    canOutsideClickClose: true,
-    handleSubmit: () => {},
-    methods: undefined,
-};
 
 export default BaseModal;

--- a/packages/frontend/src/providers/BlueprintProvider.tsx
+++ b/packages/frontend/src/providers/BlueprintProvider.tsx
@@ -1,0 +1,22 @@
+import { Dialog, FocusStyleManager, HotkeysProvider } from '@blueprintjs/core';
+import '@blueprintjs/core/lib/css/blueprint.css';
+import '@blueprintjs/datetime/lib/css/blueprint-datetime.css'; // We need to import the datetime css until this bug is fixed: https://github.com/palantir/blueprint/issues/5388
+import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
+import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
+import '@blueprintjs/select/lib/css/blueprint-select.css';
+import '@blueprintjs/table/lib/css/table.css';
+import { FC } from 'react';
+
+FocusStyleManager.onlyShowFocusOnTabs();
+
+// blueprint overrides
+Dialog.defaultProps.canOutsideClickClose = false;
+Dialog.defaultProps.canEscapeKeyClose = false;
+
+export const BlueprintProvider: FC = ({ children }) => {
+    return (
+        <HotkeysProvider>
+            <>{children}</>
+        </HotkeysProvider>
+    );
+};


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/3841

### Description:

I am overriding Blueprint's defaults here with this:

```
Dialog.defaultProps.canOutsideClickClose = false;
Dialog.defaultProps.canEscapeKeyClose = false;
```

would rather annoy users by NOT closing modals than annoy users by losing UI state by accidentally clicking outside or clicking escape.
