### PR TITLE
feat: support personal access tokens across endpoints

### DIFF
--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -2,7 +2,6 @@ import {
     ApiErrorPayload,
     ApiScheduledJobsResponse,
     ApiSchedulerAndTargetsResponse,
-    UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
 import { Delete } from '@tsoa/runtime';
 import express from 'express';
@@ -19,9 +18,12 @@ import {
     Route,
     SuccessResponse,
 } from 'tsoa';
-import { SchedulerService } from '../services/SchedulerService/SchedulerService';
 import { schedulerService } from '../services/services';
-import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from './authentication';
 
 @Route('/api/v1/schedulers')
 @Response<ApiErrorPayload>('default', 'Error')
@@ -55,7 +57,11 @@ export class SchedulerController extends Controller {
      * @param req express request
      * @param body the new scheduler data
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
     @SuccessResponse('201', 'Updated')
     @Patch('{schedulerUuid}')
     @OperationId('updateScheduler')
@@ -80,7 +86,11 @@ export class SchedulerController extends Controller {
      * @param schedulerUuid The uuid of the scheduler to delete
      * @param req express request
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
     @SuccessResponse('201', 'Deleted')
     @Delete('{schedulerUuid}')
     @OperationId('deleteScheduler')

--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -18,7 +18,7 @@ import {
     SuccessResponse,
 } from 'tsoa';
 import { shareService } from '../services/services';
-import { isAuthenticated } from './authentication';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 
 @Route('/api/v1/share')
 @Response<ApiErrorPayload>('default', 'Error')
@@ -28,7 +28,7 @@ export class ShareController extends Controller {
      * @param nanoId the short id for the share url
      * @param req express request
      */
-    @Middlewares([isAuthenticated])
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Get('{nanoId}')
     @OperationId('getShareUrl')
     async get(
@@ -47,7 +47,7 @@ export class ShareController extends Controller {
      * @param body a full URL used to generate a short url id
      * @param req express request
      */
-    @Middlewares([isAuthenticated])
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('201', 'Created')
     @Post('/')
     @OperationId('CreateShareUrl')

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -50,6 +50,7 @@ dashboardRouter.get(
 
 dashboardRouter.patch(
     '/:dashboardUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -90,6 +91,7 @@ dashboardRouter.patch(
 
 dashboardRouter.delete(
     '/:dashboardUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -128,6 +130,7 @@ dashboardRouter.post(
     '/:dashboardUuid/schedulers',
     allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
     async (req, res, next) => {
         try {
             res.json({
@@ -146,6 +149,7 @@ dashboardRouter.post(
 
 dashboardRouter.post(
     '/availableFilters',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {

--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -18,17 +18,22 @@ import {
 
 export const organizationRouter = express.Router();
 
-organizationRouter.get('/', isAuthenticated, async (req, res, next) => {
-    organizationService
-        .get(req.user!)
-        .then((results) => {
-            res.json({
-                status: 'ok',
-                results,
-            });
-        })
-        .catch(next);
-});
+organizationRouter.get(
+    '/',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        organizationService
+            .get(req.user!)
+            .then((results) => {
+                res.json({
+                    status: 'ok',
+                    results,
+                });
+            })
+            .catch(next);
+    },
+);
 
 organizationRouter.patch(
     '/',
@@ -85,6 +90,7 @@ organizationRouter.get(
 
 organizationRouter.post(
     '/projects/precompiled',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) =>

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -60,6 +60,7 @@ projectRouter.get(
 
 projectRouter.patch(
     '/',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -80,18 +81,23 @@ projectRouter.patch(
     },
 );
 
-projectRouter.get('/search/:query', isAuthenticated, async (req, res, next) => {
-    try {
-        const results = await searchService.getSearchResults(
-            req.user!,
-            req.params.projectUuid,
-            req.params.query,
-        );
-        res.json({ status: 'ok', results });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.get(
+    '/search/:query',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results = await searchService.getSearchResults(
+                req.user!,
+                req.params.projectUuid,
+                req.params.query,
+            );
+            res.json({ status: 'ok', results });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 
 projectRouter.put(
     '/explores',
@@ -110,25 +116,31 @@ projectRouter.put(
     },
 );
 
-projectRouter.get('/explores', isAuthenticated, async (req, res, next) => {
-    try {
-        const results: ApiExploresResults =
-            await projectService.getAllExploresSummary(
-                req.user!,
-                req.params.projectUuid,
-                req.query.filtered === 'true',
-            );
-        res.json({
-            status: 'ok',
-            results,
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.get(
+    '/explores',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results: ApiExploresResults =
+                await projectService.getAllExploresSummary(
+                    req.user!,
+                    req.params.projectUuid,
+                    req.query.filtered === 'true',
+                );
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 
 projectRouter.get(
     '/explores/:exploreId',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -146,6 +158,7 @@ projectRouter.get(
 
 projectRouter.post(
     '/explores/:exploreId/compileQuery',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -179,6 +192,7 @@ projectRouter.post(
 
 projectRouter.post(
     '/explores/:exploreId/runQuery',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -212,6 +226,7 @@ projectRouter.post(
 
 projectRouter.post(
     '/explores/:exploreId/downloadCsv',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -326,6 +341,7 @@ projectRouter.get(
 
 projectRouter.get(
     '/field/:fieldId/search',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -413,6 +429,7 @@ projectRouter.post(
 
 projectRouter.patch(
     '/saved',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -480,6 +497,7 @@ projectRouter.post(
 
 projectRouter.delete(
     '/spaces/:spaceUUid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -497,6 +515,7 @@ projectRouter.delete(
 
 projectRouter.patch(
     '/spaces/:spaceUUid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -514,6 +533,7 @@ projectRouter.patch(
 
 projectRouter.post(
     '/spaces/:spaceUUid/share',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -530,6 +550,7 @@ projectRouter.post(
 
 projectRouter.delete(
     '/spaces/:spaceUUid/share/:userUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -548,21 +569,26 @@ projectRouter.delete(
     },
 );
 
-projectRouter.get('/dashboards', isAuthenticated, async (req, res, next) => {
-    const chartUuid: string | undefined =
-        typeof req.query.chartUuid === 'string'
-            ? req.query.chartUuid.toString()
-            : undefined;
-    dashboardService
-        .getAllByProject(req.user!, req.params.projectUuid, chartUuid)
-        .then((results) => {
-            res.json({
-                status: 'ok',
-                results,
-            });
-        })
-        .catch(next);
-});
+projectRouter.get(
+    '/dashboards',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        const chartUuid: string | undefined =
+            typeof req.query.chartUuid === 'string'
+                ? req.query.chartUuid.toString()
+                : undefined;
+        dashboardService
+            .getAllByProject(req.user!, req.params.projectUuid, chartUuid)
+            .then((results) => {
+                res.json({
+                    status: 'ok',
+                    results,
+                });
+            })
+            .catch(next);
+    },
+);
 
 projectRouter.post(
     '/dashboards',
@@ -600,6 +626,7 @@ projectRouter.post(
 
 projectRouter.patch(
     '/dashboards',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -617,6 +644,7 @@ projectRouter.patch(
 
 projectRouter.post(
     '/sqlQuery',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -637,23 +665,29 @@ projectRouter.post(
     },
 );
 
-projectRouter.get('/catalog', isAuthenticated, async (req, res, next) => {
-    try {
-        const results: ProjectCatalog = await projectService.getCatalog(
-            req.user!,
-            req.params.projectUuid,
-        );
-        res.json({
-            status: 'ok',
-            results,
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.get(
+    '/catalog',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results: ProjectCatalog = await projectService.getCatalog(
+                req.user!,
+                req.params.projectUuid,
+            );
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 
 projectRouter.get(
     '/tablesConfiguration',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -674,6 +708,7 @@ projectRouter.get(
 
 projectRouter.patch(
     '/tablesConfiguration',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -696,6 +731,7 @@ projectRouter.patch(
 
 projectRouter.get(
     '/hasSavedCharts',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
@@ -713,39 +749,52 @@ projectRouter.get(
     },
 );
 
-projectRouter.get('/access', isAuthenticated, async (req, res, next) => {
-    try {
-        const results = await projectService.getProjectAccess(
-            req.user!,
-            req.params.projectUuid,
-        );
-        res.json({
-            status: 'ok',
-            results,
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.get(
+    '/access',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results = await projectService.getProjectAccess(
+                req.user!,
+                req.params.projectUuid,
+            );
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 
-projectRouter.post('/access', isAuthenticated, async (req, res, next) => {
-    try {
-        const results = await projectService.createProjectAccess(
-            req.user!,
-            req.params.projectUuid,
-            req.body,
-        );
-        res.json({
-            status: 'ok',
-            results,
-        });
-    } catch (e) {
-        next(e);
-    }
-});
+projectRouter.post(
+    '/access',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        try {
+            const results = await projectService.createProjectAccess(
+                req.user!,
+                req.params.projectUuid,
+                req.body,
+            );
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
 projectRouter.patch(
     '/access/:userUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
     async (req, res, next) => {
         try {
             const results = await projectService.updateProjectAccess(
@@ -765,7 +814,9 @@ projectRouter.patch(
 );
 projectRouter.delete(
     '/access/:userUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
     async (req, res, next) => {
         try {
             const results = await projectService.deleteProjectAccess(

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -48,6 +48,7 @@ savedChartRouter.get(
 
 savedChartRouter.get(
     '/:savedQueryUuid/availableFilters',
+    allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) =>
         projectService
@@ -66,6 +67,7 @@ savedChartRouter.get(
 
 savedChartRouter.delete(
     '/:savedQueryUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -83,6 +85,7 @@ savedChartRouter.delete(
 
 savedChartRouter.patch(
     '/:savedQueryUuid',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -118,6 +121,7 @@ savedChartRouter.patch(
 
 savedChartRouter.post(
     '/:savedQueryUuid/version',
+    allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
@@ -156,6 +160,7 @@ savedChartRouter.post(
     '/:savedQueryUuid/schedulers',
     allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
     async (req, res, next) => {
         try {
             res.json({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3358 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Make most endpoints support authentication with Personal Access Token. 

Excludes endpoints to create/edit/delete:
- user
- organisation
- integrations ( slack/dbt )

Also fixes some endpoints that should not be available in the demo.