### PR TITLE
fix: add GitHub token on release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -16,6 +16,8 @@ jobs:
     concurrency: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -27,7 +29,7 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           semantic_version: 19
@@ -43,7 +45,7 @@ jobs:
           steps.semantic.outputs.new_release_channel == null
         run: "git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/alpha"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       - name: Trigger helm chart update on release
         if: |
           steps.semantic.outputs.new_release_published == 'true' &&


### PR DESCRIPTION
Uses a personal access token in the repository secrets to push to main without branch protection rules


<img width="817" alt="Screenshot 2023-03-13 at 12 47 29" src="https://user-images.githubusercontent.com/11660098/224706191-40375d98-6801-4fd9-ba87-27b94d13a227.png">
