### PR TITLE
feat: move empty state metrics text to pop over

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -100,8 +100,8 @@ const TableTreeSections: FC<Props> = ({
                                     <TooltipContent>
                                         No metrics defined in your dbt project.
                                         <br />
-                                        <b>View docs</b> - To learn how to add a
-                                        metric to your project
+                                        Click to <b>view docs</b> and learn how
+                                        to add a metric to your project.
                                     </TooltipContent>
                                 ),
                             }}
@@ -157,18 +157,17 @@ const TableTreeSections: FC<Props> = ({
                 </CustomMetricsSectionRow>
             )}
 
-            {!hasNoMetrics ||
-                (additionalMetrics.length > 0 && (
-                    <TreeProvider
-                        orderFieldsBy={table.orderFieldsBy}
-                        searchQuery={searchQuery}
-                        itemsMap={customMetrics}
-                        selectedItems={selectedItems}
-                        onItemClick={(key) => onSelectedNodeChange(key, false)}
-                    >
-                        <TreeRoot depth={treeRootDepth} />
-                    </TreeProvider>
-                ))}
+            {hasNoMetrics || additionalMetrics.length > 0 ? (
+                <TreeProvider
+                    orderFieldsBy={table.orderFieldsBy}
+                    searchQuery={searchQuery}
+                    itemsMap={customMetrics}
+                    selectedItems={selectedItems}
+                    onItemClick={(key) => onSelectedNodeChange(key, false)}
+                >
+                    <TreeRoot depth={treeRootDepth} />
+                </TreeProvider>
+            ) : null}
         </>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -98,8 +98,10 @@ const TableTreeSections: FC<Props> = ({
                             tooltipProps={{
                                 content: (
                                     <TooltipContent>
-                                        <b>View docs</b> - Add a metric to your
-                                        project
+                                        No metrics defined in your dbt project.
+                                        <br />
+                                        <b>View docs</b> - To learn how to add a
+                                        metric to your project
                                     </TooltipContent>
                                 ),
                             }}
@@ -113,9 +115,7 @@ const TableTreeSections: FC<Props> = ({
                 </MetricsSectionRow>
             )}
 
-            {hasNoMetrics ? (
-                <EmptyState>No metrics defined in your dbt project</EmptyState>
-            ) : (
+            {!hasNoMetrics && (
                 <TreeProvider
                     orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}
@@ -157,22 +157,18 @@ const TableTreeSections: FC<Props> = ({
                 </CustomMetricsSectionRow>
             )}
 
-            {hasNoMetrics && additionalMetrics.length <= 0 ? (
-                <EmptyState>
-                    Add custom metrics by hovering over the dimension of your
-                    choice & selecting the three-dot Action Menu
-                </EmptyState>
-            ) : (
-                <TreeProvider
-                    orderFieldsBy={table.orderFieldsBy}
-                    searchQuery={searchQuery}
-                    itemsMap={customMetrics}
-                    selectedItems={selectedItems}
-                    onItemClick={(key) => onSelectedNodeChange(key, false)}
-                >
-                    <TreeRoot depth={treeRootDepth} />
-                </TreeProvider>
-            )}
+            {!hasNoMetrics ||
+                (additionalMetrics.length > 0 && (
+                    <TreeProvider
+                        orderFieldsBy={table.orderFieldsBy}
+                        searchQuery={searchQuery}
+                        itemsMap={customMetrics}
+                        selectedItems={selectedItems}
+                        onItemClick={(key) => onSelectedNodeChange(key, false)}
+                    >
+                        <TreeRoot depth={treeRootDepth} />
+                    </TreeProvider>
+                ))}
         </>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4663 

### Description:

Metrics
<img width="421" alt="Screenshot 2023-03-04 at 8 35 48 AM" src="https://user-images.githubusercontent.com/13311268/222908614-9c25890a-a2a0-49b4-8f68-ae8ab9146e2d.png">

Custom Metrics
<img width="430" alt="Screenshot 2023-03-04 at 8 35 54 AM" src="https://user-images.githubusercontent.com/13311268/222908611-4beb9a0d-b0b8-42ce-9b93-727d39b4fed8.png">




