### PR TITLE
feat: add table alias

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -471,7 +471,7 @@ export const exploreComplexReferenceCompiled: Explore = {
     },
 };
 
-export const exploreReferenceInJoin: UncompiledExplore = {
+export const simpleJoinedExplore: UncompiledExplore = {
     ...exploreBase,
     joinedTables: [
         {
@@ -482,7 +482,7 @@ export const exploreReferenceInJoin: UncompiledExplore = {
     tables: {
         a: {
             name: 'a',
-            label: 'a',
+            label: 'Custom A label',
             database: 'database',
             schema: 'schema',
             sqlTable: 'test.table',
@@ -493,7 +493,7 @@ export const exploreReferenceInJoin: UncompiledExplore = {
                     name: 'dim1',
                     label: 'dim1',
                     table: 'a',
-                    tableLabel: 'a',
+                    tableLabel: 'Custom A label',
                     sql: '${TABLE}.dim1',
                     source: sourceMock,
                     hidden: false,
@@ -505,7 +505,7 @@ export const exploreReferenceInJoin: UncompiledExplore = {
         },
         b: {
             name: 'b',
-            label: 'b',
+            label: 'Custom B label',
             database: 'database',
             schema: 'schema',
             sqlTable: 'test.tableb',
@@ -516,19 +516,8 @@ export const exploreReferenceInJoin: UncompiledExplore = {
                     name: 'dim1',
                     label: 'dim1',
                     table: 'b',
-                    tableLabel: 'b',
+                    tableLabel: 'Custom B label',
                     sql: '${TABLE}.dim1',
-                    source: sourceMock,
-                    hidden: false,
-                },
-                dim2: {
-                    fieldType: FieldType.DIMENSION,
-                    type: DimensionType.STRING,
-                    name: 'dim2',
-                    label: 'dim2',
-                    table: 'b',
-                    tableLabel: 'b',
-                    sql: '${a.dim1}',
                     source: sourceMock,
                     hidden: false,
                 },
@@ -540,7 +529,7 @@ export const exploreReferenceInJoin: UncompiledExplore = {
     },
 };
 
-export const exploreReferenceInJoinCompiled: Explore = {
+export const compiledSimpleJoinedExplore: Explore = {
     ...exploreBase,
     joinedTables: [
         {
@@ -552,7 +541,7 @@ export const exploreReferenceInJoinCompiled: Explore = {
     tables: {
         a: {
             name: 'a',
-            label: 'a',
+            label: 'Custom A label',
             database: 'database',
             schema: 'schema',
             sqlTable: 'test.table',
@@ -563,7 +552,7 @@ export const exploreReferenceInJoinCompiled: Explore = {
                     name: 'dim1',
                     label: 'dim1',
                     table: 'a',
-                    tableLabel: 'a',
+                    tableLabel: 'Custom A label',
                     sql: '${TABLE}.dim1',
                     compiledSql: '"a".dim1',
                     tablesReferences: ['a'],
@@ -577,7 +566,7 @@ export const exploreReferenceInJoinCompiled: Explore = {
         },
         b: {
             name: 'b',
-            label: 'b',
+            label: 'Custom B label',
             database: 'database',
             schema: 'schema',
             sqlTable: 'test.tableb',
@@ -588,20 +577,63 @@ export const exploreReferenceInJoinCompiled: Explore = {
                     name: 'dim1',
                     label: 'dim1',
                     table: 'b',
-                    tableLabel: 'b',
+                    tableLabel: 'Custom B label',
                     sql: '${TABLE}.dim1',
                     compiledSql: '"b".dim1',
                     tablesReferences: ['b'],
                     source: sourceMock,
                     hidden: false,
                 },
+            },
+            metrics: {},
+            lineageGraph: {},
+            source: sourceMock,
+        },
+    },
+};
+
+export const exploreReferenceInJoin: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    tables: {
+        ...simpleJoinedExplore.tables,
+        b: {
+            ...simpleJoinedExplore.tables.b,
+            dimensions: {
+                ...simpleJoinedExplore.tables.b.dimensions,
                 dim2: {
                     fieldType: FieldType.DIMENSION,
                     type: DimensionType.STRING,
                     name: 'dim2',
                     label: 'dim2',
                     table: 'b',
-                    tableLabel: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${a.dim1}',
+                    source: sourceMock,
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+            source: sourceMock,
+        },
+    },
+};
+
+export const exploreReferenceInJoinCompiled: Explore = {
+    ...compiledSimpleJoinedExplore,
+    tables: {
+        ...compiledSimpleJoinedExplore.tables,
+        b: {
+            ...compiledSimpleJoinedExplore.tables.b,
+            dimensions: {
+                ...compiledSimpleJoinedExplore.tables.b.dimensions,
+                dim2: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'dim2',
+                    label: 'dim2',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
                     sql: '${a.dim1}',
                     compiledSql: '("a".dim1)',
                     tablesReferences: ['b', 'a'],
@@ -612,6 +644,114 @@ export const exploreReferenceInJoinCompiled: Explore = {
             metrics: {},
             lineageGraph: {},
             source: sourceMock,
+        },
+    },
+};
+
+export const joinedExploreOverridingJoinLabel: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    joinedTables: [
+        {
+            ...simpleJoinedExplore.joinedTables[0],
+            label: 'Custom join label',
+        },
+    ],
+};
+export const compiledJoinedExploreOverridingJoinLabel: Explore = {
+    ...compiledSimpleJoinedExplore,
+    tables: {
+        ...compiledSimpleJoinedExplore.tables,
+        b: {
+            ...compiledSimpleJoinedExplore.tables.b,
+            label: 'Custom join label',
+            dimensions: {
+                ...compiledSimpleJoinedExplore.tables.b.dimensions,
+                dim1: {
+                    ...compiledSimpleJoinedExplore.tables.b.dimensions.dim1,
+                    tableLabel: 'Custom join label',
+                },
+            },
+        },
+    },
+};
+
+export const joinedExploreOverridingJoinAlias: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+            alias: 'custom_alias',
+        },
+    ],
+};
+
+export const compiledJoinedExploreOverridingJoinAlias: Explore = {
+    ...compiledSimpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'custom_alias',
+            sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+            compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
+        },
+    ],
+    tables: {
+        a: compiledSimpleJoinedExplore.tables.a,
+        custom_alias: {
+            ...compiledSimpleJoinedExplore.tables.b,
+            name: 'custom_alias',
+            label: 'Custom alias',
+            dimensions: {
+                ...compiledSimpleJoinedExplore.tables.b.dimensions,
+                dim1: {
+                    ...compiledSimpleJoinedExplore.tables.b.dimensions.dim1,
+                    table: 'custom_alias',
+                    tableLabel: 'Custom alias',
+                    compiledSql: '"custom_alias".dim1',
+                    tablesReferences: ['custom_alias'],
+                },
+            },
+        },
+    },
+};
+
+export const joinedExploreOverridingAliasAndLabel: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+            label: 'Custom join label',
+            alias: 'custom_alias',
+        },
+    ],
+};
+
+export const compiledJoinedExploreOverridingAliasAndLabel: Explore = {
+    ...compiledSimpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'custom_alias',
+            sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+            compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
+        },
+    ],
+    tables: {
+        a: compiledSimpleJoinedExplore.tables.a,
+        custom_alias: {
+            ...compiledSimpleJoinedExplore.tables.b,
+            name: 'custom_alias',
+            label: 'Custom join label',
+            dimensions: {
+                ...compiledSimpleJoinedExplore.tables.b.dimensions,
+                dim1: {
+                    ...compiledSimpleJoinedExplore.tables.b.dimensions.dim1,
+                    table: 'custom_alias',
+                    tableLabel: 'Custom join label',
+                    compiledSql: '"custom_alias".dim1',
+                    tablesReferences: ['custom_alias'],
+                },
+            },
         },
     },
 };

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -3,6 +3,10 @@ import { CompileError } from '../types/errors';
 import { friendlyName } from '../types/field';
 import { compileExplore, compileMetric } from './exploreCompiler';
 import {
+    compiledJoinedExploreOverridingAliasAndLabel,
+    compiledJoinedExploreOverridingJoinAlias,
+    compiledJoinedExploreOverridingJoinLabel,
+    compiledSimpleJoinedExplore,
     exploreCircularDimensionReference,
     exploreCircularDimensionShortReference,
     exploreCircularMetricReference,
@@ -21,6 +25,10 @@ import {
     exploreTableSelfReferenceCompiled,
     exploreWithMetricNumber,
     exploreWithMetricNumberCompiled,
+    joinedExploreOverridingAliasAndLabel,
+    joinedExploreOverridingJoinAlias,
+    joinedExploreOverridingJoinLabel,
+    simpleJoinedExplore,
     tablesWithMetricsWithFilters,
 } from './exploreCompiler.mock';
 
@@ -75,16 +83,38 @@ test('Should compile table with nested references in dimensions and metrics', ()
     );
 });
 
-test('Should compile with a reference to a dimension in a joined table', () => {
-    expect(compileExplore(exploreReferenceInJoin)).toStrictEqual(
-        exploreReferenceInJoinCompiled,
-    );
-});
-
 test('Should compile with a reference to a metric in a non-aggregate metric', () => {
     expect(compileExplore(exploreWithMetricNumber)).toStrictEqual(
         exploreWithMetricNumberCompiled,
     );
+});
+
+describe('Explores with a base table and joined table', () => {
+    test('should compile', () => {
+        expect(compileExplore(simpleJoinedExplore)).toStrictEqual(
+            compiledSimpleJoinedExplore,
+        );
+    });
+    test('should compile with a reference to a dimension in a joined table', () => {
+        expect(compileExplore(exploreReferenceInJoin)).toStrictEqual(
+            exploreReferenceInJoinCompiled,
+        );
+    });
+    test('should compile with custom label on join', () => {
+        expect(compileExplore(joinedExploreOverridingJoinLabel)).toStrictEqual(
+            compiledJoinedExploreOverridingJoinLabel,
+        );
+    });
+    test('should compile with alias on join', () => {
+        expect(compileExplore(joinedExploreOverridingJoinAlias)).toStrictEqual(
+            compiledJoinedExploreOverridingJoinAlias,
+        );
+    });
+    test('should compile with an alias and custom label on join', () => {
+        expect(
+            compileExplore(joinedExploreOverridingAliasAndLabel),
+        ).toStrictEqual(compiledJoinedExploreOverridingAliasAndLabel);
+    });
 });
 
 describe('Default field labels render for', () => {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -545,49 +545,47 @@ export const compileExplore = ({
         );
     }
     const includedTables = joinedTables.reduce<Record<string, Table>>(
-        (prev, join) => ({
-            ...prev,
-            [join.alias || join.table]: {
-                ...tables[join.table],
-                name: join.alias || tables[join.table].name,
-                label:
-                    join.label ||
-                    (join.alias && friendlyName(join.alias)) ||
-                    tables[join.table].label,
-                dimensions: Object.keys(tables[join.table].dimensions).reduce<
-                    Record<string, Dimension>
-                >(
-                    (prevDimensions, dimensionKey) => ({
-                        ...prevDimensions,
-                        [dimensionKey]: {
-                            ...tables[join.table].dimensions[dimensionKey],
-                            table: join.alias || tables[join.table].name,
-                            tableLabel:
-                                join.label ||
-                                (join.alias && friendlyName(join.alias)) ||
-                                tables[join.table].label,
-                        },
-                    }),
-                    {},
-                ),
-                metrics: Object.keys(tables[join.table].metrics).reduce<
-                    Record<string, Metric>
-                >(
-                    (prevMetrics, metricKey) => ({
-                        ...prevMetrics,
-                        [metricKey]: {
-                            ...tables[join.table].metrics[metricKey],
-                            table: join.alias || tables[join.table].name,
-                            tableLabel:
-                                join.label ||
-                                (join.alias && friendlyName(join.alias)) ||
-                                tables[join.table].label,
-                        },
-                    }),
-                    {},
-                ),
-            },
-        }),
+        (prev, join) => {
+            const joinTableName = join.alias || tables[join.table].name;
+            const joinTableLabel =
+                join.label ||
+                (join.alias && friendlyName(join.alias)) ||
+                tables[join.table].label;
+            return {
+                ...prev,
+                [join.alias || join.table]: {
+                    ...tables[join.table],
+                    name: joinTableName,
+                    label: joinTableLabel,
+                    dimensions: Object.keys(
+                        tables[join.table].dimensions,
+                    ).reduce<Record<string, Dimension>>(
+                        (prevDimensions, dimensionKey) => ({
+                            ...prevDimensions,
+                            [dimensionKey]: {
+                                ...tables[join.table].dimensions[dimensionKey],
+                                table: joinTableName,
+                                tableLabel: joinTableLabel,
+                            },
+                        }),
+                        {},
+                    ),
+                    metrics: Object.keys(tables[join.table].metrics).reduce<
+                        Record<string, Metric>
+                    >(
+                        (prevMetrics, metricKey) => ({
+                            ...prevMetrics,
+                            [metricKey]: {
+                                ...tables[join.table].metrics[metricKey],
+                                table: joinTableName,
+                                tableLabel: joinTableLabel,
+                            },
+                        }),
+                        {},
+                    ),
+                },
+            };
+        },
         { [baseTable]: tables[baseTable] },
     );
 

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -554,6 +554,38 @@ export const compileExplore = ({
                     join.label ||
                     (join.alias && friendlyName(join.alias)) ||
                     tables[join.table].label,
+                dimensions: Object.keys(tables[join.table].dimensions).reduce<
+                    Record<string, Dimension>
+                >(
+                    (prevDimensions, dimensionKey) => ({
+                        ...prevDimensions,
+                        [dimensionKey]: {
+                            ...tables[join.table].dimensions[dimensionKey],
+                            table: join.alias || tables[join.table].name,
+                            tableLabel:
+                                join.label ||
+                                (join.alias && friendlyName(join.alias)) ||
+                                tables[join.table].label,
+                        },
+                    }),
+                    {},
+                ),
+                metrics: Object.keys(tables[join.table].metrics).reduce<
+                    Record<string, Metric>
+                >(
+                    (prevMetrics, metricKey) => ({
+                        ...prevMetrics,
+                        [metricKey]: {
+                            ...tables[join.table].metrics[metricKey],
+                            table: join.alias || tables[join.table].name,
+                            tableLabel:
+                                join.label ||
+                                (join.alias && friendlyName(join.alias)) ||
+                                tables[join.table].label,
+                        },
+                    }),
+                    {},
+                ),
             },
         }),
         { [baseTable]: tables[baseTable] },

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -488,6 +488,7 @@ export const convertExplores = async (
                 joinedTables: (meta?.joins || []).map((join) => ({
                     table: join.join,
                     sqlOn: join.sql_on,
+                    alias: join.alias,
                 })),
                 tables: tableLookup,
                 targetDatabase: adapterType,

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -57,6 +57,8 @@ type DbtModelLightdashConfig = {
 type DbtModelJoin = {
     join: string;
     sql_on: string;
+    alias?: string;
+    label?: string;
 };
 type DbtColumnMetadata = DbtColumnLightdashConfig & {};
 type DbtColumnLightdashConfig = {

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -11,9 +11,11 @@ import { TableBase } from './table';
 export type ExploreJoin = {
     table: string; // Must match a tableName in containing Explore
     sqlOn: string; // Built sql
+    alias?: string; // Optional alias for the joined tableName
+    label?: string; // Optional UI label override for the underlying table
 };
 
-export type CompiledExploreJoin = ExploreJoin & {
+export type CompiledExploreJoin = Pick<ExploreJoin, 'table' | 'sqlOn'> & {
     compiledSqlOn: string; // Sql on clause with template variables resolved
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1034 

### Description:

This allows the user to join the same table multiple times under an alias. Example in dbt config:

```yaml
# my model.yam
models:
  - name: pull_requests
    meta:
      joins:
        - join: users
          sql_on: ${pull_requests.user_id} = ${users.user_id}
        - join: users
          alias: closed_by
          sql_on: ${closed_by} = ${created_by.user_id}
        - join: users
          alias: reviewed_by
          sql_on: ${pull_requests.reviewed_by} = ${reviewed_by.user_id}
          # default label would be "Reviewed by"
          label: An optional new label for the join
```


### Blocked

Need to pull `tableLabel` out of `translator.ts` into `exploreCompiler.ts` but blocked by `tableLabel` being on the base `Field` type