### PR TITLE
chore: warehouse client config methods

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -143,7 +143,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 loadSources,
                 adapterType,
                 metrics,
-                this.warehouseClient.getStartOfWeek(),
+                this.warehouseClient,
             );
             return [...lazyExplores, ...failedExplores];
         } catch (e) {
@@ -180,7 +180,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     loadSources,
                     adapterType,
                     metrics,
-                    this.warehouseClient.getStartOfWeek(),
+                    this.warehouseClient,
                 );
                 return [...explores, ...failedExplores];
             }

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -7,7 +7,52 @@ import {
     FilterOperator,
     MetricType,
     SupportedDbtAdapter,
+    WarehouseClient,
 } from '@lightdash/common';
+
+export const warehouseClientMock: WarehouseClient = {
+    getCatalog: async () => ({
+        default: {
+            public: {
+                table: {
+                    id: DimensionType.NUMBER,
+                },
+            },
+        },
+    }),
+    runQuery: () =>
+        Promise.resolve({
+            fields: {},
+            rows: [],
+        }),
+    test: () => Promise.resolve(),
+    getStartOfWeek: () => undefined,
+    getFieldQuoteChar: () => '"',
+    getStringQuoteChar: () => "'",
+    getEscapeStringQuoteChar: () => "'",
+};
+
+export const bigqueryClientMock: WarehouseClient = {
+    getCatalog: async () => ({
+        default: {
+            public: {
+                table: {
+                    id: DimensionType.NUMBER,
+                },
+            },
+        },
+    }),
+    runQuery: () =>
+        Promise.resolve({
+            fields: {},
+            rows: [],
+        }),
+    test: () => Promise.resolve(),
+    getStartOfWeek: () => undefined,
+    getFieldQuoteChar: () => '`',
+    getStringQuoteChar: () => "'",
+    getEscapeStringQuoteChar: () => '\\',
+};
 
 export const emptyTable = (name: string): CompiledTable => ({
     name,

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -1,5 +1,6 @@
 import { buildQuery } from './queryBuilder';
 import {
+    bigqueryClientMock,
     EXPLORE,
     EXPLORE_BIGQUERY,
     EXPLORE_JOIN_CHAIN,
@@ -27,6 +28,7 @@ import {
     METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL,
     METRIC_QUERY_WITH_TABLE_REFERENCE,
     METRIC_QUERY_WITH_TABLE_REFERENCE_SQL,
+    warehouseClientMock,
 } from './queryBuilder.mock';
 
 describe('Query builder', () => {
@@ -35,6 +37,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -44,6 +47,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE_BIGQUERY,
                 compiledMetricQuery: METRIC_QUERY,
+                warehouseClient: bigqueryClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL_BIGQUERY);
     });
@@ -53,6 +57,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_TWO_TABLES_SQL);
     });
@@ -62,6 +67,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_TABLE_REFERENCE_SQL);
     });
@@ -71,6 +77,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_SQL);
     });
@@ -80,6 +87,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE_JOIN_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_JOIN_CHAIN_SQL);
     });
@@ -89,6 +97,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL);
     });
@@ -97,6 +106,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL);
     });
@@ -105,6 +115,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_SQL);
     });
@@ -114,6 +125,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL);
     });
@@ -123,6 +135,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_FILTER_SQL);
     });
