### PR TITLE
chore: add sentry replays

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -197,7 +197,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             )}
                         </ButtonsWrapper>
                     </HeaderContainer>
-                    <ChartContainer className="non-draggable cohere-block">
+                    <ChartContainer className="non-draggable sentry-block cohere-block">
                         {children}
                     </ChartContainer>
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -120,7 +120,7 @@ const VisualizationCard: FC = memo(() => {
                 }
             >
                 <LightdashVisualization
-                    className="cohere-block"
+                    className="sentry-block cohere-block"
                     data-testid="visualization"
                 />
 

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -36,8 +36,6 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
         });
     }, [dashboards, savedCharts]);
 
-    throw new Error('Completely unexpected and appears in Sentry');
-
     return pinnedItems.length > 0 ? (
         <ResourceList
             items={pinnedItems}

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -36,6 +36,8 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
         });
     }, [dashboards, savedCharts]);
 
+    throw new Error('Completely unexpected and appears in Sentry');
+
     return pinnedItems.length > 0 ? (
         <ResourceList
             items={pinnedItems}

--- a/packages/frontend/src/components/ReactHookForm/PasswordInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/PasswordInput.tsx
@@ -11,7 +11,7 @@ const PasswordInput: FC<Omit<InputWrapperProps, 'render'>> = (props) => {
             render={(inputProps, { field }) => (
                 <InputGroup
                     {...inputProps}
-                    className="cohere-block"
+                    className="sentry-block cohere-block"
                     placeholder={
                         inputProps.placeholder || 'Enter your password...'
                     }

--- a/packages/frontend/src/components/UserSettings/CreateTokenPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/CreateTokenPanel/index.tsx
@@ -126,7 +126,7 @@ const CreateTokenPanel: FC<{
                             Token
                             <InputGroup
                                 id="invite-link-input"
-                                className="cohere-block"
+                                className="cohere-block sentry-block"
                                 type="text"
                                 readOnly
                                 value={data.token}
@@ -149,7 +149,7 @@ const CreateTokenPanel: FC<{
                             CLI Authentication code
                             <InputGroup
                                 id="invite-link-input"
-                                className="cohere-block"
+                                className="sentry-block cohere-block"
                                 type="text"
                                 readOnly
                                 value={`lightdash login ${health.data?.siteUrl} --token ${data.token}`}

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/InviteSuccess.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/InviteSuccess.tsx
@@ -56,7 +56,7 @@ const InviteSuccess: FC<{ invite: InviteLink; hasMarginTop?: boolean }> = ({
             </MessageWrapper>
             <InputGroup
                 id="invite-link-input"
-                className="cohere-block"
+                className="cohere-block sentry-block"
                 type="text"
                 readOnly
                 value={invite.inviteUrl}

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -34,7 +34,9 @@ const Table: FC<Props> = ({
     return (
         <TableProvider {...rest}>
             <TableContainer
-                className={`cohere-block${className ? ` ${className}` : ''}`}
+                className={`sentry-block cohere-block${
+                    className ? ` ${className}` : ''
+                }`}
                 $shouldExpand={$shouldExpand}
                 $padding={$padding}
                 data-testid={dataTestId}

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -15,8 +15,16 @@ const useSentry = (
                 dsn: sentryConfig.dsn,
                 release: sentryConfig.release,
                 environment: sentryConfig.environment,
-                integrations: [new Integrations.BrowserTracing()],
-                tracesSampleRate: 1.0,
+                integrations: [
+                    new Integrations.BrowserTracing(),
+                    new Sentry.Replay({
+                        maskAllText: false,
+                        blockAllMedia: true,
+                    }),
+                ],
+                tracesSampleRate: 0.2,
+                replaysOnErrorSampleRate: 1.0,
+                replaysSessionSampleRate: 0.0,
             });
             setIsSentryLoaded(true);
         }

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -291,7 +291,7 @@ const SqlRunnerPage = () => {
                             handleCardExpand(SqlRunnerCards.CHART, value)
                         }
                     >
-                        <LightdashVisualization className="cohere-block" />
+                        <LightdashVisualization className="sentry-block cohere-block" />
                     </CollapsableCard>
                 </VisualizationProvider>
 


### PR DESCRIPTION
As requested by @rephus - this only sends replays when there is an error (60s buffer of user activity). It doesn't capture anything otherwise