### PR TITLE
fix: chart tile loading state and duplicated requests

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -174,7 +174,9 @@ const DashboardChartTile: FC<Props> = (props) => {
         id: savedChartUuid || undefined,
         useQueryOptions: { refetchOnMount: false },
     });
-    const { data: explore } = useExplore(savedQuery?.tableName);
+    const { data: explore, isLoading: isLoadingExplore } = useExplore(
+        savedQuery?.tableName,
+    );
     const { addDimensionDashboardFilter } = useDashboardContext();
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
@@ -405,7 +407,7 @@ const DashboardChartTile: FC<Props> = (props) => {
                 clickableTitle={true}
                 titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
                 description={savedQueryWithDashboardFilters?.description}
-                isLoading={isLoading}
+                isLoading={isLoading || isLoadingExplore}
                 extraMenuItems={
                     savedChartUuid !== null && (
                         <>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -66,127 +66,152 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             isEditMode={isEditMode}
             isHovering={isHovering}
         >
-            <HeaderContainer
-                isEditMode={isEditMode}
-                onMouseEnter={() => setIsHovering(true)}
-                onMouseLeave={() => setIsHovering(false)}
-            >
-                <HeaderWrapper>
-                    {!hideTitle && description && clickableTitle ? (
-                        <Tooltip2
-                            content={
-                                <TooltipContent>{description}</TooltipContent>
-                            }
-                            position="bottom-left"
-                        >
-                            <TitleButton href={titleHref} target="_blank">
+            {!isLoading && (
+                <>
+                    <HeaderContainer
+                        isEditMode={isEditMode}
+                        onMouseEnter={() => setIsHovering(true)}
+                        onMouseLeave={() => setIsHovering(false)}
+                    >
+                        <HeaderWrapper>
+                            {!hideTitle && description && clickableTitle ? (
+                                <Tooltip2
+                                    content={
+                                        <TooltipContent>
+                                            {description}
+                                        </TooltipContent>
+                                    }
+                                    position="bottom-left"
+                                >
+                                    <TitleButton
+                                        href={titleHref}
+                                        target="_blank"
+                                    >
+                                        <TitleWrapper
+                                            hasDescription={hasDescription}
+                                        >
+                                            <Title className="non-draggable">
+                                                {title}
+                                            </Title>
+                                        </TitleWrapper>
+                                    </TitleButton>
+                                </Tooltip2>
+                            ) : !hideTitle && clickableTitle ? (
+                                <TitleButton href={titleHref} target="_blank">
+                                    <TitleWrapper
+                                        hasDescription={hasDescription}
+                                    >
+                                        <Title className="non-draggable">
+                                            {title}
+                                        </Title>
+                                    </TitleWrapper>
+                                </TitleButton>
+                            ) : !hideTitle && description ? (
+                                <Tooltip2
+                                    content={
+                                        <TooltipContent>
+                                            {description}
+                                        </TooltipContent>
+                                    }
+                                    position="bottom-left"
+                                >
+                                    <TitleWrapper hasDescription={true}>
+                                        <Title className="non-draggable">
+                                            {title}
+                                        </Title>
+                                    </TitleWrapper>
+                                </Tooltip2>
+                            ) : !hideTitle ? (
                                 <TitleWrapper hasDescription={hasDescription}>
                                     <Title className="non-draggable">
                                         {title}
                                     </Title>
                                 </TitleWrapper>
-                            </TitleButton>
-                        </Tooltip2>
-                    ) : !hideTitle && clickableTitle ? (
-                        <TitleButton href={titleHref} target="_blank">
-                            <TitleWrapper hasDescription={hasDescription}>
-                                <Title className="non-draggable">{title}</Title>
-                            </TitleWrapper>
-                        </TitleButton>
-                    ) : !hideTitle && description ? (
-                        <Tooltip2
-                            content={
-                                <TooltipContent>{description}</TooltipContent>
-                            }
-                            position="bottom-left"
-                        >
-                            <TitleWrapper hasDescription={true}>
-                                <Title className="non-draggable">{title}</Title>
-                            </TitleWrapper>
-                        </Tooltip2>
-                    ) : !hideTitle ? (
-                        <TitleWrapper hasDescription={hasDescription}>
-                            <Title className="non-draggable">{title}</Title>
-                        </TitleWrapper>
-                    ) : null}
-                </HeaderWrapper>
-                <ButtonsWrapper>
-                    {extraHeaderElement}
-                    {(isEditMode || (!isEditMode && extraMenuItems)) && (
-                        <Popover2
-                            className="non-draggable"
-                            content={
-                                <Menu>
-                                    {extraMenuItems}
-                                    {isEditMode && extraMenuItems && (
-                                        <MenuDivider />
-                                    )}
-                                    {isEditMode && (
-                                        <>
-                                            <MenuItem2
-                                                icon="edit"
-                                                text="Edit tile content"
-                                                onClick={() =>
-                                                    setIsEditing(true)
-                                                }
-                                            />
-                                            {tile.type !==
-                                                DashboardTileTypes.MARKDOWN && (
-                                                <MenuItem2
-                                                    icon={
-                                                        hideTitle
-                                                            ? 'eye-open'
-                                                            : 'eye-off'
-                                                    }
-                                                    text={`${
-                                                        hideTitle
-                                                            ? 'Show'
-                                                            : 'Hide'
-                                                    } title`}
-                                                    onClick={() =>
-                                                        onEdit({
-                                                            ...tile,
-                                                            properties: {
-                                                                ...tile.properties,
-                                                                hideTitle:
-                                                                    !hideTitle,
-                                                            },
-                                                        })
-                                                    }
-                                                />
+                            ) : null}
+                        </HeaderWrapper>
+                        <ButtonsWrapper>
+                            {extraHeaderElement}
+                            {(isEditMode ||
+                                (!isEditMode && extraMenuItems)) && (
+                                <Popover2
+                                    className="non-draggable"
+                                    content={
+                                        <Menu>
+                                            {extraMenuItems}
+                                            {isEditMode && extraMenuItems && (
+                                                <MenuDivider />
                                             )}
-                                            <MenuDivider />
-                                            <MenuItem2
-                                                icon="delete"
-                                                intent="danger"
-                                                text="Remove tile"
-                                                onClick={() => onDelete(tile)}
-                                            />
-                                        </>
-                                    )}
-                                </Menu>
-                            }
-                            position={PopoverPosition.BOTTOM_RIGHT}
-                            lazy
-                        >
-                            <Button minimal icon="more" />
-                        </Popover2>
-                    )}
-                </ButtonsWrapper>
-            </HeaderContainer>
-            <ChartContainer className="non-draggable cohere-block">
-                {children}
-            </ChartContainer>
+                                            {isEditMode && (
+                                                <>
+                                                    <MenuItem2
+                                                        icon="edit"
+                                                        text="Edit tile content"
+                                                        onClick={() =>
+                                                            setIsEditing(true)
+                                                        }
+                                                    />
+                                                    {tile.type !==
+                                                        DashboardTileTypes.MARKDOWN && (
+                                                        <MenuItem2
+                                                            icon={
+                                                                hideTitle
+                                                                    ? 'eye-open'
+                                                                    : 'eye-off'
+                                                            }
+                                                            text={`${
+                                                                hideTitle
+                                                                    ? 'Show'
+                                                                    : 'Hide'
+                                                            } title`}
+                                                            onClick={() =>
+                                                                onEdit({
+                                                                    ...tile,
+                                                                    properties:
+                                                                        {
+                                                                            ...tile.properties,
+                                                                            hideTitle:
+                                                                                !hideTitle,
+                                                                        },
+                                                                })
+                                                            }
+                                                        />
+                                                    )}
+                                                    <MenuDivider />
+                                                    <MenuItem2
+                                                        icon="delete"
+                                                        intent="danger"
+                                                        text="Remove tile"
+                                                        onClick={() =>
+                                                            onDelete(tile)
+                                                        }
+                                                    />
+                                                </>
+                                            )}
+                                        </Menu>
+                                    }
+                                    position={PopoverPosition.BOTTOM_RIGHT}
+                                    lazy
+                                >
+                                    <Button minimal icon="more" />
+                                </Popover2>
+                            )}
+                        </ButtonsWrapper>
+                    </HeaderContainer>
+                    <ChartContainer className="non-draggable cohere-block">
+                        {children}
+                    </ChartContainer>
 
-            <TileUpdateModal
-                isOpen={isEditing}
-                tile={tile}
-                onClose={() => setIsEditing(false)}
-                onConfirm={(data) => {
-                    onEdit(data);
-                    setIsEditing(false);
-                }}
-            />
+                    <TileUpdateModal
+                        isOpen={isEditing}
+                        tile={tile}
+                        onClose={() => setIsEditing(false)}
+                        onConfirm={(data) => {
+                            onEdit(data);
+                            setIsEditing(false);
+                        }}
+                    />
+                </>
+            )}
         </TileBaseWrapper>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -33,7 +33,7 @@ type Props<T> = {
     extraMenuItems?: React.ReactNode;
     onDelete: (tile: T) => void;
     onEdit: (tile: T) => void;
-    children: ReactNode;
+    children?: ReactNode;
     extraHeaderElement?: React.ReactNode;
 };
 

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -62,7 +62,15 @@ const GridTile: FC<
     });
     switch (tile.type) {
         case DashboardTileTypes.SAVED_CHART:
-            if (isLoading) return <></>;
+            if (isLoading)
+                return (
+                    <TileBase
+                        isLoading={true}
+                        title={''}
+                        {...props}
+                        clickableTitle={false}
+                    />
+                );
             if (isError)
                 return (
                     <TileBase title={''} {...props} clickableTitle={false}>


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- adds proper loading state
- await for explore to load before fetching chart results

Before:


https://user-images.githubusercontent.com/9117144/217873529-852ed6d0-a995-4344-92a2-8307f372954f.mp4




After:

https://user-images.githubusercontent.com/9117144/217873339-69cb95f0-c28a-4a52-baab-ca32d52f6a1a.mp4


 