### PR TITLE
feat: add OTP flow for email verification

### DIFF
--- a/examples/api/verify-emails.http
+++ b/examples/api/verify-emails.http
@@ -1,0 +1,17 @@
+### Login
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+### Get status of email
+GET http://localhost:8080/api/v1/user/me/email/status
+
+### Trigger a new OTP
+PUT http://localhost:8080/api/v1/user/me/email/otp
+
+### Try to get verified status
+GET http://localhost:8080/api/v1/user/me/email/status?passcode=123456

--- a/examples/api/verify-emails.http
+++ b/examples/api/verify-emails.http
@@ -14,4 +14,4 @@ GET http://localhost:8080/api/v1/user/me/email/status
 PUT http://localhost:8080/api/v1/user/me/email/otp
 
 ### Try to get verified status
-GET http://localhost:8080/api/v1/user/me/email/status?passcode=123456
+GET http://localhost:8080/api/v1/user/me/email/status?passcode=073557

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -115,6 +115,10 @@ import {
     DbAnalyticsDashboardViews,
 } from '../database/entities/analytics';
 import {
+    EmailOneTimePasscodesTableName,
+    EmailOneTimePasscodeTable,
+} from '../database/entities/email_one_time_passcodes';
+import {
     SchedulerEmailTargetTable,
     SchedulerEmailTargetTableName,
     SchedulerSlackTargetTable,
@@ -169,5 +173,6 @@ declare module 'knex/types/tables' {
         [SchedulerTableName]: SchedulerTable;
         [SchedulerSlackTargetTableName]: SchedulerSlackTargetTable;
         [SchedulerEmailTargetTableName]: SchedulerEmailTargetTable;
+        [EmailOneTimePasscodesTableName]: EmailOneTimePasscodeTable;
     }
 }

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -260,4 +260,27 @@ export default class EmailClient {
             text: title,
         });
     }
+
+    async sendOneTimePasscodeEmail({
+        recipient,
+        passcode,
+    }: {
+        recipient: string;
+        passcode: string;
+    }): Promise<void> {
+        const subject = 'Verify your email address';
+        const text = `
+        Verify your email address by entering the following passcode in Lightdash: ${passcode}
+            `;
+        return this.sendEmail({
+            to: recipient,
+            subject,
+            template: 'oneTimePasscode',
+            context: {
+                passcode,
+                title: subject,
+            },
+            text,
+        });
+    }
 }

--- a/packages/backend/src/clients/EmailClient/templates/oneTimePasscode.html
+++ b/packages/backend/src/clients/EmailClient/templates/oneTimePasscode.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>{{ title }}</title>
+</head>
+<body>
+  <h3>Verify your email with Lightdash</h3>
+  <p>Enter the following code in the Lightdash app to verify your email address:</p>
+  <h1>{{ passcode }}</h1>
+  <p>This code will expire in 15 minutes.</p>
+</body>
+</html>

