### PR TITLE
fix: multiple dashboard requests on page load

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -107,12 +107,14 @@ const DashboardHeader = ({
                         />
                     )}
 
-                    <DashboardUpdateModal
-                        uuid={dashboardUuid}
-                        isOpen={isUpdating}
-                        onClose={() => setIsUpdating(false)}
-                        onConfirm={() => setIsUpdating(false)}
-                    />
+                    {isUpdating && (
+                        <DashboardUpdateModal
+                            uuid={dashboardUuid}
+                            isOpen={isUpdating}
+                            onClose={() => setIsUpdating(false)}
+                            onConfirm={() => setIsUpdating(false)}
+                        />
+                    )}
                 </PageTitleContainer>
 
                 <PageDetailsContainer>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -25,7 +25,6 @@ import MetricQueryDataProvider from '../components/MetricQueryData/MetricQueryDa
 import UnderlyingDataModal from '../components/MetricQueryData/UnderlyingDataModal';
 import {
     appendNewTilesToBottom,
-    useDashboardQuery,
     useDeleteMutation,
     useDuplicateDashboardMutation,
     useMoveDashboardMutation,
@@ -104,6 +103,8 @@ const Dashboard = () => {
     const { data: spaces } = useSpaces(projectUuid);
 
     const {
+        dashboard,
+        dashboardError,
         dashboardFilters,
         dashboardTemporaryFilters,
         haveFiltersChanged,
@@ -120,8 +121,6 @@ const Dashboard = () => {
         [dashboardTemporaryFilters],
     );
     const isEditMode = useMemo(() => mode === 'edit', [mode]);
-    const { data: dashboard, error: dashboardError } =
-        useDashboardQuery(dashboardUuid);
     const [hasTilesChanged, setHasTilesChanged] = useState<boolean>(false);
     const {
         mutate,

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -1,4 +1,5 @@
 import {
+    ApiError,
     Dashboard,
     DashboardFilterRule,
     DashboardFilters,
@@ -28,6 +29,7 @@ const emptyFilters: DashboardFilters = {
 
 type DashboardContext = {
     dashboard: Dashboard | undefined;
+    dashboardError: ApiError | null;
     fieldsWithSuggestions: FieldsWithSuggestions;
     dashboardTiles: Dashboard['tiles'] | [];
     setDashboardTiles: Dispatch<SetStateAction<Dashboard['tiles'] | []>>;
@@ -64,7 +66,8 @@ export const DashboardProvider: React.FC = ({ children }) => {
         dashboardUuid: string;
     }>();
 
-    const { data: dashboard } = useDashboardQuery(dashboardUuid);
+    const { data: dashboard, error: dashboardError } =
+        useDashboardQuery(dashboardUuid);
     const [dashboardTiles, setDashboardTiles] = useState<Dashboard['tiles']>(
         [],
     );
@@ -215,6 +218,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const value = {
         dashboard,
+        dashboardError,
         fieldsWithSuggestions,
         dashboardTiles,
         setDashboardTiles,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- only request the dashboard in the provider and reuse it in the page component
- only render the update modal when needed
