### PR TITLE
fix: sorting spaces alphabetically in browse menu

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu/index.tsx
@@ -64,18 +64,25 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                             <>
                                 <MenuDivider />
 
-                                {spaces.map((space) => (
-                                    <NavLink
-                                        key={space.uuid}
-                                        to={`/projects/${projectUuid}/spaces/${space.uuid}`}
-                                    >
-                                        <NavbarMenuItem
-                                            roleStructure="menuitem"
-                                            icon={<IconFolder size={17} />}
-                                            text={space.name}
-                                        />
-                                    </NavLink>
-                                ))}
+                                {spaces
+                                    .sort((a, b) =>
+                                        a.name.toLowerCase() >
+                                        b.name.toLowerCase()
+                                            ? 1
+                                            : -1,
+                                    )
+                                    .map((space) => (
+                                        <NavLink
+                                            key={space.uuid}
+                                            to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+                                        >
+                                            <NavbarMenuItem
+                                                roleStructure="menuitem"
+                                                icon={<IconFolder size={17} />}
+                                                text={space.name}
+                                            />
+                                        </NavLink>
+                                    ))}
                             </>
                         )}
                     </Menu>


### PR DESCRIPTION
Closes: #4803

### Description:
before
<img width="247" alt="Screenshot 2023-03-15 at 11 32 11" src="https://user-images.githubusercontent.com/67699259/225283445-cbbd37a3-9f73-4efb-b133-f1074493569e.png">


after
<img width="275" alt="Screenshot 2023-03-15 at 11 32 20" src="https://user-images.githubusercontent.com/67699259/225283457-014063d4-4e57-4d87-8384-d2a195f23b7e.png">