@@ -132,6 +145,7 @@ describe('Query builder', () => {
             buildQuery({
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL);
     });
@@ -141,6 +155,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY,
                 allResults: true,
+                warehouseClient: warehouseClientMock,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL_WITH_NO_LIMIT);
     });

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -7,16 +7,14 @@ import {
     FilterGroup,
     FilterRule,
     getDimensions,
-    getEscapeStringQuoteChar,
-    getFieldQuoteChar,
     getFields,
     getFilterRulesFromGroup,
     getMetrics,
-    getStringQuoteChar,
     isAndFilterGroup,
     isFilterGroup,
     parseAllReferences,
     renderFilterRuleSql,
+    WarehouseClient,
 } from '@lightdash/common';
 
 const getDimensionFromId = (dimId: FieldId, explore: Explore) => {
@@ -57,20 +55,21 @@ export type BuildQueryProps = {
     explore: Explore;
     compiledMetricQuery: CompiledMetricQuery;
     allResults?: boolean;
+
+    warehouseClient: WarehouseClient;
 };
 export const buildQuery = ({
     explore,
     compiledMetricQuery,
     allResults,
+    warehouseClient,
 }: BuildQueryProps): { query: string; hasExampleMetric: boolean } => {
     let hasExampleMetric: boolean = false;
     const { dimensions, metrics, filters, sorts, limit } = compiledMetricQuery;
     const baseTable = explore.tables[explore.baseTable].sqlTable;
-    const fieldQuoteChar = getFieldQuoteChar(explore.targetDatabase);
-    const stringQuoteChar = getStringQuoteChar(explore.targetDatabase);
-    const escapeStringQuoteChar = getEscapeStringQuoteChar(
-        explore.targetDatabase,
-    );
+    const fieldQuoteChar = warehouseClient.getFieldQuoteChar();
+    const stringQuoteChar = warehouseClient.getStringQuoteChar();
+    const escapeStringQuoteChar = warehouseClient.getEscapeStringQuoteChar();
     const sqlFrom = `FROM ${baseTable} AS ${fieldQuoteChar}${explore.baseTable}${fieldQuoteChar}`;
 
     const dimensionSelects = dimensions.map((field) => {

--- a/packages/backend/src/queryCompiler.mock.ts
+++ b/packages/backend/src/queryCompiler.mock.ts
@@ -7,6 +7,7 @@ import {
     MetricQuery,
     MetricType,
     SupportedDbtAdapter,
+    WarehouseClient,
 } from '@lightdash/common';
 import { emptyTable } from './queryBuilder.mock';
 

--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1,4 +1,5 @@
 import { CompiledMetricQuery, CompileError } from '@lightdash/common';
+import { warehouseClientMock } from './queryBuilder.mock';
 import { compileMetricQuery } from './queryCompiler';
 import {
     EXPLORE,
@@ -23,6 +24,7 @@ test('Should compile without table calculations', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_NO_CALCS,
+            warehouseClient: warehouseClientMock,
         }),
     ).toStrictEqual(expected);
 });
@@ -32,6 +34,7 @@ test('Should compile table calculations', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_VALID_REFERENCES,
+            warehouseClient: warehouseClientMock,
         }),
     ).toStrictEqual(METRIC_QUERY_VALID_REFERENCES_COMPILED);
 });
@@ -41,6 +44,7 @@ test('Should throw error when table calculation contains missing reference', () 
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_MISSING_REFERENCE,
+            warehouseClient: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -50,6 +54,7 @@ test('Should throw error when table calculation has invalid reference format', (
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_INVALID_REFERENCE_FORMAT,
+            warehouseClient: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -59,6 +64,7 @@ test('Should throw error when table calculation has duplicate name', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_DUPLICATE_NAME,
+            warehouseClient: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -68,6 +74,7 @@ test('Should compile query with additional metrics', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRICS,
+            warehouseClient: warehouseClientMock,
         }),
     ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRICS_COMPILED);
 });
@@ -77,6 +84,7 @@ test('Should throw compile error if metric in non existent table', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_WITH_INVALID_ADDITIONAL_METRIC,
+            warehouseClient: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -53,7 +53,12 @@ export const compile = async (options: GenerateHandlerOptions) => {
         targetName: options.target,
     });
     const credentials = await warehouseCredentialsFromDbtTarget(target);
-    const warehouseClient = warehouseClientFromCredentials(credentials);
+    const warehouseClient = warehouseClientFromCredentials({
+        ...credentials,
+        startOfWeek: isWeekDay(options.startOfWeek)
+            ? options.startOfWeek
+            : undefined,
+    });
     const manifest = await loadManifest({ targetDir: context.targetDir });
     const models = getModelsFromManifest(manifest);
 
