### PR TITLE
feat: conditional formatting show applied rules on hover

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -67,7 +67,7 @@ export type DashboardFilterRule<
 };
 
 export const isDashboardFilterRule = (
-    value: FilterRule,
+    value: ConditionalRule,
 ): value is DashboardFilterRule => 'tileTargets' in value;
 
 export type DateFilterRule = FilterRule<

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -23,6 +23,7 @@ export const createConditionalFormattingConfig =
 
 export const getConditionalFormattingConfigs = (
     conditionalFormattings: ConditionalFormattingConfig[] | undefined,
+    // remove table calculation from here
     field: Field | TableCalculation | undefined,
 ) => {
     if (

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -21,25 +21,6 @@ export const createConditionalFormattingConfig =
         rules: [createConditionalFormatingRule()],
     });
 
-export const getConditionalFormattingConfigs = (
-    conditionalFormattings: ConditionalFormattingConfig[] | undefined,
-    // remove table calculation from here
-    field: Field | TableCalculation | undefined,
-) => {
-    if (
-        !conditionalFormattings ||
-        !field ||
-        !isField(field) ||
-        !isNumericItem(field)
-    ) {
-        return undefined;
-    }
-
-    return conditionalFormattings.filter(
-        (c) => c.target?.fieldId === getItemId(field) || !c.target,
-    );
-};
-
 export const hasMatchingConditionalRules = (
     value: number | string | undefined,
     config: ConditionalFormattingConfig | undefined,
@@ -83,4 +64,26 @@ export const hasMatchingConditionalRules = (
                 );
         }
     });
+};
+
+export const getConditionalFormattingConfig = (
+    field: Field | TableCalculation | undefined,
+    value: number | string | undefined,
+    conditionalFormattings: ConditionalFormattingConfig[] | undefined,
+) => {
+    if (
+        !conditionalFormattings ||
+        !field ||
+        !isField(field) ||
+        !isNumericItem(field)
+    )
+        return undefined;
+
+    const fieldConfigs = conditionalFormattings.filter(
+        (c) => c.target?.fieldId === getItemId(field) || !c.target,
+    );
+
+    return fieldConfigs
+        .reverse()
+        .find((c) => hasMatchingConditionalRules(value, c));
 };

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -39,7 +39,7 @@ export const getDateFormat = (
     return dateForm;
 };
 
-const isMomentInput = (value: unknown): value is MomentInput =>
+export const isMomentInput = (value: unknown): value is MomentInput =>
     typeof value === 'string' ||
     typeof value === 'number' ||
     value instanceof Date ||

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -9,7 +9,7 @@ import { useExplores } from '../../../hooks/useExplores';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import {
-    getFilterRuleLabel,
+    getConditionalRuleLabel,
     getFilterRuleTables,
 } from '../../common/Filters/configs';
 import { useTableContext } from '../../common/Table/TableProvider';
@@ -66,7 +66,7 @@ const ActiveFilter: FC<Props> = ({
             </InvalidFilterTag>
         );
     }
