### PR TITLE
chore: pinned_list.updated event added

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -8,6 +8,7 @@ import {
     LightdashInstallType,
     LightdashUser,
     OrganizationMemberRole,
+    PinnedItem,
     RequestMethod,
     Space,
     TableSelectionType,
@@ -463,10 +464,7 @@ type PinnedListUpdated = BaseTrack & {
         organizationId: string;
         location: 'homepage';
         pinnedListId: string;
-        pinnedItems: {
-            chartIds: string[];
-            dashboardIds: string[];
-        };
+        pinnedItems: PinnedItem[];
     };
 };
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -461,13 +461,12 @@ type PinnedListUpdated = BaseTrack & {
     properties: {
         projectId: string;
         organizationId: string;
-        source: 'homepage' | Space['name'];
-        pinnedListUuid: string;
+        location: 'homepage';
+        pinnedListId: string;
         pinnedItems: {
-            charts: CreateChartPinnedItem[];
-            dashboards: CreateDashboardPinnedItem[];
+            chartIds: string[];
+            dashboardIds: string[];
         };
-        timestamp: string;
     };
 };
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2,11 +2,14 @@
 import {
     CartesianSeriesType,
     ChartType,
+    CreateChartPinnedItem,
+    CreateDashboardPinnedItem,
     DbtProjectType,
     LightdashInstallType,
     LightdashUser,
     OrganizationMemberRole,
     RequestMethod,
+    Space,
     TableSelectionType,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -452,6 +455,22 @@ type AnalyticsDashboardView = BaseTrack & {
     };
 };
 
+type PinnedListUpdated = BaseTrack & {
+    event: 'pinned_list.updated';
+    userId: string;
+    properties: {
+        projectId: string;
+        organizationId: string;
+        source: 'homepage' | Space['name'];
+        pinnedListUuid: string;
+        pinnedItems: {
+            charts: CreateChartPinnedItem[];
+            dashboards: CreateDashboardPinnedItem[];
+        };
+        timestamp: string;
+    };
+};
+
 type Track =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -489,7 +508,8 @@ type Track =
     | ShareSlack
     | SavedChartView
     | DashboardView
