### PR TITLE
fix: explore from here button is too big

### DIFF
--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
 import LinkButton from '../common/LinkButton';
+import { StyledLinkButton } from '../Home/LandingPanel/LandingPanel.styles';
 
 const ExploreFromHereButton = () => {
     const savedChart = useExplorerContext(
@@ -21,14 +22,14 @@ const ExploreFromHereButton = () => {
     if (!exploreFromHereUrl) return null;
 
     return (
-        <LinkButton
+        <StyledLinkButton
             intent="primary"
             large
             icon="series-search"
             href={exploreFromHereUrl}
         >
             Explore from here
-        </LinkButton>
+        </StyledLinkButton>
     );
 };
 


### PR DESCRIPTION
Closes: #4400 

### Description:
before
<img width="324" alt="Screenshot 2023-02-20 at 11 43 29" src="https://user-images.githubusercontent.com/67699259/220083648-95d492b8-83ad-4e97-a970-f10c1316bd6e.png">

after
<img width="320" alt="Screenshot 2023-02-20 at 11 43 35" src="https://user-images.githubusercontent.com/67699259/220083656-e303dd6a-f8ca-42a1-8a36-f1269a41970b.png">
