### PR TITLE
fix: show dashboard header without action buttons to viewers

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -80,8 +80,10 @@ const DashboardHeader = ({
     };
 
     const { user } = useApp();
-
-    if (user.data?.ability?.cannot('manage', 'Dashboard')) return <></>;
+    const userCanManageDashboard = user.data?.ability.can(
+        'manage',
+        'Dashboard',
+    );
 
     return (
         <PageHeaderContainer>
@@ -98,7 +100,7 @@ const DashboardHeader = ({
                         </Tooltip2>
                     )}
 
-                    {user.data?.ability?.can('manage', 'Dashboard') && (
+                    {userCanManageDashboard && (
                         <Button
                             icon="edit"
                             disabled={isSaving}
@@ -139,8 +141,7 @@ const DashboardHeader = ({
                     )}
                 </PageDetailsContainer>
             </PageTitleAndDetailsContainer>
-
-            {isEditMode ? (
+            {userCanManageDashboard && isEditMode ? (
                 <PageActionsContainer>
                     <AddTileButton onAddTiles={onAddTiles} />
 
@@ -166,7 +167,7 @@ const DashboardHeader = ({
                         onClick={onCancel}
                     />
                 </PageActionsContainer>
-            ) : (
+            ) : userCanManageDashboard ? (
                 <PageActionsContainer>
                     <Button
                         icon="edit"
@@ -292,7 +293,7 @@ const DashboardHeader = ({
                         />
                     )}
                 </PageActionsContainer>
-            )}
+            ) : null}
         </PageHeaderContainer>
     );
 };


### PR DESCRIPTION
Closes: #4549 

### Description:
before
<img width="1512" alt="Screenshot 2023-02-22 at 10 15 11" src="https://user-images.githubusercontent.com/67699259/220575356-e3a7f4ea-4bc0-4df0-a285-3e4ae426a913.png">

after
<img width="1512" alt="Screenshot 2023-02-22 at 10 14 43" src="https://user-images.githubusercontent.com/67699259/220575363-6b4cf6c2-bc24-46cb-b66f-8f68e322b635.png">
