### PR TITLE
fix: unknown chart type appearing as dashboard

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -258,7 +258,7 @@ export type SpaceQuery = Pick<
     | 'spaceUuid'
     | 'views'
     | 'pinnedListUuid'
-> & { chartType: ChartKind | null };
+> & { chartType: ChartKind | undefined };
 
 export const isCompleteLayout = (
     value: CartesianChartLayout | undefined,
@@ -325,8 +325,8 @@ export const isSeriesWithMixedChartTypes = (
 export const getChartType = (
     chartType: ChartType,
     value: ChartConfig['config'],
-): ChartKind | null => {
-    if (value === undefined) return null;
+): ChartKind | undefined => {
+    if (value === undefined) return undefined;
 
     switch (chartType) {
         case ChartType.BIG_NUMBER:
@@ -342,7 +342,7 @@ export const getChartType = (
                 }
 
                 const type = series?.[0]?.type;
-                if (!type) return null;
+                if (!type) return undefined;
 
                 switch (type) {
                     case CartesianSeriesType.AREA:
@@ -365,8 +365,8 @@ export const getChartType = (
                 }
             }
 
-            return null;
+            return undefined;
         default:
-            return null;
+            return undefined;
     }
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -258,7 +258,7 @@ export type SpaceQuery = Pick<
     | 'spaceUuid'
     | 'views'
     | 'pinnedListUuid'
-> & { chartType: ChartKind | undefined };
+> & { chartType: ChartKind | null };
 
 export const isCompleteLayout = (
     value: CartesianChartLayout | undefined,
@@ -325,8 +325,8 @@ export const isSeriesWithMixedChartTypes = (
 export const getChartType = (
     chartType: ChartType,
     value: ChartConfig['config'],
-): ChartKind | undefined => {
-    if (value === undefined) return undefined;
+): ChartKind | null => {
+    if (value === undefined) return null;
 
     switch (chartType) {
         case ChartType.BIG_NUMBER:
@@ -342,7 +342,7 @@ export const getChartType = (
                 }
 
                 const type = series?.[0]?.type;
-                if (!type) return undefined;
+                if (!type) return null;
 
                 switch (type) {
                     case CartesianSeriesType.AREA:
@@ -365,8 +365,8 @@ export const getChartType = (
                 }
             }
 
-            return undefined;
+            return null;
         default:
-            return undefined;
+            return null;
     }
 };

--- a/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
@@ -28,7 +28,8 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
                 </ResourceIconBox>
             );
         case 'chart':
-            switch ((resource as SpaceQuery).chartType) {
+            const chartType = (resource as SpaceQuery).chartType;
+            switch (chartType) {
                 case ChartKind.LINE:
                     return (
                         <ResourceIconBox color={Colors.BLUE3}>
@@ -81,8 +82,17 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
                             <Icon123 color={Colors.BLUE3} size={20} />
                         </ResourceIconBox>
                     );
+                case null:
+                    return (
+                        <ResourceIconBox color={Colors.BLUE3}>
+                            <IconChartBar color={Colors.BLUE3} size={20} />
+                        </ResourceIconBox>
+                    );
                 default:
-                    return null;
+                    return assertUnreachable(
+                        chartType,
+                        `Chart type ${chartType} not supported`,
+                    );
             }
         default:
             return assertUnreachable(

--- a/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
@@ -30,7 +30,7 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
         case 'chart':
             const chartType = (resource as SpaceQuery).chartType;
             switch (chartType) {
-                case null:
+                case undefined:
                 case ChartKind.VERTICAL_BAR:
                     return (
                         <ResourceIconBox color={Colors.BLUE3}>

--- a/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceIcon.tsx
@@ -30,12 +30,7 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
         case 'chart':
             const chartType = (resource as SpaceQuery).chartType;
             switch (chartType) {
-                case ChartKind.LINE:
-                    return (
-                        <ResourceIconBox color={Colors.BLUE3}>
-                            <IconChartLine color={Colors.BLUE3} size={20} />
-                        </ResourceIconBox>
-                    );
+                case null:
                 case ChartKind.VERTICAL_BAR:
                     return (
                         <ResourceIconBox color={Colors.BLUE3}>
@@ -50,6 +45,12 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
                                 size={20}
                                 style={{ rotate: '90deg' }}
                             />
+                        </ResourceIconBox>
+                    );
+                case ChartKind.LINE:
+                    return (
+                        <ResourceIconBox color={Colors.BLUE3}>
+                            <IconChartLine color={Colors.BLUE3} size={20} />
                         </ResourceIconBox>
                     );
                 case ChartKind.SCATTER:
@@ -80,12 +81,6 @@ const ResourceIcon: FC<ResourceIconProps> = ({ resource, resourceType }) => {
                     return (
                         <ResourceIconBox color={Colors.BLUE3}>
                             <Icon123 color={Colors.BLUE3} size={20} />
-                        </ResourceIconBox>
-                    );
-                case null:
-                    return (
-                        <ResourceIconBox color={Colors.BLUE3}>
-                            <IconChartBar color={Colors.BLUE3} size={20} />
                         </ResourceIconBox>
                     );
                 default:

--- a/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
@@ -15,7 +15,7 @@ const ResourceType: FC<ResourceTypeProps> = ({ resource, resourceType }) => {
             const chartType = (resource as SpaceQuery).chartType;
 
             switch (chartType) {
-                case null:
+                case undefined:
                 case ChartKind.VERTICAL_BAR:
                     return <>Bar chart</>;
                 case ChartKind.HORIZONTAL_BAR:

--- a/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
@@ -12,7 +12,9 @@ const ResourceType: FC<ResourceTypeProps> = ({ resource, resourceType }) => {
         case 'dashboard':
             return <>Dashboard</>;
         case 'chart':
-            switch ((resource as SpaceQuery).chartType) {
+            const chartType = (resource as SpaceQuery).chartType;
+
+            switch (chartType) {
                 case ChartKind.LINE:
                     return <>Line chart</>;
                 case ChartKind.VERTICAL_BAR:
@@ -29,8 +31,13 @@ const ResourceType: FC<ResourceTypeProps> = ({ resource, resourceType }) => {
                     return <>Table</>;
                 case ChartKind.BIG_NUMBER:
                     return <>Big number</>;
+                case null:
+                    return <>Chart</>;
                 default:
-                    return null;
+                    return assertUnreachable(
+                        chartType,
+                        `Chart type ${chartType} not supported`,
+                    );
             }
         default:
             return assertUnreachable(

--- a/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceType.tsx
@@ -15,12 +15,13 @@ const ResourceType: FC<ResourceTypeProps> = ({ resource, resourceType }) => {
             const chartType = (resource as SpaceQuery).chartType;
 
             switch (chartType) {
-                case ChartKind.LINE:
-                    return <>Line chart</>;
+                case null:
                 case ChartKind.VERTICAL_BAR:
                     return <>Bar chart</>;
                 case ChartKind.HORIZONTAL_BAR:
                     return <>Horizontal bar chart</>;
+                case ChartKind.LINE:
+                    return <>Line chart</>;
                 case ChartKind.SCATTER:
                     return <>Scatter chart</>;
                 case ChartKind.AREA:
@@ -31,8 +32,6 @@ const ResourceType: FC<ResourceTypeProps> = ({ resource, resourceType }) => {
                     return <>Table</>;
                 case ChartKind.BIG_NUMBER:
                     return <>Big number</>;
-                case null:
-                    return <>Chart</>;
                 default:
                     return assertUnreachable(
                         chartType,

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -25,10 +25,10 @@ export type AcceptedResourceTypes = 'chart' | 'dashboard';
 export const getResourceType = (
     resource: AcceptedResources,
 ): AcceptedResourceTypes => {
-    if ('chartType' in resource) {
-        return 'chart';
-    } else {
+    if ('organizationUuid' in resource) {
         return 'dashboard';
+    } else {
+        return 'chart';
     }
 };
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/4342

### Description:

before:
![image](https://user-images.githubusercontent.com/962095/215774292-1086491d-33fb-4a96-a8af-c0ee469aa71e.png)


after:
![CleanShot 2023-01-31 at 17 30 34@2x](https://user-images.githubusercontent.com/962095/215774258-c4cdd493-241b-4cd6-a025-98ebef41775e.png)

I am labeling unknown chart type as "Chart" with "Bar icon"
but might be better to claim unknown chart type as "Bar Chart"

open to suggestion