### PR TITLE
fix: improving loading states

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -342,7 +342,11 @@ const Dashboard = () => {
         return <ErrorState error={dashboardError.error} />;
     }
     if (dashboard === undefined) {
-        return <Spinner />;
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <NonIdealState title="Loading..." icon={<Spinner />} />
+            </div>
+        );
     }
     const dashboardChartTiles = dashboardTiles.filter(
         (tile) => tile.type === DashboardTileTypes.SAVED_CHART,

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,4 +1,3 @@
-import { NonIdealState, Spinner } from '@blueprintjs/core';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
@@ -10,6 +9,7 @@ import ForbiddenPanel from '../components/ForbiddenPanel';
 import LandingPanel from '../components/Home/LandingPanel';
 import OnboardingPanel from '../components/Home/OnboardingPanel/index';
 import RecentlyUpdatedPanel from '../components/Home/RecentlyUpdatedPanel';
+import PageSpinner from '../components/PageSpinner';
 import PinnedItemsPanel from '../components/PinnedItemsPanel';
 import {
     useOnboardingStatus,
@@ -38,11 +38,7 @@ const Home: FC = () => {
     }
 
     if (isLoading) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <NonIdealState title="Loading..." icon={<Spinner />} />
-            </div>
-        );
+        return <PageSpinner />;
     }
 
     if (error) {

--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -1,20 +1,16 @@
-import { NonIdealState, Spinner } from '@blueprintjs/core';
 import React, { FC } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import ErrorState from '../components/common/ErrorState';
+import PageSpinner from '../components/PageSpinner';
 import { getLastProject, useProjects } from '../hooks/useProjects';
 
 export const Projects: FC = () => {
     const params = useParams<{ projectUuid: string | undefined }>();
     const { isLoading, data, error } = useProjects();
     if (isLoading) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <NonIdealState title="Loading..." icon={<Spinner />} />
-            </div>
-        );
+        return <PageSpinner />;
     }
-    if (error) {
+    if (error && error.error) {
         return <ErrorState error={error.error} />;
     }
     if (!data || data.length <= 0) {


### PR DESCRIPTION
Closes: #3191 

### Description:
- [x] Spinner is no longer cut off on dashboard pages
- [x] When you log in or open the home page, there used to be 2 different spinners > now it's the same one! 