### PR TITLE
fix: hide learn link when there are no items in the recently updated …

### DIFF
--- a/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
@@ -59,12 +59,14 @@ const RecentlyUpdatedPanel: FC<Props> = ({ projectUuid }) => {
             showCount={false}
             headerTitle="Recently updated"
             headerAction={
-                <AnchorButton
-                    text="Learn"
-                    minimal
-                    target="_blank"
-                    href="https://docs.lightdash.com/get-started/exploring-data/intro"
-                />
+                recentItems.length === 0 && (
+                    <AnchorButton
+                        text="Learn"
+                        minimal
+                        target="_blank"
+                        href="https://docs.lightdash.com/get-started/exploring-data/intro"
+                    />
+                )
             }
             renderEmptyState={() => (
                 <>


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/4332#event-8396457496

<img width="1020" alt="CleanShot 2023-01-31 at 13 23 30@2x" src="https://user-images.githubusercontent.com/962095/215720211-1df50fb7-1bcc-4698-abaa-452a0132d1d5.png">
