### PR TITLE
chore: use node env for render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -17,6 +17,8 @@ services:
     startCommand: yarn start
     initialDeployHook: /usr/bin/renderDeployHook.sh
     envVars:
+      - key: NODE_VERSION
+        value: 16.16.0
       - key: PGHOST
         fromDatabase:
           name: jaffle_db

--- a/render.yaml
+++ b/render.yaml
@@ -10,11 +10,11 @@ services:
     name: headless-browser
     dockerfilePath: docker/Dockerfile.headless-browser
   - type: web
-    env: docker
+    env: node
     name: lightdash
     plan: standard
-    dockerContext: .
-    dockerfilePath: dockerfile-prs
+    buildCommand: yarn install && yarn build
+    startCommand: yarn start
     initialDeployHook: /usr/bin/renderDeployHook.sh
     envVars:
       - key: PGHOST


### PR DESCRIPTION
Try using node env instead of docker (no longer needed since we dumped odbc) - hope it reduces deployment time substantially