### PR TITLE
feat: csv performance tweaks

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Build warehouses
       run: yarn warehouses-build
 
-    - name: Test backend
-      run: yarn test
+    - name: Run unit tests
+      run: yarn backend-build && yarn test
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -547,6 +547,32 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
     };
 };
 
+export type DownloadCsv = BaseTrack & {
+    event:
+        | 'download_results.started'
+        | 'download_results.completed'
+        | 'download_results.error';
+    anonymousId: string;
+    properties: {
+        jobId: string;
+        userId: string;
+        organizationId: string;
+        projectId: string;
+        tableId: string;
+        fileType: 'csv';
+        values: 'raw' | 'formatted';
+        limit: 'results' | 'all' | 'custom';
+        context: 'results' | 'chart' | 'scheduled delivery';
+        numRows: number;
+        numColumns: number;
+        schedulerId: string;
+        schedulerTargetId: string;
+        resourceType?: 'dashboard' | 'chart';
+        type: 'slack' | 'email';
+        format?: 'csv' | 'image';
+    };
+};
+
 type Track =
     | TrackSimpleEvent
     | CreateUserEvent

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -547,32 +547,6 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
     };
 };
 
-export type DownloadCsv = BaseTrack & {
-    event:
-        | 'download_results.started'
-        | 'download_results.completed'
-        | 'download_results.error';
-    anonymousId: string;
-    properties: {
-        jobId: string;
-        userId: string;
-        organizationId: string;
-        projectId: string;
-        tableId: string;
-        fileType: 'csv';
-        values: 'raw' | 'formatted';
-        limit: 'results' | 'all' | 'custom';
-        context: 'results' | 'chart' | 'scheduled delivery';
-        numRows: number;
-        numColumns: number;
-        schedulerId: string;
-        schedulerTargetId: string;
-        resourceType?: 'dashboard' | 'chart';
-        type: 'slack' | 'email';
-        format?: 'csv' | 'image';
-    };
-};
-
 type Track =
     | TrackSimpleEvent
     | CreateUserEvent

