### PR TITLE
fix: reference line missing value

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -57,7 +57,7 @@ export const ReferenceLine: FC<Props> = ({
     }, [items, dirtyLayout]);
 
     const markLineKey = useMemo(() => {
-        return 'xAxis' in referenceLine.data ? 'xAxis' : 'yAxis';
+        return referenceLine.data.xAxis !== undefined ? 'xAxis' : 'yAxis';
     }, [referenceLine]);
 
     const [value, setValue] = useState<string | undefined>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4191

### Description:
Before, the key was either xAxis or yAxis, now both axis keys can exist in data, but they can be undefined. I fixed the method that gets the right axis. 



[Screencast from 19-01-23 10:42:34.webm](https://user-images.githubusercontent.com/1983672/213409166-10c39a1c-d70b-4114-85b8-98b8803f6e27.webm)

