### PR TITLE
feat: support join fields

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -779,6 +779,43 @@ export const compiledJoinedExploreOverridingAliasAndLabel: Explore = {
     },
 };
 
+export const joinedExploreWithSubsetOfFields: UncompiledExplore = {
+    ...exploreReferenceInJoin,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${b.dim1}',
+            fields: ['dim1'],
+        },
+    ],
+};
+
+export const joinedExploreWithSubsetOfFieldsCausingError: UncompiledExplore = {
+    ...exploreReferenceInJoin,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${b.dim1}',
+            fields: ['dim2'], // not possible because it dim1 is also needed for the join sql
+        },
+    ],
+};
+
+export const compiledJoinedExploreWithSubsetOfFields: Explore = {
+    ...exploreReferenceInJoinCompiled,
+    tables: {
+        ...exploreReferenceInJoinCompiled.tables,
+        b: {
+            ...exploreReferenceInJoinCompiled.tables.b,
+            dimensions: {
+                dim1: {
+                    ...exploreReferenceInJoinCompiled.tables.b.dimensions.dim1,
+                },
+            },
+        },
+    },
+};
+
 export const exploreWithMetricNumber: UncompiledExplore = {
     ...exploreBase,
     tables: {

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -6,6 +6,7 @@ import {
     compiledJoinedExploreOverridingAliasAndLabel,
     compiledJoinedExploreOverridingJoinAlias,
     compiledJoinedExploreOverridingJoinLabel,
+    compiledJoinedExploreWithSubsetOfFields,
     compiledSimpleJoinedExplore,
     exploreCircularDimensionReference,
     exploreCircularDimensionShortReference,
@@ -28,6 +29,8 @@ import {
     joinedExploreOverridingAliasAndLabel,
     joinedExploreOverridingJoinAlias,
     joinedExploreOverridingJoinLabel,
+    joinedExploreWithSubsetOfFields,
+    joinedExploreWithSubsetOfFieldsCausingError,
     simpleJoinedExplore,
     tablesWithMetricsWithFilters,
     warehouseClientMock,
@@ -136,6 +139,22 @@ describe('Explores with a base table and joined table', () => {
                 warehouseClientMock,
             ),
         ).toStrictEqual(compiledJoinedExploreOverridingAliasAndLabel);
+    });
+    test('should compile with a subset of fields selected on join', () => {
+        expect(
+            compileExplore(
+                joinedExploreWithSubsetOfFields,
+                warehouseClientMock,
+            ),
+        ).toStrictEqual(compiledJoinedExploreWithSubsetOfFields);
+    });
+    test('should throw error if referenced field is removed from join', () => {
+        expect(() =>
+            compileExplore(
+                joinedExploreWithSubsetOfFieldsCausingError,
+                warehouseClientMock,
+            ),
+        ).toThrowError(CompileError);
     });
 });
 

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -502,32 +502,42 @@ export const compileExplore = (
                     ...tables[join.table],
                     name: joinTableName,
                     label: joinTableLabel,
-                    dimensions: Object.keys(
-                        tables[join.table].dimensions,
-                    ).reduce<Record<string, Dimension>>(
-                        (prevDimensions, dimensionKey) => ({
-                            ...prevDimensions,
-                            [dimensionKey]: {
-                                ...tables[join.table].dimensions[dimensionKey],
-                                table: joinTableName,
-                                tableLabel: joinTableLabel,
-                            },
-                        }),
-                        {},
-                    ),
-                    metrics: Object.keys(tables[join.table].metrics).reduce<
-                        Record<string, Metric>
-                    >(
-                        (prevMetrics, metricKey) => ({
-                            ...prevMetrics,
-                            [metricKey]: {
-                                ...tables[join.table].metrics[metricKey],
-                                table: joinTableName,
-                                tableLabel: joinTableLabel,
-                            },
-                        }),
-                        {},
-                    ),
+                    dimensions: Object.keys(tables[join.table].dimensions)
+                        .filter(
+                            (d) =>
+                                join.fields === undefined ||
+                                join.fields.includes(d),
+                        )
+                        .reduce<Record<string, Dimension>>(
+                            (prevDimensions, dimensionKey) => ({
+                                ...prevDimensions,
+                                [dimensionKey]: {
+                                    ...tables[join.table].dimensions[
+                                        dimensionKey
+                                    ],
+                                    table: joinTableName,
+                                    tableLabel: joinTableLabel,
+                                },
+                            }),
+                            {},
+                        ),
+                    metrics: Object.keys(tables[join.table].metrics)
+                        .filter(
+                            (d) =>
+                                join.fields === undefined ||
+                                join.fields.includes(d),
+                        )
+                        .reduce<Record<string, Metric>>(
+                            (prevMetrics, metricKey) => ({
+                                ...prevMetrics,
+                                [metricKey]: {
+                                    ...tables[join.table].metrics[metricKey],
+                                    table: joinTableName,
+                                    tableLabel: joinTableLabel,
+                                },
+                            }),
+                            {},
+                        ),
                 },
             };
         },

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -492,6 +492,7 @@ export const convertExplores = async (
                         sqlOn: join.sql_on,
                         alias: join.alias,
                         label: join.label,
+                        fields: join.fields,
                     })),
                     tables: tableLookup,
                     targetDatabase: adapterType,

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -59,6 +59,8 @@ type DbtModelJoin = {
     sql_on: string;
     alias?: string;
     label?: string;
+
+    fields?: string[];
 };
 type DbtColumnMetadata = DbtColumnLightdashConfig & {};
 type DbtColumnLightdashConfig = {

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -13,6 +13,8 @@ export type ExploreJoin = {
     sqlOn: string; // Built sql
     alias?: string; // Optional alias for the joined tableName
     label?: string; // Optional UI label override for the underlying table
+
+    fields?: string[]; // Optional list of fields to include from the joined table
 };
 
 export type CompiledExploreJoin = Pick<ExploreJoin, 'table' | 'sqlOn'> & {


### PR DESCRIPTION
Closes: #2009

Allows the user to specify a subset of fields (dimensions/metrics) to pull through on a joined model. This must include the join key to successfully compile the join sql.
