### PR TITLE
fix: explorer icons for metrics and dimensions updated

### DIFF
--- a/packages/frontend/src/components/ExploreMenuItem/index.tsx
+++ b/packages/frontend/src/components/ExploreMenuItem/index.tsx
@@ -1,6 +1,7 @@
 import { Colors, Icon, Intent, Position } from '@blueprintjs/core';
 import { MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
 import { InlineErrorType, SummaryExplore } from '@lightdash/common';
+import { IconTable } from '@tabler/icons-react';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -55,7 +56,7 @@ export const ExploreMenuItem: React.FC<ExploreMenuItemProps> = ({
             <Tooltip2 content={errorMessage} targetTagName="div">
                 <MenuItem2
                     roleStructure="listoption"
-                    icon="th"
+                    icon={<IconTable size={20} />}
                     text={explore.label}
                     disabled
                     labelElement={
@@ -72,7 +73,7 @@ export const ExploreMenuItem: React.FC<ExploreMenuItemProps> = ({
     return (
         <StyledMenuItem2
             roleStructure="listoption"
-            icon="th"
+            icon={<IconTable size={20} />}
             text={explore.label}
             onClick={onClick}
             labelClassName="menu-item-label-element"

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -11,6 +11,7 @@ import {
 import React, { FC } from 'react';
 import { useToggle } from 'react-use';
 import { getItemBgColor } from '../../../../../hooks/useColumns';
+import FieldIcon from '../../../../common/Filters/FieldIcon';
 import HighlightedText from '../../../../common/HighlightedText';
 import { Highlighted, Row, RowIcon, SpanFlex } from '../TableTree.styles';
 import CustomMetricButtons from './CustomMetricButtons';
@@ -68,10 +69,11 @@ const TreeSingleNode: FC<{ node: Node; depth: number }> = ({ node, depth }) => {
             onMouseEnter={() => toggle(true)}
             onMouseLeave={() => toggle(false)}
         >
-            <RowIcon
-                icon={getItemIconName(item.type)}
+            <FieldIcon
+                item={item}
                 color={isDimension(item) ? Colors.BLUE1 : Colors.ORANGE1}
                 size={16}
+                style={{ marginRight: '8px' }}
             />
             <Tooltip2
                 lazy

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -64,7 +64,13 @@ const FieldAutoComplete = <T extends Field | TableCalculation>({
                     name,
                     autoFocus,
                     placeholder: placeholder || 'Search field...',
-                    leftIcon: activeField && <FieldIcon item={activeField} />,
+                    leftElement: activeField && (
+                        <FieldIcon
+                            item={activeField}
+                            size={16}
+                            style={{ margin: '6px 8px' }}
+                        />
+                    ),
                     ...inputProps,
                 }}
                 items={sortedFields}

--- a/packages/frontend/src/components/common/Filters/FieldIcon.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldIcon.tsx
@@ -9,7 +9,20 @@ import {
     isMetric,
     TableCalculation,
 } from '@lightdash/common';
-import { FC } from 'react';
+import {
+    Icon123,
+    IconAbc,
+    IconAlphabetLatin,
+    IconCalendar,
+    IconClockHour4,
+    IconFunction,
+    IconLetterCase,
+    IconMathFunction,
+    IconQuote,
+    IconTag,
+    IconToggleLeft,
+} from '@tabler/icons-react';
+import { CSSProperties, FC } from 'react';
 import { getItemIconName } from '../../Explorer/ExploreTree/TableTree/Tree/TreeSingleNode';
 
 const getFieldIcon = (field: Field | TableCalculation | AdditionalMetric) => {
@@ -19,12 +32,51 @@ const getFieldIcon = (field: Field | TableCalculation | AdditionalMetric) => {
     return getItemIcon(field);
 };
 
-interface FieldIconProps {
+const FieldIcon: FC<{
     item: Field | TableCalculation | AdditionalMetric;
-}
+    color?: string | undefined;
+    size?: number | undefined;
+    style?: CSSProperties | undefined;
+}> = ({ item, color, size, style }) => {
+    const iconColor = color ? color : getItemColor(item);
+    const iconSize = size ? size : 20;
 
-const FieldIcon: FC<FieldIconProps> = ({ item }) => {
-    return <Icon icon={getFieldIcon(item)} color={getItemColor(item)} />;
+    switch (getFieldIcon(item)) {
+        case 'citation':
+            return <IconAbc color={iconColor} size={iconSize} style={style} />;
+        case 'numerical':
+            return <Icon123 color={iconColor} size={iconSize} style={style} />;
+        case 'calendar':
+            return (
+                <IconCalendar color={iconColor} size={iconSize} style={style} />
+            );
+        case 'time':
+            return (
+                <IconClockHour4
+                    color={iconColor}
+                    size={iconSize}
+                    style={style}
+                />
+            );
+        case 'segmented-control':
+            return (
+                <IconToggleLeft
+                    color={iconColor}
+                    size={iconSize}
+                    style={style}
+                />
+            );
+        case 'function':
+            return (
+                <IconMathFunction
+                    color={iconColor}
+                    size={iconSize}
+                    style={style}
+                />
+            );
+        case 'tag':
+            return <IconTag color={iconColor} size={iconSize} style={style} />;
+    }
 };
 
 export default FieldIcon;

--- a/packages/frontend/src/hooks/useProjectCatalogTree.tsx
+++ b/packages/frontend/src/hooks/useProjectCatalogTree.tsx
@@ -1,5 +1,6 @@
-import { TreeNodeInfo } from '@blueprintjs/core';
+import { Colors, TreeNodeInfo } from '@blueprintjs/core';
 import { ProjectCatalog } from '@lightdash/common';
+import { IconBinaryTree2, IconDatabase, IconTable } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
 export type ProjectCatalogTreeNode = TreeNodeInfo<
@@ -20,7 +21,13 @@ export const useProjectCatalogTree = (
                         id: database,
                         isExpanded: databaseIndex === 0,
                         label: database,
-                        icon: 'database',
+                        icon: (
+                            <IconDatabase
+                                color={Colors.GRAY1}
+                                size={20}
+                                style={{ marginRight: '7px' }}
+                            />
+                        ),
                         childNodes: Object.entries(schemas).reduce<
                             ProjectCatalogTreeNode[]
                         >(
@@ -30,7 +37,13 @@ export const useProjectCatalogTree = (
                                     id: schema,
                                     isExpanded: schemaIndex === 0,
                                     label: schema,
-                                    icon: 'diagram-tree',
+                                    icon: (
+                                        <IconBinaryTree2
+                                            color={Colors.GRAY1}
+                                            size={20}
+                                            style={{ marginRight: '7px' }}
+                                        />
+                                    ),
                                     childNodes: Object.entries(tables).reduce<
                                         ProjectCatalogTreeNode[]
                                     >(
@@ -39,7 +52,15 @@ export const useProjectCatalogTree = (
                                             {
                                                 id: table,
                                                 label: table,
-                                                icon: 'th',
+                                                icon: (
+                                                    <IconTable
+                                                        color={Colors.GRAY1}
+                                                        size={20}
+                                                        style={{
+                                                            marginRight: '7px',
+                                                        }}
+                                                    />
+                                                ),
                                                 nodeData,
                                             },
                                         ],

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -12,6 +12,7 @@ import {
     NotFoundError,
     TableBase,
 } from '@lightdash/common';
+import { Icon123, IconTable } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
@@ -247,7 +248,7 @@ const SqlRunnerPage = () => {
                                 {metrics.data.metrics.map((metric) => (
                                     <MenuItem2
                                         key={metric.uniqueId}
-                                        icon="numerical"
+                                        icon={<Icon123 />}
                                         text={metric.label}
                                         onClick={() =>
                                             setSql(


### PR DESCRIPTION
### Description:

<img width="383" alt="Screenshot 2023-02-24 at 18 12 29" src="https://user-images.githubusercontent.com/67699259/221246617-3e060d2e-559c-49b1-bc8b-05f156b5187f.png">
<img width="383" alt="Screenshot 2023-02-24 at 18 12 37" src="https://user-images.githubusercontent.com/67699259/221246621-9bee26ba-1497-4417-82c3-50b82fb10b72.png">
<img width="391" alt="Screenshot 2023-02-24 at 18 12 47" src="https://user-images.githubusercontent.com/67699259/221246627-21940e6f-8e49-4a2b-8042-6e04d844d0e3.png">
<img width="306" alt="Screenshot 2023-02-24 at 18 13 16" src="https://user-images.githubusercontent.com/67699259/221246631-8644ff00-d3e5-4af7-84b7-4730784cf1fa.png">
<img width="367" alt="Screenshot 2023-02-24 at 18 13 22" src="https://user-images.githubusercontent.com/67699259/221246632-79a79fce-47f7-4b66-9f5d-13b1aef24512.png">
