### PR TITLE
chore: set asset headers to immutable

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -178,8 +178,21 @@ if (
     );
 }
 
-// frontend
-app.use(express.static(path.join(__dirname, '../../frontend/build')));
+// frontend assets - immutable because vite appends hash to filenames
+app.use(
+    '/assets',
+    express.static(path.join(__dirname, '../../frontend/build/assets'), {
+        immutable: true,
+        maxAge: '1y',
+    }),
+);
+
+// frontend static files - no cache
+app.use(
+    express.static(path.join(__dirname, '../../frontend/build'), {
+        maxAge: 0,
+    }),
+);
 
 app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '../../frontend/build', 'index.html'));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

All asset files in the `/build/assets` dir generated by vite are appended with a hash, which changes if the content changes. This PR marks those as immutable and `max-age: 1yr` for the `cache-control` header. Enabling CDNs to cache these.

All other build files (index.html, robots.txt, and icons) have a no cache policy (as before).


### Tests

```
curl -s -D - -o /dev/null http://localhost:8080/
# Cache-Control: public, max-age=0

curl -s -D - -o /dev/null http://localhost:8080/favicon.ico
# Cache-Control: public, max-age=0

# (for your local deployment or PR preview the hash might be different in this one)
curl -s -D - -o /dev/null http://localhost:8080/assets/blueprint-icons-vendor.27956899.js
# Cache-Control: public, max-age=31536000, immutable