### PR TITLE
fix: add indices to analytics tables

### DIFF
--- a/packages/backend/src/database/migrations/20230202114455_add_index_to_analytics_tables.ts
+++ b/packages/backend/src/database/migrations/20230202114455_add_index_to_analytics_tables.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('analytics_chart_views')) {
+        await knex.schema.alterTable('analytics_chart_views', (table) => {
+            table.index(['chart_uuid']);
+        });
+    }
+    if (await knex.schema.hasTable('analytics_dashboard_views')) {
+        await knex.schema.alterTable('analytics_dashboard_views', (table) => {
+            table.index(['dashboard_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('analytics_chart_views')) {
+        await knex.schema.alterTable('analytics_chart_views', (table) => {
+            table.dropIndex(['chart_uuid']);
+        });
+    }
+    if (await knex.schema.hasTable('analytics_dashboard_views')) {
+        await knex.schema.alterTable('analytics_dashboard_views', (table) => {
+            table.dropIndex(['dashboard_uuid']);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fetching a chart definition now includes views and the database is query is very slow. This is because counting views involves a full table scan. I've added an index to make it much faster to search for chart views and dashboard views by uuid.