### PR TITLE
feat: pinned charts and dashboards component added to homepage

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -325,33 +325,30 @@ export class DashboardService {
         const existingDashboard = await this.dashboardModel.getById(
             dashboardUuid,
         );
+        const { projectUuid, organizationUuid, pinnedListUuid, spaceUuid } =
+            existingDashboard;
         if (
             user.ability.cannot(
                 'update',
-                subject('Dashboard', existingDashboard),
+                subject('Project', { projectUuid, organizationUuid }),
             )
         ) {
             throw new ForbiddenError();
         }
 
-        if (
-            !(await this.hasDashboardSpaceAccess(
-                existingDashboard.spaceUuid,
-                user.userUuid,
-            ))
-        ) {
+        if (!(await this.hasDashboardSpaceAccess(spaceUuid, user.userUuid))) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
         }
-        if (existingDashboard.pinnedListUuid) {
+        if (pinnedListUuid) {
             await this.pinnedListModel.deleteItem({
-                pinnedListUuid: existingDashboard.pinnedListUuid,
+                pinnedListUuid,
                 dashboardUuid,
             });
         } else {
             await this.pinnedListModel.addItem({
-                projectUuid: existingDashboard.projectUuid,
+                projectUuid,
                 dashboardUuid,
             });
         }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -192,7 +192,7 @@ export class SavedChartService {
         if (
             user.ability.cannot(
                 'update',
-                subject('SavedChart', { organizationUuid, projectUuid }),
+                subject('Project', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -33,7 +33,6 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             defaultColumnVisibility={{ space: false }}
             showCount={false}
             headerTitle="Pinned items"
-            renderEmptyState={() => <></>}
         />
     ) : null;
 };

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useSavedCharts } from '../../hooks/useSpaces';
 import ResourceList from '../common/ResourceList';
@@ -21,7 +21,7 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             ...wrapResourceList(dashboards, ResourceListType.DASHBOARD),
             ...wrapResourceList(savedCharts, ResourceListType.CHART),
         ].filter((item) => {
-            return item.data.pinnedListUuid ? item : null;
+            return !!item.data.pinnedListUuid;
         });
     }, [dashboards, savedCharts]);
 

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,0 +1,43 @@
+import { FC, useMemo } from 'react';
+import { useDashboards } from '../../hooks/dashboard/useDashboards';
+import { useSavedCharts } from '../../hooks/useSpaces';
+import ResourceList from '../common/ResourceList';
+import { SortDirection } from '../common/ResourceList/ResourceTable';
+import {
+    ResourceListType,
+    wrapResourceList,
+} from '../common/ResourceList/ResourceTypeUtils';
+
+interface Props {
+    projectUuid: string;
+}
+
+const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
+    const { data: dashboards = [] } = useDashboards(projectUuid);
+    const { data: savedCharts = [] } = useSavedCharts(projectUuid);
+
+    const pinnedItems = useMemo(() => {
+        return [
+            ...wrapResourceList(dashboards, ResourceListType.DASHBOARD),
+            ...wrapResourceList(savedCharts, ResourceListType.CHART),
+        ].filter((item) => {
+            return item.data.pinnedListUuid ? item : null;
+        });
+    }, [dashboards, savedCharts]);
+
+    return pinnedItems.length > 0 ? (
+        <ResourceList
+            items={pinnedItems}
+            enableSorting={false}
+            defaultSort={{ updatedAt: SortDirection.DESC }}
+            defaultColumnVisibility={{ space: false }}
+            showCount={false}
+            headerTitle="Pinned items"
+            renderEmptyState={() => <></>}
+        />
+    ) : (
+        <></>
+    );
+};
+
+export default PinnedItemsPanel;

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -35,9 +35,7 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             headerTitle="Pinned items"
             renderEmptyState={() => <></>}
         />
