### PR TITLE
fix: upgrade knex from 2.4.0 to 2.4.2

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -52,7 +52,7 @@
         "graphql": "^16.6.0",
         "graphql-request": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "knex": "^2.4.0",
+        "knex": "^2.4.2",
         "moment": "^2.29.4",
         "morgan": "^1.10.0",
         "nanoid": "^3.1.31",

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -635,30 +635,25 @@ export class DashboardModel {
         dashboards: UpdateMultipleDashboards[],
     ): Promise<Dashboard[]> {
         await this.database.transaction(async (trx) => {
-            try {
-                await Promise.all(
-                    dashboards.map(async (dashboard) => {
-                        const withSpaceId = dashboard.spaceUuid
-                            ? {
-                                  space_id: await getSpaceId(
-                                      this.database,
-                                      dashboard.spaceUuid,
-                                  ),
-                              }
-                            : {};
-                        await trx(DashboardsTableName)
-                            .update({
-                                name: dashboard.name,
-                                description: dashboard.description,
-                                ...withSpaceId,
-                            })
-                            .where('dashboard_uuid', dashboard.uuid);
-                    }),
-                );
-            } catch (e) {
-                trx.rollback(e);
-                throw e;
-            }
+            await Promise.all(
+                dashboards.map(async (dashboard) => {
+                    const withSpaceId = dashboard.spaceUuid
+                        ? {
+                              space_id: await getSpaceId(
+                                  this.database,
+                                  dashboard.spaceUuid,
+                              ),
+                          }
+                        : {};
+                    await trx(DashboardsTableName)
+                        .update({
+                            name: dashboard.name,
+                            description: dashboard.description,
+                            ...withSpaceId,
+                        })
+                        .where('dashboard_uuid', dashboard.uuid);
+                }),
+            );
         });
 
         return Promise.all(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -197,84 +197,68 @@ export class ProjectModel {
             throw new NotExistsError('Cannot find organization');
         }
         return this.database.transaction(async (trx) => {
+            let encryptedCredentials: Buffer;
             try {
-                let encryptedCredentials: Buffer;
-                try {
-                    encryptedCredentials = this.encryptionService.encrypt(
-                        JSON.stringify(data.dbtConnection),
-                    );
-                } catch (e) {
-                    throw new UnexpectedServerError(
-                        'Could not save credentials.',
-                    );
-                }
-                const [project] = await trx('projects')
-                    .insert({
-                        name: data.name,
-                        project_type: data.type,
-                        organization_id: orgs[0].organization_id,
-                        dbt_connection_type: data.dbtConnection.type,
-                        dbt_connection: encryptedCredentials,
-                    })
-                    .returning('*');
-
-                await this.upsertWarehouseConnection(
-                    trx,
-                    project.project_id,
-                    data.warehouseConnection,
+                encryptedCredentials = this.encryptionService.encrypt(
+                    JSON.stringify(data.dbtConnection),
                 );
-
-                await trx('spaces').insert({
-                    project_id: project.project_id,
-                    name: 'Shared',
-                    is_private: false,
-                });
-
-                return project.project_uuid;
             } catch (e) {
-                await trx.rollback(e);
-                throw e;
+                throw new UnexpectedServerError('Could not save credentials.');
             }
+            const [project] = await trx('projects')
+                .insert({
+                    name: data.name,
+                    project_type: data.type,
+                    organization_id: orgs[0].organization_id,
+                    dbt_connection_type: data.dbtConnection.type,
+                    dbt_connection: encryptedCredentials,
+                })
+                .returning('*');
+
+            await this.upsertWarehouseConnection(
+                trx,
+                project.project_id,
+                data.warehouseConnection,
+            );
+
+            await trx('spaces').insert({
+                project_id: project.project_id,
+                name: 'Shared',
+                is_private: false,
+            });
+
+            return project.project_uuid;
         });
     }
 
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
         await this.database.transaction(async (trx) => {
+            let encryptedCredentials: Buffer;
             try {
-                let encryptedCredentials: Buffer;
-                try {
-                    encryptedCredentials = this.encryptionService.encrypt(
-                        JSON.stringify(data.dbtConnection),
-                    );
-                } catch (e) {
-                    throw new UnexpectedServerError(
-                        'Could not save credentials.',
-                    );
-                }
-                const projects = await trx('projects')
-                    .update({
-                        name: data.name,
-                        dbt_connection_type: data.dbtConnection.type,
-                        dbt_connection: encryptedCredentials,
-                    })
-                    .where('project_uuid', projectUuid)
-                    .returning('*');
-                if (projects.length === 0) {
-                    throw new UnexpectedServerError(
-                        'Could not update project.',
-                    );
-                }
-                const [project] = projects;
-
-                await this.upsertWarehouseConnection(
-                    trx,
-                    project.project_id,
-                    data.warehouseConnection,
+                encryptedCredentials = this.encryptionService.encrypt(
+                    JSON.stringify(data.dbtConnection),
                 );
             } catch (e) {
-                await trx.rollback(e);
-                throw e;
+                throw new UnexpectedServerError('Could not save credentials.');
             }
+            const projects = await trx('projects')
+                .update({
+                    name: data.name,
+                    dbt_connection_type: data.dbtConnection.type,
+                    dbt_connection: encryptedCredentials,
+                })
+                .where('project_uuid', projectUuid)
+                .returning('*');
+            if (projects.length === 0) {
+                throw new UnexpectedServerError('Could not update project.');
+            }
+            const [project] = projects;
+
+            await this.upsertWarehouseConnection(
+                trx,
+                project.project_id,
+                data.warehouseConnection,
+            );
         });
     }
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -115,96 +115,84 @@ const createSavedChartVersion = async (
     }: CreateSavedChartVersion,
 ): Promise<void> => {
     await db.transaction(async (trx) => {
-        try {
-            const [version] = await trx('saved_queries_versions')
-                .insert({
-                    row_limit: limit,
-                    filters: JSON.stringify(filters),
-                    explore_name: tableName,
-                    saved_query_id: savedChartId,
-                    pivot_dimensions: pivotConfig
-                        ? pivotConfig.columns
-                        : undefined,
-                    chart_type: chartConfig.type,
-                    chart_config: chartConfig.config,
-                    updated_by_user_uuid: updatedByUser?.userUuid,
-                })
-                .returning('*');
-            const promises: Promise<any>[] = [];
-            dimensions.forEach((dimension) => {
-                promises.push(
-                    createSavedChartVersionField(trx, {
-                        name: dimension,
-                        field_type: DBFieldTypes.DIMENSION,
-                        saved_queries_version_id:
-                            version.saved_queries_version_id,
-                        order: tableConfig.columnOrder.findIndex(
-                            (column) => column === dimension,
-                        ),
-                    }),
-                );
-            });
-            metrics.forEach((metric) => {
-                promises.push(
-                    createSavedChartVersionField(trx, {
-                        name: metric,
-                        field_type: DBFieldTypes.METRIC,
-                        saved_queries_version_id:
-                            version.saved_queries_version_id,
-                        order: tableConfig.columnOrder.findIndex(
-                            (column) => column === metric,
-                        ),
-                    }),
-                );
-            });
-            sorts.forEach((sort, index) => {
-                promises.push(
-                    createSavedChartVersionSort(trx, {
-                        field_name: sort.fieldId,
-                        descending: sort.descending,
-                        saved_queries_version_id:
-                            version.saved_queries_version_id,
-                        order: index,
-                    }),
-                );
-            });
-            tableCalculations.forEach((tableCalculation) => {
-                promises.push(
-                    createSavedChartVersionTableCalculation(trx, {
-                        name: tableCalculation.name,
-                        display_name: tableCalculation.displayName,
-                        calculation_raw_sql: tableCalculation.sql,
-                        saved_queries_version_id:
-                            version.saved_queries_version_id,
-                        order: tableConfig.columnOrder.findIndex(
-                            (column) => column === tableCalculation.name,
-                        ),
-                    }),
-                );
-            });
-            additionalMetrics?.forEach((additionalMetric) => {
-                promises.push(
-                    createSavedChartVersionAdditionalMetrics(trx, {
-                        table: additionalMetric.table,
-                        name: additionalMetric.name,
-                        type: additionalMetric.type,
-                        label: additionalMetric.label,
-                        description: additionalMetric.description,
-                        sql: additionalMetric.sql,
-                        hidden: additionalMetric.hidden,
-                        compact: additionalMetric.compact,
-                        round: additionalMetric.round,
-                        format: additionalMetric.format,
-                        saved_queries_version_id:
-                            version.saved_queries_version_id,
-                    }),
-                );
-            });
-            await Promise.all(promises);
-        } catch (e) {
-            await trx.rollback(e);
-            throw e;
-        }
+        const [version] = await trx('saved_queries_versions')
+            .insert({
+                row_limit: limit,
+                filters: JSON.stringify(filters),
+                explore_name: tableName,
+                saved_query_id: savedChartId,
+                pivot_dimensions: pivotConfig ? pivotConfig.columns : undefined,
+                chart_type: chartConfig.type,
+                chart_config: chartConfig.config,
+                updated_by_user_uuid: updatedByUser?.userUuid,
+            })
+            .returning('*');
+        const promises: Promise<any>[] = [];
+        dimensions.forEach((dimension) => {
+            promises.push(
+                createSavedChartVersionField(trx, {
+                    name: dimension,
+                    field_type: DBFieldTypes.DIMENSION,
+                    saved_queries_version_id: version.saved_queries_version_id,
+                    order: tableConfig.columnOrder.findIndex(
+                        (column) => column === dimension,
+                    ),
+                }),
+            );
+        });
+        metrics.forEach((metric) => {
+            promises.push(
+                createSavedChartVersionField(trx, {
+                    name: metric,
+                    field_type: DBFieldTypes.METRIC,
+                    saved_queries_version_id: version.saved_queries_version_id,
+                    order: tableConfig.columnOrder.findIndex(
+                        (column) => column === metric,
+                    ),
+                }),
+            );
+        });
+        sorts.forEach((sort, index) => {
+            promises.push(
+                createSavedChartVersionSort(trx, {
+                    field_name: sort.fieldId,
+                    descending: sort.descending,
+                    saved_queries_version_id: version.saved_queries_version_id,
+                    order: index,
+                }),
+            );
+        });
+        tableCalculations.forEach((tableCalculation) => {
+            promises.push(
+                createSavedChartVersionTableCalculation(trx, {
+                    name: tableCalculation.name,
+                    display_name: tableCalculation.displayName,
+                    calculation_raw_sql: tableCalculation.sql,
+                    saved_queries_version_id: version.saved_queries_version_id,
+                    order: tableConfig.columnOrder.findIndex(
+                        (column) => column === tableCalculation.name,
+                    ),
+                }),
+            );
+        });
+        additionalMetrics?.forEach((additionalMetric) => {
+            promises.push(
+                createSavedChartVersionAdditionalMetrics(trx, {
+                    table: additionalMetric.table,
+                    name: additionalMetric.name,
+                    type: additionalMetric.type,
+                    label: additionalMetric.label,
+                    description: additionalMetric.description,
+                    sql: additionalMetric.sql,
+                    hidden: additionalMetric.hidden,
+                    compact: additionalMetric.compact,
+                    round: additionalMetric.round,
+                    format: additionalMetric.format,
+                    saved_queries_version_id: version.saved_queries_version_id,
+                }),
+            );
+        });
+        await Promise.all(promises);
     });
 };
 
@@ -235,30 +223,25 @@ export class SavedChartModel {
     ): Promise<SavedChart> {
         const newSavedChartUuid = await this.database.transaction(
             async (trx) => {
-                try {
-                    const spaceId = spaceUuid
-                        ? await getSpaceId(trx, spaceUuid)
-                        : (await getSpace(trx, projectUuid)).space_id;
-                    const [newSavedChart] = await trx('saved_queries')
-                        .insert({ name, space_id: spaceId, description })
-                        .returning('*');
-                    await createSavedChartVersion(
-                        trx,
-                        newSavedChart.saved_query_id,
-                        {
-                            tableName,
-                            metricQuery,
-                            chartConfig,
-                            tableConfig,
-                            pivotConfig,
-                            updatedByUser,
-                        },
-                    );
-                    return newSavedChart.saved_query_uuid;
-                } catch (e) {
-                    await trx.rollback(e);
-                    throw e;
-                }
+                const spaceId = spaceUuid
+                    ? await getSpaceId(trx, spaceUuid)
+                    : (await getSpace(trx, projectUuid)).space_id;
+                const [newSavedChart] = await trx('saved_queries')
+                    .insert({ name, space_id: spaceId, description })
+                    .returning('*');
+                await createSavedChartVersion(
+                    trx,
+                    newSavedChart.saved_query_id,
+                    {
+                        tableName,
+                        metricQuery,
+                        chartConfig,
+                        tableConfig,
+                        pivotConfig,
+                        updatedByUser,
+                    },
+                );
+                return newSavedChart.saved_query_uuid;
             },
         );
         return this.get(newSavedChartUuid);
@@ -270,19 +253,14 @@ export class SavedChartModel {
         user: SessionUser,
     ): Promise<SavedChart> {
         await this.database.transaction(async (trx) => {
-            try {
-                const [savedChart] = await trx('saved_queries')
-                    .select(['saved_query_id'])
-                    .where('saved_query_uuid', savedChartUuid);
+            const [savedChart] = await trx('saved_queries')
+                .select(['saved_query_id'])
+                .where('saved_query_uuid', savedChartUuid);
 
-                await createSavedChartVersion(trx, savedChart.saved_query_id, {
-                    ...data,
-                    updatedByUser: user,
-                });
-            } catch (e) {
-                trx.rollback(e);
-                throw e;
-            }
+            await createSavedChartVersion(trx, savedChart.saved_query_id, {
+                ...data,
+                updatedByUser: user,
+            });
         });
         return this.get(savedChartUuid);
     }
@@ -305,24 +283,16 @@ export class SavedChartModel {
         data: UpdateMultipleSavedChart[],
     ): Promise<SavedChart[]> {
         await this.database.transaction(async (trx) => {
-            try {
-                const promises = data.map(async (savedChart) =>
-                    trx('saved_queries')
-                        .update({
-                            name: savedChart.name,
-                            description: savedChart.description,
-                            space_id: await getSpaceId(
-                                trx,
-                                savedChart.spaceUuid,
-                            ),
-                        })
-                        .where('saved_query_uuid', savedChart.uuid),
-                );
-                await Promise.all(promises);
-            } catch (e) {
-                trx.rollback(e);
-                throw e;
-            }
+            const promises = data.map(async (savedChart) =>
+                trx('saved_queries')
+                    .update({
+                        name: savedChart.name,
+                        description: savedChart.description,
+                        space_id: await getSpaceId(trx, savedChart.spaceUuid),
+                    })
+                    .where('saved_query_uuid', savedChart.uuid),
+            );
+            await Promise.all(promises);
         });
         return Promise.all(
             data.map(async (savedChart) => this.get(savedChart.uuid)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,10 +9271,10 @@ knex@^0.21.5:
     tildify "2.0.0"
     v8flags "^3.2.0"
 
-knex@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-2.4.0.tgz#7d33cc36f320cdac98741010544b4c6a98b8b19e"
-  integrity sha512-i0GWwqYp1Hs2yvc2rlDO6nzzkLhwdyOZKRdsMTB8ZxOs2IXQyL5rBjSbS1krowCh6V65T4X9CJaKtuIfkaPGSA==
+knex@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-2.4.2.tgz#a34a289d38406dc19a0447a78eeaf2d16ebedd61"
+  integrity sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==
   dependencies:
     colorette "2.0.19"
     commander "^9.1.0"


### PR DESCRIPTION
Also fixes new warnings with double rollbacks in transaction blocks

2.4.0 contains a bug when inserting arrays: https://github.com/knex/knex/issues/5365

### Reviewing

The diff looks big but I've only made two changes:

 - upgrading to 2.4.2
 - Removing the `try {} except {trx.rollback(e); throw e;}` from a bunch of transacting blocks