### PR TITLE
refactor: filter explores in cache

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -431,6 +431,25 @@ export class ProjectModel {
         return undefined;
     }
 
+    async getExploreFromCache(
+        projectUuid: string,
+        exploreName: string,
+    ): Promise<Explore | ExploreError> {
+        const [explore] = await this.database('cached_explores')
+            .select<(Explore | ExploreError)[]>(['explore'])
+            .crossJoin(
+                this.database.raw('jsonb_array_elements(explores) as explore'),
+            )
+            .where('project_uuid', projectUuid)
+            .andWhere("explore->>'name'", exploreName);
+        if (explore === undefined) {
+            throw new NotExistsError(
+                `Explore "${exploreName}" does not exist.`,
+            );
+        }
+        return explore;
+    }
+
     async saveExploresToCache(
         projectUuid: string,
         explores: (Explore | ExploreError)[],


### PR DESCRIPTION
Reduce amount of IO from the database by only loading a single explore from the cache (currently we load all of them to get a single explore)

This is a large part of the time spent during `/availableFilters` (see: #4259)
