### PR TITLE
fix: styling changes for scheduled deliveries

### DIFF
--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalBase.styles.ts
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalBase.styles.ts
@@ -27,11 +27,12 @@ export const TargetRow = styled.div`
 export const SchedulerContainer = styled(Card)`
     display: flex;
     flex-direction: column;
-    padding: 10px;
+    padding: 5px 10px 11px;
     margin-bottom: 10px;
 `;
 
 export const SchedulerName = styled(H5)`
+    font-size: 14px !important;
     flex: 1;
     margin: 0;
 `;
@@ -39,7 +40,6 @@ export const SchedulerName = styled(H5)`
 export const SchedulerDetailsContainer = styled.div`
     display: flex;
     align-items: center;
-    gap: 10px;
 `;
 
 export const Title = styled.p`

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/index.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/index.tsx
@@ -15,11 +15,7 @@ const SchedulersModalBase: FC<
     return (
         <Dialog
             lazy
-            title={
-                <ModalTitle>
-                    Scheduled deliveries <b>"{name}"</b>
-                </ModalTitle>
-            }
+            title={<ModalTitle>Scheduled deliveries</ModalTitle>}
             icon="send-message"
             style={{
                 minHeight: '300px',


### PR DESCRIPTION
Closes: #4644 

### Description:
- [x] - The title of the modal should just say 'Scheduled Deliveries'
- [x] The scheduled name should be at 14px and the padding above and below the content should be equal.

before
<img width="588" alt="Screenshot 2023-03-01 at 18 25 55" src="https://user-images.githubusercontent.com/67699259/222215846-214643b2-be6d-4583-9c42-a2141a2eee77.png">

after
<img width="545" alt="Screenshot 2023-03-01 at 18 25 36" src="https://user-images.githubusercontent.com/67699259/222215852-79abc445-1f07-48ce-b739-a0a700d2b979.png">