-    ) : (
-        <></>
-    );
+    ) : null;
 };
 
 export default PinnedItemsPanel;

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -2,9 +2,14 @@ import { Button, Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { assertUnreachable, Space } from '@lightdash/common';
-import { FC, useState } from 'react';
+import React, { FC, useState } from 'react';
+import { Route } from 'react-router-dom';
+import { CardContainer, Title } from '../../../pages/Settings.styles';
 import { useApp } from '../../../providers/AppProvider';
+import { DeleteOrganisationPanel } from '../../UserSettings/DeleteOrganisationPanel';
+import OrganisationPanel from '../../UserSettings/OrganisationPanel';
 import { Can } from '../Authorization';
+import Content from '../Page/Content';
 import {
     ResourceListAction,
     ResourceListActionState,
@@ -22,7 +27,7 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     const { user } = useApp();
-    const isPinned = item.data.pinnedListUuid ? true : false;
+    const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage =
         url.includes('/dashboards') || item.type === ResourceListType.DASHBOARD;
 
@@ -78,12 +83,7 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                             });
                         }}
                     />
-                    <Can
-                        I="manage"
-                        this={subject('SavedChart', {
-                            spaceUuid: item.data?.spaceUuid,
-                        })}
-                    >
+                    {user.data?.ability.can('manage', 'Project') && (
                         <MenuItem2
                             role="menuitem"
                             icon="pin"
@@ -103,7 +103,7 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                                 });
                             }}
                         />
-                    </Can>
+                    )}
                     {!isDashboardPage && (
                         <MenuItem2
                             icon="insert"

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -3,6 +3,7 @@ import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { assertUnreachable, Space } from '@lightdash/common';
 import { FC, useState } from 'react';
 import { useApp } from '../../../providers/AppProvider';
+import { Can } from '../Authorization';
 import {
     ResourceListAction,
     ResourceListActionState,
@@ -76,23 +77,27 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                             });
                         }}
                     />
-                    <MenuItem2
-                        role="menuitem"
-                        icon="pin"
-                        text={
-                            isPinned ? 'Unpin from homepage' : 'Pin to homepage'
-                        }
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
+                    <Can I="manage" a="SavedChart">
+                        <MenuItem2
+                            role="menuitem"
+                            icon="pin"
+                            text={
+                                isPinned
+                                    ? 'Unpin from homepage'
+                                    : 'Pin to homepage'
+                            }
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
 
-                            setIsOpen(false);
-                            onAction({
-                                type: ResourceListAction.PIN_TO_HOMEPAGE,
-                                item,
-                            });
-                        }}
-                    />
+                                setIsOpen(false);
+                                onAction({
+                                    type: ResourceListAction.PIN_TO_HOMEPAGE,
+                                    item,
+                                });
+                            }}
+                        />
+                    </Can>
                     {!isDashboardPage && (
                         <MenuItem2
                             icon="insert"

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -20,6 +20,7 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     const { user } = useApp();
+    const isPinned = item.data.pinnedListUuid ? true : false;
     const isDashboardPage =
         url.includes('/dashboards') || item.type === ResourceListType.DASHBOARD;
 
@@ -71,6 +72,23 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                             setIsOpen(false);
                             onAction({
                                 type: ResourceListAction.DUPLICATE,
+                                item,
+                            });
+                        }}
+                    />
+                    <MenuItem2
+                        role="menuitem"
+                        icon="pin"
+                        text={
+                            isPinned ? 'Unpin from homepage' : 'Pin to homepage'
+                        }
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+
+                            setIsOpen(false);
+                            onAction({
+                                type: ResourceListAction.PIN_TO_HOMEPAGE,
                                 item,
                             });
                         }}

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -1,5 +1,6 @@
 import { Button, Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { assertUnreachable, Space } from '@lightdash/common';
 import { FC, useState } from 'react';
 import { useApp } from '../../../providers/AppProvider';
@@ -77,7 +78,12 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                             });
                         }}
                     />
