### PR TITLE
fix: corrupt csv files because of commas and semicolons

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -44,6 +44,7 @@
         "connect-session-knex": "^2.1.0",
         "cookie-parser": "^1.4.5",
         "cron-converter": "^2.0.0",
+        "csv-stringify": "^6.2.4",
         "execa": "^5.0.0",
         "express": "^4.17.3",
         "express-openapi-validator": "^4.13.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4846,6 +4846,11 @@ csstype@^3.0.6:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
+csv-stringify@^6.2.4:
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.2.4.tgz#9ae7a660b771e55c09d6cf4cf936fbbdf9499962"
+  integrity sha512-RVzGaBeHl0IspzOSiNr1e7XDM7ajuESlqetQbxH2pBPplIWycx0gAVclxNEa4lc91brK6LIE0PrdEoHtZYIHIQ==
+
 cypress-file-upload@^5.0.8:
   version "5.0.8"
   resolved "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz"


### PR DESCRIPTION
Closes: #4417 

### Description:

- [x] CSV files with big numbers containing `,`, `;`, `:` and dates/timestamps are not corrupt anymore
- [x] Timestamp formatting updated to match `YYYY-MM-DD HH:mm:ss`
- [x] Date formatting updated to match `YYYY-MM-DD`

<img width="929" alt="Screenshot 2023-02-09 at 18 24 44" src="https://user-images.githubusercontent.com/67699259/217890670-2c01176c-fa4f-48db-9bb0-019539005b00.png">
