### PR TITLE
fix: force no public cache on index.html

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -191,12 +191,18 @@ app.use(
 // frontend static files - no cache
 app.use(
     express.static(path.join(__dirname, '../../frontend/build'), {
-        maxAge: 0,
+        setHeaders: () => ({
+            // private - browsers can cache but not CDNs
+            // no-cache - caches must revalidate with the origin server before using a cached copy
+            'Cache-Control': 'no-cache, private',
+        }),
     }),
 );
 
 app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '../../frontend/build', 'index.html'));
+    res.sendFile(path.join(__dirname, '../../frontend/build', 'index.html'), {
+        headers: { 'Cache-Control': 'no-cache, private' },
+    });
 });
 
 // errors


### PR DESCRIPTION
Fixing headers for index.html

Use `no-cache` to make sure every request checks for a new version of `index.html`. To be safe I'm also adding `private` which turns off public caching entirely (e.g. CDNs) but allows browsers to continue caching. In future for performance we may want to replace `private` with `public`. But in this case I'll take the performance hit to prevent errors loading `.js` assets in production behind a CDN

```
// private - browsers can cache but not CDNs
// no-cache - caches must revalidate with the origin server before using a cached copy
```