### PR TITLE
fix: hover state for clickable dashboard chart titles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -397,6 +397,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                     )
                 }
                 title={savedQueryWithDashboardFilters?.name || ''}
+                clickableTitle={true}
                 titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
                 description={savedQueryWithDashboardFilters?.description}
                 isLoading={isLoading}

--- a/packages/frontend/src/components/DashboardTiles/DashboardLoomTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardLoomTile.tsx
@@ -15,7 +15,7 @@ const LoomTile: FC<Props> = (props) => {
         },
     } = props;
     return (
-        <TileBase title={title} {...props}>
+        <TileBase title={title} clickableTitle={false} {...props}>
             <iframe
                 title={title}
                 className="non-draggable"

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -16,7 +16,7 @@ const MarkdownTile: FC<Props> = (props) => {
         },
     } = props;
     return (
-        <TileBase title={title} {...props}>
+        <TileBase title={title} clickableTitle={false} {...props}>
             <MarkdownWrapper className="non-draggable">
                 <MDEditor.Markdown source={content} linkTarget="_blank" />
             </MarkdownWrapper>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -118,6 +118,7 @@ export const FilterLabel = styled.p`
 
 export const TitleButton = styled.a`
     :hover {
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-color: ${Colors.GRAY5};
     }
 `;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -24,7 +24,8 @@ import {
 type Props<T> = {
     isEditMode: boolean;
     title: string;
-    titleHref: string;
+    clickableTitle: boolean;
+    titleHref?: string;
     description?: string;
     hasDescription: boolean;
     tile: T;
@@ -48,6 +49,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     children,
     extraHeaderElement,
     hasDescription,
+    clickableTitle,
     titleHref,
 }: Props<T>) => {
     const [isEditing, setIsEditing] = useState(false);
@@ -69,7 +71,28 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 onMouseLeave={() => setIsHovering(false)}
             >
                 <HeaderWrapper>
-                    {!hideTitle && description ? (
+                    {!hideTitle && description && clickableTitle ? (
+                        <Tooltip2
+                            content={
+                                <TooltipContent>{description}</TooltipContent>
+                            }
+                            position="bottom-left"
+                        >
+                            <TitleButton href={titleHref} target="_blank">
+                                <TitleWrapper hasDescription={hasDescription}>
+                                    <Title className="non-draggable">
+                                        {title}
+                                    </Title>
+                                </TitleWrapper>
+                            </TitleButton>
+                        </Tooltip2>
+                    ) : !hideTitle && clickableTitle ? (
+                        <TitleButton href={titleHref} target="_blank">
+                            <TitleWrapper hasDescription={hasDescription}>
+                                <Title className="non-draggable">{title}</Title>
+                            </TitleWrapper>
+                        </TitleButton>
+                    ) : !hideTitle && description ? (
                         <Tooltip2
                             content={
                                 <TooltipContent>{description}</TooltipContent>
@@ -77,19 +100,13 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             position="bottom-left"
                         >
                             <TitleWrapper hasDescription={true}>
-                                <TitleButton href={titleHref} target="_blank">
-                                    <Title className="non-draggable">
-                                        {title}
-                                    </Title>
-                                </TitleButton>
+                                <Title className="non-draggable">{title}</Title>
                             </TitleWrapper>
                         </Tooltip2>
                     ) : !hideTitle ? (
-                        <TitleButton href={titleHref} target="_blank">
-                            <TitleWrapper hasDescription={hasDescription}>
-                                <Title className="non-draggable">{title}</Title>
-                            </TitleWrapper>
-                        </TitleButton>
+                        <TitleWrapper hasDescription={hasDescription}>
+                            <Title className="non-draggable">{title}</Title>
+                        </TitleWrapper>
                     ) : null}
                 </HeaderWrapper>
                 <ButtonsWrapper>


### PR DESCRIPTION
Closes: #4275 #4274

### Description

- [x] Add a clearer hover state to clickable titles (underlined)
- [x] Remove hover state over tiles with titles that are not clickable (looms and markdowns)