@@ -110,7 +115,7 @@ ${errors.join('')}`),
         false,
         manifest.metadata.adapter_type,
         Object.values(manifest.metrics),
-        isWeekDay(options.startOfWeek) ? options.startOfWeek : undefined,
+        warehouseClient,
     );
     console.error('');
 

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -2,7 +2,30 @@ import { SupportedDbtAdapter } from '../types/dbt';
 import { Explore, Table } from '../types/explore';
 import { DimensionType, FieldType, MetricType, Source } from '../types/field';
 import { FilterOperator } from '../types/filter';
+import { WarehouseClient } from '../types/warehouse';
 import { UncompiledExplore } from './exploreCompiler';
+
+export const warehouseClientMock: WarehouseClient = {
+    getCatalog: async () => ({
+        default: {
+            public: {
+                table: {
+                    id: DimensionType.NUMBER,
+                },
+            },
+        },
+    }),
+    runQuery: () =>
+        Promise.resolve({
+            fields: {},
+            rows: [],
+        }),
+    test: () => Promise.resolve(),
+    getStartOfWeek: () => undefined,
+    getFieldQuoteChar: () => '"',
+    getStringQuoteChar: () => "'",
+    getEscapeStringQuoteChar: () => "'",
+};
 
 const sourceMock: Source = {
     path: '',

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -30,89 +30,111 @@ import {
     joinedExploreOverridingJoinLabel,
     simpleJoinedExplore,
     tablesWithMetricsWithFilters,
+    warehouseClientMock,
 } from './exploreCompiler.mock';
 
 test('Should compile empty table', () => {
-    expect(compileExplore(exploreOneEmptyTable)).toStrictEqual(
-        exploreOneEmptyTableCompiled,
-    );
+    expect(
+        compileExplore(exploreOneEmptyTable, warehouseClientMock),
+    ).toStrictEqual(exploreOneEmptyTableCompiled);
 });
 
 test('Should throw error when missing base table', () => {
-    expect(() => compileExplore(exploreMissingBaseTable)).toThrowError(
-        CompileError,
-    );
+    expect(() =>
+        compileExplore(exploreMissingBaseTable, warehouseClientMock),
+    ).toThrowError(CompileError);
 });
 
 test('Should throw error when missing joined table', () => {
-    expect(() => compileExplore(exploreMissingJoinTable)).toThrowError(
-        CompileError,
-    );
+    expect(() =>
+        compileExplore(exploreMissingJoinTable, warehouseClientMock),
+    ).toThrowError(CompileError);
 });
 
 test('Should throw error when dimension/metric has circular reference', () => {
     expect(() =>
-        compileExplore(exploreCircularDimensionReference),
+        compileExplore(exploreCircularDimensionReference, warehouseClientMock),
     ).toThrowError(CompileError);
     expect(() =>
-        compileExplore(exploreCircularDimensionShortReference),
+        compileExplore(
+            exploreCircularDimensionShortReference,
+            warehouseClientMock,
+        ),
     ).toThrowError(CompileError);
-    expect(() => compileExplore(exploreCircularMetricReference)).toThrowError(
-        CompileError,
-    );
     expect(() =>
-        compileExplore(exploreCircularMetricShortReference),
+        compileExplore(exploreCircularMetricReference, warehouseClientMock),
+    ).toThrowError(CompileError);
+    expect(() =>
+        compileExplore(
+            exploreCircularMetricShortReference,
+            warehouseClientMock,
+        ),
     ).toThrowError(CompileError);
 });
 
 test('Should compile table with TABLE reference', () => {
-    expect(compileExplore(exploreTableSelfReference)).toStrictEqual(
-        exploreTableSelfReferenceCompiled,
-    );
+    expect(
+        compileExplore(exploreTableSelfReference, warehouseClientMock),
+    ).toStrictEqual(exploreTableSelfReferenceCompiled);
 });
 
 test('Should compile table with reference to another dimension', () => {
-    expect(compileExplore(exploreReferenceDimension)).toStrictEqual(
-        exploreReferenceDimensionCompiled,
-    );
+    expect(
+        compileExplore(exploreReferenceDimension, warehouseClientMock),
+    ).toStrictEqual(exploreReferenceDimensionCompiled);
 });
 
 test('Should compile table with nested references in dimensions and metrics', () => {
-    expect(compileExplore(exploreComplexReference)).toStrictEqual(
-        exploreComplexReferenceCompiled,
-    );
+    expect(
+        compileExplore(exploreComplexReference, warehouseClientMock),
+    ).toStrictEqual(exploreComplexReferenceCompiled);
+});
+
+test('Should compile with a reference to a dimension in a joined table', () => {
+    expect(
+        compileExplore(exploreReferenceInJoin, warehouseClientMock),
+    ).toStrictEqual(exploreReferenceInJoinCompiled);
 });
 
 test('Should compile with a reference to a metric in a non-aggregate metric', () => {
-    expect(compileExplore(exploreWithMetricNumber)).toStrictEqual(
-        exploreWithMetricNumberCompiled,
-    );
+    expect(
+        compileExplore(exploreWithMetricNumber, warehouseClientMock),
+    ).toStrictEqual(exploreWithMetricNumberCompiled);
 });
 
 describe('Explores with a base table and joined table', () => {
     test('should compile', () => {
-        expect(compileExplore(simpleJoinedExplore)).toStrictEqual(
-            compiledSimpleJoinedExplore,
-        );
+        expect(
+            compileExplore(simpleJoinedExplore, warehouseClientMock),
+        ).toStrictEqual(compiledSimpleJoinedExplore);
     });
     test('should compile with a reference to a dimension in a joined table', () => {
-        expect(compileExplore(exploreReferenceInJoin)).toStrictEqual(
-            exploreReferenceInJoinCompiled,
-        );
+        expect(
+            compileExplore(exploreReferenceInJoin, warehouseClientMock),
+        ).toStrictEqual(exploreReferenceInJoinCompiled);
     });
     test('should compile with custom label on join', () => {
-        expect(compileExplore(joinedExploreOverridingJoinLabel)).toStrictEqual(
-            compiledJoinedExploreOverridingJoinLabel,
-        );
+        expect(
+            compileExplore(
+                joinedExploreOverridingJoinLabel,
+                warehouseClientMock,
+            ),
+        ).toStrictEqual(compiledJoinedExploreOverridingJoinLabel);
     });
     test('should compile with alias on join', () => {
-        expect(compileExplore(joinedExploreOverridingJoinAlias)).toStrictEqual(
-            compiledJoinedExploreOverridingJoinAlias,
-        );
+        expect(
+            compileExplore(
+                joinedExploreOverridingJoinAlias,
+                warehouseClientMock,
+            ),
+        ).toStrictEqual(compiledJoinedExploreOverridingJoinAlias);
     });
     test('should compile with an alias and custom label on join', () => {
         expect(
-            compileExplore(joinedExploreOverridingAliasAndLabel),
+            compileExplore(
+                joinedExploreOverridingAliasAndLabel,
+                warehouseClientMock,
+            ),
         ).toStrictEqual(compiledJoinedExploreOverridingAliasAndLabel);
     });
 });

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -27,6 +27,7 @@ import {
 } from '../types/field';
 import { parseFilters } from '../types/filterGrammar';
 import { TimeFrames } from '../types/timeFrames';
+import { WarehouseClient } from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     getDefaultTimeFrames,
@@ -420,7 +421,7 @@ export const convertExplores = async (
     loadSources: boolean,
     adapterType: SupportedDbtAdapter,
     metrics: DbtMetric[],
-    startOfWeek?: WeekDay | null,
+    warehouseClient: WarehouseClient,
 ): Promise<(Explore | ExploreError)[]> => {
     const tableLineage = translateDbtModelsToTableLineage(models);
     const [tables, exploreErrors] = models.reduce(
@@ -436,7 +437,7 @@ export const convertExplores = async (
                     adapterType,
                     model,
                     tableMetrics,
-                    startOfWeek,
+                    warehouseClient.getStartOfWeek(),
                 );
 
                 // add sources
@@ -480,20 +481,23 @@ export const convertExplores = async (
     const explores: (Explore | ExploreError)[] = validModels.map((model) => {
         const meta = model.config?.meta || model.meta; // Config block takes priority, then meta block
         try {
-            return compileExplore({
-                name: model.name,
-                label: meta.label || friendlyName(model.name),
-                tags: model.tags || [],
-                baseTable: model.name,
-                joinedTables: (meta?.joins || []).map((join) => ({
-                    table: join.join,
-                    sqlOn: join.sql_on,
-                    alias: join.alias,
-                    label: join.label,
-                })),
-                tables: tableLookup,
-                targetDatabase: adapterType,
-            });
+            return compileExplore(
+                {
+                    name: model.name,
+                    label: meta.label || friendlyName(model.name),
+                    tags: model.tags || [],
+                    baseTable: model.name,
+                    joinedTables: (meta?.joins || []).map((join) => ({
+                        table: join.join,
+                        sqlOn: join.sql_on,
+                        alias: join.alias,
+                        label: join.label,
+                    })),
+                    tables: tableLookup,
+                    targetDatabase: adapterType,
+                },
+                warehouseClient,
+            );
         } catch (e) {
             return {
                 name: model.name,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -83,6 +83,7 @@ export * from './types/space';
 export * from './types/table';
 export * from './types/timeFrames';
 export * from './types/user';
+export * from './types/warehouse';
 export * from './utils/api';
 export { default as assertUnreachable } from './utils/assertUnreachable';
 export * from './utils/conditionalFormatting';

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -1,0 +1,38 @@
+import { WeekDay } from '../utils/timeFrames';
+import { DimensionType } from './field';
+
+export type WarehouseTableSchema = {
+    [column: string]: DimensionType;
+};
+export type WarehouseCatalog = {
+    [database: string]: {
+        [schema: string]: {
+            [table: string]: WarehouseTableSchema;
+        };
+    };
+};
+
+export interface WarehouseClient {
+    getCatalog: (
+        config: {
+            database: string;
+            schema: string;
+            table: string;
+        }[],
+    ) => Promise<WarehouseCatalog>;
+
+    runQuery(sql: string): Promise<{
+        fields: Record<string, { type: DimensionType }>;
+        rows: Record<string, any>[];
+    }>;
+
+    test(): Promise<void>;
+
+    getStartOfWeek(): WeekDay | null | undefined;
+
+    getFieldQuoteChar(): string;
+
+    getStringQuoteChar(): string;
+
+    getEscapeStringQuoteChar(): string;
+}

--- a/packages/warehouses/.eslintrc.js
+++ b/packages/warehouses/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': 'off',
         'no-case-declarations': 'off',
         'import/prefer-default-export': 'off',
+        'class-methods-use-this': 'off',
     },
 };

--- a/packages/warehouses/src/types.ts
+++ b/packages/warehouses/src/types.ts
@@ -1,31 +1,5 @@
-import { DimensionType, WeekDay } from '@lightdash/common';
-
-export type WarehouseTableSchema = {
-    [column: string]: DimensionType;
-};
-export type WarehouseCatalog = {
-    [database: string]: {
-        [schema: string]: {
-            [table: string]: WarehouseTableSchema;
-        };
-    };
-};
-
-export interface WarehouseClient {
-    getCatalog: (
-        config: {
-            database: string;
-            schema: string;
-            table: string;
-        }[],
-    ) => Promise<WarehouseCatalog>;
-
-    runQuery(sql: string): Promise<{
-        fields: Record<string, { type: DimensionType }>;
-        rows: Record<string, any>[];
-    }>;
-
-    test(): Promise<void>;
-
-    getStartOfWeek(): WeekDay | null | undefined;
-}
+export {
+    WarehouseCatalog,
+    WarehouseClient,
+    WarehouseTableSchema,
+} from '@lightdash/common';

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -244,4 +244,16 @@ export class BigqueryWarehouseClient implements WarehouseClient {
             return acc;
         }, {});
     }
+
+    getFieldQuoteChar() {
+        return '`';
+    }
+
+    getStringQuoteChar() {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar() {
+        return '\\';
+    }
 }

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -305,4 +305,16 @@ export class DatabricksWarehouseClient implements WarehouseClient {
             { [catalog]: {} } as WarehouseCatalog,
         );
     }
