### PR TITLE
fix: create a new dashboard flow should be uniform

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -53,7 +53,6 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 </LargeMenuItemIconWrapper>
                             }
                             href={`/projects/${projectUuid}/tables`}
-                            // onClick={() => setIsOpen(false)}
                             text={
                                 <>
                                     <LargeMenuItemText>

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useApp } from '../../providers/AppProvider';
 import { Can } from '../common/Authorization';
+import DashboardCreateModal from '../common/modal/DashboardCreateModal';
 import {
     PageBreadcrumbsWrapper,
     PageContentWrapper,
@@ -46,6 +47,8 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
 
     const [updateSpace, setUpdateSpace] = useState<boolean>(false);
     const [deleteSpace, setDeleteSpace] = useState<boolean>(false);
+    const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
+        useState<boolean>(false);
     const [addToSpace, setAddToSpace] = useState<AddToSpaceResources>();
     const [createToSpace, setCreateToSpace] = useState<AddToSpaceResources>();
 
@@ -156,7 +159,8 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                                 setAddToSpace(AddToSpaceResources.DASHBOARD)
                             }
                             onCreate={() =>
-                                setCreateToSpace(AddToSpaceResources.DASHBOARD)
+                                // setCreateToSpace(AddToSpaceResources.DASHBOARD)
+                                setIsCreateDashboardOpen(true)
                             }
                         >
                             <Button icon="plus" intent="primary" />
@@ -217,6 +221,18 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
             {createToSpace && (
                 <CreateResourceToSpace resourceType={createToSpace} />
             )}
+            <DashboardCreateModal
+                projectUuid={projectUuid}
+                isOpen={isCreateDashboardOpen}
+                onClose={() => setIsCreateDashboardOpen(false)}
+                onConfirm={(dashboard) => {
+                    history.push(
+                        `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                    );
+
+                    setIsCreateDashboardOpen(false);
+                }}
+            />
         </PageContentWrapper>
     );
 };

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -158,10 +158,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                             onAdd={() =>
                                 setAddToSpace(AddToSpaceResources.DASHBOARD)
                             }
-                            onCreate={() =>
-                                // setCreateToSpace(AddToSpaceResources.DASHBOARD)
-                                setIsCreateDashboardOpen(true)
-                            }
+                            onCreate={() => setIsCreateDashboardOpen(true)}
                         >
                             <Button icon="plus" intent="primary" />
                         </AddResourceToSpaceMenu>


### PR DESCRIPTION
Closes: #4454 

### Description:
Space panels (image below) were using the old `Create a new dashboard` flow i.e. a dashboard named `Untitled` is created by default and the user is redirected to it. 
New flow: popover to choose `name` and `description`, on `create` button click, user is redirected to new dashboard in `edit mode`.

I thoroughly tested all other places in the app from which we can `Create a dashboard` and the new flow is now implemented throughout the app. This was the only miss.

![image](https://user-images.githubusercontent.com/67699259/218682034-e21c3b04-5350-4451-9c2b-6412484bc94a.png)
