### PR TITLE
fix: skip compile on project update

### DIFF
--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
@@ -1,84 +1,45 @@
-import {
-    CreateWarehouseCredentials,
-    DbtProjectEnvironmentVariable,
-} from '@lightdash/common';
+import { DbtPackages, Explore, ExploreError } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
-import { writeFileSync } from 'fs';
-import * as fspromises from 'fs/promises';
-import * as path from 'path';
-import tempy from 'tempy';
-import {
-    LIGHTDASH_PROFILE_NAME,
-    LIGHTDASH_TARGET_NAME,
-    profileFromCredentials,
-} from '../dbt/profiles';
 import Logger from '../logger';
-import { CachedWarehouse } from '../types';
-import { DbtLocalProjectAdapter } from './dbtLocalProjectAdapter';
+import { ProjectAdapter } from '../types';
 
 type DbtNoneCredentialsProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
-    projectDir: string;
-    warehouseCredentials: CreateWarehouseCredentials;
-    targetName: string | undefined;
-    environment: DbtProjectEnvironmentVariable[] | undefined;
-    cachedWarehouse: CachedWarehouse;
 };
 
-export class DbtNoneCredentialsProjectAdapter extends DbtLocalProjectAdapter {
-    profilesDir: string;
+export class DbtNoneCredentialsProjectAdapter implements ProjectAdapter {
+    warehouseClient: WarehouseClient;
 
-    constructor({
-        warehouseClient,
-        projectDir,
-        warehouseCredentials,
-        targetName,
-        environment,
-        cachedWarehouse,
-    }: DbtNoneCredentialsProjectAdapterArgs) {
-        const profilesDir = tempy.directory();
-        const profilesFilename = path.join(profilesDir, 'profiles.yml');
-        const {
-            profile,
-            environment: injectedEnvironment,
-            files,
-        } = profileFromCredentials(
-            warehouseCredentials,
-            profilesDir,
-            targetName,
-        );
-        if (files) {
-            Object.entries(files).forEach(([filePath, content]) => {
-                writeFileSync(filePath, content);
-            });
-        }
-        writeFileSync(profilesFilename, profile);
-        const e = (environment || []).reduce<Record<string, string>>(
-            (previousValue, { key, value }) => ({
-                ...previousValue,
-                ...(key.length > 0 ? { [key]: value } : {}), // ignore empty strings
-            }),
-            {},
-        );
-        const updatedEnvironment = {
-            ...e,
-            ...injectedEnvironment,
-        };
-        super({
-            warehouseClient,
-            target: targetName || LIGHTDASH_TARGET_NAME,
-            profileName: LIGHTDASH_PROFILE_NAME,
-            profilesDir,
-            projectDir,
-            environment: updatedEnvironment,
-            cachedWarehouse,
-        });
-        this.profilesDir = profilesDir;
+    constructor({ warehouseClient }: DbtNoneCredentialsProjectAdapterArgs) {
+        this.warehouseClient = warehouseClient;
     }
 
-    async destroy() {
+    // eslint-disable-next-line class-methods-use-this
+    async destroy(): Promise<void> {
         Logger.debug(`Destroy none project adapter`);
-        await fspromises.rm(this.profilesDir, { recursive: true, force: true });
-        await super.destroy();
+    }
+
+    public async test(): Promise<void> {
+        Logger.debug('Test warehouse client');
+        await this.warehouseClient.test();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public async compileAllExplores(
+        loadSources: boolean = false,
+    ): Promise<(Explore | ExploreError)[]> {
+        throw new Error('Cannot compile explores with CLI-created projects');
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public async getDbtPackages(): Promise<DbtPackages | undefined> {
+        Logger.debug(`Get dbt packages`);
+        return undefined;
+    }
+
+    public async runQuery(sql: string) {
+        Logger.debug(`Run query against warehouse`);
+        // Possible error if query is ran before dependencies are installed
+        return this.warehouseClient.runQuery(sql);
     }
 }

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -40,11 +40,6 @@ export const projectAdapterFromConfig = async (
         case DbtProjectType.NONE:
             return new DbtNoneCredentialsProjectAdapter({
                 warehouseClient,
-                projectDir: '/usr/app/dbt',
-                warehouseCredentials,
-                targetName: config.target,
-                environment: config.environment,
-                cachedWarehouse,
             });
 
         case DbtProjectType.DBT_CLOUD_IDE:

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
@@ -27,7 +27,7 @@ const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => (
                 rel="noreferrer"
             >
                 GitHub action
-            </a>
+            </a>{' '}
             or, run{' '}
             <a
                 href={
@@ -40,27 +40,6 @@ const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => (
             </a>
             ) from your command line.
         </Callout>
-        <BooleanSwitch
-            name="dbt.hideRefreshButton"
-            label="Hide refresh dbt button in the app"
-            labelHelp={
-                <p>
-                    This will hide the refresh dbt button from the explore page.
-                    Read more about your{' '}
-                    <a
-                        href={
-                            'https://docs.lightdash.com/references/syncing_your_dbt_changes#2-in-the-ui-syncing-your-dbt-changes-using-refresh-dbt'
-                        }
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        options for refreshing dbt here
-                    </a>
-                </p>
-            }
-            disabled={disabled}
-            defaultValue={false}
-        />
     </>
 );
 

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
@@ -1,8 +1,6 @@
 import { Callout } from '@blueprintjs/core';
-import { WarehouseTypes } from '@lightdash/common';
 import React, { FC } from 'react';
 import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
-import SelectField from '../../ReactHookForm/Select';
 
 const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => (
     <>
@@ -40,6 +38,27 @@ const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => (
             </a>
             ) from your command line.
         </Callout>
+        <BooleanSwitch
+            name="dbt.hideRefreshButton"
+            label="Hide refresh dbt button in the app"
+            labelHelp={
+                <p>
+                    This will hide the refresh dbt button from the explore page.
+                    Read more about your{' '}
+                    <a
+                        href={
+                            'https://docs.lightdash.com/references/syncing_your_dbt_changes#2-in-the-ui-syncing-your-dbt-changes-using-refresh-dbt'
+                        }
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        options for refreshing dbt here
+                    </a>
+                </p>
+            }
+            disabled={disabled}
+            defaultValue={false}
+        />
     </>
 );
 

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -160,42 +160,51 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                 defaultValue={DbtProjectType.GITHUB}
             />
             {form}
-            <FormSection name="target">
-                <Input
-                    name="dbt.target"
-                    label="Target name"
-                    labelHelp={
-                        <p>
-                            <b>target</b> is the dataset/schema in your data
-                            warehouse that Lightdash will look for your dbt
-                            models. By default, we set this to be the same value
-                            as you have as the default in your profiles.yml
-                            file.
-                        </p>
-                    }
-                    disabled={disabled}
-                    placeholder="prod"
-                />
-                {warehouseSchemaInput}
-            </FormSection>
-            <FormSection name={'Advanced'} isOpen={isAdvancedSettingsOpen}>
-                <MultiKeyValuePairsInput
-                    name="dbt.environment"
-                    label="Environment variables"
-                    documentationUrl={`${baseDocUrl}${typeDocUrls[type].env}`}
-                    disabled={disabled}
-                />
-                <></>
-            </FormSection>
-            <AdvancedButtonWrapper>
-                <AdvancedButton
-                    icon={
-                        isAdvancedSettingsOpen ? 'chevron-up' : 'chevron-down'
-                    }
-                    text={`Advanced configuration options`}
-                    onClick={toggleAdvancedSettingsOpen}
-                />
-            </AdvancedButtonWrapper>
+            {type !== DbtProjectType.NONE && (
+                <>
+                    <FormSection name="target">
+                        <Input
+                            name="dbt.target"
+                            label="Target name"
+                            labelHelp={
+                                <p>
+                                    <b>target</b> is the dataset/schema in your
+                                    data warehouse that Lightdash will look for
+                                    your dbt models. By default, we set this to
+                                    be the same value as you have as the default
+                                    in your profiles.yml file.
+                                </p>
+                            }
+                            disabled={disabled}
+                            placeholder="prod"
+                        />
+                        {warehouseSchemaInput}
+                    </FormSection>
+                    <FormSection
+                        name={'Advanced'}
+                        isOpen={isAdvancedSettingsOpen}
+                    >
+                        <MultiKeyValuePairsInput
+                            name="dbt.environment"
+                            label="Environment variables"
+                            documentationUrl={`${baseDocUrl}${typeDocUrls[type].env}`}
+                            disabled={disabled}
+                        />
+                        <></>
+                    </FormSection>
+                    <AdvancedButtonWrapper>
+                        <AdvancedButton
+                            icon={
+                                isAdvancedSettingsOpen
+                                    ? 'chevron-up'
+                                    : 'chevron-down'
+                            }
+                            text={`Advanced configuration options`}
+                            onClick={toggleAdvancedSettingsOpen}
+                        />
+                    </AdvancedButtonWrapper>
+                </>
+            )}
         </div>
     );
 };

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -277,7 +277,12 @@ export const UpdateProjectConnection: FC<{
                             large
                             type="submit"
                             intent={Intent.PRIMARY}
-                            text="Test &amp; compile project"
+                            text={
+                                data?.dbtConnection?.type ===
+                                DbtProjectType.NONE
+                                    ? 'Save and test'
+                                    : 'Test &amp; compile project'
+                            }
                             loading={isSaving}
                             disabled={isDisabled}
                         />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4356

Temporary fix until we refactor the settings page and endpoints to decouple compiling from updating warehouse settings.

### Description:

* Simplify the none project adapter by removing unneeded logic
* Add error if trying to compile a project with a none adapter (possible on the `/refresh` endpoint and `/create` endpoint for projects)
* Remove extra fields from the dbt form in the UI for CLI projects
* Switch the `PATCH /project/{projectUuid}` endpoint to skip compilation for CLI projects
* Switch UI copy on th dbt form for CLI projects

## Before
<img width="942" alt="Screenshot 2023-02-15 at 09 27 51" src="https://user-images.githubusercontent.com/11660098/218996270-fff35d49-a7e0-431f-8299-f4259de951c1.png">

<img width="884" alt="Screenshot 2023-02-15 at 10 03 03" src="https://user-images.githubusercontent.com/11660098/218996495-0cbe0152-5acd-4baa-a314-aa8a15f12c36.png">


## After

<img width="941" alt="Screenshot 2023-02-15 at 09 57 31" src="https://user-images.githubusercontent.com/11660098/218996307-6304e360-34d9-4df2-bc4f-dbf591ee88cb.png">
