### PR TITLE
fix: updating styling on usage analytics tab

### DIFF
--- a/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
@@ -8,6 +8,7 @@ import {
     Icon,
     Tag,
 } from '@blueprintjs/core';
+import { IconLayoutDashboard } from '@tabler/icons-react';
 import styled, { css } from 'styled-components';
 
 export const Header = styled.div`
@@ -42,13 +43,6 @@ export const CardWrapper = styled(Card)`
 
 export const CardContent = styled.div`
     display: flex;
+    gap: 10px;
     height: 24px;
-`;
-
-export const ActivityIcon = styled(Icon)`
-    margin-right: 20px;
-    color: ${Colors.GRAY3};
-`;
-export const ActivityLabel = styled.p`
-    font-size: 20px;
 `;

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -1,16 +1,9 @@
-import { Colors, Icon } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
+import { Colors, H5 } from '@blueprintjs/core';
+import { IconLayoutDashboard } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useHistory } from 'react-router-dom';
-import {
-    ActivityIcon,
-    ActivityLabel,
-    CardContent,
-    CardWrapper,
-    Header,
-    Title,
-    TitleWrapper,
-} from './SettingsUsageAnalytics.styles';
+import { Subtitle } from '../../pages/CreateProject.styles';
+import { CardContent, CardWrapper } from './SettingsUsageAnalytics.styles';
 
 interface ProjectUserAccessProps {
     projectUuid: string;
@@ -24,17 +17,11 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
     return (
         <>
             <>
-                <Header>
-                    <TitleWrapper>
-                        <Title>Usage analytics</Title>
-                        <Tooltip2 content="Lightdash curated dashboards that show usage and performance information about your project.">
-                            <Icon
-                                icon="info-sign"
-                                style={{ color: Colors.GRAY5 }}
-                            />
-                        </Tooltip2>
-                    </TitleWrapper>
-                </Header>
+                <Subtitle>
+                    Lightdash curated dashboards that show usage and performance
+                    information about your project.
+                </Subtitle>
+
                 <>
                     <CardWrapper
                         onClick={() => {
@@ -44,8 +31,11 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
                         }}
                     >
                         <CardContent>
-                            <ActivityIcon icon="control" size={24} />
-                            <ActivityLabel>User activity</ActivityLabel>
+                            <IconLayoutDashboard
+                                size={20}
+                                color={Colors.GRAY3}
+                            />
+                            <H5>User activity</H5>
                         </CardContent>
                     </CardWrapper>
                 </>


### PR DESCRIPTION
### Description:
before
<img width="890" alt="Screenshot 2023-02-17 at 16 00 44" src="https://user-images.githubusercontent.com/67699259/219691350-ea80f5ea-8904-469b-a144-eb05af069a7c.png">


after
<img width="857" alt="Screenshot 2023-02-17 at 16 08 08" src="https://user-images.githubusercontent.com/67699259/219691370-1189071e-cd9d-47be-b654-f1c6a1347f8e.png">
