### PR TITLE
feat: hide table names from chart labels

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -52,7 +52,7 @@ import { Space } from './types/space';
 import { TableBase } from './types/table';
 import { LightdashUser } from './types/user';
 import { formatItemValue } from './utils/formatting';
-import { getItemId, getItemLabel } from './utils/item';
+import { getItemId, getItemLabelWithoutTableName } from './utils/item';
 import { WeekDay } from './utils/timeFrames';
 
 export * from './authorization/index';
@@ -903,7 +903,8 @@ export const getAxisName = ({
     );
     const fallbackSeriesName: string | undefined =
         series && series.length === 1
-            ? series[0].name || (defaultItem && getItemLabel(defaultItem))
+            ? series[0].name ||
+              (defaultItem && getItemLabelWithoutTableName(defaultItem))
             : undefined;
     return !isAxisTheSameForAllSeries || selectedAxisIndex === axisIndex
         ? axisName || fallbackSeriesName

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -45,7 +45,7 @@ export const getItemId = (item: Field | AdditionalMetric | TableCalculation) =>
     isField(item) || isAdditionalMetric(item) ? fieldId(item) : item.name;
 
 export const getItemLabel = (item: Field | TableCalculation) =>
-    isField(item) ? `${item.tableLabel} ${item.label}` : item.displayName;
+    isField(item) ? `${item.label}` : item.displayName;
 
 export const getItemIcon = (
     item: Field | TableCalculation | AdditionalMetric,

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -45,6 +45,9 @@ export const getItemId = (item: Field | AdditionalMetric | TableCalculation) =>
     isField(item) || isAdditionalMetric(item) ? fieldId(item) : item.name;
 
 export const getItemLabel = (item: Field | TableCalculation) =>
+    isField(item) ? `${item.tableLabel} ${item.label}` : item.displayName;
+
+export const getItemLabelWithoutTableName = (item: Field | TableCalculation) =>
     isField(item) ? `${item.label}` : item.displayName;
 
 export const getItemIcon = (

--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -133,7 +133,7 @@ const testCompile = () => {
         .should('not.be.disabled')
         .click();
     cy.url().should('include', '/home', { timeout: 30000 });
-    cy.findByText('Welcome, David! ⚡');
+    cy.findByText('Welcome, David!');
     cy.findByText('Shared');
     cy.findByText('Spaces');
     cy.findByText('get started by creating some charts');

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -259,12 +259,12 @@ describe('Explore', () => {
                     cy.findByTestId('visualization')
                         .find('th')
                         .eq(1)
-                        .contains('First name')
+                        .contains('Customers First name')
                         .should('exist');
 
                     // open configuration and flip Show table names in the config
                     cy.get('button').contains('Configure').click();
-                    cy.findByPlaceholderText('First name')
+                    cy.findByPlaceholderText('Customers First name')
                         .focus()
                         .type('Overridden header')
                         .blur();

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -70,7 +70,7 @@ describe('Explore', () => {
         // cy.findByText('Save changes').parent().should('not.be.disabled');
         cy.findByText('Save changes').parent().click();
 
-        cy.findByText('Success! Chart was saved.');
+        cy.findByText('Success! Chart was updated.');
     });
 
     it('Should change chart config type', () => {
@@ -259,12 +259,12 @@ describe('Explore', () => {
                     cy.findByTestId('visualization')
                         .find('th')
                         .eq(1)
-                        .contains('Customers First name')
+                        .contains('First name')
                         .should('exist');
 
                     // open configuration and flip Show table names in the config
                     cy.get('button').contains('Configure').click();
-                    cy.findByPlaceholderText('Customers First name')
+                    cy.findByPlaceholderText('First name')
                         .focus()
                         .type('Overridden header')
                         .blur();

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -12,7 +12,7 @@ import {
     getAxisName,
     getDimensions,
     getItemId,
-    getItemLabel,
+    getItemLabelWithoutTableName,
     getMetrics,
     isField,
     isNumericItem,
@@ -212,7 +212,10 @@ const ChartConfigTabs: FC = () => {
                                     placeholder="Enter axis label"
                                     defaultValue={
                                         dirtyEchartsConfig?.xAxis?.[0]?.name ||
-                                        (xAxisField && getItemLabel(xAxisField))
+                                        (xAxisField &&
+                                            getItemLabelWithoutTableName(
+                                                xAxisField,
+                                            ))
                                     }
                                     onBlur={(e) =>
                                         setXAxisName(e.currentTarget.value)

--- a/packages/frontend/src/components/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@blueprintjs/core';
 import {
     CartesianChartLayout,
     Field,
-    getItemLabel,
+    getItemLabelWithoutTableName,
     getSeriesId,
     Series,
     TableCalculation,
@@ -39,13 +39,13 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                     icon="drag-handle-vertical"
                     {...dragHandleProps}
                 />
-                {getItemLabel(item)}
+                {getItemLabelWithoutTableName(item)}
             </SeriesTitle>
             <SingleSeriesConfiguration
                 layout={layout}
                 series={series}
                 isSingle={isSingle}
-                seriesLabel={getItemLabel(item)}
+                seriesLabel={getItemLabelWithoutTableName(item)}
                 fallbackColor={getSeriesColor(getSeriesId(series))}
                 updateSingleSeries={updateSingleSeries}
             />

--- a/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -5,7 +5,7 @@ import {
     Field,
     formatItemValue,
     getItemId,
-    getItemLabel,
+    getItemLabelWithoutTableName,
     getSeriesId,
     isSeriesWithMixedChartTypes,
     Series,
@@ -168,7 +168,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                     icon="drag-handle-vertical"
                     {...dragHandleProps}
                 />
-                {getItemLabel(item)} (grouped)
+                {getItemLabelWithoutTableName(item)} (grouped)
             </SeriesTitle>
             <GroupSeriesInputs>
                 <SeriesExtraInputWrapper label="Chart type">
@@ -373,7 +373,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                                                         .yField
                                                                         .length >
                                                                         1
-                                                                        ? `[${pivotLabel}] ${getItemLabel(
+                                                                        ? `[${pivotLabel}] ${getItemLabelWithoutTableName(
                                                                               item,
                                                                           )}`
                                                                         : pivotLabel

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -49,7 +49,9 @@ const getLabelFromField = (
 ) => {
     const item = findItem(fields, key);
     if (item) {
-        return isField(item) ? getFieldLabel(item) : item.displayName;
+        return isField(item)
+            ? getItemLabelWithoutTableName(item)
+            : item.displayName;
     } else if (key) {
         return friendlyName(key);
     } else {

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -17,7 +17,7 @@ import {
     getFieldMap,
     getFields,
     getItemId,
-    getItemLabel,
+    getItemLabelWithoutTableName,
     getResultValues,
     hashFieldReference,
     isCompleteLayout,
@@ -856,7 +856,9 @@ const getEchartAxis = ({
                           series: validCartesianConfig.eChartsConfig.series,
                       })
                     : xAxisConfiguration?.[0]?.name ||
-                      (xAxisItem ? getItemLabel(xAxisItem) : undefined),
+                      (xAxisItem
+                          ? getItemLabelWithoutTableName(xAxisItem)
+                          : undefined),
                 min: validCartesianConfig.layout.flipAxes
                     ? xAxisConfiguration?.[0]?.min ||
                       maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
@@ -916,7 +918,9 @@ const getEchartAxis = ({
                 type: leftAxisType,
                 name: validCartesianConfig.layout.flipAxes
                     ? yAxisConfiguration?.[0]?.name ||
-                      (yAxisItem ? getItemLabel(yAxisItem) : undefined)
+                      (yAxisItem
+                          ? getItemLabelWithoutTableName(yAxisItem)
+                          : undefined)
                     : getAxisName({
                           isAxisTheSameForAllSeries,
                           selectedAxisIndex,


### PR DESCRIPTION
Closes: #4391 

### Description:
Table names can make labels and legends confusing, even when joining other tables it might be unhelpful. 
They should be hidden. Based on user research, there have been no real convincing cases that have come up to suggest that table names are useful in axes.