### PR TITLE
fix: when editing tile click affects elements behind modal

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -202,6 +202,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     </ChartContainer>
 
                     <TileUpdateModal
+                        className="non-draggable"
                         isOpen={isEditing}
                         tile={tile}
                         onClose={() => setIsEditing(false)}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -56,6 +56,7 @@ const TileUpdateModal = <T extends Tile>({
             title="Edit tile content"
             {...modalProps}
             onClose={handleClose}
+            backdropClassName="non-draggable"
         >
             <Form
                 name="Edit tile content"


### PR DESCRIPTION
Closes: #4312 

### Description:
before
https://user-images.githubusercontent.com/67699259/220104899-4548b63e-90d8-4a28-b724-a7b09f668fb2.mov

after
https://user-images.githubusercontent.com/67699259/220104917-b094c338-56f5-4dd2-a0b8-7176e6c07ff5.mov

