### PR TITLE
feat: limit csv download

### DIFF
--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -146,20 +146,23 @@ const SchedulerOptions: FC<
                 <Radio label="Results in Table" value={Limit.TABLE} />
                 <Radio label="All Results" value={Limit.ALL} />
                 <Radio label="Custom..." value={Limit.CUSTOM} />
-
-                {limit === Limit.CUSTOM && (
-                    <InputWrapper>
-                        <NumericInput
-                            value={customLimit}
-                            min={1}
-                            fill
-                            onValueChange={(value: any) => {
-                                setCustomLimit(value);
-                            }}
-                        />
-                    </InputWrapper>
-                )}
             </RadioGroup>
+            {limit === Limit.CUSTOM && (
+                <InputWrapper>
+                    <NumericInput
+                        value={customLimit}
+                        min={1}
+                        fill
+                        onValueChange={(value: any) => {
+                            setCustomLimit(value);
+                        }}
+                    />
+                </InputWrapper>
+            )}
+
+            {(limit === Limit.ALL || limit === Limit.CUSTOM) && (
+                <i>Results are limited to 100,000 cells for each table</i>
+            )}
         </Form>
     );
 };
@@ -253,13 +256,16 @@ const SchedulerForm: FC<
                                 { value: 'csv', label: 'CSV' },
                             ]}
                         />
-                        {format === 'csv' && (
+                    </InlinedInputs>
+
+                    {format === 'csv' && (
+                        <InlinedInputs>
                             <SchedulerOptions
                                 disabled={disabled}
                                 methods={methods}
                             />
-                        )}
-                    </InlinedInputs>
+                        </InlinedInputs>
+                    )}
                     <InlinedInputs>
                         {showDestinationLabel && (
                             <InlinedLabel>

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalBase.styles.ts
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalBase.styles.ts
@@ -57,6 +57,7 @@ export const StyledSelect = styled(HTMLSelect)`
 
 export const InputWrapper = styled.div`
     width: 130px;
+    margin-bottom: 10px;
 `;
 
 export const InputGroupWrapper = styled.div`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 4639

### Acceptance Criteria
Miro sketch here: https://miro.com/app/board/uXjVP1D_L4w=/?moveToWidget=3458764548021557892&cot=14

 

- [ ] There is a limit on the size of each individual .csv file that you can schedule in a delivery.
- [ ]  This limit is cell-based and is set to 100,000 cells
- [ ]  This is a limit per-table. For example, I can send a dashboard with 3 tables that have 100,000 cells.
- [ ]  When a user selects all results or custom, there is helper text that pops up and tells the user about the cell limits.
- [ ]  If a user sends a .csv that exceeds this limit, we crop the results to fit the 100,000 limit.
    - [ ]  e.g. I try to send a .csv with 25,000 rows and 10 columns (so, 250,000 cells). We would limit the number of rows in the query so that we are only trying to export 100,000 cells. So, we would say LIMIT 10000 in the SQL query or something like that. Since 10,000 * 10 columns = 100,000 cells.
    - [ ]  ^we could be smart about this and always set a limit in the query based on the number of columns in the table. E.g. if I have 20 columns, then my limit will be 10,000 rows. If I have 15 columns, my limit will be floor(100000/15)
- [ ]  update the docs to include this limit
- [ ] 
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
