### PR TITLE
fix: big number responsiveness doesn't work on all tiles

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/SimpleStatistics.styles.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/SimpleStatistics.styles.tsx
@@ -14,11 +14,13 @@ interface BigNumberProps extends React.HTMLAttributes<HTMLDivElement> {
     $interactive?: boolean;
 }
 
-export const BigNumber = styled.div<BigNumberProps>`
+export const BigNumber = styled.h1<BigNumberProps>`
     ${({ $interactive }) => ($interactive ? 'cursor: pointer;' : '')}
     font-weight: 500;
     color: ${Colors.DARK_GRAY4};
     text-align: center;
+    line-height: 50px;
+    margin: 0;
 `;
 
 export const BigNumberLabel = styled.h2`

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -26,7 +26,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({ ...wrapperProps }) => {
     return validData ? (
         <BigNumberContainer {...wrapperProps}>
             {isSqlRunner ? (
-                <Textfit mode="single" style={{ width: '45%' }} max={100}>
+                <Textfit mode="single" min={15} max={70}>
                     <BigNumber>{bigNumber}</BigNumber>
                 </Textfit>
             ) : (
@@ -34,7 +34,8 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({ ...wrapperProps }) => {
                     renderTarget={({ ref, ...popoverProps }) => (
                         <Textfit
                             mode="single"
-                            style={{ width: '45%' }}
+                            forceSingleModeWidth={true}
+                            min={15}
                             max={100}
                         >
                             <BigNumber
@@ -48,7 +49,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({ ...wrapperProps }) => {
                     )}
                 />
             )}
-            <Textfit mode="single" style={{ width: '80%' }} max={20}>
+            <Textfit mode="multi" min={5} max={70}>
                 <BigNumberLabel>
                     {bigNumberLabel || defaultLabel}
                 </BigNumberLabel>


### PR DESCRIPTION
Closes: #4396 

### Description:
before
<img width="1076" alt="Screenshot 2023-02-07 at 17 38 46" src="https://user-images.githubusercontent.com/67699259/217307435-064c5b6b-d243-49e0-bd90-76568ad468c2.png">
after
<img width="947" alt="Screenshot 2023-02-07 at 17 40 25" src="https://user-images.githubusercontent.com/67699259/217307489-35c74b37-6466-4de8-9c91-c1340d986fff.png">