-                    <Can I="manage" a="SavedChart">
+                    <Can
+                        I="manage"
+                        this={subject('SavedChart', {
+                            spaceUuid: item.data?.spaceUuid,
+                        })}
+                    >
                         <MenuItem2
                             role="menuitem"
                             icon="pin"

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -1,15 +1,8 @@
 import { Button, Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
-import { subject } from '@casl/ability';
 import { assertUnreachable, Space } from '@lightdash/common';
 import React, { FC, useState } from 'react';
-import { Route } from 'react-router-dom';
-import { CardContainer, Title } from '../../../pages/Settings.styles';
 import { useApp } from '../../../providers/AppProvider';
-import { DeleteOrganisationPanel } from '../../UserSettings/DeleteOrganisationPanel';
-import OrganisationPanel from '../../UserSettings/OrganisationPanel';
-import { Can } from '../Authorization';
-import Content from '../Page/Content';
 import {
     ResourceListAction,
     ResourceListActionState,

--- a/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceActionMenu.tsx
@@ -1,7 +1,9 @@
 import { Button, Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { assertUnreachable, Space } from '@lightdash/common';
 import React, { FC, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useApp } from '../../../providers/AppProvider';
 import {
     ResourceListAction,
@@ -23,6 +25,8 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
     const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage =
         url.includes('/dashboards') || item.type === ResourceListType.DASHBOARD;
+    const organizationUuid = user.data?.organizationUuid;
+    const { projectUuid } = useParams<{ projectUuid: string }>();
 
     switch (item.type) {
         case ResourceListType.CHART:
@@ -76,7 +80,10 @@ const ResourceListActionMenu: FC<Props> = ({ item, spaces, url, onAction }) => {
                             });
                         }}
                     />
-                    {user.data?.ability.can('manage', 'Project') && (
+                    {user.data?.ability.can(
+                        'update',
+                        subject('Project', { organizationUuid, projectUuid }),
+                    ) && (
                         <MenuItem2
                             role="menuitem"
                             icon="pin"

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -15,7 +15,7 @@ export interface ResourceListCommonProps {
     headerAction?: React.ReactNode;
     items: ResourceListItem[];
     showCount?: boolean;
-    renderEmptyState: () => React.ReactNode;
+    renderEmptyState?: () => React.ReactNode;
 }
 
 type ResourceListProps = ResourceListCommonProps &
@@ -51,7 +51,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
             >
                 {items.length === 0 ? (
                     <ResourceEmptyStateWrapper>
-                        {renderEmptyState()}
+                        {renderEmptyState ? renderEmptyState() : null}
                     </ResourceEmptyStateWrapper>
                 ) : (
                     <ResourceTable

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -50,9 +50,11 @@ const ResourceList: React.FC<ResourceListProps> = ({
                 showCount={showCount}
             >
                 {items.length === 0 ? (
-                    <ResourceEmptyStateWrapper>
-                        {renderEmptyState ? renderEmptyState() : null}
-                    </ResourceEmptyStateWrapper>
+                    !!renderEmptyState ? (
+                        <ResourceEmptyStateWrapper>
+                            {renderEmptyState()}
+                        </ResourceEmptyStateWrapper>
+                    ) : null
                 ) : (
                     <ResourceTable
                         items={items}

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -1,10 +1,10 @@
-import { ApiError } from '@lightdash/common';
+import { ApiError, SavedChart } from '@lightdash/common';
 import { useMutation, useQueryClient } from 'react-query';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 
 const updateChartPinning = async (data: { uuid: string }) =>
-    lightdashApi<undefined>({
+    lightdashApi<SavedChart>({
         url: `/saved/${data.uuid}/pinning`,
         method: 'PATCH',
         body: JSON.stringify({}),
@@ -13,17 +13,23 @@ const updateChartPinning = async (data: { uuid: string }) =>
 export const useChartPinningMutation = () => {
     const queryClient = useQueryClient();
     const { showToastError, showToastSuccess } = useToaster();
-    return useMutation<undefined, ApiError, { uuid: string }>(
+    return useMutation<SavedChart, ApiError, { uuid: string }>(
         updateChartPinning,
         {
             mutationKey: ['chart_pinning_update'],
-            onSuccess: async (_, variables) => {
+            onSuccess: async (savedChart, variables) => {
                 await queryClient.invalidateQueries([
                     'saved_query',
                     variables.uuid,
                 ]);
+                await queryClient.invalidateQueries('spaces');
+                if (savedChart.pinnedListUuid) {
+                    showToastSuccess({
+                        title: 'Success! Dashboard was pinned to homepage',
+                    });
+                }
                 showToastSuccess({
-                    title: 'Success! Chart was pinned to homepage',
+                    title: 'Success! Dashboard was unpinned from homepage',
                 });
             },
             onError: (error) => {

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -25,12 +25,13 @@ export const useChartPinningMutation = () => {
                 await queryClient.invalidateQueries('spaces');
                 if (savedChart.pinnedListUuid) {
                     showToastSuccess({
-                        title: 'Success! Dashboard was pinned to homepage',
+                        title: 'Success! Chart was pinned to homepage',
+                    });
+                } else {
+                    showToastSuccess({
+                        title: 'Success! Chart was unpinned from homepage',
                     });
                 }
-                showToastSuccess({
-                    title: 'Success! Dashboard was unpinned from homepage',
-                });
             },
             onError: (error) => {
                 showToastError({

--- a/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
@@ -27,10 +27,11 @@ export const useDashboardPinningMutation = () => {
                     showToastSuccess({
                         title: 'Success! Dashboard was pinned to homepage',
                     });
+                } else {
+                    showToastSuccess({
+                        title: 'Success! Dashboard was unpinned from homepage',
+                    });
                 }
-                showToastSuccess({
-                    title: 'Success! Dashboard was unpinned from homepage',
-                });
             },
             onError: (error) => {
                 showToastError({

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import ForbiddenPanel from '../components/ForbiddenPanel';
 import LandingPanel from '../components/Home/LandingPanel';
 import OnboardingPanel from '../components/Home/OnboardingPanel/index';
 import RecentlyUpdatedPanel from '../components/Home/RecentlyUpdatedPanel';
+import PinnedItemsPanel from '../components/PinnedItemsPanel';
 import {
     useOnboardingStatus,
     useProjectSavedChartStatus,
@@ -66,7 +67,9 @@ const Home: FC = () => {
                             userName={user.data?.firstName}
                             projectUuid={project.data.projectUuid}
                         />
-
+                        <PinnedItemsPanel
+                            projectUuid={project.data.projectUuid}
+                        />
                         <SpaceBrowser projectUuid={project.data.projectUuid} />
 
                         <RecentlyUpdatedPanel


### PR DESCRIPTION
Closes: #3043 

### Description:
MVP for pinning - This ticket covers the basic functionality. The rest in this milestone will cover a better user experience and frontend improvements. 


**You can pin **charts** and **dashboards** to your homepage.** (no limit) 
- [x] If there are 1+ pinned items, a new panel appears on top of the homepage. (use the same component as the other panels on the page). **If there are no pinned items, there is no panel.** 
- [x] Pinned items will appear in a list format, reusing existing components.
<img width="737" alt="Screenshot 2023-01-04 at 09 58 17" src="https://user-images.githubusercontent.com/12776522/210529587-03d12fbc-ab5e-43e5-892d-19c84c5b8516.png">




**Where can you pin from?**

- [x] Add an item `Pin to homepage` to the dashboard and charts context menus. (the context menus appear on the homepage/space pages).
- [x] If an item is pinned, the action should turn into `Unpin from homepage`
<img width="311" alt="Screenshot 2023-01-04 at 10 05 57" src="https://user-images.githubusercontent.com/12776522/210530869-d64f64ad-0a97-4b8c-9145-d5df39966389.png">



**Permissions**
- [x]  Pinned items are public, and affect everyone in the project.  (if you have access to it and its pinned, you should see it. You should not be able to see anything you don't have access to) 
- [x] - Only admins/editors can pin/unpin items.
- [x] - Viewers can see the pinned items panels, but not add/remove anything from it.

