### PR TITLE
feat: endpoints for organisation allowed email domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.453.0](https://github.com/lightdash/lightdash/compare/0.452.0...0.453.0) (2023-03-09)
+
+
+### Features
+
+* only org admins can invite users ([#4724](https://github.com/lightdash/lightdash/issues/4724)) ([980328f](https://github.com/lightdash/lightdash/commit/980328f23c62d7b876c60ebc2cc2a97a899a484e))
+
 # [0.452.0](https://github.com/lightdash/lightdash/compare/0.451.0...0.452.0) (2023-03-09)
 
 

--- a/examples/api/org-allowed-email-domains.http
+++ b/examples/api/org-allowed-email-domains.http
@@ -21,7 +21,7 @@ Content-Type: application/json
   "projectUuids": []
 }
 
-### Update allowed email domains
+### Update allowed email domains - Member with access to project
 PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
 Content-Type: application/json
 

--- a/examples/api/org-allowed-email-domains.http
+++ b/examples/api/org-allowed-email-domains.http
@@ -1,0 +1,33 @@
+### Login
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+### Get allowed email domains
+GET http://localhost:8080/api/v1/org/allowedEmailDomains
+
+### Update allowed email domains
+PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
+Content-Type: application/json
+
+{
+  "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
+  "emailDomains": ["lightdash.com"],
+  "role": "viewer",
+  "projectUuids": []
+}
+
+### Update allowed email domains
+PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
+Content-Type: application/json
+
+{
+  "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
+  "emailDomains": ["lightdash.com"],
+  "role": "member",
+  "projectUuids": ["3675b69e-8324-4110-bdca-059031aa8da3"]
+}

--- a/examples/api/org-allowed-email-domains.http
+++ b/examples/api/org-allowed-email-domains.http
@@ -15,7 +15,6 @@ PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
 Content-Type: application/json
 
 {
-  "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
   "emailDomains": ["lightdash.com"],
   "role": "viewer",
   "projectUuids": []
@@ -26,7 +25,6 @@ PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
 Content-Type: application/json
 
 {
-  "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
   "emailDomains": ["lightdash.com"],
   "role": "member",
   "projectUuids": ["3675b69e-8324-4110-bdca-059031aa8da3"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lightdash",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "main": "index.js",
     "license": "MIT",
     "private": true,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "backend",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "main": "dist/index",
     "license": "MIT",
     "devDependencies": {
@@ -28,8 +28,8 @@
         "@aws-sdk/client-s3": "^3.272.0",
         "@aws-sdk/s3-request-presigner": "^3.272.0",
         "@casl/ability": "^5.4.3",
-        "@lightdash/common": "^0.452.0",
-        "@lightdash/warehouses": "^0.452.0",
+        "@lightdash/common": "^0.453.0",
+        "@lightdash/warehouses": "^0.453.0",
         "@rudderstack/rudder-sdk-node": "^1.1.3",
         "@sentry/node": "^7.37.2",
         "@sentry/tracing": "^7.37.2",

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -119,6 +119,10 @@ import {
     EmailOneTimePasscodeTable,
 } from '../database/entities/email_one_time_passcodes';
 import {
+    OrganizationAllowedEmailDomainsTable,
+    OrganizationAllowedEmailDomainsTableName,
+} from '../database/entities/organizationsAllowedEmailDomains';
+import {
     SchedulerEmailTargetTable,
     SchedulerEmailTargetTableName,
     SchedulerLogTable,
@@ -177,5 +181,6 @@ declare module 'knex/types/tables' {
         [SchedulerEmailTargetTableName]: SchedulerEmailTargetTable;
         [EmailOneTimePasscodesTableName]: EmailOneTimePasscodeTable;
         [SchedulerLogTableName]: SchedulerLogTable;
+        [OrganizationAllowedEmailDomainsTableName]: OrganizationAllowedEmailDomainsTable;
     }
 }

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -1,6 +1,8 @@
 import {
+    AllowedEmailDomains,
     ApiErrorPayload,
     ApiOrganization,
+    ApiOrganizationAllowedEmailDomains,
     ApiOrganizationMemberProfile,
     ApiOrganizationMemberProfiles,
     ApiSuccessEmpty,
@@ -148,6 +150,42 @@ export class OrganizationController extends Controller {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Gets allowed email domains for the current user's organization
+     * @param req express request
+     */
+    @Middlewares([isAuthenticated])
+    @Get('/allowedEmailDomains')
+    @OperationId('getOrganizationAllowedEmailDomains')
+    async getOrganizationAllowedEmailDomains(
+        @Request() req: express.Request,
+    ): Promise<ApiOrganizationAllowedEmailDomains> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await organizationService.getAllowedEmailDomains(
+                req.user!,
+            ),
+        };
+    }
+
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Patch('/allowedEmailDomains')
+    @OperationId('updateOrganizationAllowedEmailDomains')
+    async updateOrganizationAllowedEmailDomains(
+        @Request() req: express.Request,
+        @Body() body: AllowedEmailDomains,
+    ): Promise<ApiOrganizationAllowedEmailDomains> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await organizationService.updateAllowedEmailDomains(
+                req.user!,
+                body,
+            ),
         };
     }
 }

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -1,5 +1,4 @@
 import {
-    AllowedEmailDomains,
     ApiErrorPayload,
     ApiOrganization,
     ApiOrganizationAllowedEmailDomains,
@@ -7,6 +6,7 @@ import {
     ApiOrganizationMemberProfiles,
     ApiSuccessEmpty,
     OrganizationMemberProfileUpdate,
+    UpdateAllowedEmailDomains,
     UpdateOrganization,
 } from '@lightdash/common';
 import { Controller, Delete } from '@tsoa/runtime';
@@ -177,7 +177,7 @@ export class OrganizationController extends Controller {
     @OperationId('updateOrganizationAllowedEmailDomains')
     async updateOrganizationAllowedEmailDomains(
         @Request() req: express.Request,
-        @Body() body: AllowedEmailDomains,
+        @Body() body: UpdateAllowedEmailDomains,
     ): Promise<ApiOrganizationAllowedEmailDomains> {
         this.setStatus(200);
         return {

--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -4,17 +4,13 @@ export type DbOrganization = {
     organization_id: number;
     organization_uuid: string;
     organization_name: string;
-    allowed_email_domains: any; // jsonb
     created_at: Date;
     chart_colors?: string[];
 };
 
 export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;
 export type DbOrganizationUpdate = Partial<
-    Pick<
-        DbOrganization,
-        'organization_name' | 'allowed_email_domains' | 'chart_colors'
-    >
+    Pick<DbOrganization, 'organization_name' | 'chart_colors'>
 >;
 
 export type OrganizationTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/entities/organizationsAllowedEmailDomains.ts
+++ b/packages/backend/src/database/entities/organizationsAllowedEmailDomains.ts
@@ -2,7 +2,7 @@ import { OrganizationMemberRole } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const OrganizationAllowedEmailDomainsTableName =
-    'organizations_allowed_email_domains';
+    'organization_allowed_email_domains';
 
 export type DbOrganizationAllowedEmailDomains = {
     allowed_email_domains_uuid: string;

--- a/packages/backend/src/database/entities/organizationsAllowedEmailDomains.ts
+++ b/packages/backend/src/database/entities/organizationsAllowedEmailDomains.ts
@@ -1,0 +1,22 @@
+import { OrganizationMemberRole } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const OrganizationAllowedEmailDomainsTableName =
+    'organizations_allowed_email_domains';
+
+export type DbOrganizationAllowedEmailDomains = {
+    allowed_email_domains_uuid: string;
+    organization_uuid: string;
+    email_domains: string[];
+    role: OrganizationMemberRole;
+    project_uuids: string[];
+};
+
+export type OrganizationAllowedEmailDomainsTable = Knex.CompositeTableType<
+    DbOrganizationAllowedEmailDomains,
+    Omit<DbOrganizationAllowedEmailDomains, 'allowed_email_domains_uuid'>,
+    Omit<
+        DbOrganizationAllowedEmailDomains,
+        'allowed_email_domains_uuid' | 'organization_uuid'
+    >
+>;

--- a/packages/backend/src/database/migrations/20230309122217_create_org_allowed_email_domains_table.ts
+++ b/packages/backend/src/database/migrations/20230309122217_create_org_allowed_email_domains_table.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+const OrganizationTableName = 'organizations';
+const OrganizationAllowedEmailDomainsTableName =
+    'organizations_allowed_email_domains';
+const organizationMembershipRolesTableName = 'organization_membership_roles';
+
+export async function up(knex: Knex): Promise<void> {
+    if (
+        !(await knex.schema.hasTable(OrganizationAllowedEmailDomainsTableName))
+    ) {
+        await knex.schema.createTable(
+            OrganizationAllowedEmailDomainsTableName,
+            (tableBuilder) => {
+                tableBuilder
+                    .uuid('allowed_email_domains_uuid')
+                    .primary()
+                    .notNullable()
+                    .defaultTo(knex.raw('uuid_generate_v4()'));
+                tableBuilder
+                    .uuid('organization_uuid')
+                    .references('organization_uuid')
+                    .inTable(OrganizationTableName)
+                    .notNullable()
+                    .unique()
+                    .onDelete('CASCADE');
+                tableBuilder
+                    .specificType('email_domains', 'TEXT[]')
+                    .notNullable();
+                tableBuilder
+                    .text('role')
+                    .references('role')
+                    .inTable(organizationMembershipRolesTableName)
+                    .notNullable()
+                    .onDelete('RESTRICT')
+                    .defaultTo('member');
+                tableBuilder
+                    .specificType('project_uuids', 'TEXT[]')
+                    .notNullable();
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(
+        OrganizationAllowedEmailDomainsTableName,
+    );
+}

--- a/packages/backend/src/database/migrations/20230309122217_create_org_allowed_email_domains_table.ts
+++ b/packages/backend/src/database/migrations/20230309122217_create_org_allowed_email_domains_table.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 
 const OrganizationTableName = 'organizations';
 const OrganizationAllowedEmailDomainsTableName =
-    'organizations_allowed_email_domains';
+    'organization_allowed_email_domains';
 const organizationMembershipRolesTableName = 'organization_membership_roles';
 
 export async function up(knex: Knex): Promise<void> {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -289,6 +289,40 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                role: { ref: 'OrganizationMemberRole', required: true },
+                emailDomains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiOrganizationAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AllowedEmailDomains', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerCsvOptions: {
         dataType: 'refAlias',
         type: {
@@ -1135,6 +1169,95 @@ export function RegisterRoutes(app: express.Router) {
                     controller,
                     validatedArgs as any,
                 );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationAllowedEmailDomains,
+        ),
+
+        function OrganizationController_getOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new OrganizationController();
+
+                const promise =
+                    controller.getOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype
+                .updateOrganizationAllowedEmailDomains,
+        ),
+
+        function OrganizationController_updateOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'AllowedEmailDomains',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new OrganizationController();
+
+                const promise =
+                    controller.updateOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
                 promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -323,6 +323,44 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    role: { ref: 'OrganizationMemberRole', required: true },
+                    emailDomains: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                    projectUuids: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AllowedEmailDomains.organizationUuid_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_AllowedEmailDomains.organizationUuid_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerCsvOptions: {
         dataType: 'refAlias',
         type: {
@@ -1241,7 +1279,7 @@ export function RegisterRoutes(app: express.Router) {
                     in: 'body',
                     name: 'body',
                     required: true,
-                    ref: 'AllowedEmailDomains',
+                    ref: 'UpdateAllowedEmailDomains',
                 },
             };
 

--- a/packages/backend/src/models/OrganizationAllowedEmailDomainsModel.ts
+++ b/packages/backend/src/models/OrganizationAllowedEmailDomainsModel.ts
@@ -1,0 +1,73 @@
+import { AllowedEmailDomains } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    DbOrganizationAllowedEmailDomains,
+    OrganizationAllowedEmailDomainsTableName,
+} from '../database/entities/organizationsAllowedEmailDomains';
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class OrganizationAllowedEmailDomainsModel {
+    private database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+
+    static mapDbOrganizationAllowedEmailDomainsToOrganizationAllowedEmailDomains(
+        dbOrganizationAllowedEmailDomains: DbOrganizationAllowedEmailDomains,
+    ): AllowedEmailDomains {
+        return {
+            organizationUuid:
+                dbOrganizationAllowedEmailDomains.organization_uuid,
+            emailDomains: dbOrganizationAllowedEmailDomains.email_domains,
+            role: dbOrganizationAllowedEmailDomains.role,
+            projectUuids: dbOrganizationAllowedEmailDomains.project_uuids,
+        };
+    }
+
+    async findAllowedEmailDomains(
+        orgUuid: string,
+    ): Promise<AllowedEmailDomains | undefined> {
+        const [row] = await this.database(
+            OrganizationAllowedEmailDomainsTableName,
+        )
+            .where('organization_uuid', orgUuid)
+            .select('*');
+
+        if (!row) {
+            return undefined;
+        }
+        return OrganizationAllowedEmailDomainsModel.mapDbOrganizationAllowedEmailDomainsToOrganizationAllowedEmailDomains(
+            row,
+        );
+    }
+
+    async getAllowedEmailDomains(
+        orgUuid: string,
+    ): Promise<AllowedEmailDomains> {
+        const allowedEmailDomains = await this.findAllowedEmailDomains(orgUuid);
+        if (!allowedEmailDomains) {
+            throw new Error('Allowed email domains not found');
+        }
+        return allowedEmailDomains;
+    }
+
+    async upsertAllowedEmailDomains(
+        data: AllowedEmailDomains,
+    ): Promise<AllowedEmailDomains> {
+        await this.database(OrganizationAllowedEmailDomainsTableName)
+            .insert({
+                organization_uuid: data.organizationUuid,
+                email_domains: data.emailDomains,
+                role: data.role,
+                project_uuids: data.projectUuids,
+            })
+            .onConflict('organization_uuid')
+            .merge();
+
+        return this.getAllowedEmailDomains(data.organizationUuid);
+    }
+}

--- a/packages/backend/src/models/models.ts
+++ b/packages/backend/src/models/models.ts
@@ -10,6 +10,7 @@ import { InviteLinkModel } from './InviteLinkModel';
 import { JobModel } from './JobModel/JobModel';
 import { OnboardingModel } from './OnboardingModel/OnboardingModel';
 import { OpenIdIdentityModel } from './OpenIdIdentitiesModel';
+import { OrganizationAllowedEmailDomainsModel } from './OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
 import { OrganizationModel } from './OrganizationModel';
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
@@ -72,3 +73,6 @@ export const analyticsModel = new AnalyticsModel({
 export const pinnedListModel = new PinnedListModel({ database });
 
 export const schedulerModel = new SchedulerModel({ database });
+
+export const organizationAllowedEmailDomainsModel =
+    new OrganizationAllowedEmailDomainsModel({ database });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -2,6 +2,7 @@ import { LightdashInstallType } from '@lightdash/common';
 import {
     inviteLinkModel,
     onboardingModel,
+    organizationAllowedEmailDomainsModel,
     organizationMemberProfileModel,
     organizationModel,
     projectModel,
@@ -17,6 +18,7 @@ jest.mock('../../models/models', () => ({
     organizationModel: {
         get: jest.fn(async () => organisation),
     },
+    organizationAllowedEmailDomainsModel: {},
 }));
 describe('organization service', () => {
     const organizationService = new OrganizationService({
@@ -26,6 +28,7 @@ describe('organization service', () => {
         inviteLinkModel,
         organizationMemberProfileModel,
         userModel,
+        organizationAllowedEmailDomainsModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -13,6 +13,7 @@ import {
     SessionUser,
     UpdateOrganization,
 } from '@lightdash/common';
+import { UpdateAllowedEmailDomains } from '@lightdash/common/src/types/organization';
 import { analytics } from '../../analytics/client';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { InviteLinkModel } from '../../models/InviteLinkModel';
@@ -297,15 +298,23 @@ export class OrganizationService {
 
     async updateAllowedEmailDomains(
         user: SessionUser,
-        data: AllowedEmailDomains,
+        data: UpdateAllowedEmailDomains,
     ): Promise<AllowedEmailDomains> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotExistsError('Organization not found');
         }
+        if (
+            user.ability.cannot(
+                'update',
+                subject('OrganizationMemberProfile', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         return this.organizationAllowedEmailDomainsModel.upsertAllowedEmailDomains(
-            data,
+            { ...data, organizationUuid },
         );
     }
 }

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -9,6 +9,7 @@ import {
     jobModel,
     onboardingModel,
     openIdIdentityModel,
+    organizationAllowedEmailDomainsModel,
     organizationMemberProfileModel,
     organizationModel,
     passwordResetLinkModel,
@@ -60,6 +61,7 @@ export const organizationService = new OrganizationService({
     inviteLinkModel,
     organizationMemberProfileModel,
     userModel,
+    organizationAllowedEmailDomainsModel,
 });
 
 export const projectService = new ProjectService({

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/cli",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "license": "MIT",
     "bin": {
         "lightdash": "dist/index.js"
@@ -10,8 +10,8 @@
         "track.sh"
     ],
     "dependencies": {
-        "@lightdash/common": "^0.452.0",
-        "@lightdash/warehouses": "^0.452.0",
+        "@lightdash/common": "^0.453.0",
+        "@lightdash/warehouses": "^0.453.0",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "better-ajv-errors": "^1.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/common",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -76,6 +76,11 @@ export type AllowedEmailDomains = {
     projectUuids: string[];
 };
 
+export type UpdateAllowedEmailDomains = Omit<
+    AllowedEmailDomains,
+    'organizationUuid'
+>;
+
 export type ApiOrganizationAllowedEmailDomains = {
     status: 'ok';
     results: AllowedEmailDomains;

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -1,3 +1,4 @@
+import { OrganizationMemberRole } from './organizationMemberProfile';
 import { ProjectType } from './projects';
 
 /**
@@ -66,4 +67,16 @@ export type OnboardingStatus = {
 export type ApiOnboardingStatusResponse = {
     status: 'ok';
     results: OnboardingStatus;
+};
+
+export type AllowedEmailDomains = {
+    organizationUuid: string;
+    emailDomains: string[];
+    role: OrganizationMemberRole;
+    projectUuids: string[];
+};
+
+export type ApiOrganizationAllowedEmailDomains = {
+    status: 'ok';
+    results: AllowedEmailDomains;
 };

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
     "name": "e2e",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "main": "index.js",
     "license": "MIT",
     "scripts": {
@@ -19,6 +19,6 @@
         "cypress": "^12.5.1",
         "cypress-file-upload": "^5.0.8",
         "node-fetch": "^2.6.1",
-        "@lightdash/common": "^0.452.0"
+        "@lightdash/common": "^0.453.0"
     }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frontend",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "private": true,
     "dependencies": {
         "@blueprintjs/core": "^4.16.3",
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.10.6",
         "@fullstory/browser": "^1.6.2",
         "@hookform/error-message": "^2.0.0",
-        "@lightdash/common": "^0.452.0",
+        "@lightdash/common": "^0.453.0",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",
         "@sentry/react": "^7.37.2",

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/warehouses",
-    "version": "0.452.0",
+    "version": "0.453.0",
     "license": "MIT",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
         "@databricks/sql": "1.1.0",
         "trino-client": "^0.2.0",
         "@google-cloud/bigquery": "^5.9.1",
-        "@lightdash/common": "^0.452.0",
+        "@lightdash/common": "^0.453.0",
         "lodash": "^4.17.21",
         "pg": "^8.7.1",
         "snowflake-sdk": "^1.6.4"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #4716 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- new table, entity, model ( added a new table in case we want to have multiple settings for each organisation )
- new methods in organisation service to manage allowed email domains
- new endpoints

Endpoints:
```
### Get allowed email domains
GET http://localhost:8080/api/v1/org/allowedEmailDomains

### Update allowed email domains
PATCH http://localhost:8080/api/v1/org/allowedEmailDomains
Content-Type: application/json

{
  "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
  "emailDomains": ["lightdash.com"],
  "role": "viewer",
  "projectUuids": []
}
```


https://user-images.githubusercontent.com/9117144/224058113-ddf49073-8149-4949-b288-c3016368272b.mp4

