### PR TITLE
fix: spaces page action menu doesnt update pinning status

### DIFF
--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -31,7 +31,7 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             enableSorting={false}
             defaultSort={{ updatedAt: SortDirection.DESC }}
             defaultColumnVisibility={{ space: false }}
-            showCount={false}
+            showCount={true}
             headerTitle="Pinned items"
         />
     ) : null;

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -23,6 +23,11 @@ export const useChartPinningMutation = () => {
                     variables.uuid,
                 ]);
                 await queryClient.invalidateQueries('spaces');
+                await queryClient.invalidateQueries([
+                    'space',
+                    savedChart.projectUuid,
+                    savedChart.spaceUuid,
+                ]);
                 if (savedChart.pinnedListUuid) {
                     showToastSuccess({
                         title: 'Success! Chart was pinned to homepage',

--- a/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
@@ -23,6 +23,11 @@ export const useDashboardPinningMutation = () => {
                     variables.uuid,
                 ]);
                 await queryClient.invalidateQueries('dashboards');
+                await queryClient.invalidateQueries([
+                    'space',
+                    dashboard.projectUuid,
+                    dashboard.spaceUuid,
+                ]);
                 if (dashboard.pinnedListUuid) {
                     showToastSuccess({
                         title: 'Success! Dashboard was pinned to homepage',


### PR DESCRIPTION
Closes: #4433 

### Description:
When pinning or unpinning a chart or dashboard, if you select the action menu again, the copy won't have updated and will be suggesting the opposite, incorrect action. 

e.g. when you've just pinned a dashbord, the action menu still has the item "Pin to homepage" instead of "Unpin from homepage". Likewise (but inverse) with unpinning. 