### PR TITLE
feat: add jinja parser for var from cli

### DIFF
--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -7,6 +7,8 @@ nunjucksEnv.addFilter('as_number', (str) => parseFloat(str));
 // jinja global functions
 const nunjucksContext = {
     env_var: (key: string) => process.env[key],
+    var: (key: string) =>
+        JSON.parse(process.argv[process.argv.indexOf('--vars') + 1])[key],
 };
 
 export const renderProfilesYml = (


### PR DESCRIPTION
Closes: #4679

### Description:
Add's parser for `var` jinja blocks in `profiles.yml`

Example Usage:
```bash
$ node ./packages/cli/dist/index.js deploy --create --profiles-dir . --vars '{"branch": "develop"}' --target ci
```