### PR TITLE
feat: verify emails for SSO users

### DIFF
--- a/packages/backend/src/database/entities/emails.ts
+++ b/packages/backend/src/database/entities/emails.ts
@@ -6,6 +6,7 @@ export type DbEmail = {
     created_at: Date;
     email: string;
     is_primary: boolean;
+    is_verified: boolean;
 };
 
 export type DbEmailIn = Pick<DbEmail, 'user_id' | 'email' | 'is_primary'>;

--- a/packages/backend/src/database/migrations/20230301085912_add_verified_column_to_email_table.ts
+++ b/packages/backend/src/database/migrations/20230301085912_add_verified_column_to_email_table.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('emails', (table) => {
+        table.boolean('is_verified').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('emails', (table) => {
+        table.dropColumn('is_verified');
+    });
+}

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -10,7 +10,10 @@ export class EmailModel {
     }
 
     async createEmail(emailIn: DbEmailIn) {
-        await this.database('emails').insert(emailIn);
+        await this.database('emails').insert({
+            ...emailIn,
+            email: emailIn.email.toLowerCase(),
+        });
     }
 
     async deleteEmail(emailRemove: DbEmailRemove) {

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -159,18 +159,18 @@ export class UserModel {
                     issuer: createUser.openId.issuer,
                     subject: createUser.openId.subject,
                     user_id: newUser.user_id,
-                    email: createUser.openId.email,
+                    email: createUser.openId.email.toLowerCase(),
                 })
                 .returning('*');
             await createEmail(trx, {
                 user_id: newUser.user_id,
-                email: createUser.openId.email,
+                email: createUser.openId.email.toLowerCase(),
                 is_primary: true,
             });
         } else {
             await createEmail(trx, {
                 user_id: newUser.user_id,
-                email: createUser.email,
+                email: createUser.email.toLowerCase(),
                 is_primary: true,
             });
             if (createUser.password) {
@@ -307,7 +307,7 @@ export class UserModel {
                 }
                 await createEmail(trx, {
                     user_id: user.user_id,
-                    email,
+                    email: email.toLowerCase(),
                     is_primary: true,
                 });
             }
@@ -443,7 +443,7 @@ export class UserModel {
                         issuer: activateUser.openId.issuer,
                         subject: activateUser.openId.subject,
                         user_id: user.user_id,
-                        email: activateUser.openId.email,
+                        email: activateUser.openId.email.toLowerCase(),
                     })
                     .returning('*');
             }
@@ -629,7 +629,7 @@ export class UserModel {
         AND users.user_uuid = ?
         AND emails.email = ?
         RETURNING emails.email`,
-            [userUuid, email],
+            [userUuid, email.toLowerCase()],
         );
         return updatedRows;
     }

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -615,4 +615,22 @@ export class UserModel {
                 ),
             });
     }
+
+    async verifyUserEmailIfExists(
+        userUuid: string,
+        email: string,
+    ): Promise<{ email: string }[]> {
+        const updatedRows = await this.database.raw<{ email: string }[]>(
+            `
+        UPDATE emails
+        SET is_verified = true
+        FROM users
+        WHERE emails.user_id = users.user_id
+        AND users.user_uuid = ?
+        AND emails.email = ?
+        RETURNING emails.email`,
+            [userUuid, email],
+        );
+        return updatedRows;
+    }
 }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -294,7 +294,7 @@ export class UserService {
             );
             await this.userModel.verifyUserEmailIfExists(
                 loginUser.userUuid,
-                openIdUser.openId.email.toLowerCase(),
+                openIdUser.openId.email,
             );
             identifyUser(loginUser);
             analytics.track({
@@ -321,12 +321,12 @@ export class UserService {
                 userId: sessionUser.userId,
                 issuer: openIdUser.openId.issuer,
                 subject: openIdUser.openId.subject,
-                email: openIdUser.openId.email.toLowerCase(), // no guarantee on casing from OpenID
+                email: openIdUser.openId.email,
                 issuerType: openIdUser.openId.issuerType,
             });
             await this.userModel.verifyUserEmailIfExists(
                 sessionUser.userUuid,
-                openIdUser.openId.email.toLowerCase(),
+                openIdUser.openId.email,
             );
             analytics.track({
                 userId: sessionUser.userUuid,
@@ -345,7 +345,7 @@ export class UserService {
         );
         await this.userModel.verifyUserEmailIfExists(
             createdUser.userUuid,
-            openIdUser.openId.email.toLowerCase(),
+            openIdUser.openId.email,
         );
         return createdUser;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #4633 
Closes #4632 

- Adds a verified flag to emails
- Whenever an SSO user logs/in registers, we verify any emails that user has in Lightdash if it matches the email on their SSO profile
- Renamed a function in `userService`
- Enforced that emails received from OIDC signups are lower-cased before inserting into the DB, since lower case is not guaranteed from OIDC issuers (we already do this with emails on the password login endpoints)


**Testing**

Tested locally with Google SSO configured
- Verifies on login ✅ 
- Verifies on new account creation with new org ✅ 
- Verifies on new account creation from invite ✅ 
- Verifies from adding new social login to existing account ✅ 
- Cannot verify another users email ✅ (even if your SSO email is already in use by another Lightdash user as their primary email)