### PR TITLE
fix: override cache-control on express root

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -158,6 +158,13 @@ app.use(
 app.use(flash());
 app.use(passport.initialize());
 app.use(passport.session());
+
+app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, '../../frontend/build', 'index.html'), {
+        headers: { 'Cache-Control': 'no-cache, private' },
+    });
+});
+
 // api router
 app.use('/api/v1', apiV1Router);
 RegisterRoutes(app);


### PR DESCRIPTION
Fixes error where accessing the root still returned a caching policy. The root is being overridden somewhere in the `index.ts` so adding an explicit route for `/` with a higher priority fixed the headers.

### Before
* ❌ `/` is cacheable
* ✅ every other path (e.g. `/login`) returned no-cache

```
➜  ~ curl -s -o /dev/null -D - http://localhost:8080/login
HTTP/1.1 200 OK
X-Powered-By: Express
Cache-Control: no-cache, private
...

➜  ~ curl -s -o /dev/null -D - http://localhost:8080
HTTP/1.1 200 OK
X-Powered-By: Express
Cache-Control: public, max-age=0
...
```

### After
* ✅ all routes including `/` returns no-cache

```
➜  ~ curl -s -o /dev/null -D - http://localhost:8080/login
HTTP/1.1 200 OK
X-Powered-By: Express
Cache-Control: no-cache, private
...

➜  ~ curl -s -o /dev/null -D - http://localhost:8080      
HTTP/1.1 200 OK
X-Powered-By: Express
Cache-Control: no-cache, private
...
```