### PR TITLE
chore: update cypress and github actions versions

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -1,7 +1,7 @@
 name: CLI tests
 on: [ deployment_status ]
 
-env: 
+env:
   NODE_ENV: 'development'
 jobs:
   cli-run:
@@ -26,12 +26,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive  # Download DBT submodule
-      
-      - name: Get lightdash version 
+      - name: Get lightdash version
         uses: sergeysova/jq-action@v2
 
       ## Install pip
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7.x'
       - run: pip install dbt-postgres==1.3
@@ -55,11 +54,11 @@ jobs:
       - name: Build packages/warehouses module
         run: yarn warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && yarn build && npm i -g 
+        run: cd packages/cli && yarn build && npm i -g
 
       # Run cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -68,20 +67,3 @@ jobs:
         env:
           CYPRESS_PGHOST: ${{secrets.PGHOST}}
           CYPRESS_PGPASSWORD: ${{secrets.PGPASSWORD}}
-
-      # I don't think we need to save screenshots for these CLI tests,
-      # but if we add new "browser" tests like onboardin, it would be nice to enable these. 
-      # copied from e2e-tests.yml 
-      
-      # After the test run completes
-      # store videos and any screenshots
-      #- uses: actions/upload-artifact@v2
-      #  if: always()
-      #  with:
-      #    name: cypress-screenshots
-      #    path: packages/e2e/cypress/screenshots
-      #- uses: actions/upload-artifact@v2
-      #  if: always()
-      #  with:
-      #    name: cypress-videos
-      #    path: packages/e2e/cypress/videos

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,7 +5,7 @@ jobs:
     # Only trigger for correct environment and status
     if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container: cypress/browsers:node18.12.0-chrome107
     steps:
       - name: Get PR number
         id: regex
@@ -21,7 +21,7 @@ jobs:
         run:
           echo "::set-output name=url::$DEPLOYMENT_URL"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Install and build Common package
       - name: Install packages/common modules
         run: yarn workspace @lightdash/common install
@@ -31,13 +31,13 @@ jobs:
       # and run all Cypress tests
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@1.2.2
         with:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
           dir: "./packages/e2e/cypress/fixtures/"
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -62,12 +62,12 @@ jobs:
 
       # After the test run completes
       # store videos and any screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-screenshots
           path: packages/e2e/cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,7 +5,9 @@ jobs:
     # Only trigger for correct environment and status
     if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
     runs-on: ubuntu-latest
-    container: cypress/browsers:node18.12.0-chrome107
+    container:
+      image: cypress/browsers:node18.12.0-chrome107
+      options: --user 1001
     steps:
       - name: Get PR number
         id: regex
@@ -31,7 +33,7 @@ jobs:
       # and run all Cypress tests
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@1.2.2
+        uses: jsdaniell/create-json@1.1.2
         with:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/manual-trigger-e2e-tests.yml
+++ b/.github/workflows/manual-trigger-e2e-tests.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container: cypress/browsers:node18.12.0-chrome107
     steps:
       - name: Get deployment url
         run: echo "Deployment url - ${{ github.event.inputs.url }}"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Install and build Common package
       - name: Install packages/common modules
         run: yarn workspace @lightdash/common install
@@ -31,7 +31,7 @@ jobs:
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -54,12 +54,12 @@ jobs:
           CYPRESS_TZ: 'UTC'
       # After the test run completes
       # store videos and any screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-screenshots
           path: packages/e2e/cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/manual-trigger-e2e-tests.yml
+++ b/.github/workflows/manual-trigger-e2e-tests.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node18.12.0-chrome107
+    container:
+      image: cypress/browsers:node18.12.0-chrome107
+      options: --user 1001
     steps:
       - name: Get deployment url
         run: echo "Deployment url - ${{ github.event.inputs.url }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v
     - name: Dependencies audit
       run: yarn audit --groups dependencies --level high

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v
+    - uses: actions/checkout@v2
     - name: Dependencies audit
       run: yarn audit --groups dependencies --level high

--- a/.github/workflows/timezone-tests.yml
+++ b/.github/workflows/timezone-tests.yml
@@ -5,7 +5,7 @@ jobs:
     # Only trigger for correct environment and status
     if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container: cypress/browsers:node18.12.0-chrome107
     steps:
       - name: Get PR number
         id: regex
@@ -21,7 +21,7 @@ jobs:
         run:
           echo "::set-output name=url::$DEPLOYMENT_URL"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Install and build Common package
       - name: Install packages/common modules
         run: yarn workspace @lightdash/common install
