### PR TITLE
feat: info icon to give different users context on pinned items

### DIFF
--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,6 +1,10 @@
-import { FC, ReactNode, useMemo } from 'react';
+import { Colors } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { FC, useMemo } from 'react';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useSavedCharts } from '../../hooks/useSpaces';
+import { useApp } from '../../providers/AppProvider';
 import ResourceList from '../common/ResourceList';
 import { SortDirection } from '../common/ResourceList/ResourceTable';
 import {
@@ -10,11 +14,27 @@ import {
 
 interface Props {
     projectUuid: string;
+    organizationUuid: string;
 }
 
-const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
+const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
     const { data: dashboards = [] } = useDashboards(projectUuid);
     const { data: savedCharts = [] } = useSavedCharts(projectUuid);
+    const { user } = useApp();
+
+    const headerTitle = user.data?.ability.can(
+        'update',
+        subject('Project', { organizationUuid, projectUuid }),
+    )
+        ? 'Pinned items'
+        : 'Pinned for you';
+
+    const headerIconTooltipContent = user.data?.ability.can(
+        'update',
+        subject('Project', { organizationUuid, projectUuid }),
+    )
+        ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
+        : 'Your data team have pinned these items to help guide you towards the most relevant content!';
 
     const pinnedItems = useMemo(() => {
         return [
@@ -32,7 +52,17 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             defaultSort={{ updatedAt: SortDirection.DESC }}
             defaultColumnVisibility={{ space: false }}
             showCount={false}
-            headerTitle="Pinned items"
+            headerTitle={headerTitle}
+            headerIcon={
+                <IconInfoCircle
+                    color={Colors.GRAY5}
+                    size={17}
+                    style={{
+                        marginTop: '7px',
+                    }}
+                />
+            }
+            headerIconTooltipContent={headerIconTooltipContent}
         />
     ) : null;
 };

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -22,19 +22,10 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
     const { data: savedCharts = [] } = useSavedCharts(projectUuid);
     const { user } = useApp();
 
-    const headerTitle = user.data?.ability.can(
+    const userCanUpdateProject = user.data?.ability.can(
         'update',
         subject('Project', { organizationUuid, projectUuid }),
-    )
-        ? 'Pinned items'
-        : 'Pinned for you';
-
-    const headerIconTooltipContent = user.data?.ability.can(
-        'update',
-        subject('Project', { organizationUuid, projectUuid }),
-    )
-        ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
-        : 'Your data team have pinned these items to help guide you towards the most relevant content!';
+    );
 
     const pinnedItems = useMemo(() => {
         return [
@@ -52,7 +43,9 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
             defaultSort={{ updatedAt: SortDirection.DESC }}
             defaultColumnVisibility={{ space: false }}
             showCount={false}
-            headerTitle={headerTitle}
+            headerTitle={
+                userCanUpdateProject ? 'Pinned items' : 'Pinned for you'
+            }
             headerIcon={
                 <IconInfoCircle
                     color={Colors.GRAY5}
@@ -62,7 +55,11 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
                     }}
                 />
             }
-            headerIconTooltipContent={headerIconTooltipContent}
+            headerIconTooltipContent={
+                userCanUpdateProject
+                    ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
+                    : 'Your data team have pinned these items to help guide you towards the most relevant content!'
+            }
         />
     ) : null;
 };

--- a/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
+++ b/packages/frontend/src/components/common/ResourceList/ResourceList.styles.ts
@@ -17,7 +17,7 @@ export const ResourceListHeader = styled.div`
     align-items: center;
     width: 100%;
     padding: 12px ${paddingX}px;
-    gap: 10px;
+    gap: 6px;
     border-bottom: 1px solid ${Colors.LIGHT_GRAY2};
 `;
 

--- a/packages/frontend/src/components/common/ResourceList/ResourceListWrapper.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceListWrapper.tsx
@@ -1,3 +1,4 @@
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { FC } from 'react';
 import {
     ResourceListContainer,
@@ -9,6 +10,8 @@ import {
 
 export interface ResourceListWrapperProps {
     headerTitle?: string;
+    headerIcon?: JSX.Element;
+    headerIconTooltipContent?: string;
     headerAction?: React.ReactNode;
     resourceCount?: number;
     showCount?: boolean;
@@ -16,6 +19,8 @@ export interface ResourceListWrapperProps {
 
 const ResourceListWrapper: FC<ResourceListWrapperProps> = ({
     headerTitle,
+    headerIcon,
+    headerIconTooltipContent,
     headerAction,
     resourceCount,
     showCount = true,
@@ -28,7 +33,14 @@ const ResourceListWrapper: FC<ResourceListWrapperProps> = ({
                     {headerTitle && (
                         <ResourceTitle>{headerTitle}</ResourceTitle>
                     )}
-
+                    {headerIcon && (
+                        <Tooltip2
+                            content={headerIconTooltipContent || ''}
+                            disabled={!headerIconTooltipContent}
+                        >
+                            {headerIcon}
+                        </Tooltip2>
+                    )}
                     {showCount &&
                         resourceCount !== undefined &&
                         resourceCount > 0 && (

--- a/packages/frontend/src/components/common/ResourceList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceList/index.tsx
@@ -12,6 +12,8 @@ import { ResourceListItem } from './ResourceTypeUtils';
 
 export interface ResourceListCommonProps {
     headerTitle?: string;
+    headerIcon?: JSX.Element;
+    headerIconTooltipContent?: string;
     headerAction?: React.ReactNode;
     items: ResourceListItem[];
     showCount?: boolean;
@@ -25,6 +27,8 @@ type ResourceListProps = ResourceListCommonProps &
 const ResourceList: React.FC<ResourceListProps> = ({
     items,
     headerTitle,
+    headerIcon,
+    headerIconTooltipContent,
     headerAction,
     enableSorting,
     enableMultiSort,
@@ -45,6 +49,8 @@ const ResourceList: React.FC<ResourceListProps> = ({
         <>
             <ResourceListWrapper
                 headerTitle={headerTitle}
+                headerIcon={headerIcon}
+                headerIconTooltipContent={headerIconTooltipContent}
                 headerAction={headerAction}
                 resourceCount={items.length}
                 showCount={showCount}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -69,6 +69,7 @@ const Home: FC = () => {
                         />
                         <PinnedItemsPanel
                             projectUuid={project.data.projectUuid}
+                            organizationUuid={project.data.organizationUuid}
                         />
                         <SpaceBrowser projectUuid={project.data.projectUuid} />
 


### PR DESCRIPTION
Closes: #4444 

### Description:
- [x] **General information icon (for admins/editors)**
`Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.`
- [x] **General information icon (for viewers)**
`Your data team have pinned these items to help guide you towards the most relevant content!`
- [x] Use Tabler Icon `info-circle`
- [x] Change `Pinned` to `Pinned for you` for users that don't have ability to pin. (viewers) 

<img width="830" alt="Screenshot 2023-02-15 at 11 39 27" src="https://user-images.githubusercontent.com/67699259/219006348-1b35e4fc-4dc9-471a-9269-daa27edc30bc.png">
<img width="815" alt="Screenshot 2023-02-15 at 11 40 28" src="https://user-images.githubusercontent.com/67699259/219006353-02631d20-7aa1-496c-9736-da204f5aa339.png">


