### PR TITLE
feat: `All Dashboards` page migrated to Mantine

### DIFF
--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,15 +1,12 @@
-import { Button, NonIdealState, Spinner } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
-import { Stack } from '@mantine/core';
-import { IconLayoutDashboard } from '@tabler/icons-react';
+import { Button, Center, Group, Stack, Tooltip } from '@mantine/core';
+import { IconLayoutDashboard, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
+import LoadingState from '../components/common/LoadingState';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
-import Page from '../components/common/Page/Page';
-import { PageHeader } from '../components/common/Page/Page.styles';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import {
@@ -52,11 +49,7 @@ const SavedDashboards = () => {
     );
 
     if (isLoading || isLoadingSpaces) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <NonIdealState title="Loading dashboards" icon={<Spinner />} />
-            </div>
-        );
+        return <LoadingState title="Loading dashboards" />;
     }
 
     if (hasCreatedDashboard && newDashboard) {
@@ -73,13 +66,13 @@ const SavedDashboards = () => {
     };
 
     return (
-        <Page>
+        <Center my="md">
             <Helmet>
                 <title>Dashboards - Lightdash</title>
             </Helmet>
 
             <Stack spacing="xl" w={900}>
-                <PageHeader>
+                <Group position="apart" mt="xs">
                     <PageBreadcrumbs
                         items={[{ href: '/home', title: 'Home' }]}
                         mt="xs"
@@ -90,26 +83,16 @@ const SavedDashboards = () => {
                     {dashboards.length > 0 &&
                         userCanManageDashboards &&
                         !isDemo && (
-                            <Tooltip2
-                                content={
-                                    hasNoSpaces
-                                        ? 'First you must create a space for this dashboard'
-                                        : undefined
-                                }
-                                interactionKind="hover"
+                            <Button
+                                leftIcon={<IconPlus size={18} />}
+                                loading={isCreatingDashboard}
+                                onClick={handleCreateDashboard}
+                                disabled={hasNoSpaces}
                             >
-                                <Button
-                                    icon="plus"
-                                    loading={isCreatingDashboard}
-                                    onClick={handleCreateDashboard}
-                                    disabled={hasNoSpaces}
-                                    intent="primary"
-                                >
-                                    Create dashboard
-                                </Button>
-                            </Tooltip2>
+                                Create dashboard
+                            </Button>
                         )}
-                </PageHeader>
+                </Group>
 
                 <DashboardCreateModal
                     projectUuid={projectUuid}
@@ -136,30 +119,39 @@ const SavedDashboards = () => {
                         icon: <IconLayoutDashboard size={30} />,
                         title: 'No dashboards added yet',
                         action:
-                            userCanManageDashboards && !isDemo ? (
-                                <Tooltip2
-                                    content={
-                                        hasNoSpaces
-                                            ? 'First you must create a space for this dashboard'
-                                            : undefined
-                                    }
-                                    interactionKind="hover"
+                            userCanManageDashboards &&
+                            !isDemo &&
+                            hasNoSpaces ? (
+                                <Tooltip
+                                    withArrow
+                                    arrowRadius={2}
+                                    label="First you must create a space for this dashboard"
                                 >
-                                    <Button
-                                        icon="plus"
-                                        loading={isCreatingDashboard}
-                                        onClick={handleCreateDashboard}
-                                        disabled={hasNoSpaces}
-                                        intent="primary"
-                                    >
-                                        Create dashboard
-                                    </Button>
-                                </Tooltip2>
+                                    <div>
+                                        <Button
+                                            leftIcon={<IconPlus size={18} />}
+                                            loading={isCreatingDashboard}
+                                            onClick={handleCreateDashboard}
+                                            disabled={hasNoSpaces}
+                                        >
+                                            Create dashboard
+                                        </Button>
+                                    </div>
+                                </Tooltip>
+                            ) : userCanManageDashboards && !isDemo ? (
+                                <Button
+                                    leftIcon={<IconPlus size={18} />}
+                                    loading={isCreatingDashboard}
+                                    onClick={handleCreateDashboard}
+                                    disabled={hasNoSpaces}
+                                >
+                                    Create dashboard
+                                </Button>
                             ) : undefined,
                     }}
                 />
             </Stack>
-        </Page>
+        </Center>
     );
 };
 

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -122,11 +122,7 @@ const SavedDashboards = () => {
                             userCanManageDashboards &&
                             !isDemo &&
                             hasNoSpaces ? (
-                                <Tooltip
-                                    withArrow
-                                    arrowRadius={2}
-                                    label="First you must create a space for this dashboard"
-                                >
+                                <Tooltip label="First you must create a space for this dashboard">
                                     <div>
                                         <Button
                                             leftIcon={<IconPlus size={18} />}


### PR DESCRIPTION
Closes: #4847 

### Description:

<img width="946" alt="Screenshot 2023-03-17 at 17 59 08" src="https://user-images.githubusercontent.com/67699259/226302659-9a703cb0-7691-4860-8d2d-54965e30a0fb.png">
<img width="955" alt="Screenshot 2023-03-17 at 17 59 26" src="https://user-images.githubusercontent.com/67699259/226302666-5ae4aee6-9b7a-4aad-905e-62e1e9797332.png">
<img width="968" alt="Screenshot 2023-03-17 at 17 59 42" src="https://user-images.githubusercontent.com/67699259/226302667-51c31a46-cc47-42bc-964c-cb0b284fd37d.png">
<img width="318" alt="Screenshot 2023-03-17 at 18 30 15" src="https://user-images.githubusercontent.com/67699259/226302671-3692b2d8-2704-4069-a41a-ba5f02384250.png">