-    const filterRuleLabels = getFilterRuleLabel(filterRule, field);
+    const filterRuleLabels = getConditionalRuleLabel(filterRule, field);
     const filterRuleTables = getFilterRuleTables(
         filterRule,
         field,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -46,7 +46,7 @@ import { useApp } from '../../providers/AppProvider';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
-import { getFilterRuleLabel } from '../common/Filters/configs';
+import { getConditionalRuleLabel } from '../common/Filters/configs';
 import { TableColumn } from '../common/Table/types';
 import CSVExporter from '../CSVExporter';
 import { FilterValues } from '../DashboardFilter/ActiveFilters/ActiveFilters.styles';
@@ -331,7 +331,10 @@ const DashboardChartTile: FC<Props> = (props) => {
                 (f) => fieldId(f) === filterRule.target.fieldId,
             );
             if (field && isFilterableField(field)) {
-                const filterRuleLabels = getFilterRuleLabel(filterRule, field);
+                const filterRuleLabels = getConditionalRuleLabel(
+                    filterRule,
+                    field,
+                );
                 return (
                     <div key={field.name}>
                         <Tag minimal style={{ color: 'white' }}>

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../../providers/ExplorerProvider';
 import CollapsableCard from '../../common/CollapsableCard';
 import FiltersForm from '../../common/Filters';
-import { getFilterRuleLabel } from '../../common/Filters/configs';
+import { getConditionalRuleLabel } from '../../common/Filters/configs';
 import {
     FieldsWithSuggestions,
     FiltersProvider,
@@ -146,7 +146,10 @@ const FiltersCard: FC = memo(() => {
                 (f) => fieldId(f) === filterRule.target.fieldId,
             );
             if (field && isFilterableField(field)) {
-                const filterRuleLabels = getFilterRuleLabel(filterRule, field);
+                const filterRuleLabels = getConditionalRuleLabel(
+                    filterRule,
+                    field,
+                );
                 return (
                     <div key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -204,7 +204,7 @@ export const getConditionalRuleLabel = (
 };
 
 export const getFilterRuleTables = (
-    filterRule: FilterRule | DashboardFilterRule,
+    filterRule: ConditionalRule,
     field: FilterableField,
     filterableFields: FilterableField[],
 ): string[] => {

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -1,10 +1,9 @@
 import {
+    assertUnreachable,
     ConditionalRule,
-    DashboardFilterRule,
     DimensionType,
     FilterableField,
     FilterOperator,
-    FilterRule,
     FilterType,
     formatBoolean,
     formatDate,
@@ -124,8 +123,85 @@ type FilterRuleLabels = {
     value?: string;
 };
 
+export const getValueAsString = (
+    filterType: FilterType,
+    rule: ConditionalRule,
+    field: FilterableField,
+) => {
+    const { operator, values } = rule;
+    const firstValue = values?.[0];
+    const secondValue = values?.[1];
+
+    switch (filterType) {
+        case FilterType.STRING:
+        case FilterType.NUMBER:
+            return values?.join(', ');
+        case FilterType.BOOLEAN:
+            return values?.map(formatBoolean).join(', ');
+        case FilterType.DATE:
+            switch (operator) {
+                case FilterOperator.IN_THE_PAST:
+                case FilterOperator.IN_THE_NEXT:
+                    if (!isFilterRule(rule)) throw new Error('Invalid rule');
+
+                    return `${firstValue} ${
+                        rule.settings.completed ? 'completed ' : ''
+                    }${rule.settings.unitOfTime}`;
+                case FilterOperator.IN_BETWEEN:
+                    return `${firstValue} and ${secondValue}`;
+                case FilterOperator.IN_THE_CURRENT:
+                    if (!isFilterRule(rule)) throw new Error('Invalid rule');
+
+                    return rule.settings.unitOfTime.slice(0, -1);
+                case FilterOperator.NULL:
+                case FilterOperator.NOT_NULL:
+                case FilterOperator.EQUALS:
+                case FilterOperator.NOT_EQUALS:
+                case FilterOperator.STARTS_WITH:
+                case FilterOperator.INCLUDE:
+                case FilterOperator.NOT_INCLUDE:
+                case FilterOperator.LESS_THAN:
+                case FilterOperator.LESS_THAN_OR_EQUAL:
+                case FilterOperator.GREATER_THAN:
+                case FilterOperator.GREATER_THAN_OR_EQUAL:
+                    return values
+                        ?.map((value) => {
+                            if (
+                                isDimension(field) &&
+                                isMomentInput(value) &&
+                                field.type === DimensionType.TIMESTAMP
+                            ) {
+                                return formatTimestamp(
+                                    value,
+                                    field.timeInterval,
+                                );
+                            } else if (
+                                isDimension(field) &&
+                                isMomentInput(value) &&
+                                field.type === DimensionType.DATE
+                            ) {
+                                return formatDate(value, field.timeInterval);
+                            } else {
+                                return value;
+                            }
+                        })
+                        .join(', ');
+                default:
+                    return assertUnreachable(
+                        operator,
+                        `Unexpected operator: ${operator}`,
+                    );
+            }
+        default:
+            return assertUnreachable(
+                filterType,
+                `Unexpected filter type: ${filterType}`,
+            );
+    }
+};
+
 export const getConditionalRuleLabel = (
-    filterRule: ConditionalRule,
+    rule: ConditionalRule,
     field: FilterableField,
 ): FilterRuleLabels => {
     const filterType = field
@@ -133,73 +209,13 @@ export const getConditionalRuleLabel = (
         : FilterType.STRING;
     const filterConfig = FilterTypeConfig[filterType];
     const operationLabel =
-        filterConfig.operatorOptions.find(
-            (option) => option.value === filterRule.operator,
-        )?.label || filterOperatorLabel[filterRule.operator];
-    let valuesText: string | undefined;
-    switch (filterType) {
-        case FilterType.STRING:
-        case FilterType.NUMBER:
-            valuesText = filterRule.values?.join(', ');
-            break;
-        case FilterType.BOOLEAN:
-            valuesText = filterRule.values?.map(formatBoolean).join(', ');
-            break;
-        case FilterType.DATE: {
-            if (
-                filterRule.operator === FilterOperator.IN_THE_PAST ||
-                filterRule.operator === FilterOperator.IN_THE_NEXT
-            ) {
-                if (isFilterRule(filterRule)) {
-                    valuesText = `${filterRule.values?.[0]} ${
-                        filterRule.settings.completed ? 'completed ' : ''
-                    }${filterRule.settings.unitOfTime}`;
-                } else {
-                    valuesText = `${filterRule.values?.[0]}`;
-                }
-            } else if (filterRule.operator === FilterOperator.IN_BETWEEN) {
-                valuesText = `${filterRule.values?.[0]} and ${filterRule.values?.[1]}`;
-            } else if (filterRule.operator === FilterOperator.IN_THE_CURRENT) {
-                if (isFilterRule(filterRule)) {
-                    valuesText = `${filterRule.settings.unitOfTime.substring(
-                        0,
-                        filterRule.settings.unitOfTime.length - 1,
-                    )}`;
-                } else {
-                    valuesText = `${filterRule.values?.[0]}`;
-                }
-            } else {
-                valuesText = filterRule.values
-                    ?.map((value) => {
-                        if (
-                            isDimension(field) &&
-                            isMomentInput(value) &&
-                            field.type === DimensionType.TIMESTAMP
-                        ) {
-                            return formatTimestamp(value, field.timeInterval);
-                        } else if (
-                            isDimension(field) &&
-                            isMomentInput(value) &&
-                            field.type === DimensionType.DATE
-                        ) {
-                            return formatDate(value, field.timeInterval);
-                        } else {
-                            return value;
-                        }
-                    })
-                    .join(', ');
-            }
-            break;
-        }
-        default: {
-            const never: never = filterType;
-            throw new Error(`Unexpected filter type: ${filterType}`);
-        }
-    }
+        filterConfig.operatorOptions.find((o) => o.value === rule.operator)
+            ?.label || filterOperatorLabel[rule.operator];
+
     return {
         field: field.label,
         operator: operationLabel,
-        value: valuesText,
+        value: getValueAsString(filterType, rule, field),
     };
 };
 

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -13,6 +13,8 @@ import {
     getItemId,
     isDashboardFilterRule,
     isDimension,
+    isFilterRule,
+    isMomentInput,
 } from '@lightdash/common';
 import isEmpty from 'lodash-es/isEmpty';
 import uniq from 'lodash-es/uniq';
@@ -122,8 +124,8 @@ type FilterRuleLabels = {
     value?: string;
 };
 
-export const getFilterRuleLabel = (
-    filterRule: FilterRule,
+export const getConditionalRuleLabel = (
+    filterRule: ConditionalRule,
     field: FilterableField,
 ): FilterRuleLabels => {
     const filterType = field
@@ -148,26 +150,36 @@ export const getFilterRuleLabel = (
                 filterRule.operator === FilterOperator.IN_THE_PAST ||
                 filterRule.operator === FilterOperator.IN_THE_NEXT
             ) {
-                valuesText = `${filterRule.values?.[0]} ${
-                    filterRule.settings.completed ? 'completed ' : ''
-                }${filterRule.settings.unitOfTime}`;
+                if (isFilterRule(filterRule)) {
+                    valuesText = `${filterRule.values?.[0]} ${
+                        filterRule.settings.completed ? 'completed ' : ''
+                    }${filterRule.settings.unitOfTime}`;
+                } else {
+                    valuesText = `${filterRule.values?.[0]}`;
+                }
             } else if (filterRule.operator === FilterOperator.IN_BETWEEN) {
                 valuesText = `${filterRule.values?.[0]} and ${filterRule.values?.[1]}`;
             } else if (filterRule.operator === FilterOperator.IN_THE_CURRENT) {
-                valuesText = `${filterRule.settings.unitOfTime.substring(
-                    0,
-                    filterRule.settings.unitOfTime.length - 1,
-                )}`;
+                if (isFilterRule(filterRule)) {
+                    valuesText = `${filterRule.settings.unitOfTime.substring(
+                        0,
+                        filterRule.settings.unitOfTime.length - 1,
+                    )}`;
+                } else {
+                    valuesText = `${filterRule.values?.[0]}`;
+                }
             } else {
                 valuesText = filterRule.values
                     ?.map((value) => {
                         if (
                             isDimension(field) &&
+                            isMomentInput(value) &&
                             field.type === DimensionType.TIMESTAMP
                         ) {
                             return formatTimestamp(value, field.timeInterval);
                         } else if (
                             isDimension(field) &&
+                            isMomentInput(value) &&
                             field.type === DimensionType.DATE
                         ) {
                             return formatDate(value, field.timeInterval);

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -20,7 +20,7 @@ interface CommonBodyCellProps {
     fontColor?: string;
     copying?: boolean;
     selected?: boolean;
-    tooltipContent?: JSX.Element | JSX.Element[];
+    tooltipContent?: string;
     onSelect: () => void;
     onDeselect: () => void;
     onKeyDown: React.KeyboardEventHandler<HTMLElement>;

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -20,7 +20,7 @@ interface CommonBodyCellProps {
     fontColor?: string;
     copying?: boolean;
     selected?: boolean;
-    tooltipContent?: string;
+    tooltipContent?: JSX.Element | JSX.Element[];
     onSelect: () => void;
     onDeselect: () => void;
     onKeyDown: React.KeyboardEventHandler<HTMLElement>;

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -1,5 +1,5 @@
-import { Position } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
+import { mergeRefs, Position } from '@blueprintjs/core';
+import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { ResultRow } from '@lightdash/common';
 import { Cell } from '@tanstack/react-table';
 import { FC } from 'react';
@@ -20,6 +20,7 @@ interface CommonBodyCellProps {
     fontColor?: string;
     copying?: boolean;
     selected?: boolean;
+    tooltipContent?: string;
     onSelect: () => void;
     onDeselect: () => void;
     onKeyDown: React.KeyboardEventHandler<HTMLElement>;
@@ -38,6 +39,7 @@ const BodyCell: FC<CommonBodyCellProps> = ({
     rowIndex,
     selected = false,
     style,
+    tooltipContent,
     onSelect,
     onDeselect,
     onKeyDown,
@@ -72,26 +74,37 @@ const BodyCell: FC<CommonBodyCellProps> = ({
                     />
                 )
             }
-            renderTarget={({ ref }) => (
-                <Td
-                    ref={ref}
-                    className={className}
-                    style={style}
-                    $rowIndex={rowIndex}
-                    $isSelected={selected}
-                    $isInteractive={hasContextMenu}
-                    $isCopying={copying}
-                    $backgroundColor={backgroundColor}
-                    $fontColor={fontColor}
-                    $hasData={hasContextMenu}
-                    $isNaN={!hasData || !isNumericItem}
-                    onClick={selected ? handleDeselect : handleSelect}
-                    onKeyDown={onKeyDown}
-                >
-                    <RichBodyCell cell={cell as Cell<ResultRow, ResultRow[0]>}>
-                        {children}
-                    </RichBodyCell>
-                </Td>
+            renderTarget={({ ref: ref2, ...popoverProps }) => (
+                <Tooltip2
+                    lazy
+                    position={Position.TOP}
+                    content={tooltipContent}
+                    renderTarget={({ ref: ref1, ...tooltipProps }) => (
+                        <Td
+                            ref={mergeRefs(ref1, ref2)}
+                            {...tooltipProps}
+                            {...popoverProps}
+                            className={className}
+                            style={style}
+                            $rowIndex={rowIndex}
+                            $isSelected={selected}
+                            $isInteractive={hasContextMenu}
+                            $isCopying={copying}
+                            $backgroundColor={backgroundColor}
+                            $fontColor={fontColor}
+                            $hasData={hasContextMenu}
+                            $isNaN={!hasData || !isNumericItem}
+                            onClick={selected ? handleDeselect : handleSelect}
+                            onKeyDown={onKeyDown}
+                        >
+                            <RichBodyCell
+                                cell={cell as Cell<ResultRow, ResultRow[0]>}
+                            >
+                                {children}
+                            </RichBodyCell>
+                        </Td>
+                    )}
+                />
             )}
         />
     );

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -37,7 +37,6 @@ const TableBody: FC = () => {
                             | undefined;
 
                         const fieldConditionalConfigs =
-                            cellValue &&
                             getConditionalFormattingConfigs(
                                 conditionalFormattings,
                                 field,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,6 +1,8 @@
 import {
     getConditionalFormattingConfigs,
     hasMatchingConditionalRules,
+    isField,
+    isFilterableField,
     isNumericItem,
     ResultRow,
 } from '@lightdash/common';
@@ -8,6 +10,7 @@ import { flexRender } from '@tanstack/react-table';
 import findLast from 'lodash-es/findLast';
 import { FC } from 'react';
 import { readableColor } from '../../../../utils/colorUtils';
+import { getConditionalRuleLabel } from '../../Filters/configs';
 import BodyCell from '../BodyCell';
 import { useTableContext } from '../TableProvider';
 
@@ -49,6 +52,32 @@ const TableBody: FC = () => {
                                 );
                             });
 
+                        const ruleLabels =
+                            cellHasFormatting &&
+                            field &&
+                            isField(field) &&
+                            isFilterableField(field) &&
+                            fieldConditionalConfig &&
+                            fieldConditionalConfig.rules.length > 0
+                                ? fieldConditionalConfig?.rules.map((rule) =>
+                                      getConditionalRuleLabel(rule, field),
+                                  )
+                                : undefined;
+
+                        const tooltipContent = ruleLabels?.map((label) => {
+                            return (
+                                <div
+                                    key={
+                                        label.field +
+                                        label.operator +
+                                        label.value
+                                    }
+                                >
+                                    {label.operator} {label.value}
+                                </div>
+                            );
+                        });
+
                         return (
                             <BodyCell
                                 style={meta?.style}
@@ -73,9 +102,9 @@ const TableBody: FC = () => {
                                 copying={cell.id === copyingCellId}
                                 selected={cell.id === selectedCell?.id}
                                 tooltipContent={
-                                    cellHasFormatting
-                                        ? 'has formatting'
-                                        : undefined
+                                    tooltipContent ? (
+                                        <div>{tooltipContent}</div>
+                                    ) : undefined
                                 }
                                 onSelect={() => onSelectCell(cell)}
                                 onDeselect={() => onSelectCell(undefined)}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -72,6 +72,11 @@ const TableBody: FC = () => {
                                 cellContextMenu={cellContextMenu}
                                 copying={cell.id === copyingCellId}
                                 selected={cell.id === selectedCell?.id}
+                                tooltipContent={
+                                    cellHasFormatting
+                                        ? 'has formatting'
+                                        : undefined
+                                }
                                 onSelect={() => onSelectCell(cell)}
                                 onDeselect={() => onSelectCell(undefined)}
                                 onKeyDown={onCopyCell}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -42,29 +42,27 @@ const TableBody: FC = () => {
                                 field,
                             );
 
-                        const conditionalFormattingConfig =
-                            fieldConditionalConfigs &&
-                            findLast(fieldConditionalConfigs, (c) => {
-                                return hasMatchingConditionalRules(
+                        const conditionalFormattingConfig = findLast(
+                            fieldConditionalConfigs,
+                            (c) =>
+                                hasMatchingConditionalRules(
                                     cellValue?.value.raw as number | string,
                                     c,
-                                );
-                            });
+                                ),
+                        );
 
-                        const ruleLabels =
-                            field &&
+                        const tooltipContent =
                             isField(field) &&
                             isFilterableField(field) &&
                             conditionalFormattingConfig &&
-                            conditionalFormattingConfig.rules.length > 0
-                                ? conditionalFormattingConfig.rules.map((r) =>
-                                      getConditionalRuleLabel(r, field),
-                                  )
+                            conditionalFormattingConfig?.rules.length > 0
+                                ? conditionalFormattingConfig.rules
+                                      .map((r) =>
+                                          getConditionalRuleLabel(r, field),
+                                      )
+                                      .map((l) => `${l.operator} ${l.value}`)
+                                      .join(' and ')
                                 : undefined;
-
-                        const tooltipContent = ruleLabels
-                            ?.map((l) => `${l.operator} ${l.value}`)
-                            .join(' and ');
 
                         return (
                             <BodyCell

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,13 +1,11 @@
 import {
-    getConditionalFormattingConfigs,
-    hasMatchingConditionalRules,
+    getConditionalFormattingConfig,
     isField,
     isFilterableField,
     isNumericItem,
     ResultRow,
 } from '@lightdash/common';
 import { flexRender } from '@tanstack/react-table';
-import findLast from 'lodash-es/findLast';
 import { FC } from 'react';
 import { readableColor } from '../../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../../Filters/configs';
@@ -36,20 +34,12 @@ const TableBody: FC = () => {
                             | ResultRow[0]
                             | undefined;
 
-                        const fieldConditionalConfigs =
-                            getConditionalFormattingConfigs(
-                                conditionalFormattings,
+                        const conditionalFormattingConfig =
+                            getConditionalFormattingConfig(
                                 field,
+                                cellValue?.value.raw,
+                                conditionalFormattings,
                             );
-
-                        const conditionalFormattingConfig = findLast(
-                            fieldConditionalConfigs,
-                            (c) =>
-                                hasMatchingConditionalRules(
-                                    cellValue?.value.raw as number | string,
-                                    c,
-                                ),
-                        );
 
                         const tooltipContent =
                             isField(field) &&

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -53,33 +53,23 @@ const TableBody: FC = () => {
                             });
 
                         const ruleLabels =
-                            cellHasFormatting &&
                             field &&
                             isField(field) &&
                             isFilterableField(field) &&
-                            fieldConditionalConfig &&
-                            fieldConditionalConfig.rules.length > 0
-                                ? fieldConditionalConfig?.rules.map((rule) =>
-                                      getConditionalRuleLabel(rule, field),
+                            conditionalFormattingConfig &&
+                            conditionalFormattingConfig.rules.length > 0
+                                ? conditionalFormattingConfig.rules.map((r) =>
+                                      getConditionalRuleLabel(r, field),
                                   )
                                 : undefined;
 
-                        const tooltipContent = ruleLabels?.map((label) => {
-                            return (
-                                <div
-                                    key={
-                                        label.field +
-                                        label.operator +
-                                        label.value
-                                    }
-                                >
-                                    {label.operator} {label.value}
-                                </div>
-                            );
-                        });
+                        const tooltipContent = ruleLabels
+                            ?.map((l) => `${l.operator} ${l.value}`)
+                            .join(' and ');
 
                         return (
                             <BodyCell
+                                key={cell.id}
                                 style={meta?.style}
                                 backgroundColor={
                                     conditionalFormattingConfig?.color
@@ -93,7 +83,6 @@ const TableBody: FC = () => {
                                         : undefined
                                 }
                                 className={meta?.className}
-                                key={cell.id}
                                 rowIndex={rowIndex}
                                 cell={cell}
                                 isNumericItem={isNumericItem(meta?.item)}
@@ -101,11 +90,7 @@ const TableBody: FC = () => {
                                 cellContextMenu={cellContextMenu}
                                 copying={cell.id === copyingCellId}
                                 selected={cell.id === selectedCell?.id}
-                                tooltipContent={
-                                    tooltipContent ? (
-                                        <div>{tooltipContent}</div>
-                                    ) : undefined
-                                }
+                                tooltipContent={tooltipContent}
                                 onSelect={() => onSelectCell(cell)}
                                 onDeselect={() => onSelectCell(undefined)}
                                 onKeyDown={onCopyCell}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/4197

### Description:

- [x] on hover, I can see the rules applied to a cell that has conditional formatting applied to it (i.e. only cells with colour show anything on hover. unaffected cells don't show anything on hover.)
- [x] Here are some examples of rules and what would show in the hover:
Rule 1:
  - product_value is greater than 5 (and condition 2:) is less than 10
  - on hover, it would show: is greater than 5 and is less than 10

![CleanShot 2023-01-18 at 20 10 02@2x](https://user-images.githubusercontent.com/962095/213229198-8b75d1e6-8eef-4143-a1ea-c7cf29cbe3f3.png)