--- a/packages/backend/src/clients/EmailClient/templates/oneTimePasscode.html
+++ b/packages/backend/src/clients/EmailClient/templates/oneTimePasscode.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>{{ title }}</title>
-</head>
-<body>
-  <h3>Verify your email with Lightdash</h3>
-  <p>Enter the following code in the Lightdash app to verify your email address:</p>
-  <h1>{{ passcode }}</h1>
-  <p>This code will expire in 15 minutes.</p>
-</body>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>{{ title }}</title>
+    </head>
+    <body>
+        <h3>Verify your email with Lightdash</h3>
+        <p>
+            Enter the following code in the Lightdash app to verify your email
+            address:
+        </p>
+        <h1>{{ passcode }}</h1>
+        <p>This code will expire in 15 minutes.</p>
+    </body>
 </html>

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -45,12 +45,12 @@ export class UserController extends Controller {
     @OperationId('getEmailVerificationStatus')
     async getEmailVerificationStatus(
         @Request() req: express.Request,
-        @Query() pascode?: string,
+        @Query() passcode?: string,
     ): Promise<ApiEmailStatusResponse> {
         // Throws 404 error if not found
         const status = await userService.getPrimaryEmailStatus(
             req.user!,
-            pascode,
+            passcode,
         );
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -1,0 +1,29 @@
+import { ApiEmailStatusResponse, ApiErrorPayload } from '@lightdash/common';
+import { Controller } from '@tsoa/runtime';
+import express from 'express';
+import { Middlewares, OperationId, Put, Request, Response, Route } from 'tsoa';
+import { userService } from '../services/services';
+import { isAuthenticated, unauthorisedInDemo } from './authentication';
+
+@Route('/api/v1/user')
+@Response<ApiErrorPayload>('default', 'Error')
+export class UserController extends Controller {
+    /**
+     * Create a new one-time passcode for the current user's primary email
+     * @param req express request
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Put('/me/email/otp')
+    @OperationId('createEmailOneTimePasscode')
+    async createEmailOneTimePasscode(
+        @Request() req: express.Request,
+    ): Promise<ApiEmailStatusResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await userService.sendOneTimePasscodeToPrimaryEmail(
+                req.user!,
+            ),
+        };
+    }
+}

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -26,12 +26,13 @@ export class UserController extends Controller {
     async createEmailOneTimePasscode(
         @Request() req: express.Request,
     ): Promise<ApiEmailStatusResponse> {
+        const status = await userService.sendOneTimePasscodeToPrimaryEmail(
+            req.user!,
+        );
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await userService.sendOneTimePasscodeToPrimaryEmail(
-                req.user!,
-            ),
+            results: status,
         };
     }
 

--- a/packages/backend/src/database/entities/email_one_time_passcodes.ts
+++ b/packages/backend/src/database/entities/email_one_time_passcodes.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export const EmailOneTimePasscodesTableName = 'email_one_time_passcodes';
+
+export type DbEmailOneTimePasscode = {
+    email_id: number;
+    passcode: string;
+    created_at: Date;
+    number_of_attempts: number;
+};
+
+export type DbEmailOneTimePasscodeIn = Pick<
+    DbEmailOneTimePasscode,
+    'email_id' | 'passcode'
+>;
+export type EmailOneTimePasscodeTable = Knex.CompositeTableType<
+    DbEmailOneTimePasscode,
+    DbEmailOneTimePasscodeIn
+>;

--- a/packages/backend/src/database/entities/email_one_time_passcodes.ts
+++ b/packages/backend/src/database/entities/email_one_time_passcodes.ts
@@ -13,7 +13,13 @@ export type DbEmailOneTimePasscodeIn = Pick<
     DbEmailOneTimePasscode,
     'email_id' | 'passcode'
 >;
+
+export type DbEmailOneTimePasscodeUpdate = Pick<
+    DbEmailOneTimePasscode,
+    'number_of_attempts'
+>;
 export type EmailOneTimePasscodeTable = Knex.CompositeTableType<
     DbEmailOneTimePasscode,
-    DbEmailOneTimePasscodeIn
+    DbEmailOneTimePasscodeIn,
+    DbEmailOneTimePasscodeUpdate
 >;

--- a/packages/backend/src/database/entities/emails.ts
+++ b/packages/backend/src/database/entities/emails.ts
@@ -11,8 +11,13 @@ export type DbEmail = {
 
 export type DbEmailIn = Pick<DbEmail, 'user_id' | 'email' | 'is_primary'>;
 export type DbEmailRemove = Pick<DbEmail, 'user_id' | 'email'>;
+export type DbEmailUpdate = Pick<DbEmail, 'is_verified'>;
 
-export type EmailTable = Knex.CompositeTableType<DbEmail, DbEmailIn>;
+export type EmailTable = Knex.CompositeTableType<
+    DbEmail,
+    DbEmailIn,
+    DbEmailUpdate
+>;
 
 export const EmailTableName = 'emails';
 

--- a/packages/backend/src/database/migrations/20230301161351_add_email_otp_table.ts
+++ b/packages/backend/src/database/migrations/20230301161351_add_email_otp_table.ts
@@ -4,7 +4,7 @@ export async function up(knex: Knex): Promise<void> {
     if (!(await knex.schema.hasTable('email_one_time_passcodes'))) {
         await knex.schema.createTable('email_one_time_passcodes', (table) => {
             table
-                .increments('email_id')
+                .integer('email_id')
                 .primary()
                 .references('email_id')
                 .inTable('emails');

--- a/packages/backend/src/database/migrations/20230301161351_add_email_otp_table.ts
+++ b/packages/backend/src/database/migrations/20230301161351_add_email_otp_table.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable('email_one_time_passcodes'))) {
+        await knex.schema.createTable('email_one_time_passcodes', (table) => {
+            table
+                .increments('email_id')
+                .primary()
+                .references('email_id')
+                .inTable('emails');
+            table.string('passcode').notNullable();
+            table
+                .timestamp('created_at', { useTz: true })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.integer('number_of_attempts').notNullable().defaultTo(0);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists('email_one_time_passcodes');
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -20,9 +20,11 @@ import { SchedulerController } from './../controllers/schedulerController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ShareController } from './../controllers/shareController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { SlackController } from './../controllers/slackController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import type { RequestHandler } from 'express';
 import * as express from 'express';
-import { SlackController } from './../controllers/slackController';
+import { UserController } from './../controllers/userController';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
@@ -514,7 +516,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                channel: { dataType: 'string' },
                 id: { dataType: 'string', required: true },
                 date: { dataType: 'datetime', required: true },
             },
@@ -607,6 +608,43 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'SlackChannel' },
                     required: true,
                 },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePassword: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                numberOfAttempts: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                otp: { ref: 'EmailOneTimePassword' },
+                isVerified: { dataType: 'boolean', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiEmailStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'EmailStatus', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -1377,6 +1415,46 @@ export function RegisterRoutes(app: express.Router) {
                     validatedArgs as any,
                 );
                 promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/user/me/email/otp',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.createEmailOneTimePasscode,
+        ),
+
+        function UserController_createEmailOneTimePasscode(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new UserController();
+
+                const promise = controller.createEmailOneTimePasscode.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -648,6 +648,8 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        isMaxAttempts: { dataType: 'boolean', required: true },
+                        isExpired: { dataType: 'boolean', required: true },
                         expiresAt: { dataType: 'datetime', required: true },
                     },
                 },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -639,12 +639,46 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePasswordExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailOneTimePassword' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        expiresAt: { dataType: 'datetime', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatusExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailStatus' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        otp: { ref: 'EmailOneTimePasswordExpiring' },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiEmailStatusResponse: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                results: { ref: 'EmailStatus', required: true },
+                results: { ref: 'EmailStatusExpiring', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -1451,6 +1485,47 @@ export function RegisterRoutes(app: express.Router) {
                 const controller = new UserController();
 
                 const promise = controller.createEmailOneTimePasscode.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/user/me/email/status',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getEmailVerificationStatus,
+        ),
+
+        function UserController_getEmailVerificationStatus(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                passcode: { in: 'query', name: 'passcode', dataType: 'string' },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new UserController();
+
+                const promise = controller.getEmailVerificationStatus.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -201,4 +201,17 @@ export class EmailModel {
         );
         return updatedRows;
     }
+
+    async deleteEmailOtp(userUuid: string, email: string): Promise<void> {
+        await this.database('email_one_time_passcodes')
+            .innerJoin(
+                'emails',
+                'emails.email_id',
+                'email_one_time_passcodes.email_id',
+            )
+            .innerJoin('users', 'users.user_id', 'emails.user_id')
+            .where('users.user_uuid', userUuid)
+            .andWhere('emails.email', email)
+            .delete();
+    }
 }

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -1,7 +1,52 @@
-import { NotFoundError } from '@lightdash/common';
+import { EmailStatus, NotFoundError } from '@lightdash/common';
+import bcrypt from 'bcrypt';
 import { Knex } from 'knex';
 import { DbEmailIn, DbEmailRemove } from '../database/entities/emails';
 
+const getPrimaryEmailStatus = async (
+    userUuid: string,
+    trx: Knex,
+): Promise<EmailStatus> => {
+    const rows = await trx('emails')
+        .innerJoin('users', 'users.user_id', 'emails.user_id')
+        .leftJoin(
+            'email_one_time_passcodes',
+            'email_one_time_passcodes.email_id',
+            'emails.email_id',
+        )
+        .where('email.is_primary', true)
+        .andWhere('users.user_uuid', userUuid)
+        .select<
+            {
+                email: string;
+                is_verified: boolean;
+                created_at?: Date;
+                number_of_attempts?: number;
+            }[]
+        >([
+            'emails.email',
+            'emails.is_verified',
+            'email_one_time_passcodes.created_at',
+            'email_one_time_passcodes.number_of_attempts',
+        ]);
+    if (rows.length === 0) {
+        throw new NotFoundError('Cannot find primary email for user');
+    }
+    const row = rows[0];
+    const emailStatus: EmailStatus = {
+        email: row.email,
+        isVerified: row.is_verified,
+        otp: undefined,
+    };
+    console.log(row);
+    if (row.created_at && row.number_of_attempts !== undefined) {
+        emailStatus.otp = {
+            createdAt: row.created_at,
+            numberOfAttempts: row.number_of_attempts,
+        };
+    }
+    return emailStatus;
+};
 export class EmailModel {
     readonly database: Knex;
 
@@ -33,5 +78,70 @@ export class EmailModel {
             email: email.email,
             userId: email.user_id,
         };
+    }
+
+    async getPrimaryEmailStatus(userUuid: string): Promise<EmailStatus> {
+        return getPrimaryEmailStatus(userUuid, this.database);
+    }
+
+    async createPrimaryEmailOtp({
+        passcode,
+        userUuid,
+    }: {
+        passcode: string;
+        userUuid: string;
+    }): Promise<EmailStatus> {
+        const hashedPasscode = await bcrypt.hash(
+            passcode,
+            await bcrypt.genSalt(),
+        );
+        return this.database.transaction(async (trx) => {
+            trx.raw(
+                `
+            INSERT INTO email_one_time_passcodes (email_id, passcode)
+            SELECT email_id, ?
+            FROM emails
+            INNER JOIN users ON users.user_id = emails.user_id
+            WHERE is_primary = true
+            AND users.user_uuid = ?
+            ON CONFLICT (email_id) 
+            DO UPDATE 
+                SET passcode = EXCLUDED.passcode, 
+                created_at = DEFAULT, 
+                number_of_attempts = DEFAULT;
+        `,
+                [hashedPasscode, userUuid],
+            );
+            return getPrimaryEmailStatus(userUuid, trx);
+        });
+    }
+
+    async verifyPrimaryEmailOtp({
+        userUuid,
+        passcode,
+    }: {
+        userUuid: string;
+        passcode: string;
+    }): Promise<EmailStatus> {
+        const emailStatus = await this.database.transaction(async (trx) => {
+            const [row] = await trx('email_one_time_passcodes')
+                .innerJoin(
+                    'emails',
+                    'emails.email_id',
+                    'email_one_time_passcodes.email_id',
+                )
+                .innerJoin('users', 'users.user_id', 'emails.user_id')
+                .where('users.user_uuid', userUuid)
+                .andWhere('is_primary', true)
+                .select('passcode');
+            const match = await bcrypt.compare(passcode, row?.passcode || '');
+            if (row?.email_id && match) {
+                trx('emails')
+                    .update({ is_verified: true })
+                    .where('email_id', row.email_id);
+            }
+            return getPrimaryEmailStatus(userUuid, trx);
+        });
+        return emailStatus;
     }
 }

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -89,7 +89,7 @@ export class EmailModel {
             passcode,
             await bcrypt.genSalt(),
         );
-        const result = await this.database.raw<{ rows: DbEmailStatus[] }>(
+        await this.database.raw<{ rows: DbEmailStatus[] }>(
             `
             WITH inserted AS (
                 INSERT
@@ -115,13 +115,7 @@ export class EmailModel {
         `,
             [hashedPasscode, userUuid],
         );
-        const [updated] = result.rows;
-        if (updated === undefined) {
-            throw new NotFoundError(
-                'Cannot find user with primary email to create otp',
-            );
-        }
-        return convertEmailStatusRow(updated);
+        return this.getPrimaryEmailStatus(userUuid);
     }
 
     async getPrimaryEmailStatusByUserAndOtp({

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -13,7 +13,6 @@ const convertEmailStatusRow = (row: DbEmailStatus): EmailStatus => {
         isVerified: row.is_verified,
         otp: undefined,
     };
-    console.log(row);
     if (row.created_at && row.number_of_attempts !== undefined) {
         emailStatus.otp = {
             createdAt: row.created_at,

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -615,22 +615,4 @@ export class UserModel {
                 ),
             });
     }
-
-    async verifyUserEmailIfExists(
-        userUuid: string,
-        email: string,
-    ): Promise<{ email: string }[]> {
-        const updatedRows = await this.database.raw<{ email: string }[]>(
-            `
-        UPDATE emails
-        SET is_verified = true
-        FROM users
-        WHERE emails.user_id = users.user_id
-        AND users.user_uuid = ?
-        AND emails.email = ?
-        RETURNING emails.email`,
-            [userUuid, email.toLowerCase()],
-        );
-        return updatedRows;
-    }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -85,6 +85,7 @@ export * from './types/conditionalRule';
 export * from './types/dashboard';
 export * from './types/dbt';
 export * from './types/dbtCloud';
+export * from './types/email';
 export * from './types/errors';
 export * from './types/explore';
 export * from './types/field';

--- a/packages/common/src/types/email.ts
+++ b/packages/common/src/types/email.ts
@@ -11,6 +11,8 @@ type EmailOneTimePassword = {
 
 type EmailOneTimePasswordExpiring = EmailOneTimePassword & {
     expiresAt: Date;
+    isExpired: boolean;
+    isMaxAttempts: boolean;
 };
 
 export type EmailStatus = {

--- a/packages/common/src/types/email.ts
+++ b/packages/common/src/types/email.ts
@@ -9,17 +9,25 @@ type EmailOneTimePassword = {
     numberOfAttempts: number;
 };
 
-/**
- * Verification status of an email address
- */
+type EmailOneTimePasswordExpiring = EmailOneTimePassword & {
+    expiresAt: Date;
+};
+
 export type EmailStatus = {
     email: string;
     isVerified: boolean;
+    otp?: EmailOneTimePassword;
+};
+
+/**
+ * Verification status of an email address
+ */
+export type EmailStatusExpiring = EmailStatus & {
     /**
      * One time passcode information
      * If there is no active passcode, this will be undefined
      */
-    otp?: EmailOneTimePassword;
+    otp?: EmailOneTimePasswordExpiring;
 };
 
 /**
@@ -27,5 +35,5 @@ export type EmailStatus = {
  */
 export type ApiEmailStatusResponse = {
     status: 'ok';
-    results: EmailStatus;
+    results: EmailStatusExpiring;
 };

--- a/packages/common/src/types/email.ts
+++ b/packages/common/src/types/email.ts
@@ -1,0 +1,31 @@
+type EmailOneTimePassword = {
+    /**
+     * Time that the passcode was created
+     */
+    createdAt: Date;
+    /**
+     * Number of times the passcode has been attempted
+     */
+    numberOfAttempts: number;
+};
+
+/**
+ * Verification status of an email address
+ */
+export type EmailStatus = {
+    email: string;
+    isVerified: boolean;
+    /**
+     * One time passcode information
+     * If there is no active passcode, this will be undefined
+     */
+    otp?: EmailOneTimePassword;
+};
+
+/**
+ * Shows the current verification status of an email address
+ */
+export type ApiEmailStatusResponse = {
+    status: 'ok';
+    results: EmailStatus;
+};


### PR DESCRIPTION
Closes: #4635 

Blocked by: #4648 

### Description:

- Adds OTP table to db
- Adds models manage OTPs
- New endpoint to trigger OTP emails

### To test

See `examples/api/verify-emails.http` to:

- login
- check your verification status
- trigger a new top
- check verification status again
- try and verify with a passcode
