### PR TITLE
fix: org members can get share urls

### DIFF
--- a/packages/backend/src/services/ShareService/ShareService.mock.ts
+++ b/packages/backend/src/services/ShareService/ShareService.mock.ts
@@ -25,9 +25,27 @@ export const User: SessionUser = {
     isSetupComplete: true,
     userId: 0,
     role: OrganizationMemberRole.ADMIN,
-    ability: new Ability([{ subject: 'Organization', action: ['view'] }]),
+    ability: new Ability([
+        {
+            subject: 'OrganizationMemberProfile',
+            action: ['view'],
+            conditions: { organizationUuid: 'organizationUuid' },
+        },
+    ]),
     isActive: true,
     abilityRules: [],
+};
+
+export const UserFromAnotherOrg: SessionUser = {
+    ...User,
+    organizationUuid: 'anotherOrg',
+    ability: new Ability([
+        {
+            subject: 'OrganizationMemberProfile',
+            action: ['view'],
+            conditions: { organizationUuid: 'anotherOrg' },
+        },
+    ]),
 };
 
 export const SampleShareUrl: ShareUrl = {

--- a/packages/backend/src/services/ShareService/ShareService.mock.ts
+++ b/packages/backend/src/services/ShareService/ShareService.mock.ts
@@ -64,6 +64,7 @@ export const FullShareUrl = {
 };
 
 export const ShareUrlWithoutParams = {
+    ...SampleShareUrl,
     nanoid: 'abc123',
     params: '',
     path: '/projects/uuid/tables/customers',

--- a/packages/backend/src/services/ShareService/ShareService.test.ts
+++ b/packages/backend/src/services/ShareService/ShareService.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '@lightdash/common';
 import { shareModel } from '../../models/models';
 import { ShareService } from './ShareService';
 import {
@@ -7,6 +8,7 @@ import {
     SampleShareUrl,
     ShareUrlWithoutParams,
     User,
+    UserFromAnotherOrg,
 } from './ShareService.mock';
 
 jest.mock('../../models/models', () => ({
@@ -49,5 +51,11 @@ describe('share', () => {
         expect(
             await shareService.getShareUrl(User, ShareUrlWithoutParams.nanoid),
         ).toEqual(FullShareUrlWithoutParams);
+    });
+
+    it('Should throw error if user does not have access to the organization', async () => {
+        await expect(
+            shareService.getShareUrl(UserFromAnotherOrg, SampleShareUrl.nanoid),
+        ).rejects.toThrowError(ForbiddenError);
     });
 });

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -36,7 +36,7 @@ export class ShareService {
         if (
             user.ability.cannot(
                 'view',
-                subject('Organization', {
+                subject('OrganizationMemberProfile', {
                     organizationUuid: shareUrl.organizationUuid,
                 }),
             )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4623

### Description

Converting a shared URL to a full URL needed at least view access to the whole org. Now we just check that they can access a member profile in the org (effectively, whether they are a member).

Before: https://www.loom.com/share/582d7ee21e2c40dfab8b46e7d7f1d47a

After: https://www.loom.com/share/769d0b7ffc3540e29be50a19dde2c653

I'm not sure why we track organizationUuid on the share URLs at all, from what I can see I'm 80% sure we could delete that relationship, since we always enforce all checks on access after getting the full URL. I suppose this stops people from outside the org being able to see the full URL. Is that necessary? 