### PR TITLE
feat: icons shouldnt have white fill when active

### DIFF
--- a/packages/frontend/src/components/NavBar/NavBar.styles.tsx
+++ b/packages/frontend/src/components/NavBar/NavBar.styles.tsx
@@ -39,7 +39,7 @@ export const NavbarMenuItem = styled(MenuItem2)`
 
                 svg,
                 path {
-                    fill: ${Colors.WHITE} !important;
+                    stroke: ${Colors.WHITE} !important;
                 }
             `
             : ''}


### PR DESCRIPTION
Closes: #4530 

### Description:
before
![image](https://user-images.githubusercontent.com/67699259/220337849-db2c22bb-c816-4c3b-b645-dba2422a589f.png)

after
<img width="249" alt="Screenshot 2023-02-21 at 12 51 29" src="https://user-images.githubusercontent.com/67699259/220337807-38eccfa8-89f7-43e3-a828-9eaed45738ee.png">

