### PR TITLE
feat: order fields by index

### DIFF
--- a/packages/backend/src/schema.json
+++ b/packages/backend/src/schema.json
@@ -107,6 +107,10 @@
                             }
                         }
                     }
+                },
+                "order_fields_by": {
+                    "type": "string",
+                    "enum": ["index", "label"]
                 }
             },
             "default": {}

--- a/packages/cli/src/schema.json
+++ b/packages/cli/src/schema.json
@@ -107,6 +107,10 @@
                             }
                         }
                     }
+                },
+                "order_fields_by": {
+                    "type": "string",
+                    "enum": ["index", "label"]
                 }
             },
             "default": {}

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -1,6 +1,7 @@
 import { DbtMetric, DbtModelColumn, DbtModelNode } from '../types/dbt';
 import { Table } from '../types/explore';
 import { DimensionType, FieldType, MetricType } from '../types/field';
+import { OrderFieldsByStrategy } from '../types/table';
 import { TimeFrames } from '../types/timeFrames';
 
 type WarehouseCatalog = {
@@ -233,9 +234,11 @@ export const LIGHTDASH_TABLE_WITHOUT_AUTO_METRICS: Omit<Table, 'lineageGraph'> =
                 round: undefined,
                 compact: undefined,
                 groupLabel: undefined,
+                index: 0,
             },
         },
         metrics: {},
+        orderFieldsBy: OrderFieldsByStrategy.LABEL,
     };
 
 export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
@@ -260,6 +263,7 @@ export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
             source: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 0,
         },
         dbt_metric_2: {
             description: 'Description',
@@ -280,6 +284,7 @@ export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
             source: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 1,
         },
         dbt_metric_3: {
             description: 'Description',
@@ -300,6 +305,7 @@ export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
             source: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 2,
         },
         dbt_metric_4: {
             description: 'Description',
@@ -320,6 +326,7 @@ export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
             source: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 3,
         },
         dbt_metric_5: {
             description: 'Description',
@@ -340,6 +347,7 @@ export const LIGHTDASH_TABLE_WITH_DBT_METRICS: Omit<Table, 'lineageGraph'> = {
             source: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 4,
         },
     },
 };
@@ -420,6 +428,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         num_participating_athletes: {
             fieldType: FieldType.DIMENSION,
@@ -438,6 +447,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 1,
         },
     },
     metrics: {
@@ -460,6 +470,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             showUnderlyingValues: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 0,
         },
         total_num_participating_athletes: {
             fieldType: FieldType.METRIC,
@@ -480,8 +491,10 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             showUnderlyingValues: undefined,
             groupLabel: undefined,
             filters: [],
+            index: 1,
         },
     },
