### PR TITLE
chore: fix invite email e2e test

### DIFF
--- a/packages/e2e/cypress/e2e/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/invites.cy.ts
@@ -13,7 +13,7 @@ describe('Settings - Invites', () => {
         cy.findByLabelText('Enter user email address *').type(
             'marygreen@lightdash.com',
         );
-        cy.contains('Generate invite').click();
+        cy.contains(/(Generate|Send) invite/).click();
         cy.get('#invite-link-input')
             .should('be.visible')
             .then(($input) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
When we enable email on PRs, a e2e test fails because the text of the `generate invite` button changes. 

This PR allows both buttons 

![image](https://user-images.githubusercontent.com/1983672/220556364-f8c0ac79-7a7a-4b87-8f02-a1774dba330a.png)
