### PR TITLE
feat: migrate landing panel to Mantine

### DIFF
--- a/packages/frontend/src/components/Home/LandingPanel/LandingPanel.styles.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/LandingPanel.styles.tsx
@@ -1,25 +1,5 @@
-import { Colors, H3 } from '@blueprintjs/core';
 import styled from 'styled-components';
 import LinkButton from '../../common/LinkButton';
-
-export const LandingHeaderWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    padding-top: 60px;
-`;
-
-export const WelcomeText = styled.div`
-    flex: 1;
-`;
-
-export const Title = styled(H3)`
-    margin: 0 0 0.455em;
-    color: ${Colors.BLACK};
-`;
-
-export const Intro = styled.p`
-    color: ${Colors.GRAY1};
-`;
 
 export const StyledLinkButton = styled(LinkButton)`
     font-size: 14px !important;

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,11 +1,7 @@
+import { Group, Stack, Text, Title } from '@mantine/core';
+import { IconTable } from '@tabler/icons-react';
 import { FC } from 'react';
-import {
-    Intro,
-    LandingHeaderWrapper,
-    StyledLinkButton,
-    Title,
-    WelcomeText,
-} from './LandingPanel.styles';
+import PrimaryLinkButton from '../../common/PrimaryLinkButton';
 
 interface Props {
     userName: string | undefined;
@@ -14,28 +10,24 @@ interface Props {
 
 const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
     return (
-        <LandingHeaderWrapper>
-            <WelcomeText>
-                <Title>
+        <Group position="apart" my="xl" pt="xl">
+            <Stack justify="flex-start" spacing="xs">
+                <Title order={3}>
                     {`Welcome${userName ? ', ' + userName : ' to Lightdash'}!`}{' '}
                     ⚡️
                 </Title>
-
-                <Intro>
+                <Text color="gray.7">
                     Run a query to ask a business question or browse your data
                     below:
-                </Intro>
-            </WelcomeText>
-
-            <StyledLinkButton
-                large
+                </Text>
+            </Stack>
+            <PrimaryLinkButton
                 href={`/projects/${projectUuid}/tables`}
-                intent="primary"
-                icon="series-search"
+                leftIcon={<IconTable size={18} />}
             >
                 Run a query
-            </StyledLinkButton>
-        </LandingHeaderWrapper>
+            </PrimaryLinkButton>
+        </Group>
     );
 };
 

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,7 +1,7 @@
 import { Group, Stack, Text, Title } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
 import { FC } from 'react';
-import PrimaryLinkButton from '../../common/PrimaryLinkButton';
+import MantineLinkButton from '../../common/MantineLinkButton';
 
 interface Props {
     userName: string | undefined;
@@ -21,12 +21,9 @@ const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
                     below:
                 </Text>
             </Stack>
-            <PrimaryLinkButton
-                href={`/projects/${projectUuid}/tables`}
-                leftIcon={<IconTable size={18} />}
-            >
+            <MantineLinkButton href={`/projects/${projectUuid}/tables`}>
                 Run a query
-            </PrimaryLinkButton>
+            </MantineLinkButton>
         </Group>
     );
 };


### PR DESCRIPTION
Closes: #4810 

### Description:
before
<img width="994" alt="Screenshot 2023-03-16 at 15 39 11" src="https://user-images.githubusercontent.com/67699259/225651905-a30cbf6f-5014-4be7-b624-f016647b0269.png">


after
<img width="957" alt="Screenshot 2023-03-17 at 12 37 27" src="https://user-images.githubusercontent.com/67699259/225894223-ef77556d-6ac5-4aa3-8fa9-874034b29089.png">