--- a/packages/backend/src/clients/Aws/s3.ts
+++ b/packages/backend/src/clients/Aws/s3.ts
@@ -5,6 +5,7 @@ import {
     S3,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { ReadStream } from 'fs-extra';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logger';
 
@@ -84,7 +85,10 @@ export class S3Service {
         return this.uploadFile(imageId, image);
     }
 
-    async uploadCsv(csv: string, csvName: string): Promise<string> {
+    async uploadCsv(
+        csv: string | ReadStream,
+        csvName: string,
+    ): Promise<string> {
         return this.uploadFile(csvName, csv);
     }
 

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -274,7 +274,8 @@ projectRouter.post(
             };
             const initialHeap = process.memoryUsage().heapUsed;
             logMemoryUsage();
-            Logger.debug(
+            const startTime = Date.now();
+            console.debug(
                 'downloadCsv initial memory before runquery: ',
                 formatMemoryUsage(initialHeap),
             );
@@ -286,7 +287,7 @@ projectRouter.post(
                 req.params.exploreId,
                 csvLimit,
             );
-            Logger.debug(
+            console.debug(
                 'downloadCsv after runquery: ',
                 formatMemoryUsage(process.memoryUsage().heapUsed - initialHeap),
             );
@@ -302,12 +303,12 @@ projectRouter.post(
                 metricQuery.tableCalculations,
             );
 
-            Logger.debug(
+            console.debug(
                 'downloadCsv before convertapiresults: ',
                 formatMemoryUsage(process.memoryUsage().heapUsed - initialHeap),
             );
 
-            Logger.debug(
+            console.debug(
                 'results Size ',
                 rows.length,
                 formatMemoryUsage(Buffer.from(JSON.stringify(rows)).byteLength),
@@ -321,10 +322,11 @@ projectRouter.post(
                 customLabels,
                 columnOrder || [],
             );
-            Logger.debug(
+            console.debug(
                 'downloadCsv after convertapiresults: ',
                 formatMemoryUsage(process.memoryUsage().heapUsed - initialHeap),
             );
+            console.debug('downloadCsv took ', Date.now() - startTime, 'ms');
 
             let fileUrl;
             try {
@@ -333,7 +335,7 @@ projectRouter.post(
             } catch (e) {
                 fileUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${req.params.projectUuid}/csv/${fileId}`;
             }
-            Logger.debug(
+            console.debug(
                 'downloadCsv after saving file: ',
                 formatMemoryUsage(process.memoryUsage().heapUsed - initialHeap),
             );

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -13,8 +13,8 @@ import {
     TablesConfiguration,
 } from '@lightdash/common';
 import express from 'express';
-import * as fsSync from 'fs';
-import * as fs from 'fs/promises';
+import * as fs from 'fs';
+import * as fsPromise from 'fs/promises';
 
 import { nanoid } from 'nanoid';
 import path from 'path';
@@ -281,7 +281,7 @@ projectRouter.post(
 
             let fileUrl;
             try {
-                const csvContent = fsSync.createReadStream(`/tmp/${fileId}`);
+                const csvContent = fs.createReadStream(`/tmp/${fileId}`);
                 fileUrl = await s3Service.uploadCsv(csvContent, fileId);
             } catch (e) {
                 fileUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${req.params.projectUuid}/csv/${fileId}`;
@@ -692,7 +692,11 @@ projectRouter.post(
                 fileUrl = await s3Service.uploadCsv(csvContent, fileId);
             } catch (e) {
                 // Can't store file in S3, storing locally
-                await fs.writeFile(`/tmp/${fileId}`, csvContent, 'utf-8');
+                await fsPromise.writeFile(
+                    `/tmp/${fileId}`,
+                    csvContent,
+                    'utf-8',
+                );
                 fileUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${req.params.projectUuid}/csv/${fileId}`;
             }
 

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -283,6 +283,8 @@ projectRouter.post(
             try {
                 const csvContent = fs.createReadStream(`/tmp/${fileId}`);
                 fileUrl = await s3Service.uploadCsv(csvContent, fileId);
+
+                await fsPromise.unlink(`/tmp/${fileId}`);
             } catch (e) {
                 fileUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${req.params.projectUuid}/csv/${fileId}`;
             }

--- a/packages/backend/src/services/CsvService/CsvService.mock.ts
+++ b/packages/backend/src/services/CsvService/CsvService.mock.ts
@@ -1,0 +1,60 @@
+import {
+    Field,
+    FieldType,
+    LightdashMode,
+    MetricQuery,
+    TableCalculation,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
+
+export const rows = [...Array(5).keys()].map((i) => ({
+    column_number: i,
+    column_string: `value_${i}`,
+    column_date: '2020-03-16T11:32:55.000Z',
+}));
+
+export const metricQuery: MetricQuery = {
+    dimensions: ['column_number', 'column_date'],
+
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [
+        {
+            name: 'column_string',
+            displayName: 'column_string',
+            sql: '',
+        },
+    ],
+    additionalMetrics: [],
+};
+
+export const itemMap: Record<string, Field | TableCalculation> = {
+    column_number: {
+        name: 'column_number',
+        fieldType: FieldType.DIMENSION,
+        type: 'number',
+        displayName: 'column number',
+        format: 'usd',
+        tableLabel: 'table',
+        label: 'column number',
+        sql: '${TABLE}.column_number',
+    },
+    column_string: {
+        // like a table calculation
+        name: 'column_string',
+        displayName: 'column string',
+        sql: 'md5(random()::text)',
+    },
+    column_date: {
+        name: 'column_date',
+        type: 'date',
+        displayName: 'column date',
+        tableLabel: 'table',
+        label: 'column date',
+
+        fieldType: FieldType.DIMENSION,
+        sql: '${TABLE}.column_date',
+    },
+};

--- a/packages/backend/src/services/CsvService/CsvService.mock.ts
+++ b/packages/backend/src/services/CsvService/CsvService.mock.ts
@@ -7,12 +7,6 @@ import {
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 
-export const rows = [...Array(5).keys()].map((i) => ({
-    column_number: i,
-    column_string: `value_${i}`,
-    column_date: '2020-03-16T11:32:55.000Z',
-}));
-
 export const metricQuery: MetricQuery = {
     dimensions: ['column_number', 'column_date'],
 

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 import { dashboardModel, savedChartModel } from '../../models/models';
 import { projectService, s3Service } from '../services';
 import { CsvService } from './CsvService';
-import { itemMap, metricQuery, rows } from './CsvService.mock';
+import { itemMap, metricQuery } from './CsvService.mock';
 
 jest.mock('../../models/models', () => ({
     savedChartModel: {},
@@ -23,8 +23,13 @@ describe('Csv service', () => {
     });
 
     it('Should convert rows to CSV with format', async () => {
+        const rows = [...Array(5).keys()].map((i) => ({
+            column_number: i,
+            column_string: `value_${i}`,
+            column_date: '2020-03-16T11:32:55.000Z',
+        }));
         const fileId = await CsvService.convertRowsToCsv(
-            [...rows],
+            rows,
             false,
             metricQuery,
             itemMap,
@@ -33,7 +38,9 @@ describe('Csv service', () => {
             [],
         );
 
-        const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
+        const csvContent = await fs.readFile(`/tmp/${fileId}`, {
+            encoding: 'utf-8',
+        });
 
         expect(csvContent).toEqual(
             `column number,column string,column date
@@ -47,8 +54,13 @@ $4.00,value_4,2020-03-16
     });
 
     it('Should convert rows to RAW CSV with table names', async () => {
+        const rows = [...Array(5).keys()].map((i) => ({
+            column_number: i,
+            column_string: `value_${i}`,
+            column_date: '2020-03-16T11:32:55.000Z',
+        }));
         const fileId = await CsvService.convertRowsToCsv(
-            [...rows],
+            rows,
             true,
             metricQuery,
             itemMap,
@@ -57,7 +69,9 @@ $4.00,value_4,2020-03-16
             [],
         );
 
-        const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
+        const csvContent = await fs.readFile(`/tmp/${fileId}`, {
+            encoding: 'utf-8',
+        });
 
         expect(csvContent).toEqual(
             `table column number,column string,table column date

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,0 +1,76 @@
+import { LightdashInstallType, LightdashMode } from '@lightdash/common';
+import * as fs from 'fs';
+import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
+import { dashboardModel, savedChartModel } from '../../models/models';
+import { projectService, s3Service } from '../services';
+import { CsvService } from './CsvService';
+import { itemMap, metricQuery, rows } from './CsvService.mock';
+
+jest.mock('../../models/models', () => ({
+    savedChartModel: {},
+    dashboardModel: {},
+}));
+
+jest.mock('../services', () => ({
+    s3Service: {},
+    projectService: {},
+}));
+
+describe('Csv service', () => {
+    const csvService = new CsvService({
+        projectService,
+        s3Service,
+        savedChartModel,
+        dashboardModel,
+    });
+
+    it('Should convert rows to CSV with format', async () => {
+        const fileId = await CsvService.convertRowsToCsv(
+            [...rows],
+            false,
+            metricQuery,
+            itemMap,
+            false,
+            {},
+            [],
+        );
+        expect(fileId).not.toBeNull();
+
+        const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
+
+        expect(csvContent).toEqual(
+            `column number,column string,column date
+$0.00,value_0,2020-03-16
+$1.00,value_1,2020-03-16
+$2.00,value_2,2020-03-16
+$3.00,value_3,2020-03-16
+$4.00,value_4,2020-03-16
+`,
+        );
+    });
+
+    it('Should convert rows to RAW CSV with table names', async () => {
+        const fileId = await CsvService.convertRowsToCsv(
+            [...rows],
+            true,
+            metricQuery,
+            itemMap,
+            true,
+            {},
+            [],
+        );
+        expect(fileId).not.toBeNull();
+
+        const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
+
+        expect(csvContent).toEqual(
+            `table column number,column string,table column date
+0,value_0,2020-03-16
+1,value_1,2020-03-16
+2,value_2,2020-03-16
+3,value_3,2020-03-16
+4,value_4,2020-03-16
+`,
+        );
+    });
+});

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,6 +1,4 @@
-import { LightdashInstallType, LightdashMode } from '@lightdash/common';
 import * as fs from 'fs';
-import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
 import { dashboardModel, savedChartModel } from '../../models/models';
 import { projectService, s3Service } from '../services';
 import { CsvService } from './CsvService';
@@ -34,7 +32,6 @@ describe('Csv service', () => {
             {},
             [],
         );
-        expect(fileId).not.toBeNull();
 
         const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
 
@@ -59,7 +56,6 @@ $4.00,value_4,2020-03-16
             {},
             [],
         );
-        expect(fileId).not.toBeNull();
 
         const csvContent = fs.readFileSync(`/tmp/${fileId}`, 'utf-8');
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -19,8 +19,7 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify';
-import * as fsSync from 'fs';
-import * as fs from 'fs/promises';
+import * as fs from 'fs';
 
 import moment from 'moment';
 import { nanoid } from 'nanoid';
@@ -135,7 +134,7 @@ export class CsvService {
         );
 
         const fileId = `csv-${nanoid()}.csv`;
-        const writeStream = fsSync.createWriteStream(`/tmp/${fileId}`);
+        const writeStream = fs.createWriteStream(`/tmp/${fileId}`);
 
         const sortedFieldIds = Object.keys(rows[0])
             .filter((id) => selectedFieldIds.includes(id))
@@ -263,7 +262,7 @@ export class CsvService {
         );
 
         try {
-            const csvContent = fsSync.createReadStream(`/tmp/${fileId}`);
+            const csvContent = fs.createReadStream(`/tmp/${fileId}`);
             const s3Url = await this.s3Service.uploadCsv(csvContent, fileId);
             return { filename: `${chart.name}`, path: s3Url };
         } catch (e) {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -79,69 +79,6 @@ export const convertSqlToCsv = (
     });
 };
 
-export const convertApiToCsv = (
-    fieldIds: string[],
-    rows: { [col: string]: any }[],
-    onlyRaw: boolean,
-    itemMap: Record<string, Field | TableCalculation>,
-    showTableNames: boolean,
-    columnOrder: string[],
-    customLabels: Record<string, string> = {},
-): Promise<string> => {
-    // Ignore fields from results that are not selected in metrics or dimensions
-
-    const sortedFieldIds = Object.keys(rows[0])
-        .filter((id) => fieldIds.includes(id))
-        .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
-
-    const csvHeader = sortedFieldIds.map((id) => {
-        if (customLabels[id]) {
-            return customLabels[id];
-        }
-        if (itemMap[id]) {
-            return showTableNames
-                ? getItemLabel(itemMap[id])
-                : getItemLabelWithoutTableName(itemMap[id]);
-        }
-        return id;
-    });
-    const csvBody = rows.map((row) =>
-        sortedFieldIds.map((id) => {
-            const rowData = row[id];
-            const item = itemMap[id];
-            const itemIsField = isField(item);
-
-            if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                return moment(rowData.value.raw).format('YYYY-MM-DD HH:mm:ss');
-            }
-            if (itemIsField && item.type === DimensionType.DATE) {
-                return moment(rowData.value.raw).format('YYYY-MM-DD');
-            }
-
-            if (onlyRaw) {
-                return rowData.value.raw;
-            }
-
-            return rowData.value.formatted;
-        }),
-    );
-
-    return new Promise((resolve, reject) => {
-        stringify(
-            [csvHeader, ...csvBody],
-            {
-                delimiter: ',',
-            },
-            (err, output) => {
-                if (err) {
-                    reject(new Error(err.message));
-                }
-                resolve(output);
-            },
-        );
-    });
-};
-
 const getSchedulerCsvLimit = (
     options: SchedulerCsvOptions | undefined,
 ): number | null | undefined => {
@@ -198,10 +135,7 @@ export class CsvService {
         );
 
         const fileId = `csv-${nanoid()}.csv`;
-        Logger.debug('file id', fileId);
         const writeStream = fsSync.createWriteStream(`/tmp/${fileId}`);
-
-        // const formattedRows = formatRows(rows, itemMap);
 
         const sortedFieldIds = Object.keys(rows[0])
             .filter((id) => selectedFieldIds.includes(id))
@@ -219,27 +153,6 @@ export class CsvService {
             return id;
         });
 
-        /*
-        const csvBody = formattedRows.map((row) =>
-            sortedFieldIds.map((id) => {
-                const rowData = row[id];
-                const item = itemMap[id];
-                const itemIsField = isField(item);
-
-                if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                    return moment(rowData.value.raw).format('YYYY-MM-DD HH:mm:ss');
-                }
-                if (itemIsField && item.type === DimensionType.DATE) {
-                    return moment(rowData.value.raw).format('YYYY-MM-DD');
-                }
-
-                if (onlyRaw) {
-                    return rowData.value.raw;
-                }
-
-                return rowData.value.formatted;
-            }),
-        ); */
         const stringifier = stringify({
             delimiter: ',',
         });
@@ -251,7 +164,7 @@ export class CsvService {
             } while (row);
         });
 
-        return new Promise((resolve, reject) => {
+        const writePromise = new Promise<string>((resolve, reject) => {
             stringifier.on('error', (err) => {
                 reject(new Error(err.message));
             });
@@ -259,130 +172,32 @@ export class CsvService {
                 writeStream.close();
                 resolve(fileId);
             });
-
-            stringifier.write(csvHeader);
-
-            rows.forEach(async (row, index) => {
-                const formattedRow = sortedFieldIds.map((id) => {
-                    const data = row[id];
-                    const item = itemMap[id];
-
-                    const itemIsField = isField(item);
-                    if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                        return moment(data).format('YYYY-MM-DD HH:mm:ss');
-                    }
-                    if (itemIsField && item.type === DimensionType.DATE) {
-                        return moment(data).format('YYYY-MM-DD');
-                    }
-                    if (onlyRaw) return data;
-                    return formatItemValue(item, data);
-                });
-
-                /*  if (index % 1000 === 0)
-                        await new Promise(r => setTimeout(r, 100))
-*/
-                stringifier.write(formattedRow);
-                /* Object.keys(row).reduce((acc, columnName) => {
-                        const col = row[columnName];
-            
-                        const item = itemMap[columnName];
-                        return {
-                            ...acc,
-                            [columnName]: {
-                                value: {
-                                    raw: col,
-                                    formatted: formatItemValue(item, col),
-                                },
-                            },
-                        };
-                    }, {}), */
-
-                // formatRows(rows, itemMap);
-            });
-
-            //  stringifier.write(rows);
-
-            stringifier.end();
         });
 
-        /*
-        const csvContentPromise: Promise<string> = new Promise((resolve, reject) => {
-            stringify(
-                [csvHeader, ...csvBody],
-                {
-                    delimiter: ',',
-                },
-                (err, output) => {
-                    if (err) {
-                        reject(new Error(err.message));
-                    }
-                    resolve(output);
-                },
-            ).pipe(writeStream);
-        });
+        stringifier.write(csvHeader);
 
-        const csvContent = await csvContentPromise; */
-
-        // Can't store file in S3, storing locally
-        //  await fs.writeFile(`/tmp/${fileId}`, csvContent, 'utf-8');
-
-        // return fileId
-
-        /*
-        return convertApiToCsv(
-            selectedFieldIds,
-            formattedRows,
-            onlyRaw,
-            itemMap,
-            showTableNames,
-            columnOrder,
-            customLabels,
-        ); */
-    }
-
-    static async convertApiResultsToCsv(
-        results: ApiQueryResults,
-        onlyRaw: boolean,
-        metricQuery: MetricQuery,
-        itemMap: Record<string, Field | TableCalculation>,
-        showTableNames: boolean,
-        customLabels: Record<string, string> | undefined,
-        columnOrder: string[],
-    ): Promise<string> {
-        // Ignore fields from results that are not selected in metrics or dimensions
-        const selectedFieldIds = [
-            ...metricQuery.metrics,
-            ...metricQuery.dimensions,
-            ...metricQuery.tableCalculations.map((tc: any) => tc.name),
-        ];
-
-        if (results.rows.length > 500) {
-            Logger.debug(
-                `Using worker to format csv with ${results.rows.length} lines`,
-            );
-            return runWorkerThread<string>(
-                new Worker('./dist/services/CsvService/convertApiToCsv.js', {
+        // Increasing CHUNK_SIZE increases memory usage, but increases speed of CSV generation
+        const CHUNK_SIZE = 50000;
+        while (rows.length > 0) {
+            const chunk = rows.splice(0, CHUNK_SIZE);
+            // eslint-disable-next-line no-await-in-loop
+            const formattedRows = await runWorkerThread<string[]>(
+                new Worker('./dist/services/CsvService/convertRowsToCsv.js', {
                     workerData: {
-                        fieldIds: selectedFieldIds,
-                        rows: results.rows,
+                        sortedFieldIds,
+                        rows: chunk,
                         onlyRaw,
                         itemMap,
-                        showTableNames,
-                        columnOrder,
-                        customLabels,
                     },
                 }),
             );
+            formattedRows.forEach((row) => {
+                stringifier.write(row);
+            });
         }
-        return convertApiToCsv(
-            selectedFieldIds,
-            results.rows,
-            onlyRaw,
-            itemMap,
-            showTableNames,
-            columnOrder,
-            customLabels,
-        );
+        stringifier.end();
+
+        return writePromise;
     }
 
     static async convertSqlQueryResultsToCsv(
@@ -418,14 +233,13 @@ export class CsvService {
         const exploreId = chart.tableName;
         const onlyRaw = options?.formatted === false;
 
-        const results: ApiQueryResults =
-            await this.projectService.runQueryAndFormatRows(
-                user,
-                metricQuery,
-                chart.projectUuid,
-                exploreId,
-                getSchedulerCsvLimit(options),
-            );
+        const rows = await this.projectService.runQuery(
+            user,
+            metricQuery,
+            chart.projectUuid,
+            exploreId,
+            getSchedulerCsvLimit(options),
+        );
 
         const explore = await this.projectService.getExplore(
             user,
@@ -438,8 +252,8 @@ export class CsvService {
             metricQuery.tableCalculations,
         );
 
-        const csvContent = await CsvService.convertApiResultsToCsv(
-            results,
+        const fileId = await CsvService.convertRowsToCsv(
+            rows,
             onlyRaw,
             metricQuery,
             itemMap,
@@ -448,14 +262,12 @@ export class CsvService {
             chart.tableConfig.columnOrder,
         );
 
-        const fileId = `csv-${nanoid()}.csv`;
-
         try {
+            const csvContent = fsSync.createReadStream(`/tmp/${fileId}`);
             const s3Url = await this.s3Service.uploadCsv(csvContent, fileId);
             return { filename: `${chart.name}`, path: s3Url };
         } catch (e) {
             // Can't store file in S3, storing locally
-            await fs.writeFile(`/tmp/${fileId}`, csvContent, 'utf-8');
             const localUrl = `${lightdashConfig.siteUrl}/api/v1/projects/${chart.projectUuid}/csv/${fileId}`;
             return { filename: `${chart.name}`, path: localUrl };
         }

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -20,6 +20,7 @@ import {
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify';
 import * as fs from 'fs';
+import * as fsPromise from 'fs/promises';
 
 import moment from 'moment';
 import { nanoid } from 'nanoid';
@@ -264,6 +265,9 @@ export class CsvService {
         try {
             const csvContent = fs.createReadStream(`/tmp/${fileId}`);
             const s3Url = await this.s3Service.uploadCsv(csvContent, fileId);
+
+            await fsPromise.unlink(`/tmp/${fileId}`);
+
             return { filename: `${chart.name}`, path: s3Url };
         } catch (e) {
             // Can't store file in S3, storing locally

--- a/packages/backend/src/services/CsvService/convertRowsToCsv.js
+++ b/packages/backend/src/services/CsvService/convertRowsToCsv.js
@@ -1,0 +1,41 @@
+/* tslint:disable */
+/* eslint-disable */
+const { workerData, parentPort } = require('worker_threads');
+
+const moment = require('moment');
+const {
+    DimensionType,
+    formatItemValue,
+    isField
+} = require('@lightdash/common');
+/**
+ * Workerdata fields:
+ * - rows: Record<string, any>[]
+ * - onlyRaw: boolean
+ * - itemMap: Record<string, Item>
+ * - sortedFieldIds: string[]
+ * */
+
+function formatRowsWorker() {
+
+
+    parentPort.postMessage(
+        workerData.rows.map((row) => {
+        return workerData.sortedFieldIds.map((id) => {
+            const data = row[id];
+            const item = workerData.itemMap[id];
+
+            const itemIsField = isField(item);
+            if (itemIsField && item.type === DimensionType.TIMESTAMP) {
+                return moment(data).format('YYYY-MM-DD HH:mm:ss');
+            }
+            if (itemIsField && item.type === DimensionType.DATE) {
+                return moment(data).format('YYYY-MM-DD');
+            }
+            if (workerData.onlyRaw) return data;
+            return formatItemValue(item, data);
+        })
+    }))
+}
+
+formatRowsWorker();

--- a/packages/backend/src/services/CsvService/convertRowsToCsv.js
+++ b/packages/backend/src/services/CsvService/convertRowsToCsv.js
@@ -6,7 +6,7 @@ const moment = require('moment');
 const {
     DimensionType,
     formatItemValue,
-    isField
+    isField,
 } = require('@lightdash/common');
 /**
  * Workerdata fields:
@@ -17,25 +17,24 @@ const {
  * */
 
 function formatRowsWorker() {
-
-
     parentPort.postMessage(
         workerData.rows.map((row) => {
-        return workerData.sortedFieldIds.map((id) => {
-            const data = row[id];
-            const item = workerData.itemMap[id];
+            return workerData.sortedFieldIds.map((id) => {
+                const data = row[id];
+                const item = workerData.itemMap[id];
 
-            const itemIsField = isField(item);
-            if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                return moment(data).format('YYYY-MM-DD HH:mm:ss');
-            }
-            if (itemIsField && item.type === DimensionType.DATE) {
-                return moment(data).format('YYYY-MM-DD');
-            }
-            if (workerData.onlyRaw) return data;
-            return formatItemValue(item, data);
-        })
-    }))
+                const itemIsField = isField(item);
+                if (itemIsField && item.type === DimensionType.TIMESTAMP) {
+                    return moment(data).format('YYYY-MM-DD HH:mm:ss');
+                }
+                if (itemIsField && item.type === DimensionType.DATE) {
+                    return moment(data).format('YYYY-MM-DD');
+                }
+                if (workerData.onlyRaw) return data;
+                return formatItemValue(item, data);
+            });
+        }),
+    );
 }
 
 formatRowsWorker();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4737

List of changes: 
- instead of using APItoCSv, I created a RowToCsv, which takes the raw results form the warehouse, and format the row and convert to CSV in chunks. 
- We still need the worker to not lock the thread and  keep the API responsive
- I always write into a file using a stream, if S3 is enabled, then I read the file and push into S3, otherwise I serve the same file locally
- Added CSV unit tests ! 
- Updated both /downloadCsv endpoint and scheduler job 


Before: 

1M cells CSVs was taking about 1.5Gb memory, and crashing with 2M

500k
![Screenshot from 2023-03-15 09-59-15](https://user-images.githubusercontent.com/1983672/225563836-b7976302-4f31-438f-b7b3-e591028e8260.png)

1M 

![image](https://user-images.githubusercontent.com/1983672/225565611-27a65019-8464-4aa7-b34f-8deb9a17e4c6.png)

Now 1M:

![Screenshot from 2023-03-16 09-23-35](https://user-images.githubusercontent.com/1983672/225564041-d19f3a0b-a9fd-4297-b8b1-8da68b28c364.png)
