### PR TITLE
feat: chart with empty x axis

### DIFF
--- a/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -8,6 +8,7 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
+import { EMPTY_X_AXIS } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import SimpleButton from '../common/SimpleButton';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
@@ -128,15 +129,32 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
                         onClick={() => setFlipAxis(!dirtyLayout?.flipAxes)}
                     />
                 </AxisTitleWrapper>
-                <AxisFieldDropdown>
-                    <FieldAutoComplete
-                        fields={items}
-                        activeField={xAxisField}
-                        onChange={(item) => {
-                            setXField(getItemId(item));
-                        }}
-                    />
-                </AxisFieldDropdown>
+                {dirtyLayout?.xField === EMPTY_X_AXIS ? (
+                    <Button
+                        minimal
+                        intent="primary"
+                        onClick={() => setXField(getItemId(items[0]))}
+                    >
+                        + Add
+                    </Button>
+                ) : (
+                    <AxisFieldDropdown>
+                        <FieldAutoComplete
+                            fields={items}
+                            activeField={xAxisField}
+                            onChange={(item) => {
+                                setXField(getItemId(item));
+                            }}
+                        />
+                        <DeleteFieldButton
+                            minimal
+                            icon="cross"
+                            onClick={() => {
+                                setXField(EMPTY_X_AXIS);
+                            }}
+                        />
+                    </AxisFieldDropdown>
+                )}
             </AxisGroup>
             <AxisGroup>
                 <AxisTitle>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -24,6 +24,8 @@ import {
     sortDimensions,
 } from './utils';
 
+export const EMPTY_X_AXIS = 'empty_x_axis';
+
 type Args = {
     chartType: ChartType;
     initialChartConfig: CartesianChart | undefined;
@@ -381,7 +383,8 @@ const useCartesianChartConfig = ({
         if (availableFields.length > 0 && chartType === ChartType.CARTESIAN) {
             setDirtyLayout((prev) => {
                 const isCurrentXFieldValid: boolean =
-                    !!prev?.xField && availableFields.includes(prev.xField);
+                    prev?.xField === EMPTY_X_AXIS ||
+                    (!!prev?.xField && availableFields.includes(prev.xField));
                 const currentValidYFields = prev?.yField
                     ? prev.yField.filter((y) => availableFields.includes(y))
                     : [];

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -38,8 +38,8 @@ import toNumber from 'lodash-es/toNumber';
 import moment from 'moment';
 import { useMemo } from 'react';
 import { defaultGrid } from '../../components/ChartConfigPanel/Grid';
-import { SeriesExtraInputWrapper } from '../../components/ChartConfigPanel/Series/Series.styles';
 import { useVisualizationContext } from '../../components/LightdashVisualization/VisualizationProvider';
+import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
 import { useOrganisation } from '../organisation/useOrganisation';
 import usePlottedData from '../plottedData/usePlottedData';
 
@@ -102,9 +102,12 @@ const getAxisType = ({
     const topAxisType = getAxisTypeFromField(
         topAxisXId ? itemMap[topAxisXId] : undefined,
     );
-    const bottomAxisType = getAxisTypeFromField(
-        bottomAxisXId ? itemMap[bottomAxisXId] : undefined,
-    );
+    const bottomAxisType =
+        bottomAxisXId === EMPTY_X_AXIS
+            ? 'category'
+            : getAxisTypeFromField(
+                  bottomAxisXId ? itemMap[bottomAxisXId] : undefined,
+              );
     // horizontal bar chart needs the type 'category' in the left/right axis
     const defaultRightAxisType = getAxisTypeFromField(
         rightAxisYId ? itemMap[rightAxisYId] : undefined,
@@ -1211,7 +1214,13 @@ const useEcharts = () => {
             },
             dataset: {
                 id: 'lightdashResults',
-                source: getResultValues(rows, true),
+                source:
+                    validCartesianConfig?.layout?.xField === EMPTY_X_AXIS
+                        ? getResultValues(rows, true).map((s) => ({
+                              ...s,
+                              [EMPTY_X_AXIS]: ' ',
+                          }))
+                        : getResultValues(rows, true),
             },
             tooltip: {
                 show: true,
@@ -1241,7 +1250,6 @@ const useEcharts = () => {
     ) {
         return undefined;
     }
-
     return eChartsOptions;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3553

### Description:

I tried to implement this with minimal changes and side effects , so instead of setting `xField` to undefined, I'm giving it an special state that I can check when setting `category` axis and values. 

[Screencast from 25-01-23 16:15:43.webm](https://user-images.githubusercontent.com/1983672/214601997-8e500f24-faac-4480-b9d4-317031ca1fa4.webm)

Also works with groups

![Screenshot from 2023-01-25 16-16-29](https://user-images.githubusercontent.com/1983672/214602051-9f558c81-95b9-4bc5-9560-2aade327391e.png)


