### PR TITLE
docs: add docs + test for underscores in filters

### DIFF
--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -588,6 +588,26 @@ These filters do not appear in the `Filters` tab in the Explore view, instead, t
 | is less than                | Number of orders is less than 4                | `num_orders: '< 4'`   |
 | is less than or equal to    | Number of orders is less than or equal to 4    | `num_orders: '<= 4'`  |
 
+
+:::info
+
+To use special characters such as `%!_>` in your filter value you must escape them with a backslash `\`. For example,
+if you wanted to filter for users with subscription status `is_subscribed` you should write the metric like:
+
+
+```yaml
+columns:
+  - name: user_id
+    meta:
+      metrics:
+        total_subscribed_users:
+          type: count_distinct
+          filters:
+            - subscription_status: is\_subscribed
+```
+
+:::
+
 ### If you have many filters in your list, they will be joined using `AND`.
 
 For example:

--- a/packages/common/src/types/filterGrammar.test.ts
+++ b/packages/common/src/types/filterGrammar.test.ts
@@ -26,6 +26,14 @@ describe('attachTypesToModels', () => {
         });
     });
 
+    it('should compile grammar with escaped underscore', async () => {
+        expect(parser.parse('katie\\_')).toEqual({
+            is: true,
+            type: 'equals',
+            values: ['katie_'],
+        });
+    });
+
     it('Not equals grammar', async () => {
         expect(parser.parse('!pedram')).toEqual({
             is: false,
@@ -41,6 +49,7 @@ describe('attachTypesToModels', () => {
             values: ['katie'],
         });
     });
+
     it('Not contains grammar', async () => {
         expect(parser.parse('!%katie%')).toEqual({
             is: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

@rephus do we support underscore as an operator? It's not in the docs but in the grammar it looks like it has a special meaning
