### PR TITLE
fix: typo in email scheduled delivery tooltip

### DIFF
--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -397,7 +397,7 @@ const SchedulerForm: FC<
                                                     No Email integration found
                                                 </p>
                                                 <p>
-                                                    To create a slack scheduled
+                                                    To create an email scheduled
                                                     delivery, you need to add
                                                     <a href="https://docs.lightdash.com/references/environmentVariables">
                                                         {' '}


### PR DESCRIPTION
### Description:
The tooltip on hover for adding a scheduled delivery via email references "a slack scheduled delivery" where it should instead say "an email scheduled delivery"

<img src="https://user-images.githubusercontent.com/3476400/224515889-b5807cbf-1cd5-4efc-a243-9af31df44b2a.png" width="300" />
