### PR TITLE
feat: groups are collapsable in explorer sidebar even when a field is…

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,4 +1,4 @@
-import { Collapse, Colors, Text } from '@blueprintjs/core';
+import { Collapse, Colors, Intent, Tag, Text } from '@blueprintjs/core';
 import { hasIntersection } from '@lightdash/common';
 import { FC } from 'react';
 import { useToggle } from 'react-use';
@@ -26,6 +26,7 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
         allChildrenKeys,
         Array.from(selectedItems),
     );
+
     const hasVisibleChildren =
         !isSearching ||
         hasIntersection(allChildrenKeys, Array.from(searchResults));
@@ -53,6 +54,17 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
                         highlightElement={Highlighted}
                     />
                 </Text>
+                {!isOpen && hasSelectedChildren && (
+                    <Tag
+                        round
+                        minimal
+                        intent={Intent.PRIMARY}
+                        style={{ marginLeft: '10px' }}
+                    >
+                        {Array.from(selectedItems).length -
+                            allChildrenKeys.length}
+                    </Tag>
+                )}
             </Row>
 
             <Collapse isOpen={isOpen || forceOpen}>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -35,7 +35,6 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
         !isSearching ||
         hasIntersection(allChildrenKeys, Array.from(searchResults));
     const forceOpen = isSearching && hasVisibleChildren;
-    const isDisabled = forceOpen;
 
     if (!hasVisibleChildren) {
         return null;
@@ -43,13 +42,12 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
 
     return (
         <>
-            <Row depth={depth} onClick={isDisabled ? undefined : toggle}>
+            <Row depth={depth} onClick={toggle}>
                 <RowIcon
                     icon={
                         isOpen || forceOpen ? 'chevron-down' : 'chevron-right'
                     }
                     size={16}
-                    color={isDisabled ? Colors.LIGHT_GRAY1 : undefined}
                 />
                 <Text ellipsize>
                     <HighlightedText

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,6 +1,6 @@
 import { Collapse, Colors, Text } from '@blueprintjs/core';
 import { hasIntersection } from '@lightdash/common';
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 import { useToggle } from 'react-use';
 import HighlightedText from '../../../../common/HighlightedText';
 import { Highlighted, Row, RowIcon } from '../TableTree.styles';
@@ -30,13 +30,7 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
         !isSearching ||
         hasIntersection(allChildrenKeys, Array.from(searchResults));
     const forceOpen = isSearching && hasVisibleChildren;
-    const isDisabled = hasSelectedChildren || forceOpen;
-
-    useEffect(() => {
-        if (hasSelectedChildren) {
-            toggle(true);
-        }
-    }, [hasSelectedChildren, toggle]);
+    const isDisabled = forceOpen;
 
     if (!hasVisibleChildren) {
         return null;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -1,5 +1,6 @@
 import { Collapse, Colors, Intent, Tag, Text } from '@blueprintjs/core';
 import { hasIntersection } from '@lightdash/common';
+import { intersectionBy } from 'lodash-es';
 import { FC } from 'react';
 import { useToggle } from 'react-use';
 import HighlightedText from '../../../../common/HighlightedText';
@@ -26,7 +27,10 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
         allChildrenKeys,
         Array.from(selectedItems),
     );
-
+    const selectedChildrenCount = intersectionBy(
+        allChildrenKeys,
+        Array.from(selectedItems),
+    ).length;
     const hasVisibleChildren =
         !isSearching ||
         hasIntersection(allChildrenKeys, Array.from(searchResults));
@@ -61,8 +65,7 @@ const TreeGroupNode: FC<{ node: GroupNode; depth: number }> = ({
                         intent={Intent.PRIMARY}
                         style={{ marginLeft: '10px' }}
                     >
-                        {Array.from(selectedItems).length -
-                            allChildrenKeys.length}
+                        {selectedChildrenCount}
                     </Tag>
                 )}
             </Row>


### PR DESCRIPTION
Closes: #4210 

### Description

In the Explore sidebar, when you select a field from the toggle list, the toggle list can no longer be collapsed. This is a bit annoying if you have really wide tables with loads of dimensions. 

<img width="367" alt="Screenshot 2023-01-18 at 17 00 22" src="https://user-images.githubusercontent.com/12776522/213249932-f9a7d74e-93e7-4f47-a6a5-13c2c66e77f2.png">

- [x] I can collapse the group even if there is a selected field in the group
- [x] I can see a tag with the number of selected fields near the group label when the group is **collapsed**