+    orderFieldsBy: OrderFieldsByStrategy.LABEL,
 };
 
 export const MODEL_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS: DbtModelNode & {
@@ -524,6 +537,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_RAW: {
             fieldType: FieldType.DIMENSION,
@@ -542,6 +556,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_DAY: {
             fieldType: FieldType.DIMENSION,
@@ -560,6 +575,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_WEEK: {
             fieldType: FieldType.DIMENSION,
@@ -578,6 +594,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_MONTH: {
             fieldType: FieldType.DIMENSION,
@@ -596,6 +613,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_QUARTER: {
             description: undefined,
@@ -614,6 +632,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             tableLabel: 'My table',
             timeInterval: TimeFrames.QUARTER,
             type: DimensionType.DATE,
+            index: 0,
         },
         user_created_YEAR: {
             fieldType: FieldType.DIMENSION,
@@ -632,9 +651,11 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
     },
     metrics: {},
+    orderFieldsBy: OrderFieldsByStrategy.LABEL,
 };
 
 export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Omit<
@@ -665,6 +686,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_RAW: {
             fieldType: FieldType.DIMENSION,
@@ -685,6 +707,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_DAY: {
             fieldType: FieldType.DIMENSION,
@@ -705,6 +728,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_WEEK: {
             fieldType: FieldType.DIMENSION,
@@ -726,6 +750,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_MONTH: {
             fieldType: FieldType.DIMENSION,
@@ -747,6 +772,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_QUARTER: {
             description: undefined,
@@ -765,6 +791,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             tableLabel: 'My table',
             timeInterval: TimeFrames.QUARTER,
             type: DimensionType.DATE,
+            index: 0,
         },
         user_created_YEAR: {
             fieldType: FieldType.DIMENSION,
@@ -785,9 +812,11 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
     },
     metrics: {},
+    orderFieldsBy: OrderFieldsByStrategy.LABEL,
 };
 
 export const MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS: DbtModelNode & {
@@ -825,9 +854,11 @@ export const LIGHTDASH_TABLE_WITH_OFF_TIME_INTERVAL_DIMENSIONS: Omit<
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
     },
     metrics: {},
+    orderFieldsBy: OrderFieldsByStrategy.LABEL,
 };
 
 export const MODEL_WITH_CUSTOM_TIME_INTERVAL_DIMENSIONS: DbtModelNode & {
@@ -865,6 +896,7 @@ export const LIGHTDASH_TABLE_WITH_CUSTOM_TIME_INTERVAL_DIMENSIONS: Omit<
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
         user_created_YEAR: {
             fieldType: FieldType.DIMENSION,
@@ -883,9 +915,11 @@ export const LIGHTDASH_TABLE_WITH_CUSTOM_TIME_INTERVAL_DIMENSIONS: Omit<
             round: undefined,
             compact: undefined,
             groupLabel: undefined,
+            index: 0,
         },
     },
     metrics: {},
+    orderFieldsBy: OrderFieldsByStrategy.LABEL,
 };
 
 export const warehouseSchema: WarehouseCatalog = {

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -56,6 +56,10 @@
                                     "required": ["join", "sql_on"]
                                 }
                             },
+                            "order_fields_by": {
+                                "type": "string",
+                                "enum": ["index", "label"]
+                            },
                             "metrics": {
                                 "type": "object",
                                 "patternProperties": {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -14,7 +14,7 @@ import {
 } from './field';
 import { parseFilters } from './filterGrammar';
 import { AdditionalMetric } from './metricQuery';
-import { TableBase } from './table';
+import { OrderFieldsByStrategy, TableBase } from './table';
 import { TimeFrames } from './timeFrames';
 
 export enum SupportedDbtAdapter {
@@ -53,6 +53,7 @@ type DbtModelLightdashConfig = {
     label?: string;
     joins?: DbtModelJoin[];
     metrics?: Record<string, DbtModelLightdashMetric>;
+    order_fields_by?: OrderFieldsByStrategy;
 };
 type DbtModelJoin = {
     join: string;

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -108,6 +108,7 @@ export interface Field {
     format?: string;
     groupLabel?: string;
     urls?: FieldUrl[];
+    index?: number;
 }
 
 export const isField = (field: any): field is Field =>

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -20,6 +20,7 @@ export interface AdditionalMetric {
     format?: string;
     table: string;
     name: string;
+    index?: number;
 }
 
 export const isAdditionalMetric = (value: any): value is AdditionalMetric =>

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -1,3 +1,8 @@
+export enum OrderFieldsByStrategy {
+    LABEL = 'LABEL',
+    INDEX = 'INDEX',
+}
+
 export type TableBase = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
@@ -5,4 +10,5 @@ export type TableBase = {
     database: string;
     schema: string;
     sqlTable: string; // The sql identifier for the table
+    orderFieldsBy?: OrderFieldsByStrategy;
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -73,6 +73,7 @@ const TableTreeSections: FC<Props> = ({
                 </EmptyState>
             ) : (
                 <TreeProvider
+                    orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}
                     itemsMap={dimensions}
                     selectedItems={selectedItems}
@@ -116,6 +117,7 @@ const TableTreeSections: FC<Props> = ({
                 <EmptyState>No metrics defined in your dbt project</EmptyState>
             ) : (
                 <TreeProvider
+                    orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}
                     itemsMap={metrics}
                     selectedItems={selectedItems}
@@ -162,6 +164,7 @@ const TableTreeSections: FC<Props> = ({
                 </EmptyState>
             ) : (
                 <TreeProvider
+                    orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}
                     itemsMap={customMetrics}
                     selectedItems={selectedItems}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeNodes.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeNodes.tsx
@@ -3,6 +3,7 @@ import {
     Dimension,
     isDimension,
     Metric,
+    OrderFieldsByStrategy,
     sortTimeFrames,
 } from '@lightdash/common';
 import { FC, useMemo } from 'react';
@@ -16,8 +17,15 @@ import {
 import TreeSingleNode from './TreeSingleNode';
 
 const sortNodes =
-    (itemsMap: Record<string, Dimension | Metric | AdditionalMetric>) =>
+    (
+        orderStrategy: OrderFieldsByStrategy,
+        itemsMap: Record<string, Dimension | Metric | AdditionalMetric>,
+    ) =>
     (a: Node, b: Node) => {
+        if (orderStrategy === OrderFieldsByStrategy.INDEX) {
+            return a.index - b.index;
+        }
+
         const itemA = itemsMap[a.key];
         const itemB = itemsMap[b.key];
 
@@ -37,10 +45,12 @@ const TreeNodes: FC<{ nodeMap: NodeMap; depth: number }> = ({
     nodeMap,
     depth,
 }) => {
-    const { itemsMap } = useTableTreeContext();
+    const { itemsMap, orderFieldsBy } = useTableTreeContext();
     const sortedItems = useMemo(() => {
-        return Object.values(nodeMap).sort(sortNodes(itemsMap));
-    }, [nodeMap, itemsMap]);
+        return Object.values(nodeMap).sort(
+            sortNodes(orderFieldsBy ?? OrderFieldsByStrategy.LABEL, itemsMap),
+        );
+    }, [nodeMap, orderFieldsBy, itemsMap]);
 
     return (
         <div>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
@@ -5,6 +5,7 @@ import {
     isDimension,
     isField,
     Metric,
+    OrderFieldsByStrategy,
 } from '@lightdash/common';
 import Fuse from 'fuse.js';
 import React, { createContext, FC, useContext } from 'react';
@@ -35,6 +36,7 @@ const getNodeMapFromItemsMap = (
             const node: Node = {
                 key: itemId,
                 label: item.label || item.name,
+                index: item.index ?? Number.MAX_SAFE_INTEGER,
             };
             if (isField(item) && item.groupLabel) {
                 // first in group
@@ -43,6 +45,7 @@ const getNodeMapFromItemsMap = (
                         key: item.groupLabel,
                         label: item.groupLabel,
                         children: { [node.key]: node },
+                        index: item.index ?? Number.MAX_SAFE_INTEGER,
                     };
                     return { ...acc, [item.groupLabel]: groupNode };
                 }
@@ -121,6 +124,7 @@ const getNodeMapFromItemsMap = (
 export type Node = {
     key: string;
     label: string;
+    index: number;
     children?: NodeMap;
 };
 
@@ -134,6 +138,7 @@ export const isGroupNode = (node: Node): node is GroupNode =>
 type Item = Dimension | Metric | AdditionalMetric;
 
 type Props = {
+    orderFieldsBy?: OrderFieldsByStrategy;
     searchQuery?: string;
     itemsMap: Record<string, Item>;
     selectedItems: Set<string>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4000 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Example yml:
```
models:
  - name: customers
    meta:
      order_fields_by: index // or 'label'
```

We went with `index` and `label` instead of `yml` and `alphabetically` because this opens the possibilities for future order options. eg: `type`, `name` 

Notes on the order logic:
- since metrics can be declared in multiple places we forced the following order: `dbt metrics > metrics in model metadata > metrics in dimension metadata`
- group labels inherit the index of the first dimension that uses it
- fields order defaults to `label` 

The code is also 90% ready to support the `index` in the dimension/metric metadata, in case the user wants to override the order mentioned above. We can add this in a future PR if users ask for it. 

Preview:

https://user-images.githubusercontent.com/9117144/215830450-8572558b-ae69-43e0-9bf7-1f7f0ea2bcc4.mp4

Code changes:
- update json schemas ( for validation purposes )
- store the dimension and metrics index when we compile the dbt project
- when generating the sidebar tree nodes, use the dimension and metric index (if available)
- update sorting function
- update test mocks

TODO: following PR with docs updates