### PR TITLE
fix: Add Snowflake private key credentials to sensitive credentials list

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -596,6 +596,8 @@ export const sensitiveCredentialsFieldNames = [
     'password',
     'keyfileContents',
     'personalAccessToken',
+    'privateKey',
+    'privateKeyPass',
 ] as const;
 
 export const sensitiveDbtCredentialsFieldNames = [


### PR DESCRIPTION


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4234 
### Description:
`privateKey` and `privateKeyPass` are sensitive Snowflake credentials that shouldn’t be send to browser in plain text.

This change also fixes issues with updating Snowflake setting in UI as sensitive credentials are automatically copied to updates configs.