### PR TITLE
fix: multiple run queries on page load

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -1,7 +1,6 @@
 import {
     ApiError,
     ApiQueryResults,
-    CreateSavedChartVersion,
     MetricQuery,
     SavedChart,
 } from '@lightdash/common';
@@ -52,26 +51,25 @@ export const useQueryResults = () => {
     const { mutateAsync } = mutation;
 
     const mutateAsyncOverride = useCallback(
-        (unsavedChartVersion: CreateSavedChartVersion) => {
+        (tableName: string, metricQuery: MetricQuery) => {
             const fields = new Set([
-                ...unsavedChartVersion.metricQuery.dimensions,
-                ...unsavedChartVersion.metricQuery.metrics,
-                ...unsavedChartVersion.metricQuery.tableCalculations.map(
-                    ({ name }) => name,
-                ),
+                ...metricQuery.dimensions,
+                ...metricQuery.metrics,
+                ...metricQuery.tableCalculations.map(({ name }) => name),
             ]);
             const isValidQuery = fields.size > 0;
-            if (!!unsavedChartVersion.tableName && isValidQuery) {
+            if (!!tableName && isValidQuery) {
                 return mutateAsync({
                     projectUuid,
-                    tableId: unsavedChartVersion.tableName,
-                    query: unsavedChartVersion.metricQuery,
+                    tableId: tableName,
+                    query: metricQuery,
                 });
             } else {
                 console.warn(
                     `Can't make SQL request, invalid state`,
-                    unsavedChartVersion.tableName,
+                    tableName,
                     isValidQuery,
+                    metricQuery,
                 );
                 return Promise.reject();
             }

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -1052,10 +1052,7 @@ export const ExplorerProvider: FC<{
             savedChart,
         ],
     );
-    const queryResults = useQueryResults(
-        state.isValidQuery,
-        state.unsavedChartVersion,
-    );
+    const queryResults = useQueryResults();
 
     // Fetch query results after state update
     const { mutateAsync: mutateAsyncQuery, reset: resetQueryResults } =
@@ -1063,7 +1060,7 @@ export const ExplorerProvider: FC<{
 
     const mutateAsync = useCallback(async () => {
         try {
-            const result = await mutateAsyncQuery();
+            const result = await mutateAsyncQuery(state.unsavedChartVersion);
 
             dispatch({
                 type: ActionType.SET_PREVIOUSLY_FETCHED_STATE,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -73,7 +73,7 @@ type Action =
     | { type: ActionType.SET_FETCH_RESULTS_FALSE }
     | {
           type: ActionType.SET_PREVIOUSLY_FETCHED_STATE;
-          payload: CreateSavedChartVersion;
+          payload: MetricQuery;
       }
     | { type: ActionType.SET_TABLE_NAME; payload: string }
     | { type: ActionType.TOGGLE_EXPANDED_SECTION; payload: ExplorerSection }
@@ -150,7 +150,7 @@ export interface ExplorerReduceState {
     shouldFetchResults: boolean;
     expandedSections: ExplorerSection[];
     unsavedChartVersion: CreateSavedChartVersion;
-    previouslyFetchedState?: CreateSavedChartVersion;
+    previouslyFetchedState?: MetricQuery;
 }
 
 export interface ExplorerState extends ExplorerReduceState {
@@ -1060,25 +1060,32 @@ export const ExplorerProvider: FC<{
 
     const mutateAsync = useCallback(async () => {
         try {
-            const result = await mutateAsyncQuery(state.unsavedChartVersion);
+            const result = await mutateAsyncQuery(
+                unsavedChartVersion.tableName,
+                unsavedChartVersion.metricQuery,
+            );
 
             dispatch({
                 type: ActionType.SET_PREVIOUSLY_FETCHED_STATE,
-                payload: cloneDeep(state.unsavedChartVersion),
+                payload: cloneDeep(unsavedChartVersion.metricQuery),
             });
 
             return result;
         } catch (e) {
             console.error(e);
         }
-    }, [mutateAsyncQuery, state.unsavedChartVersion]);
+    }, [
+        mutateAsyncQuery,
+        unsavedChartVersion.tableName,
+        unsavedChartVersion.metricQuery,
+    ]);
 
     const hasUnfetchedChanges = useMemo(() => {
         return !isEqual(
-            state.unsavedChartVersion,
+            state.unsavedChartVersion.metricQuery,
             state.previouslyFetchedState,
         );
-    }, [state.unsavedChartVersion, state.previouslyFetchedState]);
+    }, [state.unsavedChartVersion.metricQuery, state.previouslyFetchedState]);
 
     useEffect(() => {
         if (!state.shouldFetchResults) return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4393 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Reduced the scope of the hook dependencies to the essential. Any significant change in the chart config was causing the query to run. eg: pivoting

Before:

https://user-images.githubusercontent.com/9117144/217612526-93f85ef3-270d-4b45-ac49-313e7c00f8f4.mp4

Now: 

https://user-images.githubusercontent.com/9117144/217612640-ddb6ff47-4c22-4237-8281-c4e8160a13c2.mp4

