### PR TITLE
fix: scheduler migration

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -291,10 +291,8 @@ export const slackService = new SlackService({
 });
 
 if (lightdashConfig.scheduler?.enabled) {
-    try {
-        const worker = new SchedulerWorker({ lightdashConfig });
-        worker.run();
-    } catch (e) {
+    const worker = new SchedulerWorker({ lightdashConfig });
+    worker.run().catch((e) => {
         Logger.error('Error starting scheduler worker', e);
-    }
+    });
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -291,6 +291,10 @@ export const slackService = new SlackService({
 });
 
 if (lightdashConfig.scheduler?.enabled) {
-    const worker = new SchedulerWorker({ lightdashConfig });
-    worker.run();
+    try {
+        const worker = new SchedulerWorker({ lightdashConfig });
+        worker.run();
+    } catch (e) {
+        Logger.error('Error starting scheduler worker', e);
+    }
 }

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -25,12 +25,10 @@ Sentry.init({
 });
 
 if (process.env.CI !== 'true') {
-    try {
-        const worker = new SchedulerWorker({ lightdashConfig });
-        worker.run();
-    } catch (e) {
+    const worker = new SchedulerWorker({ lightdashConfig });
+    worker.run().catch((e) => {
         Logger.error('Error starting standalone scheduler worker', e);
-    }
+    });
 } else {
     Logger.info('Not running scheduler on CI');
 }

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -25,8 +25,12 @@ Sentry.init({
 });
 
 if (process.env.CI !== 'true') {
-    const worker = new SchedulerWorker({ lightdashConfig });
-    worker.run();
+    try {
+        const worker = new SchedulerWorker({ lightdashConfig });
+        worker.run();
+    } catch (e) {
+        Logger.error('Error starting standalone scheduler worker', e);
+    }
 } else {
     Logger.info('Not running scheduler on CI');
 }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -53,13 +53,15 @@ export class SchedulerClient {
         this.lightdashConfig = lightdashConfig;
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
-        });
-
-        this.graphileUtils.then((utils) => {
-            utils.migrate().catch((e: any) => {
-                Logger.warn('Error migrating graphile worker', e);
-            });
-        });
+        }).then((utils) =>
+            utils
+                .migrate()
+                .then(() => utils)
+                .catch((e: any) => {
+                    Logger.warn('Error migrating graphile worker', e);
+                    return utils;
+                }),
+        );
     }
 
     async getScheduledJobs(schedulerUuid: string): Promise<ScheduledJobs[]> {

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1,6 +1,7 @@
 import { getSchedule, stringToArray } from 'cron-converter';
 import {
     JobHelpers,
+    Logger as GraphileLogger,
     parseCronItems,
     run as runGraphileWorker,
 } from 'graphile-worker';
@@ -37,6 +38,11 @@ export const getDailyDatesFromCron = (
     return dailyDates;
 };
 
+const workerLogger = new GraphileLogger((scope) => (level, message, meta) => {
+    const sanitizedLevel = level === 'warning' ? 'warn' : level;
+    Logger[sanitizedLevel](message, meta, scope);
+});
+
 export class SchedulerWorker {
     lightdashConfig: LightdashConfig;
 
@@ -45,10 +51,13 @@ export class SchedulerWorker {
     }
 
     async run() {
+        // Wait for graphile utils to finish migration and prevent race conditions
+        await schedulerClient.graphileUtils;
         // Run a worker to execute jobs:
         Logger.info('Running scheduler');
         const runner = await runGraphileWorker({
             connectionString: this.lightdashConfig.database.connectionUri,
+            logger: workerLogger,
             concurrency: this.lightdashConfig.scheduler?.concurrency,
             noHandleSignals: false,
             pollInterval: 1000,

--- a/packages/e2e/cypress/e2e/api/scheduler.cy.ts
+++ b/packages/e2e/cypress/e2e/api/scheduler.cy.ts
@@ -52,7 +52,6 @@ describe('Lightdash scheduler endpoints', () => {
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
                     body: createSchedulerBody,
-                    failOnStatusCode: false,
                 }).then((createResponse) => {
                     expect(createResponse.body.results).to.have.property(
                         'schedulerUuid',
@@ -71,7 +70,6 @@ describe('Lightdash scheduler endpoints', () => {
                     cy.request<{ results: ChartScheduler[] }>({
                         url: `${apiUrl}/saved/${savedChart.uuid}/schedulers`,
                         method: 'GET',
-                        failOnStatusCode: false,
                     }).then((response) => {
                         const schedulerIds = response.body.results.map(
                             (r) => r.schedulerUuid,
@@ -83,7 +81,6 @@ describe('Lightdash scheduler endpoints', () => {
                     cy.request<{ results: ScheduledJobs[] }>({
                         url: `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
                         method: 'GET',
-                        failOnStatusCode: false,
                     }).then((response) => {
                         expect(response.body.results).to.be.length(1);
                         expect(
@@ -100,7 +97,6 @@ describe('Lightdash scheduler endpoints', () => {
                             (targets[0] as SchedulerSlackTarget)
                                 .schedulerSlackTargetUuid,
                         ),
-                        failOnStatusCode: false,
                     }).then((updateResponse) => {
                         expect(updateResponse.body.results.name).to.eq('test2');
                         expect(updateResponse.body.results.cron).to.eq(cron);
@@ -155,7 +151,6 @@ describe('Lightdash scheduler endpoints', () => {
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
                     body: createSchedulerBody,
-                    failOnStatusCode: false,
                 }).then((createResponse) => {
                     expect(createResponse.body.results).to.have.property(
                         'schedulerUuid',
@@ -174,7 +169,6 @@ describe('Lightdash scheduler endpoints', () => {
                     cy.request<{ results: ScheduledJobs[] }>({
                         url: `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
                         method: 'GET',
-                        failOnStatusCode: false,
                     }).then((response) => {
                         expect(response.body.results).to.be.length(1);
                         expect(
@@ -186,7 +180,6 @@ describe('Lightdash scheduler endpoints', () => {
                     cy.request<{ results: DashboardScheduler[] }>({
                         url: `${apiUrl}/dashboards/${dashboard.uuid}/schedulers`,
                         method: 'GET',
-                        failOnStatusCode: false,
                     }).then((response) => {
                         const schedulerIds = response.body.results.map(
                             (r) => r.schedulerUuid,
@@ -205,7 +198,6 @@ describe('Lightdash scheduler endpoints', () => {
                             (targets[0] as SchedulerSlackTarget)
                                 .schedulerSlackTargetUuid,
                         ),
-                        failOnStatusCode: false,
                     }).then((updateResponse) => {
                         expect(updateResponse.body.results.name).to.eq('test2');
                         expect(updateResponse.body.results.cron).to.eq(cron);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fix error:

```[Lightdash] error: Unable to schedule job for scheduler 53852685-84f6-4c95-96ab-ea45dbadbec4 duplicate key value violates unique constraint "pg_namespace_nspname_index"```


We should have more logs about the schedule worker. eg:
```
2023-03-02 12:07:03 [Lightdash] info: Worker connected and looking for jobs... (task names: 'generateDailyJobs', 'handleScheduledDelivery', 'sendSlackNotification', 'sendEmailNotification')
2023-03-02 12:07:03 [Lightdash] debug: Found task 1345 (handleScheduledDelivery)
2023-03-02 12:07:38 [Lightdash] info: Completed task 1345 (handleScheduledDelivery) with success (35377.41ms)
```