-    | AnalyticsDashboardView;
+    | AnalyticsDashboardView
+    | PinnedListUpdated;
 
 export class LightdashAnalytics extends Analytics {
     static lightdashContext = {

--- a/packages/backend/src/database/entities/pinnedList.ts
+++ b/packages/backend/src/database/entities/pinnedList.ts
@@ -7,7 +7,7 @@ export const PinnedDashboardTableName = 'pinned_dashboard';
 export type DbPinnedList = {
     pinned_list_uuid: string;
     project_uuid: string;
-    created_at: Date;
+    created_at?: Date;
 };
 
 export type DbPinnedChart = {

--- a/packages/backend/src/database/entities/pinnedList.ts
+++ b/packages/backend/src/database/entities/pinnedList.ts
@@ -7,7 +7,7 @@ export const PinnedDashboardTableName = 'pinned_dashboard';
 export type DbPinnedList = {
     pinned_list_uuid: string;
     project_uuid: string;
-    created_at?: Date;
+    created_at: Date;
 };
 
 export type DbPinnedChart = {
@@ -41,6 +41,6 @@ export type PinnedChartTable = Knex.CompositeTableType<
     CreatePinnedChart
 >;
 export type PinnedDashboardTable = Knex.CompositeTableType<
-    DbPinnedChart,
+    DbPinnedDashboard,
     CreatePinnedDashboard
 >;

--- a/packages/backend/src/database/entities/pinnedList.ts
+++ b/packages/backend/src/database/entities/pinnedList.ts
@@ -4,19 +4,19 @@ export const PinnedListTableName = 'pinned_list';
 export const PinnedChartTableName = 'pinned_chart';
 export const PinnedDashboardTableName = 'pinned_dashboard';
 
-type PinnedList = {
+export type DbPinnedList = {
     pinned_list_uuid: string;
     project_uuid: string;
-    created_at: Date;
+    created_at?: Date;
 };
 
-type PinnedChart = {
+export type DbPinnedChart = {
     pinned_item_uuid: string;
     pinned_list_uuid: string;
     saved_chart_uuid: string;
     created_at: Date;
 };
-type PinnedDashboard = {
+export type DbPinnedDashboard = {
     pinned_item_uuid: string;
     pinned_list_uuid: string;
     dashboard_uuid: string;
@@ -24,23 +24,23 @@ type PinnedDashboard = {
 };
 
 export type CreatePinnedChart = Omit<
-    PinnedChart,
+    DbPinnedChart,
     'pinned_item_uuid' | 'created_at'
 >;
 export type CreatePinnedDashboard = Omit<
-    PinnedDashboard,
+    DbPinnedDashboard,
     'pinned_item_uuid' | 'created_at'
 >;
 
 export type PinnedListTable = Knex.CompositeTableType<
-    PinnedList,
-    Pick<PinnedList, 'project_uuid'>
+    DbPinnedList,
+    Pick<DbPinnedList, 'project_uuid'>
 >;
 export type PinnedChartTable = Knex.CompositeTableType<
-    PinnedChart,
+    DbPinnedChart,
     CreatePinnedChart
 >;
 export type PinnedDashboardTable = Knex.CompositeTableType<
-    PinnedDashboard,
+    DbPinnedChart,
     CreatePinnedDashboard
 >;

--- a/packages/backend/src/models/PinnedListModel.ts
+++ b/packages/backend/src/models/PinnedListModel.ts
@@ -112,7 +112,7 @@ export class PinnedListModel {
         projectUuid: string,
     ): Promise<PinnedListAndItems> {
         const [list] = await this.database(PinnedListTableName)
-            .select(['pinned_list_uuid', 'project_uuid'])
+            .select('pinned_list_uuid', 'project_uuid')
             .where('project_uuid', projectUuid);
         if (!list) {
             throw new NotFoundError('No pinned list found');
@@ -126,7 +126,7 @@ export class PinnedListModel {
                 'saved_chart_uuid',
                 'created_at',
             )
-            .where(['pinned_list_uuid', pinnedListUuid]);
+            .where('pinned_list_uuid', pinnedListUuid);
         const pinnedDashboards = await this.database(PinnedDashboardTableName)
             .select(
                 'pinned_list_uuid',
@@ -134,7 +134,7 @@ export class PinnedListModel {
                 'dashboard_uuid',
                 'created_at',
             )
-            .where(['pinned_list_uuid', pinnedListUuid]);
+            .where('pinned_list_uuid', pinnedListUuid);
 
         const pinnedList = PinnedListModel.convertPinnedList(list);
         const pinnedItems = [...pinnedCharts, ...pinnedDashboards].map(

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -7,6 +7,7 @@ import {
     ForbiddenError,
     isDashboardUnversionedFields,
     isDashboardVersionedFields,
+    PinnedListAndItems,
     SessionUser,
     UpdateDashboard,
     UpdateMultipleDashboards,
@@ -352,6 +353,22 @@ export class DashboardService {
                 dashboardUuid,
             });
         }
+
+        const pinnedList = await this.pinnedListModel.getPinnedListAndItems(
+            existingDashboard.projectUuid,
+        );
+
+        analytics.track({
+            event: 'pinned_list.updated',
+            userId: user.userUuid,
+            properties: {
+                projectId: existingDashboard.projectUuid,
+                organizationId: existingDashboard.organizationUuid,
+                location: 'homepage',
+                pinnedListId: pinnedList.pinnedListUuid,
+                pinnedItems: pinnedList.items,
+            },
+        });
 
         return this.getById(user, dashboardUuid);
     }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -209,6 +209,22 @@ export class SavedChartService {
             });
         }
 
+        const pinnedList = await this.pinnedListModel.getPinnedListAndItems(
+            projectUuid,
+        );
+
+        analytics.track({
+            event: 'pinned_list.updated',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+                location: 'homepage',
+                pinnedListId: pinnedList.pinnedListUuid,
+                pinnedItems: pinnedList.items,
+            },
+        });
+
         return this.get(savedChartUuid, user);
     }
 

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -1,4 +1,8 @@
 import { ParameterError, validateEmail } from '@lightdash/common';
+import {
+    DbPinnedChart,
+    DbPinnedDashboard,
+} from './database/entities/pinnedList';
 
 export const sanitizeStringParam = (value: any) => {
     if (!value || typeof value !== 'string') {
@@ -18,3 +22,8 @@ export const sanitizeEmailParam = (value: any) => {
     }
     return email;
 };
+
+export const isDbPinnedChart = (
+    data: DbPinnedChart | DbPinnedDashboard,
+): data is DbPinnedChart =>
+    'saved_chart_uuid' in data && !!data.saved_chart_uuid;

--- a/packages/common/src/types/pinning.ts
+++ b/packages/common/src/types/pinning.ts
@@ -3,6 +3,18 @@ export type PinnedList = {
     projectUuid: string;
 };
 
+export type PinnedItem = {
+    pinnedItemUuid: string;
+    pinnedListUuid: string;
+    savedChartUuid?: string;
+    dashboardUuid?: string;
+    createdAt: Date;
+};
+
+export type PinnedListAndItems = PinnedList & {
+    items: PinnedItem[];
+};
+
 export type CreateChartPinnedItem = {
     projectUuid: string;
     savedChartUuid: string;


### PR DESCRIPTION
Closes: #4128 

### Description:
analytics event `pinned_list.updated`

triggered when a pinned list is updated (has an item added or removed from the list)

parameters include:
- user_id (user who updated the list)
- source (`homepage` if homepage, otherwise `space.the_space_name` when we create pinned lists in spaces)
- project_id (where the pinned list exists)
- organization_id (where the pinned list exists)
- timestamp
- pinned_list_id (unique identifier for a pinned list)
- pinned_items (this is a JSON blob which has the pinned items as a list. 

### Rudderstack screenshots
#### 1. pinning
<img width="1483" alt="Screenshot 2023-02-07 at 15 59 59" src="https://user-images.githubusercontent.com/67699259/217280923-e18dcd17-6d89-4f6a-a94f-942cc772d23e.png">

#### 2. unpinning
<img width="1476" alt="Screenshot 2023-02-07 at 16 01 29" src="https://user-images.githubusercontent.com/67699259/217281390-f49bf0a3-d06d-4a14-aa21-22e53ff67ac7.png">