+
+    getFieldQuoteChar() {
+        return '`';
+    }
+
+    getStringQuoteChar() {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar() {
+        return '\\';
+    }
 }

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -232,6 +232,18 @@ export class PostgresClient implements WarehouseClient {
         );
         return catalog;
     }
+
+    getFieldQuoteChar() {
+        return '"';
+    }
+
+    getStringQuoteChar() {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar() {
+        return "'";
+    }
 }
 
 export class PostgresWarehouseClient

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -257,4 +257,16 @@ export class SnowflakeWarehouseClient implements WarehouseClient {
             return acc;
         }, {});
     }
+
+    getFieldQuoteChar() {
+        return '"';
+    }
+
+    getStringQuoteChar() {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar() {
+        return '\\';
+    }
 }

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -250,4 +250,16 @@ export class TrinoWarehouseClient implements WarehouseClient {
         }
         return catalogToSchema(results);
     }
+
+    getFieldQuoteChar() {
+        return '"';
+    }
+
+    getStringQuoteChar() {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar() {
+        return "'";
+    }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Move the configuration around quote chars to the warehouse client. 
This work is a preparation to convert the explore compiler functions into a class. 

Changes:
- move warehouse client types to common since we need to use it there
- move warehouse config to warehouse clients 
- amend mocks/tests
