### PR TITLE
fix: safari mantine divider issue

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -44,7 +44,12 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                 align="center"
                 spacing="md"
                 noWrap
-                sx={{ flexGrow: 1 }}
+                sx={{
+                    flexGrow: 1,
+                    borderBottomWidth: 1,
+                    borderBottomStyle: 'solid',
+                    borderBottomColor: theme.colors.gray[3],
+                }}
             >
                 <ResourceIcon item={item} />
 
@@ -52,8 +57,6 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                     {item.data.name}
                 </Text>
             </Group>
-
-            <Divider color="gray.3" />
 
             <Flex pl="md" pr="xs" h={32} justify="space-between" align="center">
                 <Flex align="center" gap={4}>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -44,7 +44,12 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                 align="center"
                 spacing="md"
                 noWrap
-                sx={{ flexGrow: 1 }}
+                sx={{
+                    flexGrow: 1,
+                    borderBottomWidth: 1,
+                    borderBottomStyle: 'solid',
+                    borderBottomColor: theme.colors.gray[3],
+                }}
             >
                 <ResourceIcon item={item} />
 
@@ -52,8 +57,6 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                     {item.data.name}
                 </Text>
             </Group>
-
-            <Divider color="gray.3" />
 
             <Flex pl="md" pr="xs" h={32} justify="space-between" align="center">
                 <Flex align="center" gap={4}>


### PR DESCRIPTION
Closes: #4657 

### Description:

this issue is a combination of:
- bug with Safari rendering < only addressing this bug in the PR.
- DIV inside A tag (kinda an anti-pattern)

<img width="1056" alt="CleanShot 2023-03-06 at 12 40 00@2x" src="https://user-images.githubusercontent.com/962095/223059405-1dba5bf8-7a93-4170-b17c-8f9e4845e6dd.png">
