### PR TITLE
feat: tooltip on refresh dbt button added

### DIFF
--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -112,12 +112,14 @@ const RefreshDbtButton: FC<ComponentProps<typeof BigButton>> = (props) => {
     }
 
     return (
-        <RefreshDbt
-            {...props}
-            icon={!isLoading ? 'refresh' : <LoadingSpinner size={15} />}
-            text={!isLoading ? 'Refresh dbt' : 'Refreshing dbt'}
-            onClick={onClick}
-        />
+        <Tooltip2 content="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button.">
+            <RefreshDbt
+                {...props}
+                icon={!isLoading ? 'refresh' : <LoadingSpinner size={15} />}
+                text={!isLoading ? 'Refresh dbt' : 'Refreshing dbt'}
+                onClick={onClick}
+            />
+        </Tooltip2>
     );
 };
 


### PR DESCRIPTION
Closes: #2063 

### Description:
When the user hovers over the refresh dbt, it would be useful to have a couple of lines explaining when this action should be carried out. 

```
If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button.
```
<img width="882" alt="Screenshot 2023-02-15 at 12 16 32" src="https://user-images.githubusercontent.com/67699259/219012909-31124d5e-af56-494c-9e7b-450f72a510a0.png">
<img width="899" alt="Screenshot 2023-02-15 at 12 16 25" src="https://user-images.githubusercontent.com/67699259/219012903-90f56d45-7e96-429a-be93-0b15d0a75537.png">


