### PR TITLE
fix: hide type column from all charts and all dashboards tables

### DIFF
--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -151,6 +151,7 @@ const SavedDashboards = () => {
                         ResourceListType.DASHBOARD,
                     )}
                     defaultSort={{ updatedAt: SortDirection.DESC }}
+                    defaultColumnVisibility={{ type: false }}
                     renderEmptyState={() => (
                         <>
                             <ResourceEmptyStateIcon icon="chart" size={40} />

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -99,6 +99,7 @@ const SavedQueries: FC = () => {
                         ResourceListType.CHART,
                     )}
                     defaultSort={{ updatedAt: SortDirection.DESC }}
+                    defaultColumnVisibility={{ type: false }}
                     renderEmptyState={() => (
                         <>
                             <ResourceEmptyStateIcon icon="chart" size={40} />


### PR DESCRIPTION
Closes: #4485 

### Description:
<img width="842" alt="Screenshot 2023-02-16 at 10 05 59" src="https://user-images.githubusercontent.com/67699259/219318780-34bde257-4a32-40a9-9f58-7908cea5be62.png">
<img width="807" alt="Screenshot 2023-02-16 at 10 06 05" src="https://user-images.githubusercontent.com/67699259/219318792-0d7b09c4-f135-4409-8d1d-8b86aaabd4e8.png">
