### PR TITLE
chore: warehouse base client

### DIFF
--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -389,9 +389,10 @@ describe('Create projects', () => {
 
         testTimeIntervalsResults(bigqueryRowValues);
 
-        testPercentile();
+        testPercentile(['2020-08-12', '1,999', '1,559', '1,999', '19,999,999']);
     });
-    it('Should create a Trino project', () => {
+    // note: we don't have a staging environment for Trino atm
+    it.skip('Should create a Trino project', () => {
         cy.visit(`/createProject`);
 
         cy.contains('button', 'Trino').click();
@@ -431,7 +432,7 @@ describe('Create projects', () => {
         testTimeIntervalsResults(trinoRowValues);
         testPercentile();
     });
-    it('Should create a Databricks project', () => {
+    it.skip('Should create a Databricks project', () => {
         cy.visit(`/createProject`);
 
         cy.contains('button', 'Databricks').click();
@@ -509,6 +510,12 @@ describe('Create projects', () => {
         ];
 
         testTimeIntervalsResults(snowflakeRowValues);
-        testPercentile();
+        testPercentile([
+            '2020-08-12',
+            '1,999',
+            '1,719.5',
+            '1,999',
+            '10,999,999',
+        ]);
     });
 });

--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -303,7 +303,7 @@ describe('Create projects', () => {
         cy.findAllByTestId('settings-menu').click();
         cy.findByRole('menuitem', { name: 'Organization settings' }).click();
 
-        cy.findByText('Project management').click();
+        cy.findByText('Projects').click();
         cy.findByText('Create new').click();
         cy.contains('button', 'PostgreSQL').click();
 

--- a/packages/e2e/cypress/e2e/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/createProjects.cy.ts
@@ -312,7 +312,7 @@ describe('Create projects', () => {
         cy.contains('a', 'Create project manually');
     });
 
-    it.only('Should create a Postgres project', () => {
+    it('Should create a Postgres project', () => {
         cy.visit(`/createProject`);
 
         cy.contains('button', 'PostgreSQL').click();
@@ -431,7 +431,7 @@ describe('Create projects', () => {
         testTimeIntervalsResults(trinoRowValues);
         testPercentile();
     });
-    it.skip('Should create a Databricks project', () => {
+    it('Should create a Databricks project', () => {
         cy.visit(`/createProject`);
 
         cy.contains('button', 'Databricks').click();

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
@@ -2,7 +2,6 @@ import { CreateRedshiftCredentials } from '@lightdash/common';
 import * as fs from 'fs';
 import path from 'path';
 import { PoolConfig } from 'pg';
-import { WarehouseClient } from '../types';
 import { PostgresClient } from './PostgresWarehouseClient';
 
 const AMAZON_CA_BUNDLE = [
@@ -34,28 +33,17 @@ const getSSLConfigFromMode = (mode: string): PoolConfig['ssl'] => {
     }
 };
 
-export class RedshiftWarehouseClient
-    extends PostgresClient
-    implements WarehouseClient
-{
-    credentials: CreateRedshiftCredentials;
-
+export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCredentials> {
     constructor(credentials: CreateRedshiftCredentials) {
         const sslmode = credentials.sslmode || 'prefer';
         const ssl = getSSLConfigFromMode(sslmode);
-        super(
-            {
-                connectionString: `postgres://${encodeURIComponent(
-                    credentials.user,
-                )}:${encodeURIComponent(
-                    credentials.password,
-                )}@${encodeURIComponent(credentials.host)}:${
-                    credentials.port
-                }/${encodeURIComponent(credentials.dbname)}`,
-                ssl,
-            },
-            credentials.startOfWeek,
-        );
-        this.credentials = credentials;
+        super(credentials, {
+            connectionString: `postgres://${encodeURIComponent(
+                credentials.user,
+            )}:${encodeURIComponent(credentials.password)}@${encodeURIComponent(
+                credentials.host,
+            )}:${credentials.port}/${encodeURIComponent(credentials.dbname)}`,
+            ssl,
+        });
     }
 }

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -1,0 +1,59 @@
+import {
+    CreateWarehouseCredentials,
+    DimensionType,
+    Metric,
+    WarehouseCatalog,
+    WeekDay,
+} from '@lightdash/common';
+import { WarehouseClient } from '../types';
+import { getDefaultMetricSql } from '../utils/sql';
+
+export default class WarehouseBaseClient<T extends CreateWarehouseCredentials>
+    implements WarehouseClient
+{
+    credentials: T;
+
+    startOfWeek: WeekDay | null | undefined;
+
+    constructor(credentials: T) {
+        this.credentials = credentials;
+        this.startOfWeek = credentials.startOfWeek;
+    }
+
+    getFieldQuoteChar(): string {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    getStringQuoteChar(): string {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    getEscapeStringQuoteChar(): string {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    async getCatalog(
+        config: { database: string; schema: string; table: string }[],
+    ): Promise<WarehouseCatalog> {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    async runQuery(sql: string): Promise<{
+        fields: Record<string, { type: DimensionType }>;
+        rows: Record<string, any>[];
+    }> {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    getMetricSql(sql: string, metric: Metric): string {
+        return getDefaultMetricSql(sql, metric.type);
+    }
+
+    getStartOfWeek(): WeekDay | null | undefined {
+        return this.startOfWeek;
+    }
+
+    async test(): Promise<void> {
+        await this.runQuery('SELECT 1');
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

**Add a base client that all warehouse clients extend from.** 
This is necessary so we can move all the SQL generation from the common package into the warehouse clients. 
The base client should have the default logic/SQL. And each warehouse client should be able to override/intercept that logic/SQL.  You can see we already do it with `getMetricSql` 


Motivation: https://lightdash-community.slack.com/archives/C03MG2VTR08/p1678734136416819



