### PR TITLE
chore: don't skip external PR tests

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   cli-run:
     # Only trigger for correct environment and status
-    if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
+    if: ${{ github.event.deployment_status.state == 'success' && (contains(github.event.deployment.environment, '- lightdash PR ' || contains(github.event.deployment.environment, '- lightdash-')))}}
     runs-on: ubuntu-latest
     steps:
       - name: Get PR number

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ on: [ deployment_status ]
 jobs:
   cypress-run:
     # Only trigger for correct environment and status
-    if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
+    if: ${{ github.event.deployment_status.state == 'success' && (contains(github.event.deployment.environment, '- lightdash PR ' || contains(github.event.deployment.environment, '- lightdash-')))}}
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node18.12.0-chrome107

--- a/.github/workflows/timezone-tests.yml
+++ b/.github/workflows/timezone-tests.yml
@@ -3,7 +3,7 @@ on: [ deployment_status ]
 jobs:
   cypress-run:
     # Only trigger for correct environment and status
-    if: ${{ github.event.deployment_status.state == 'success' && contains(github.event.deployment.environment, '- lightdash PR ')}}
+    if: ${{ github.event.deployment_status.state == 'success' && (contains(github.event.deployment.environment, '- lightdash PR ' || contains(github.event.deployment.environment, '- lightdash-')))}}
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node18.12.0-chrome107


### PR DESCRIPTION
Closes: #4744 

### Description:

this was not working because workflows have a check that automatically generated render env can't pass.

standard PR services have following names:
![image](https://user-images.githubusercontent.com/962095/224321136-87e0864a-9dcd-48ef-acab-2d55aa4b825a.png)

automatically generated render blueprint services have different names:
![image](https://user-images.githubusercontent.com/962095/224320996-2e6abf4c-c751-43b0-98ce-69c50f635766.png)
