### PR TITLE
feat: clicking dashboard chart title redirects to explorer

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -404,6 +404,11 @@ const DashboardChartTile: FC<Props> = (props) => {
                     )
                 }
                 title={savedQueryWithDashboardFilters?.name || ''}
+                titleOnClick={() =>
+                    history.push(
+                        `/projects/${projectUuid}/saved/${savedChartUuid}/`,
+                    )
+                }
                 description={savedQueryWithDashboardFilters?.description}
                 isLoading={isLoading}
                 extraMenuItems={

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -1,4 +1,4 @@
-import { Card, Colors, H5 } from '@blueprintjs/core';
+import { Button, Card, Colors, H5 } from '@blueprintjs/core';
 import styled, { createGlobalStyle } from 'styled-components';
 
 interface HeaderContainerProps {
@@ -114,4 +114,10 @@ export const FilterLabel = styled.p`
     color: ${Colors.GRAY5};
     font-size: 12px;
     font-weight: 500;
+`;
+
+export const TitleButton = styled(Button)`
+    ::selection {
+        background-color: transparent;
+    }
 `;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -8,6 +8,7 @@ import {
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import React, { ReactNode, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { TileModal } from '../TileForms/TileModal';
 import {
     ButtonsWrapper,
@@ -16,6 +17,7 @@ import {
     HeaderWrapper,
     TileBaseWrapper,
     Title,
+    TitleButton,
     TitleWrapper,
     TooltipContent,
 } from './TileBase.styles';
@@ -23,6 +25,7 @@ import {
 type Props<T> = {
     isEditMode: boolean;
     title: string;
+    titleOnClick: () => void;
     description?: string;
     hasDescription: boolean;
     tile: T;
@@ -46,6 +49,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     children,
     extraHeaderElement,
     hasDescription,
+    titleOnClick,
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
     const [isHovering, setIsHovering] = useState(false);
@@ -74,7 +78,11 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             position="bottom-left"
                         >
                             <TitleWrapper hasDescription={true}>
-                                <Title className="non-draggable">{title}</Title>
+                                <TitleButton minimal onClick={titleOnClick}>
+                                    <Title className="non-draggable">
+                                        {title}
+                                    </Title>
+                                </TitleButton>
                             </TitleWrapper>
                         </Tooltip2>
                     ) : !hideTitle ? (


### PR DESCRIPTION
Closes: [#4030](https://github.com/lightdash/lightdash/issues/4030)

### Description

Adding interactivity to the title.
Currently, the only way to get to a chart is by using either `explore from here` or `edit chart`.

- [ ] when you click on a chart dashboard tile title you should be redirected to the chart in `view` mode

### What problem does this solve?

Bad UX 