### PR TITLE
feat: remove `root_path` dependency

### DIFF
--- a/packages/backend/src/manifestv7.json
+++ b/packages/backend/src/manifestv7.json
@@ -323,7 +323,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -364,9 +363,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -870,7 +866,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -911,9 +906,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1223,7 +1215,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1264,9 +1255,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1459,7 +1447,7 @@
                     ]
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "CompiledModelNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
         },
         "CompiledHookNode": {
@@ -1472,7 +1460,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1513,9 +1500,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1731,7 +1715,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1772,9 +1755,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1980,7 +1960,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2021,9 +2000,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2230,7 +2206,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2274,9 +2249,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2519,7 +2491,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2560,9 +2531,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2934,7 +2902,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2975,9 +2942,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3182,7 +3146,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3220,9 +3183,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3396,7 +3356,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3434,9 +3393,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3602,7 +3558,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3640,9 +3595,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3826,7 +3778,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3864,9 +3815,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4040,7 +3988,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4078,9 +4025,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4254,7 +4198,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4292,9 +4235,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4469,7 +4409,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4510,9 +4449,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4698,7 +4634,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4736,9 +4671,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4913,7 +4845,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4952,9 +4883,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5307,10 +5235,6 @@
                 "schema",
                 "unique_id",
                 "package_name",
-                "root_path",
-                "path",
-                "original_file_path",
-                "name",
                 "source_name",
                 "source_description",
                 "loader",
@@ -5341,9 +5265,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5854,7 +5775,6 @@
             "required": [
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -5866,9 +5786,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5999,7 +5916,6 @@
             "required": [
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6010,9 +5926,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6037,7 +5950,6 @@
                 "fqn",
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6055,9 +5967,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6231,7 +6140,6 @@
                 "fqn",
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6255,9 +6163,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6414,7 +6319,7 @@
                     "default": 1664991685.8293078
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "ParsedMetric(fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, description: str, label: str, calculation_method: str, expression: str, timestamp: str, filters: List[dbt.contracts.graph.unparsed.MetricFilter], time_grains: List[str], dimensions: List[str], window: Optional[dbt.contracts.graph.unparsed.MetricTime] = None, model: Optional[str] = None, model_unique_id: Optional[str] = None, resource_type: dbt.node_types.NodeType = <NodeType.Metric: 'metric'>, meta: Dict[str, Any] = <factory>, tags: List[str] = <factory>, config: dbt.contracts.graph.model_config.MetricConfig = <factory>, unrendered_config: Dict[str, Any] = <factory>, sources: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, refs: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, created_at: float = <factory>)"
         },
         "MetricFilter": {

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -21,7 +21,6 @@ type CompiledModel = {
     name: string;
     schema: string;
     database: string;
-    rootPath: string;
     originalFilePath: string;
     patchPath: string | null | undefined;
     alias?: string;
@@ -137,12 +136,14 @@ type FindAndUpdateModelYamlArgs = {
     table: WarehouseTableSchema;
     docs: Record<string, DbtDoc>;
     includeMeta: boolean;
+    projectDir: string;
 };
 export const findAndUpdateModelYaml = async ({
     model,
     table,
     docs,
     includeMeta,
+    projectDir,
 }: FindAndUpdateModelYamlArgs): Promise<{
     updatedYml: YamlSchema;
     outputFilePath: string;
@@ -156,11 +157,11 @@ export const findAndUpdateModelYaml = async ({
     const { patchPath } = model;
     if (patchPath) {
         const { path: expectedYamlSubPath } = patchPathParts(patchPath);
-        const expectedYamlPath = path.join(model.rootPath, expectedYamlSubPath);
+        const expectedYamlPath = path.join(projectDir, expectedYamlSubPath);
         filenames.push(expectedYamlPath);
     }
     const defaultYmlPath = path.join(
-        path.dirname(path.join(model.rootPath, model.originalFilePath)),
+        path.dirname(path.join(projectDir, model.originalFilePath)),
         `${model.name}.yml`,
     );
     filenames.push(defaultYmlPath);
@@ -434,7 +435,6 @@ export const getCompiledModelsFromManifest = ({
         name: modelLookup[nodeId].name,
         schema: modelLookup[nodeId].schema,
         database: modelLookup[nodeId].database,
-        rootPath: modelLookup[nodeId].root_path,
         originalFilePath: modelLookup[nodeId].original_file_path,
         patchPath: modelLookup[nodeId].patch_path,
         alias: modelLookup[nodeId].alias,

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -107,6 +107,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     table,
                     docs: manifest.docs,
                     includeMeta: !options.excludeMeta,
+                    projectDir: absoluteProjectPath,
                 },
             );
             try {

--- a/packages/cli/src/manifestv7.json
+++ b/packages/cli/src/manifestv7.json
@@ -323,7 +323,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -364,9 +363,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -870,7 +866,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -911,9 +906,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1223,7 +1215,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1264,9 +1255,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1459,7 +1447,7 @@
                     ]
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "CompiledModelNode(compiled: bool, database: Optional[str], schema: str, fqn: List[str], unique_id: str, raw_code: str, language: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, resource_type: dbt.node_types.NodeType, alias: str, checksum: dbt.contracts.files.FileHash, config: dbt.contracts.graph.model_config.NodeConfig = <factory>, _event_status: Dict[str, Any] = <factory>, tags: List[str] = <factory>, refs: List[List[str]] = <factory>, sources: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, description: str = '', columns: Dict[str, dbt.contracts.graph.parsed.ColumnInfo] = <factory>, meta: Dict[str, Any] = <factory>, docs: dbt.contracts.graph.unparsed.Docs = <factory>, patch_path: Optional[str] = None, compiled_path: Optional[str] = None, build_path: Optional[str] = None, deferred: bool = False, unrendered_config: Dict[str, Any] = <factory>, created_at: float = <factory>, config_call_dict: Dict[str, Any] = <factory>, compiled_code: Optional[str] = None, extra_ctes_injected: bool = False, extra_ctes: List[dbt.contracts.graph.compiled.InjectedCTE] = <factory>, relation_name: Optional[str] = None, _pre_injected_sql: Optional[str] = None)"
         },
         "CompiledHookNode": {
@@ -1472,7 +1460,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1513,9 +1500,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1731,7 +1715,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -1772,9 +1755,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -1980,7 +1960,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2021,9 +2000,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2230,7 +2206,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2274,9 +2249,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2519,7 +2491,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2560,9 +2531,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -2934,7 +2902,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -2975,9 +2942,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3182,7 +3146,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3220,9 +3183,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3396,7 +3356,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3434,9 +3393,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3602,7 +3558,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3640,9 +3595,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -3826,7 +3778,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -3864,9 +3815,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4040,7 +3988,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4078,9 +4025,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4254,7 +4198,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4292,9 +4235,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4469,7 +4409,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4510,9 +4449,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4698,7 +4634,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4736,9 +4671,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -4913,7 +4845,6 @@
                 "raw_code",
                 "language",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -4952,9 +4883,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5307,7 +5235,6 @@
                 "schema",
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -5341,9 +5268,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5854,7 +5778,6 @@
             "required": [
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -5866,9 +5789,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -5999,7 +5919,6 @@
             "required": [
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6010,9 +5929,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6037,7 +5953,6 @@
                 "fqn",
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6055,9 +5970,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6231,7 +6143,6 @@
                 "fqn",
                 "unique_id",
                 "package_name",
-                "root_path",
                 "path",
                 "original_file_path",
                 "name",
@@ -6255,9 +6166,6 @@
                     "type": "string"
                 },
                 "package_name": {
-                    "type": "string"
-                },
-                "root_path": {
                     "type": "string"
                 },
                 "path": {
@@ -6414,7 +6322,7 @@
                     "default": 1664991685.8293078
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "ParsedMetric(fqn: List[str], unique_id: str, package_name: str, root_path: str, path: str, original_file_path: str, name: str, description: str, label: str, calculation_method: str, expression: str, timestamp: str, filters: List[dbt.contracts.graph.unparsed.MetricFilter], time_grains: List[str], dimensions: List[str], window: Optional[dbt.contracts.graph.unparsed.MetricTime] = None, model: Optional[str] = None, model_unique_id: Optional[str] = None, resource_type: dbt.node_types.NodeType = <NodeType.Metric: 'metric'>, meta: Dict[str, Any] = <factory>, tags: List[str] = <factory>, config: dbt.contracts.graph.model_config.MetricConfig = <factory>, unrendered_config: Dict[str, Any] = <factory>, sources: List[List[str]] = <factory>, depends_on: dbt.contracts.graph.parsed.DependsOn = <factory>, refs: List[List[str]] = <factory>, metrics: List[List[str]] = <factory>, created_at: float = <factory>)"
         },
         "MetricFilter": {

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -40,7 +40,6 @@ export const DBT_METRIC: DbtMetric = {
     unique_id: 'dbt_metric_1',
     package_name: '',
     path: '',
-    root_path: '',
     original_file_path: '',
     model: "ref('myTable')",
     name: 'dbt_metric_1',
@@ -197,7 +196,6 @@ export const model: DbtModelNode & { relation_name: string } = {
     tags: [],
     relation_name: 'relation_name',
     depends_on: { nodes: [] },
-    root_path: 'root_path',
     patch_path: null,
     original_file_path: '',
 };

--- a/packages/common/src/types/dbtFromSchema.ts
+++ b/packages/common/src/types/dbtFromSchema.ts
@@ -141,7 +141,6 @@ export interface CompiledAnalysisNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -278,7 +277,6 @@ export interface CompiledSingularTestNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -360,7 +358,6 @@ export interface CompiledModelNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -461,7 +458,6 @@ export interface CompiledHookNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -563,7 +559,6 @@ export interface CompiledRPCNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -664,7 +659,6 @@ export interface CompiledSqlNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -766,7 +760,6 @@ export interface CompiledGenericTestNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -860,7 +853,6 @@ export interface CompiledSeedNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -962,7 +954,6 @@ export interface CompiledSnapshotNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1062,7 +1053,6 @@ export interface ParsedAnalysisNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1158,7 +1148,6 @@ export interface ParsedSingularTestNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1235,7 +1224,6 @@ export interface ParsedHookNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1332,7 +1320,6 @@ export interface ParsedModelNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1428,7 +1415,6 @@ export interface ParsedRPCNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1524,7 +1510,6 @@ export interface ParsedSqlNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1621,7 +1606,6 @@ export interface ParsedGenericTestNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1700,7 +1684,6 @@ export interface ParsedSeedNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1797,7 +1780,6 @@ export interface ParsedSnapshotNode {
     raw_code: string;
     language: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1897,7 +1879,6 @@ export interface ParsedSourceDefinition {
     schema: string;
     unique_id: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -1987,7 +1968,6 @@ export interface ExternalPartition {
 export interface ParsedMacro {
     unique_id: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -2030,7 +2010,6 @@ export interface MacroArgument {
 export interface ParsedDocumentation {
     unique_id: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -2043,7 +2022,6 @@ export interface ParsedExposure {
     fqn: string[];
     unique_id: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;
@@ -2106,7 +2084,6 @@ export interface ParsedMetric {
     fqn: string[];
     unique_id: string;
     package_name: string;
-    root_path: string;
     path: string;
     original_file_path: string;
     name: string;


### PR DESCRIPTION
removes dependencies on root path to support dbt 1.4.1 projects: https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.4

Closes: #4920

### reviewing

- I removed `"root_path"` from all nodes in the `manifest`
- I added `additionalProperties: true` to `CompiledModelNode` and `ParsedMetric` (the only two we validate in the CLI/backend) to allow manifests with and without `root_path`
- I refactored the CLI logic that depended on `root_path`

### With dbt 1.3

```
(dbt1-3) ➜  jaffle_shop git:(feat/add-url) ✗ lightdash deploy 
10:55:15  Running with dbt=1.3.1
10:55:18  Found 7 models, 20 tests, 0 snapshots, 0 analyses, 289 macros, 0 operations, 4 seed files, 0 sources, 0 exposures, 2 metrics
10:55:18  
10:55:18  Concurrency: 4 threads (target='prod')
10:55:18  
10:55:19  Done.


- SUCCESS> payments 
- SUCCESS> customers 
- SUCCESS> orders 
- SUCCESS> events 
- SUCCESS> stg_customers 
- SUCCESS> stg_payments 
- SUCCESS> stg_orders 

Compiled 7 explores, SUCCESS=7 ERRORS=0
```

### With dbt 1.4

```
(dbt1-4) ➜  jaffle_shop git:(feat/add-url) ✗ lightdash deploy 
? Your DBT version 1.4.1 does not match our supported version (1.3.0), this could cause problems on compile or validation.
Do you still want to continue? Yes
10:49:55  Running with dbt=1.4.1
10:49:56  Found 7 models, 20 tests, 0 snapshots, 0 analyses, 289 macros, 0 operations, 4 seed files, 0 sources, 0 exposures, 2 metrics
10:49:56  
10:49:56  Concurrency: 4 threads (target='prod')
10:49:56  
10:49:56  Done.


- SUCCESS> payments 
- SUCCESS> customers 
- SUCCESS> orders 
- SUCCESS> events 
- SUCCESS> stg_customers 
- SUCCESS> stg_payments 
- SUCCESS> stg_orders 

Compiled 7 explores, SUCCESS=7 ERRORS=0
```

### Via UI (dbt 1.3)

<img width="629" alt="Screenshot 2023-01-30 at 10 54 46" src="https://user-images.githubusercontent.com/11660098/215458880-452fabb4-3cb8-45bc-9bec-a8aef9d88ae9.png">
