### PR TITLE
feat: csv full download

### DIFF
--- a/packages/backend/src/clients/Aws/s3.ts
+++ b/packages/backend/src/clients/Aws/s3.ts
@@ -50,6 +50,22 @@ export class S3Service {
         return data.Location;
     }
 
+    async uploadCsv(csv: string, csvName: string): Promise<string> {
+        if (!this.lightdashConfig.s3?.bucket || this.s3 === undefined) {
+            throw new Error(
+                "Missing S3 bucket configuration, can't upload csv",
+            );
+        }
+        const params: AWS.S3.PutObjectRequest = {
+            Body: csv,
+            ACL: 'public-read',
+            Bucket: this.lightdashConfig.s3.bucket,
+            Key: csvName,
+        };
+        const data = await this.s3.upload(params).promise();
+        return data.Location;
+    }
+
     isEnabled(): boolean {
         return this.s3 !== undefined;
     }

--- a/packages/backend/src/clients/Aws/s3.ts
+++ b/packages/backend/src/clients/Aws/s3.ts
@@ -58,12 +58,17 @@ export class S3Service {
         }
         const params: AWS.S3.PutObjectRequest = {
             Body: csv,
-            ACL: 'public-read',
             Bucket: this.lightdashConfig.s3.bucket,
             Key: csvName,
         };
