### PR TITLE
fix: vertically center icons in selected fields

### DIFF
--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -68,7 +68,7 @@ const FieldAutoComplete = <T extends Field | TableCalculation>({
                         <FieldIcon
                             item={activeField}
                             size={16}
-                            style={{ margin: '6px 8px' }}
+                            style={{ margin: '7px 8px' }}
                         />
                     ),
                     ...inputProps,


### PR DESCRIPTION
### Description:
<img width="301" alt="Screenshot 2023-02-27 at 09 24 13" src="https://user-images.githubusercontent.com/12776522/221523786-a88060ae-8b68-4778-bf5f-b26fa5b876ae.png">
it looks like the icons for selected fields aren't vertically centered. 