@@ -29,7 +29,7 @@ jobs:
         run: yarn common-build
 
       - name: Cypress run with UTC
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -39,7 +39,7 @@ jobs:
           TZ: 'UTC'
           CYPRESS_TZ: 'UTC' # For tests
       - name: Cypress run with America/New_York
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -50,7 +50,7 @@ jobs:
           CYPRESS_TZ: 'America/New_York' # For tests
 
       - name: Cypress run with Europe/Madrid
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -60,7 +60,7 @@ jobs:
           TZ: 'Europe/Madrid'
           CYPRESS_TZ: 'Europe/Madrid' # For tests
       - name: Cypress run with Asia/Tokyo
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           project: ./packages/e2e
@@ -72,12 +72,12 @@ jobs:
 
       # After the test run completes
       # store videos and any screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-screenshots
           path: packages/e2e/cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/timezone-tests.yml
+++ b/.github/workflows/timezone-tests.yml
@@ -5,7 +5,9 @@ jobs:
     # Only trigger for correct environment and status
     if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
     runs-on: ubuntu-latest
-    container: cypress/browsers:node18.12.0-chrome107
+    container:
+      image: cypress/browsers:node18.12.0-chrome107
+      options: --user 1001
     steps:
       - name: Get PR number
         id: regex

--- a/packages/e2e/cypress/e2e/api/api.cy.ts
+++ b/packages/e2e/cypress/e2e/api/api.cy.ts
@@ -13,12 +13,8 @@ const runqueryBody = {
 };
 const sqlQueryBody = { sql: 'select 1' };
 describe('Lightdash API', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should identify user', () => {

--- a/packages/e2e/cypress/e2e/api/pinning.cy.ts
+++ b/packages/e2e/cypress/e2e/api/pinning.cy.ts
@@ -3,11 +3,8 @@ import { SEED_PROJECT } from '@lightdash/common';
 const apiUrl = '/api/v1';
 
 describe('Lightdash pinning endpoints', () => {
-    before(() => {
-        cy.login();
-    });
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
     it('Should pin/unpin chart', () => {
         const projectUuid = SEED_PROJECT.project_uuid;

--- a/packages/e2e/cypress/e2e/api/scheduler.cy.ts
+++ b/packages/e2e/cypress/e2e/api/scheduler.cy.ts
@@ -4,6 +4,7 @@ import {
     DashboardScheduler,
     ScheduledJobs,
     SchedulerAndTargets,
+    SchedulerSlackTarget,
     SEED_PROJECT,
     UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
@@ -26,11 +27,8 @@ const getUpdateSchedulerBody = (
 });
 
 describe('Lightdash scheduler endpoints', () => {
-    before(() => {
-        cy.login();
-    });
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
     it('Should create/update/delete chart scheduler', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
@@ -96,7 +94,8 @@ describe('Lightdash scheduler endpoints', () => {
                         headers: { 'Content-type': 'application/json' },
                         method: 'PATCH',
                         body: getUpdateSchedulerBody(
-                            targets[0].schedulerSlackTargetUuid,
+                            (targets[0] as SchedulerSlackTarget)
+                                .schedulerSlackTargetUuid,
                         ),
                         failOnStatusCode: false,
                     }).then((updateResponse) => {
@@ -106,10 +105,16 @@ describe('Lightdash scheduler endpoints', () => {
                             updateResponse.body.results.targets,
                         ).to.have.length(2);
                         expect(
-                            updateResponse.body.results.targets[0].channel,
+                            (
+                                updateResponse.body.results
+                                    .targets[0] as SchedulerSlackTarget
+                            ).channel,
                         ).to.eq('C1');
                         expect(
-                            updateResponse.body.results.targets[1].channel,
+                            (
+                                updateResponse.body.results
+                                    .targets[1] as SchedulerSlackTarget
+                            ).channel,
                         ).to.eq('C3');
                     });
 
@@ -199,7 +204,8 @@ describe('Lightdash scheduler endpoints', () => {
                         headers: { 'Content-type': 'application/json' },
                         method: 'PATCH',
                         body: getUpdateSchedulerBody(
-                            targets[0].schedulerSlackTargetUuid,
+                            (targets[0] as SchedulerSlackTarget)
+                                .schedulerSlackTargetUuid,
                         ),
                         failOnStatusCode: false,
                     }).then((updateResponse) => {
@@ -209,10 +215,16 @@ describe('Lightdash scheduler endpoints', () => {
                             updateResponse.body.results.targets,
                         ).to.have.length(2);
                         expect(
-                            updateResponse.body.results.targets[0].channel,
+                            (
+                                updateResponse.body.results
+                                    .targets[0] as SchedulerSlackTarget
+                            ).channel,
                         ).to.eq('C1');
                         expect(
-                            updateResponse.body.results.targets[1].channel,
+                            (
+                                updateResponse.body.results
+                                    .targets[1] as SchedulerSlackTarget
+                            ).channel,
                         ).to.eq('C3');
                     });
 

--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -293,12 +293,8 @@ const testTimeIntervalsResults = (rowValues = defaultRowValues) => {
 };
 
 describe('Create projects', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should be able to create new project from settings', () => {

--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -1,12 +1,8 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
 describe('Dashboard', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should see dashboard', () => {

--- a/packages/e2e/cypress/e2e/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/dates.cy.ts
@@ -14,12 +14,8 @@ function getLocalISOString(date: Date) {
 }
 
 describe('Explore', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Check current timezone', () => {

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -1,12 +1,8 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
 describe('Explore', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should query orders', () => {

--- a/packages/e2e/cypress/e2e/formats.cy.ts
+++ b/packages/e2e/cypress/e2e/formats.cy.ts
@@ -1,12 +1,8 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
 describe('Explore', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should query in explore with formats and rounds', () => {

--- a/packages/e2e/cypress/e2e/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/globalSearch.cy.ts
@@ -6,12 +6,8 @@ function search(query: string) {
 }
 
 describe('Global search', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should search all result types', () => {

--- a/packages/e2e/cypress/e2e/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/savedDashboards.cy.ts
@@ -1,12 +1,8 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
 describe('Dashboard List', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
+        cy.login();
     });
 
     it('Should display dashboards', () => {

--- a/packages/e2e/cypress/e2e/settings/profile.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/profile.cy.ts
@@ -1,7 +1,7 @@
 import { SEED_ORG_1_ADMIN, SEED_ORG_1_ADMIN_EMAIL } from '@lightdash/common';
 
 describe('Settings - Profile', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 
@@ -16,10 +16,6 @@ describe('Settings - Profile', () => {
                 email: SEED_ORG_1_ADMIN_EMAIL.email,
             },
         });
-    });
-
-    beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
     });
 
     it('Should change name and email', () => {

--- a/packages/e2e/cypress/e2e/sqlrunner.cy.ts
+++ b/packages/e2e/cypress/e2e/sqlrunner.cy.ts
@@ -8,6 +8,7 @@ const firstCustomer = {
 describe('SQL Runner', () => {
     beforeEach(() => {
         cy.login();
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/sqlRunner`);
     });
 
     it('Should see results from customers by typing', () => {

--- a/packages/e2e/cypress/e2e/sqlrunner.cy.ts
+++ b/packages/e2e/cypress/e2e/sqlrunner.cy.ts
@@ -6,13 +6,8 @@ const firstCustomer = {
     created: '2017-01-30T06:00:00.000Z',
 };
 describe('SQL Runner', () => {
-    before(() => {
-        cy.login();
-    });
-
     beforeEach(() => {
-        Cypress.Cookies.preserveOnce('connect.sid');
-        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/sqlRunner`);
+        cy.login();
     });
 
     it('Should see results from customers by typing', () => {

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -52,25 +52,49 @@ declare global {
 }
 
 Cypress.Commands.add('login', () => {
-    cy.request({
-        url: 'api/v1/login',
-        method: 'POST',
-        body: {
-            email: SEED_ORG_1_ADMIN_EMAIL.email,
-            password: SEED_ORG_1_ADMIN_PASSWORD.password,
+    cy.session(
+        SEED_ORG_1_ADMIN_EMAIL.email,
+        () => {
+            cy.request({
+                url: 'api/v1/login',
+                method: 'POST',
+                body: {
+                    email: SEED_ORG_1_ADMIN_EMAIL.email,
+                    password: SEED_ORG_1_ADMIN_PASSWORD.password,
+                },
+            })
+                .its('status')
+                .should('eq', 200);
         },
-    });
+        {
+            validate() {
+                cy.request('api/v1/user').its('status').should('eq', 200);
+            },
+        },
+    );
 });
 
 Cypress.Commands.add('anotherLogin', () => {
-    cy.request({
-        url: 'api/v1/login',
-        method: 'POST',
-        body: {
-            email: SEED_ORG_2_ADMIN_EMAIL.email,
-            password: SEED_ORG_2_ADMIN_PASSWORD.password,
+    cy.session(
+        SEED_ORG_2_ADMIN_EMAIL.email,
+        () => {
+            cy.request({
+                url: 'api/v1/login',
+                method: 'POST',
+                body: {
+                    email: SEED_ORG_2_ADMIN_EMAIL.email,
+                    password: SEED_ORG_2_ADMIN_PASSWORD.password,
+                },
+            })
+                .its('status')
+                .should('eq', 200);
         },
-    });
+        {
+            validate() {
+                cy.request('api/v1/user').its('status').should('eq', 200);
+            },
+        },
+    );
 });
 Cypress.Commands.add('registerNewUser', () => {
     const email = `test+${new Date().getTime()}@lightdash.com`;

--- a/packages/e2e/cypress/support/e2e.ts
+++ b/packages/e2e/cypress/support/e2e.ts
@@ -18,8 +18,10 @@ import './commands';
 
 // Hide all requests from
 const cypressLogOriginal = Cypress.log;
+
+// @ts-ignore
 Cypress.log = function name(opts, ...other) {
-    const isFetchLog = ['fetch'].includes(opts.displayName);
+    const isFetchLog = opts.displayName && ['fetch'].includes(opts.displayName);
     if (isFetchLog) return;
     // eslint-disable-next-line consistent-return
     return cypressLogOriginal(opts, ...other);

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "license": "MIT",
     "scripts": {
-        "cypress:open": "cypress open",
+        "cypress:open": "cypress open --e2e",
         "cypress:run": "cypress run",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "prettier --config .prettierrc.js --ignore-unknown --ignore-path ./../../.gitignore",
@@ -15,8 +15,8 @@
     },
     "devDependencies": {},
     "dependencies": {
-        "@testing-library/cypress": "^8.0.3",
-        "cypress": "^10.1.0",
+        "@testing-library/cypress": "^9.0.0",
+        "cypress": "^12.5.1",
         "cypress-file-upload": "^5.0.8",
         "node-fetch": "^2.6.1",
         "@lightdash/common": "^0.416.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,10 +1718,10 @@
   resolved "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.5.11.tgz"
   integrity sha512-ZN61ockLaIAiiPbZfMKT2S03nbWx28OHg/nAiDnNfmN4QmAMcdwVajPn2QQwnNVGAr4jS4nbhbYzCcjq8livXQ==
 
-"@testing-library/cypress@^8.0.3":
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.3.tgz"
-  integrity sha512-nY2YaSbmuPo5k6kL0iLj/pGPPfka3iwb3kpTx8QN/vOCns92Saz9wfACqB8FJzcR7+lfA4d5HUOWqmTddBzczg==
+"@testing-library/cypress@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-9.0.0.tgz#3facad49c4654a99bbd138f83f33b415d2d6f097"
+  integrity sha512-c1XiCGeHGGTWn0LAU12sFUfoX3qfId5gcSE2yHode+vsyHDWraxDPALjVnHd4/Fa3j4KBcc5k++Ccy6A9qnkMA==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^8.1.0"
@@ -4789,10 +4789,10 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz"
-  integrity sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==
+cypress@^12.5.1:
+  version "12.5.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.5.1.tgz#effdcccdd5a6187d61d497300903d4f3b5b21b6e"
+  integrity sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -4813,7 +4813,7 @@ cypress@^10.1.0:
     dayjs "^1.10.4"
     debug "^4.3.2"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -6030,10 +6030,10 @@ event-target-shim@^5.0.0:
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter2@^6.4.3:
-  version "6.4.4"
-  resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz"
-  integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
+eventemitter2@6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Update GitHub action versions:
- actions/checkout@v2 -> actions/checkout@v3
- actions/setup-python@v1 -> actions/setup-python@v4
- cypress-io/github-action@v4 -> cypress-io/github-action@v5
- actions/upload-artifact@v2 -> actions/upload-artifact@v3

Update cypress container:
- cypress/browsers:node14.19.0-chrome100-ff99-edge -> cypress/browsers:node18.12.0-chrome107 

It only installs chrome, instead of chrome + firefox+edge, so it should be much faster 🙏 

Cypress:
- Update to latest version
- Update how cypress stores and reuses the session cookies
- Fix some typing issues

Creates and then reuses
![Captura de ecrã 2023-02-16, às 12 32 33](https://user-images.githubusercontent.com/9117144/219395655-dcca5a92-161a-47fa-b664-921417854e52.png)

Recreates after we logout
![Captura de ecrã 2023-02-16, às 12 34 50](https://user-images.githubusercontent.com/9117144/219395670-0e70953f-c3f7-4df1-b868-c76b134e045f.png)