-        const data = await this.s3.upload(params).promise();
-        return data.Location;
+        await this.s3.upload(params).promise();
+        const url = await this.s3.getSignedUrl('getObject', {
+            Bucket: this.lightdashConfig.s3.bucket,
+            Key: csvName,
+            Expires: 3600, // an hour
+        });
+
+        return url;
     }
 
     isEnabled(): boolean {

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -7,10 +7,15 @@ import {
     getRequestMethod,
     LightdashRequestMethodHeader,
     MetricQuery,
+    NotFoundError,
     ProjectCatalog,
     TablesConfiguration,
 } from '@lightdash/common';
 import express from 'express';
+import * as fs from 'fs/promises';
+import { nanoid } from 'nanoid';
+import path from 'path';
+import { lightdashConfig } from '../config/lightdashConfig';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -19,6 +24,7 @@ import {
 import {
     dashboardService,
     projectService,
+    s3Service,
     savedChartsService,
     searchService,
     spaceService,
@@ -193,6 +199,78 @@ projectRouter.post(
             });
         } catch (e) {
             next(e);
+        }
+    },
+);
+
+projectRouter.post(
+    '/explores/:exploreId/downloadCsv',
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const { body } = req;
+            const { csvLimit } = body;
+            const metricQuery: MetricQuery = {
+                dimensions: body.dimensions,
+                metrics: body.metrics,
+                filters: body.filters,
+                sorts: body.sorts,
+                limit: body.limit,
+                tableCalculations: body.tableCalculations,
+                additionalMetrics: body.additionalMetrics,
+            };
+            const results: ApiQueryResults = await projectService.runQuery(
+                req.user!,
+                metricQuery,
+                req.params.projectUuid,
+                req.params.exploreId,
+                csvLimit,
+            );
+
+            const csvHeader = Object.keys(results.rows[0]);
+            // TODO formatted or raw argument
+            // TODO improve column naming
+            const csvBody = results.rows.map((row) =>
+                Object.values(row)
+                    .map((r) => r.value.formatted)
+                    .join(','),
+            );
+            const csvContent = [csvHeader, ...csvBody].join('\n');
+            const fileId = `csv-${nanoid()}.csv`;
+
+            let fileUrl;
+            try {
+                fileUrl = await s3Service.uploadCsv(csvContent, fileId);
+            } catch (e) {
+                // Can't store file in S3, storing locally
+                await fs.writeFile(`/tmp/${fileId}`, csvContent, 'utf-8');
+                fileUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${req.params.projectUuid}/csv/${fileId}`;
+            }
+
+            res.json({
+                status: 'ok',
+                results: {
+                    url: fileUrl,
+                },
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
+projectRouter.get(
+    '/csv/:fileId',
+
+    async (req, res, next) => {
+        if (!req.params.fileId.startsWith('csv-')) {
+            throw new NotFoundError(`File not found ${req.params.fileId}`);
+        }
+        try {
+            const filePath = path.join('/tmp', req.params.fileId);
+            res.sendFile(filePath);
+        } catch (error) {
+            next(error);
         }
     },
 );

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -209,7 +209,7 @@ projectRouter.post(
     async (req, res, next) => {
         try {
             const { body } = req;
-            const { csvLimit } = body;
+            const { csvLimit, onlyRaw } = body;
             const metricQuery: MetricQuery = {
                 dimensions: body.dimensions,
                 metrics: body.metrics,
@@ -232,7 +232,7 @@ projectRouter.post(
             // TODO improve column naming
             const csvBody = results.rows.map((row) =>
                 Object.values(row)
-                    .map((r) => r.value.formatted)
+                    .map((r) => (onlyRaw ? r.value.raw : r.value.formatted))
                     .join(','),
             );
             const csvContent = [csvHeader, ...csvBody].join('\n');

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -263,6 +263,9 @@ export type ApiSqlQueryResults = {
     rows: { [col: string]: any }[];
 };
 
+export type ApiDownloadCsv = {
+    url: string;
+};
 export type ProjectCatalog = {
     [database: string]: {
         [schema: string]: {
@@ -478,7 +481,8 @@ type ApiResults =
     | DbtCloudIntegration
     | ShareUrl
     | SlackSettings
-    | UserActivity;
+    | UserActivity
+    | ApiDownloadCsv;
 
 export type ApiResponse = {
     status: 'ok';

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,6 +1,7 @@
 import { getResultValues } from '@lightdash/common';
 import { FC, memo, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { downloadCsv } from '../../../hooks/useDownloadCsv';
 import { getQueryResults } from '../../../hooks/useQueryResults';
 import {
     ExplorerSection,
@@ -43,13 +44,15 @@ const ResultsCard: FC = memo(() => {
     );
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
-    const getCsvResults = (csvLimit: number | null, onlyRaw: boolean) => {
-        return getQueryResults({
+    const getCsvLink = async (csvLimit: number | null, onlyRaw: boolean) => {
+        const csvResponse = await downloadCsv({
             projectUuid,
             tableId: tableName,
             query: metricQuery,
             csvLimit,
-        }).then((results) => getResultValues(results.rows, onlyRaw));
+            onlyRaw,
+        });
+        return csvResponse.url;
     };
 
     const resultsIsOpen = useMemo(
@@ -89,7 +92,7 @@ const ResultsCard: FC = memo(() => {
                         <DownloadCsvPopup
                             fileName={tableName}
                             rows={rows}
-                            getCsvResults={getCsvResults}
+                            getCsvLink={getCsvLink}
                         />
                     </>
                 )

--- a/packages/frontend/src/hooks/useDownloadCsv.tsx
+++ b/packages/frontend/src/hooks/useDownloadCsv.tsx
@@ -1,0 +1,25 @@
+import { ApiDownloadCsv, MetricQuery } from '@lightdash/common';
+
+import { lightdashApi } from '../api';
+import { convertDateFilters } from '../utils/dateFilter';
+
+export const downloadCsv = async ({
+    projectUuid,
+    tableId,
+    query,
+    csvLimit,
+    onlyRaw,
+}: {
+    projectUuid: string;
+    tableId: string;
+    query: MetricQuery;
+    csvLimit?: number | null; //giving null returns all results (no limit)
+    onlyRaw: boolean;
+}) => {
+    const timezoneFixQuery = convertDateFilters(query);
+    return lightdashApi<ApiDownloadCsv>({
+        url: `/projects/${projectUuid}/explores/${tableId}/downloadCsv`,
+        method: 'POST',
+        body: JSON.stringify({ ...timezoneFixQuery, csvLimit, onlyRaw }),
+    });
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:   #4411

### Description:
This feature will allow users to download a  csv directly from the browser, without processing all the data in the frontend

If the server has S3 enabled, it will store it on S3 and return its url, otherwise it will store it locally (/tmp) and return the file using a new lightdash endpoint

Sample CSV on s3: https://lightdash-slack-screenshots.storage.googleapis.com/csv-gOvCpyyvTB_qXUDC0pLfo.csv

## Things left to do

- [ ] new Api documentation
- [ ] Better name for csv headers
- [x] Download csv with formatted/raw
- [x] S3 storage
- [ ] Move logic to service, instead of router (will have to extract s3 storage to avoid circular imports) 
- [ ] New Local storage class and unify logic on slack 
- [ ] download file using a custom name (might need  to use `anchor` for that) 
- [ ] Unify s3 upload method with image ? 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
