### PR TITLE
feat: updates to spaces page

### DIFF
--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.styles.ts
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.styles.ts
@@ -1,0 +1,10 @@
+import { MenuItem2 } from '@blueprintjs/popover2';
+import styled from 'styled-components';
+
+export const AddExistingResourceToSpaceMenuItem = styled(MenuItem2)`
+    margin: 0px -5px -5px;
+`;
+
+export const AddNewResourceToSpaceMenuItem = styled(MenuItem2)`
+    margin: -5px -0px -5px;
+`;

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
@@ -1,32 +1,34 @@
 import { Menu } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import React from 'react';
-import { AddResourceToSpaceMenuContainer } from './SpaceBrowser.styles';
+import { ResourceListType } from '../../common/ResourceList/ResourceTypeUtils';
 
 interface AddResourceToSpaceMenuProps {
+    resourceType: ResourceListType;
     onAdd: () => void;
     onCreate: () => void;
 }
 
 const AddResourceToSpaceMenu: React.FC<AddResourceToSpaceMenuProps> = ({
+    resourceType,
     onAdd,
     onCreate,
 }) => {
     return (
-        <AddResourceToSpaceMenuContainer>
+        <Menu>
             <MenuItem2
                 icon="plus"
-                text={`Add existing`}
+                text={`Add existing ${resourceType}`}
                 onClick={onAdd}
                 style={{ margin: '-3px' }}
             />
             <MenuItem2
                 icon="clean"
-                text={`Create new`}
+                text={`Create new ${resourceType}`}
                 onClick={onCreate}
                 style={{ margin: '-3px' }}
             />
-        </AddResourceToSpaceMenuContainer>
+        </Menu>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
@@ -20,13 +20,13 @@ const AddResourceToSpaceMenu: React.FC<AddResourceToSpaceMenuProps> = ({
                 icon="plus"
                 text={`Add existing ${resourceType}`}
                 onClick={onAdd}
-                style={{ margin: '-3px' }}
+                style={{ margin: '-5px', marginBottom: '0px' }}
             />
             <MenuItem2
                 icon="clean"
                 text={`Create new ${resourceType}`}
                 onClick={onCreate}
-                style={{ margin: '-3px' }}
+                style={{ margin: '-5px', marginTop: '0px' }}
             />
         </Menu>
     );

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
@@ -1,10 +1,10 @@
 import { Menu } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import React from 'react';
-import { ResourceListType } from '../../common/ResourceList/ResourceTypeUtils';
+import { AddToSpaceResources } from './AddResourceToSpaceModal';
 
 interface AddResourceToSpaceMenuProps {
-    resourceType: ResourceListType;
+    resourceType: AddToSpaceResources;
     onAdd: () => void;
     onCreate: () => void;
 }

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
@@ -1,6 +1,10 @@
 import { Menu } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import React from 'react';
+import {
+    AddExistingResourceToSpaceMenuItem,
+    AddNewResourceToSpaceMenuItem,
+} from './AddResourceToSpaceMenu.styles';
 import { AddToSpaceResources } from './AddResourceToSpaceModal';
 
 interface AddResourceToSpaceMenuProps {
@@ -16,13 +20,13 @@ const AddResourceToSpaceMenu: React.FC<AddResourceToSpaceMenuProps> = ({
 }) => {
     return (
         <Menu>
-            <MenuItem2
+            <AddExistingResourceToSpaceMenuItem
                 icon="plus"
                 text={`Add existing ${resourceType}`}
                 onClick={onAdd}
                 style={{ margin: '-5px', marginBottom: '0px' }}
             />
-            <MenuItem2
+            <AddNewResourceToSpaceMenuItem
                 icon="clean"
                 text={`Create new ${resourceType}`}
                 onClick={onCreate}

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceMenu.tsx
@@ -1,41 +1,32 @@
-import { Menu, PopoverPosition } from '@blueprintjs/core';
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { Menu } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import React from 'react';
-import { AddToSpaceResources } from './AddResourceToSpaceModal';
+import { AddResourceToSpaceMenuContainer } from './SpaceBrowser.styles';
 
 interface AddResourceToSpaceMenuProps {
-    resourceType: AddToSpaceResources;
     onAdd: () => void;
     onCreate: () => void;
 }
 
 const AddResourceToSpaceMenu: React.FC<AddResourceToSpaceMenuProps> = ({
-    resourceType,
     onAdd,
     onCreate,
-    children,
 }) => {
     return (
-        <Popover2
-            captureDismiss
-            position={PopoverPosition.BOTTOM_RIGHT}
-            content={
-                <Menu>
-                    <MenuItem2
-                        icon="plus"
-                        text={`Add existing ${resourceType}`}
-                        onClick={onAdd}
-                    />
-                    <MenuItem2
-                        icon="clean"
-                        text={`Create new ${resourceType}`}
-                        onClick={onCreate}
-                    />
-                </Menu>
-            }
-        >
-            {children}
-        </Popover2>
+        <AddResourceToSpaceMenuContainer>
+            <MenuItem2
+                icon="plus"
+                text={`Add existing`}
+                onClick={onAdd}
+                style={{ margin: '-3px' }}
+            />
+            <MenuItem2
+                icon="clean"
+                text={`Create new`}
+                onClick={onCreate}
+                style={{ margin: '-3px' }}
+            />
+        </AddResourceToSpaceMenuContainer>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowser.styles.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowser.styles.tsx
@@ -1,5 +1,4 @@
-import { Colors, Icon, IconName, Menu, Text } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
+import { Colors, Icon, IconName, Text } from '@blueprintjs/core';
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import LinkButton from '../../common/LinkButton';
@@ -65,10 +64,3 @@ export const SpaceItemCount: FC<{ icon: IconName; value: number }> = ({
         </CountWrapper>
     );
 };
-
-export const AddResourceToSpaceMenuContainer = styled(Menu)`
-    .bp4-menu {
-        maxwidth: 100px;
-        background-color: red;
-    }
-`;

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowser.styles.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowser.styles.tsx
@@ -1,4 +1,5 @@
-import { Colors, Icon, IconName, Text } from '@blueprintjs/core';
+import { Colors, Icon, IconName, Menu, Text } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import LinkButton from '../../common/LinkButton';
@@ -64,3 +65,10 @@ export const SpaceItemCount: FC<{ icon: IconName; value: number }> = ({
         </CountWrapper>
     );
 };
+
+export const AddResourceToSpaceMenuContainer = styled(Menu)`
+    .bp4-menu {
+        maxwidth: 100px;
+        background-color: red;
+    }
+`;

--- a/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
@@ -62,7 +62,7 @@ const RecentlyUpdatedPanel: FC<Props> = ({ projectUuid }) => {
             items={recentItems}
             enableSorting={false}
             defaultSort={{ updatedAt: SortDirection.DESC }}
-            defaultColumnVisibility={{ space: false }}
+            defaultColumnVisibility={{ space: false, type: false }}
             showCount={false}
             headerTitle="Recently updated"
             headerAction={

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -30,7 +30,7 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid }) => {
             items={pinnedItems}
             enableSorting={false}
             defaultSort={{ updatedAt: SortDirection.DESC }}
-            defaultColumnVisibility={{ space: false }}
+            defaultColumnVisibility={{ space: false, type: false }}
             showCount={false}
             headerTitle="Pinned items"
         />

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -1,7 +1,8 @@
-import { Button, Intent } from '@blueprintjs/core';
-import { Breadcrumbs2 } from '@blueprintjs/popover2';
+import { Button, Intent, Menu, PopoverPosition } from '@blueprintjs/core';
+import { Breadcrumbs2, MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { LightdashMode, Space } from '@lightdash/common';
+import { IconChartAreaLine, IconLayoutDashboard } from '@tabler/icons-react';
 import React, { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useApp } from '../../providers/AppProvider';
@@ -35,8 +36,6 @@ interface Props {
     space: Space;
 }
 
-export const DEFAULT_DASHBOARD_NAME = 'Untitled dashboard';
-
 export const SpacePanel: React.FC<Props> = ({ space }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user, health } = useApp();
@@ -67,6 +66,10 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
             projectUuid,
         }),
     );
+    const allItems = [
+        ...wrapResourceList(savedDashboards, ResourceListType.DASHBOARD),
+        ...wrapResourceList(savedCharts, ResourceListType.CHART),
+    ];
 
     return (
         <PageContentWrapper>
@@ -141,67 +144,75 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                     />
                 )}
             </PageHeader>
-
             <ResourceList
-                items={wrapResourceList(
-                    savedDashboards,
-                    ResourceListType.DASHBOARD,
-                )}
-                defaultSort={{ updatedAt: SortDirection.DESC }}
-                defaultColumnVisibility={{ space: false }}
-                headerTitle="Dashboards"
+                items={allItems}
+                defaultSort={{ type: SortDirection.DESC }}
+                defaultColumnVisibility={{ space: false, type: false }}
+                headerTitle="All items"
+                showCount={false}
                 headerAction={
-                    !isDemo &&
-                    userCanManageDashboards && (
-                        <AddResourceToSpaceMenu
-                            resourceType={AddToSpaceResources.DASHBOARD}
-                            onAdd={() =>
-                                setAddToSpace(AddToSpaceResources.DASHBOARD)
+                    !isDemo && (
+                        <Popover2
+                            captureDismiss
+                            position={PopoverPosition.BOTTOM_RIGHT}
+                            content={
+                                <Menu>
+                                    {userCanManageDashboards && (
+                                        <MenuItem2
+                                            icon={
+                                                <IconLayoutDashboard
+                                                    size={20}
+                                                />
+                                            }
+                                            text={`Add dashboard`}
+                                        >
+                                            <AddResourceToSpaceMenu
+                                                onAdd={() =>
+                                                    setAddToSpace(
+                                                        AddToSpaceResources.DASHBOARD,
+                                                    )
+                                                }
+                                                onCreate={() =>
+                                                    setIsCreateDashboardOpen(
+                                                        true,
+                                                    )
+                                                }
+                                            />
+                                        </MenuItem2>
+                                    )}
+                                    {userCanManageCharts && (
+                                        <MenuItem2
+                                            icon={
+                                                <IconChartAreaLine size={20} />
+                                            }
+                                            text={`Add chart`}
+                                        >
+                                            <AddResourceToSpaceMenu
+                                                onAdd={() =>
+                                                    setAddToSpace(
+                                                        AddToSpaceResources.CHART,
+                                                    )
+                                                }
+                                                onCreate={() =>
+                                                    setCreateToSpace(
+                                                        AddToSpaceResources.CHART,
+                                                    )
+                                                }
+                                            />
+                                        </MenuItem2>
+                                    )}
+                                </Menu>
                             }
-                            onCreate={() => setIsCreateDashboardOpen(true)}
                         >
                             <Button icon="plus" intent="primary" />
-                        </AddResourceToSpaceMenu>
+                        </Popover2>
                     )
                 }
                 renderEmptyState={() => (
                     <>
                         <ResourceEmptyStateIcon icon="control" size={40} />
-
                         <ResourceEmptyStateHeader>
-                            No dashboards added yet
-                        </ResourceEmptyStateHeader>
-                    </>
-                )}
-            />
-
-            <ResourceList
-                headerTitle="Saved charts"
-                items={wrapResourceList(savedCharts, ResourceListType.CHART)}
-                defaultSort={{ updatedAt: SortDirection.DESC }}
-                defaultColumnVisibility={{ space: false }}
-                headerAction={
-                    !isDemo &&
-                    userCanManageCharts && (
-                        <AddResourceToSpaceMenu
-                            resourceType={AddToSpaceResources.CHART}
-                            onAdd={() =>
-                                setAddToSpace(AddToSpaceResources.CHART)
-                            }
-                            onCreate={() =>
-                                setCreateToSpace(AddToSpaceResources.CHART)
-                            }
-                        >
-                            <Button icon="plus" intent="primary" />
-                        </AddResourceToSpaceMenu>
-                    )
-                }
-                renderEmptyState={() => (
-                    <>
-                        <ResourceEmptyStateIcon icon="chart" size={40} />
-
-                        <ResourceEmptyStateHeader>
-                            No charts added yet
+                            No items added yet
                         </ResourceEmptyStateHeader>
                     </>
                 )}
@@ -218,6 +229,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
             {createToSpace && (
                 <CreateResourceToSpace resourceType={createToSpace} />
             )}
+
             <DashboardCreateModal
                 projectUuid={projectUuid}
                 isOpen={isCreateDashboardOpen}

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -168,7 +168,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                                         >
                                             <AddResourceToSpaceMenu
                                                 resourceType={
-                                                    ResourceListType.DASHBOARD
+                                                    AddToSpaceResources.DASHBOARD
                                                 }
                                                 onAdd={() =>
                                                     setAddToSpace(
@@ -192,7 +192,7 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                                         >
                                             <AddResourceToSpaceMenu
                                                 resourceType={
-                                                    ResourceListType.CHART
+                                                    AddToSpaceResources.CHART
                                                 }
                                                 onAdd={() =>
                                                     setAddToSpace(

--- a/packages/frontend/src/components/SpacePanel/index.tsx
+++ b/packages/frontend/src/components/SpacePanel/index.tsx
@@ -167,6 +167,9 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                                             text={`Add dashboard`}
                                         >
                                             <AddResourceToSpaceMenu
+                                                resourceType={
+                                                    ResourceListType.DASHBOARD
+                                                }
                                                 onAdd={() =>
                                                     setAddToSpace(
                                                         AddToSpaceResources.DASHBOARD,
@@ -188,6 +191,9 @@ export const SpacePanel: React.FC<Props> = ({ space }) => {
                                             text={`Add chart`}
                                         >
                                             <AddResourceToSpaceMenu
+                                                resourceType={
+                                                    ResourceListType.CHART
+                                                }
                                                 onAdd={() =>
                                                     setAddToSpace(
                                                         AddToSpaceResources.CHART,

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable.tsx
@@ -215,6 +215,33 @@ const ResourceTable: FC<ResourceTableProps> = ({
                 },
             },
             {
+                id: 'type',
+                label: 'Type',
+                cell: (item: ResourceListItem) => (
+                    <ResourceNameBox>
+                        <ResourceMetadata>
+                            <ResourceType item={item} />
+                        </ResourceMetadata>
+                    </ResourceNameBox>
+                ),
+                enableSorting,
+                sortingFn: (a: ResourceListItem) => {
+                    return a.type === ResourceListType.DASHBOARD
+                        ? 1
+                        : a.type === ResourceListType.CHART
+                        ? -1
+                        : 0;
+                },
+                meta: {
+                    style: {
+                        width:
+                            columnVisibility.get('type') === false
+                                ? undefined
+                                : '25%',
+                    },
+                },
+            },
+            {
                 id: 'actions',
                 cell: (item: ResourceListItem) => (
                     <ResourceActionMenu
@@ -247,9 +274,7 @@ const ResourceTable: FC<ResourceTableProps> = ({
         return items.sort((a, b) => {
             return [...columnSorts.entries()].reduce(
                 (acc, [columnId, sortDirection]) => {
-                    const column = visibleColumns.find(
-                        (c) => c.id === columnId,
-                    );
+                    const column = columns.find((c) => c.id === columnId);
                     if (!column) {
                         throw new Error('Column with id does not exist!');
                     }
@@ -274,7 +299,7 @@ const ResourceTable: FC<ResourceTableProps> = ({
                 0,
             );
         });
-    }, [items, columnSorts, visibleColumns]);
+    }, [items, columnSorts]);
 
     return (
         <StyledTable>

--- a/packages/frontend/src/components/common/ResourceList/ResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceList/ResourceTable.tsx
@@ -226,11 +226,7 @@ const ResourceTable: FC<ResourceTableProps> = ({
                 ),
                 enableSorting,
                 sortingFn: (a: ResourceListItem) => {
-                    return a.type === ResourceListType.DASHBOARD
-                        ? 1
-                        : a.type === ResourceListType.CHART
-                        ? -1
-                        : 0;
+                    return a.type === ResourceListType.DASHBOARD ? 1 : -1;
                 },
                 meta: {
                     style: {


### PR DESCRIPTION
Closes: #4456 

### Description:
- [x] Merge dashboards and charts panel together (always display dashboards first)
- [x] Get rid of grey number pills
- [x] Panel title should be 'All items'
- [x] The add button should show items 'Add dashboard' and 'Add chart'. Each option should open a submenu 'Add existing chart/dashboard' and 'Create new chart/dashboard' 

<img width="995" alt="Screenshot 2023-02-15 at 13 26 28" src="https://user-images.githubusercontent.com/67699259/219027235-e5c9027c-2e14-4570-bdd6-805114ed3f2c.png">