### PR TITLE
feat: hide `View underlying data` for dimensions

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
+    isDimension,
     isField,
     isFilterableField,
     ResultRow,
@@ -52,17 +53,19 @@ const CellContextMenu: FC<
                 <MenuItem2 text="Copy value" icon="duplicate" />
             </CopyToClipboard>
 
-            <MenuItem2
-                text="View underlying data"
-                icon="layers"
-                onClick={() => {
-                    openUnderlyingDataModel(
-                        value,
-                        meta,
-                        cell.row.original || {},
-                    );
-                }}
-            />
+            {item && !isDimension(item) && (
+                <MenuItem2
+                    text="View underlying data"
+                    icon="layers"
+                    onClick={() => {
+                        openUnderlyingDataModel(
+                            value,
+                            meta,
+                            cell.row.original || {},
+                        );
+                    }}
+                />
+            )}
 
             {isEditMode && isField(item) && isFilterableField(item) && (
                 <MenuItem2

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuDivider } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
-import { isField, ResultRow } from '@lightdash/common';
+import { isDimension, isField, ResultRow } from '@lightdash/common';
 import React, { FC } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import useToaster from '../../hooks/toaster/useToaster';
@@ -34,19 +34,19 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                 <MenuItem2 text="Copy value" icon="duplicate" />
             </CopyToClipboard>
 
-            <MenuItem2
-                text="View underlying data"
-                icon="layers"
-                onClick={() => {
-                    openUnderlyingDataModel(
-                        value,
-                        meta,
-                        cell.row.original || {},
-                        undefined,
-                        meta?.pivotReference,
-                    );
-                }}
-            />
+            {item && !isDimension(item) && (
+                <MenuItem2
+                    text="View underlying data"
+                    icon="layers"
+                    onClick={() => {
+                        openUnderlyingDataModel(
+                            value,
+                            meta,
+                            cell.row.original || {},
+                        );
+                    }}
+                />
+            )}
 
             <DrillDownMenuItem
                 row={cell.row.original || {}}

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -99,20 +99,22 @@ const DashboardCellContextMenu: FC<
                 <MenuItem2 text="Copy value" icon="duplicate" />
             </CopyToClipboard>
 
-            <MenuItem2
-                text="View underlying data"
-                icon="layers"
-                onClick={() => {
-                    openUnderlyingDataModel(
-                        value,
-                        meta,
-                        cell.row.original || {},
-                        undefined,
-                        meta?.pivotReference,
-                        dashboardFiltersThatApplyToChart,
-                    );
-                }}
-            />
+            {item && !isDimension(item) && (
+                <MenuItem2
+                    text="View underlying data"
+                    icon="layers"
+                    onClick={() => {
+                        openUnderlyingDataModel(
+                            value,
+                            meta,
+                            cell.row.original || {},
+                            undefined,
+                            meta?.pivotReference,
+                            dashboardFiltersThatApplyToChart,
+                        );
+                    }}
+                />
+            )}
 
             <DrillDownMenuItem
                 row={cell.row.original || {}}


### PR DESCRIPTION
Closes: #4493

### Description:
- [x] Removes `View underlying data` for dimensions in Results card in Explorer
- [x] Removes `View underlying data` for dimensions in Charts card in Explorer
- [x] Removes `View underlying data` for dimensions on Dashboard

before (screenshots from dashboard)
<img width="476" alt="Screenshot 2023-02-22 at 15 44 11" src="https://user-images.githubusercontent.com/67699259/220656854-77522cdc-5f97-4f34-87b4-50c59e345c06.png">
after
<img width="492" alt="Screenshot 2023-02-22 at 15 44 00" src="https://user-images.githubusercontent.com/67699259/220656921-68df950f-9ad7-404e-a2b4-4217c7f5e472.png">
