### PR TITLE
feat: verify email when user signs up or is invited

### DIFF
--- a/packages/backend/src/database/migrations/20230309224308_fix_email_id_on_delete.ts
+++ b/packages/backend/src/database/migrations/20230309224308_fix_email_id_on_delete.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('email_one_time_passcodes', (tableBuilder) => {
+        tableBuilder.dropForeign('email_id');
+        tableBuilder
+            .foreign('email_id')
+            .references('email_id')
+            .inTable('emails')
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // no down migration, keep cascade delete
+}

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -138,6 +138,9 @@ export class UserService {
                 userConnectionType: 'password',
             },
         });
+        if (!isOpenIdUser(activateUser)) {
+            await this.sendOneTimePasscodeToPrimaryEmail(user);
+        }
         return user;
     }
 
@@ -551,6 +554,8 @@ export class UserService {
                     loginProvider: 'google',
                 },
             });
+        } else {
+            await this.sendOneTimePasscodeToPrimaryEmail(user);
         }
         return user;
     }
@@ -608,6 +613,8 @@ export class UserService {
                     loginProvider: 'google',
                 },
             });
+        } else {
+            await this.sendOneTimePasscodeToPrimaryEmail(user);
         }
         return user;
     }
@@ -694,7 +701,7 @@ export class UserService {
     }
 
     async sendOneTimePasscodeToPrimaryEmail(
-        user: SessionUser,
+        user: Pick<SessionUser, 'userUuid'>,
     ): Promise<EmailStatusExpiring> {
         const passcode = randomInt(999999).toString().padStart(6, '0');
         const emailStatus = await this.emailModel.createPrimaryEmailOtp({

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import Space from './pages/Space';
 import Spaces from './pages/Spaces';
 import SqlRunner from './pages/SqlRunner';
 import UserActivity from './pages/UserActivity';
+import { VerifyEmailPage } from './pages/VerifyEmail';
 import { ActiveJobProvider } from './providers/ActiveJobProvider';
 import { AppProvider } from './providers/AppProvider';
 import { BlueprintProvider } from './providers/BlueprintProvider';
@@ -122,6 +123,10 @@ const App = () => (
                                                             >
                                                                 <Register />
                                                             </TrackPage>
+                                                        </Route>
+
+                                                        <Route path="/verify-email">
+                                                            <VerifyEmailPage />
                                                         </Route>
 
                                                         <Route path="/login">

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -125,10 +125,6 @@ const App = () => (
                                                             </TrackPage>
                                                         </Route>
 
-                                                        <Route path="/verify-email">
-                                                            <VerifyEmailPage />
-                                                        </Route>
-
                                                         <Route path="/login">
                                                             <TrackPage
                                                                 name={
@@ -166,6 +162,15 @@ const App = () => (
                                                                 }
                                                             >
                                                                 <Signup />
+                                                            </TrackPage>
+                                                        </Route>
+                                                        <Route path="/verify-email">
+                                                            <TrackPage
+                                                                name={
+                                                                    PageName.VERIFY_EMAIL
+                                                                }
+                                                            >
+                                                                <VerifyEmailPage />
                                                             </TrackPage>
                                                         </Route>
 

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,3 +1,4 @@
+import { LightdashMode } from '@lightdash/common';
 import React, { ComponentProps, FC } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
@@ -8,7 +9,7 @@ import PageSpinner from './PageSpinner';
 
 const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
     const { health, user } = useApp();
-    const { data } = useEmailStatus();
+    const emailStatus = useEmailStatus();
     const isEmailServerConfigured = health.data?.hasEmailClient;
     const orgRequest = useOrganisation();
 
@@ -16,7 +17,11 @@ const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
         <Route
             {...rest}
             render={({ location }) => {
-                if (health.isLoading || orgRequest.isLoading) {
+                if (
+                    health.isLoading ||
+                    orgRequest.isLoading ||
+                    emailStatus.isLoading
+                ) {
                     return <PageSpinner />;
                 }
 
@@ -31,7 +36,8 @@ const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
                 }
 
                 if (
-                    !data?.isVerified &&
+                    health.data?.mode !== LightdashMode.PR &&
+                    !emailStatus.data?.isVerified &&
                     isEmailServerConfigured &&
                     !user.data?.isSetupComplete
                 ) {
@@ -45,7 +51,7 @@ const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
                     );
                 }
 
-                if (data?.isVerified && orgRequest?.data?.needsProject) {
+                if (orgRequest?.data?.needsProject) {
                     return (
                         <Redirect
                             to={{

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,27 +1,20 @@
-import { LightdashMode } from '@lightdash/common';
 import React, { ComponentProps, FC } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { useOrganisation } from '../hooks/organisation/useOrganisation';
-import { useEmailStatus } from '../hooks/useEmailVerification';
 import { useApp } from '../providers/AppProvider';
 import ErrorState from './common/ErrorState';
 import PageSpinner from './PageSpinner';
 
 const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
-    const { health, user } = useApp();
-    const emailStatus = useEmailStatus();
-    const isEmailServerConfigured = health.data?.hasEmailClient;
+    const { health } = useApp();
+
     const orgRequest = useOrganisation();
 
     return (
         <Route
             {...rest}
             render={({ location }) => {
-                if (
-                    health.isLoading ||
-                    orgRequest.isLoading ||
-                    emailStatus.isLoading
-                ) {
+                if (health.isLoading || orgRequest.isLoading) {
                     return <PageSpinner />;
                 }
 
@@ -31,22 +24,6 @@ const AppRoute: FC<ComponentProps<typeof Route>> = ({ children, ...rest }) => {
                             error={
                                 orgRequest.error?.error || health.error?.error
                             }
-                        />
-                    );
-                }
-
-                if (
-                    health.data?.mode !== LightdashMode.PR &&
-                    !emailStatus.data?.isVerified &&
-                    isEmailServerConfigured &&
-                    !user.data?.isSetupComplete
-                ) {
-                    return (
-                        <Redirect
-                            to={{
-                                pathname: '/verify-email',
-                                state: { from: location },
-                            }}
                         />
                     );
                 }

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -1,5 +1,7 @@
+import { LightdashMode } from '@lightdash/common';
 import React, { ComponentProps, FC, useEffect } from 'react';
 import { Redirect, Route } from 'react-router-dom';
+import { useEmailStatus } from '../hooks/useEmailVerification';
 import { useApp } from '../providers/AppProvider';
 import { useAbilityContext } from './common/Authorization';
 import PageSpinner from './PageSpinner';
@@ -13,6 +15,8 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
         user: { data, isLoading },
     } = useApp();
     const ability = useAbilityContext();
+    const emailStatus = useEmailStatus(!!health.data?.isAuthenticated);
+    const isEmailServerConfigured = health.data?.hasEmailClient;
 
     useEffect(() => {
         if (data) {
@@ -24,7 +28,7 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
         <Route
             {...rest}
             render={({ location }) => {
-                if (health.isLoading || health.error) {
+                if (health.isLoading || health.error || emailStatus.isLoading) {
                     return <PageSpinner />;
                 }
 
@@ -41,6 +45,22 @@ const PrivateRoute: FC<ComponentProps<typeof Route>> = ({
 
                 if (isLoading) {
                     return <PageSpinner />;
+                }
+
+                if (
+                    health.data?.mode !== LightdashMode.PR &&
+                    !emailStatus.data?.isVerified &&
+                    isEmailServerConfigured &&
+                    !data?.isSetupComplete
+                ) {
+                    return (
+                        <Redirect
+                            to={{
+                                pathname: '/verify-email',
+                                state: { from: location },
+                            }}
+                        />
+                    );
                 }
 
                 return children;

--- a/packages/frontend/src/hooks/useEmailVerification.tsx
+++ b/packages/frontend/src/hooks/useEmailVerification.tsx
@@ -27,10 +27,11 @@ export const verifyOTPQuery = async (code: string) => {
     });
 };
 
-export const useEmailStatus = () =>
+export const useEmailStatus = (enabled = true) =>
     useQuery<EmailStatusExpiring, ApiError>({
         queryKey: ['email_status'],
         queryFn: () => getEmailStatusQuery(),
+        enabled,
     });
 
 export const useOneTimePassword = () => {

--- a/packages/frontend/src/pages/SignUp.styles.tsx
+++ b/packages/frontend/src/pages/SignUp.styles.tsx
@@ -1,4 +1,4 @@
-import { Card, Colors, H3 } from '@blueprintjs/core';
+import { Card, Colors, Dialog, H3 } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 import { BigButton } from '../components/common/BigButton';
 import Input from '../components/ReactHookForm/Input';
@@ -103,4 +103,18 @@ export const BoldSubtitle = styled.p`
     text-align: center;
     color: ${Colors.DARK_GRAY1};
     margin-bottom: 15px;
+`;
+
+export const EmailVerifiedModal = styled(Dialog)`
+    width: fit-content;
+    height: fit-content;
+`;
+
+export const EmailVerifiedWrapper = styled.div`
+    width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin: 30px 0;
 `;

--- a/packages/frontend/src/pages/Signup.tsx
+++ b/packages/frontend/src/pages/Signup.tsx
@@ -175,7 +175,7 @@ const Signup: FC = () => {
                 <DividerWrapper>
                     <Divider />
                     <b>OR</b>
-                    <Divider></Divider>
+                    <Divider />
                 </DividerWrapper>
             )}
             {passwordLogin}

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -1,5 +1,5 @@
 import { Colors, Dialog, DialogBody, Intent } from '@blueprintjs/core';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
@@ -13,13 +13,11 @@ import {
     StyledSuccessIcon,
     Title,
 } from '../components/ProjectConnection/ProjectConnectFlow/ProjectConnectFlow.styles';
-import { useOrganisation } from '../hooks/organisation/useOrganisation';
 import {
     useEmailStatus,
     useOneTimePassword,
     useVerifyEmail,
 } from '../hooks/useEmailVerification';
-import useSearchParams from '../hooks/useSearchParams';
 import { useApp } from '../providers/AppProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
 import {
@@ -30,7 +28,6 @@ import {
     FormWrapper,
     Logo,
     LogoWrapper,
-    Subtitle,
 } from './SignUp.styles';
 
 export const VerificationSuccess: FC<{
@@ -67,13 +64,6 @@ export const VerifyEmailPage: FC = () => {
         useOneTimePassword();
     const { show: showIntercom } = useIntercom();
     const history = useHistory();
-    const orgRequest = useOrganisation();
-    const userHasProject = !orgRequest?.data?.needsProject;
-    const projectUuid = useSearchParams('projectUuid');
-
-    useEffect(() => {
-        sendVerificationEmail();
-    }, [sendVerificationEmail]);
 
     if (health.isLoading || statusLoading) {
         return <PageSpinner />;
@@ -112,18 +102,10 @@ export const VerifyEmailPage: FC = () => {
                 <VerificationSuccess
                     isOpen={data?.isVerified}
                     onClose={() => {
-                        history.push(
-                            userHasProject
-                                ? `/projects/${projectUuid}`
-                                : '/createProject',
-                        );
+                        history.push('/');
                     }}
                     onContinue={() => {
-                        history.push(
-                            userHasProject
-                                ? `/projects/${projectUuid}`
-                                : '/createProject',
-                        );
+                        history.push('/');
                     }}
                 />
             </FormWrapper>

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -38,6 +38,7 @@ export enum PageName {
     SPACES = 'spaces',
     SHARE = 'share',
     USER_ACTIVITY = 'user_activity',
+    VERIFY_EMAIL = 'verify_email',
 }
 
 export enum CategoryName {


### PR DESCRIPTION
Closes: #3650 

### Description:

If the email server is configured, the user needs to verify their email during onboarding. 

Note that we had to **disable verification for PR environments** so the e2e tests could pass. **All tests need to be done locally.** 

### Verify invited user

https://user-images.githubusercontent.com/9117144/224180602-7bdebe52-9c44-4037-8b28-393aaa5548b8.mp4


### Verify new user+org

https://user-images.githubusercontent.com/9117144/224180661-9fc8b682-5892-4e0f-a71c-79c2caf210c2.mp4


### Auto verify invited user that signs up with SSO


https://user-images.githubusercontent.com/9117144/224182635-96e27471-c0e4-4754-95ae-904a91d2eec0.mp4

 
### Auto verify new user that signs up with SSO

https://user-images.githubusercontent.com/9117144/224182894-0f8a3111-fbb3-400e-8604-5f449e32e300.mp4

### When there is no email server, don't verify the invited user

https://user-images.githubusercontent.com/9117144/224185392-6e75801b-81e0-4486-ab9d-544d272ae77a.mp4



### When there is no email server, don't verify new user


https://user-images.githubusercontent.com/9117144/224185230-b02f6402-cbec-4f6f-b151-00c6d74bc4d2.mp4


