### PR TITLE
fix: success message on file upload is missing context

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/FileInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/FileInput.tsx
@@ -55,7 +55,8 @@ const FileInput: FC<FileFieldProps> = ({
             />
             {fileName && (
                 <Callout intent="success">
-                    Your file <b>{fileName}</b> was uploaded successfully!
+                    Your file <b>{fileName}</b> was uploaded successfully! Click
+                    `test and compile` to apply these changes to your project.
                 </Callout>
             )}
         </>


### PR DESCRIPTION
Closes: #4108

### Description:
before
![image](https://user-images.githubusercontent.com/67699259/218512769-61b1e185-1f6d-4066-b11f-7e0c9e07c6c4.png)

after
<img width="496" alt="Screenshot 2023-02-13 at 17 18 02" src="https://user-images.githubusercontent.com/67699259/218512730-9b5423a7-2728-4b02-830a-6d0e968335c3.png">
