### PR TITLE
feat: `All Saved Charts` page components migrated to Mantine

### DIFF
--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -1,13 +1,11 @@
-import { Button } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
-import { Stack } from '@mantine/core';
-import { IconChartBar } from '@tabler/icons-react';
+import { Button, Center, Group, Stack } from '@mantine/core';
+import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import { useHistory, useParams } from 'react-router-dom';
-import Page from '../components/common/Page/Page';
-import { PageHeader } from '../components/common/Page/Page.styles';
+import LoadingState from '../components/common/LoadingState';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import {
@@ -15,7 +13,6 @@ import {
     wrapResourceView,
 } from '../components/common/ResourceView/resourceTypeUtils';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { LoadingChart } from '../components/SimpleChart';
 import { useSavedCharts } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
@@ -38,7 +35,7 @@ const SavedQueries: FC = () => {
     );
 
     if (isLoading && !cannotView) {
-        return <LoadingChart />;
+        return <LoadingState title="Loading charts" />;
     }
 
     const handleCreateChart = () => {
@@ -46,13 +43,13 @@ const SavedQueries: FC = () => {
     };
 
     return (
-        <Page>
+        <Center my="md">
             <Helmet>
                 <title>Saved charts - Lightdash</title>
             </Helmet>
 
             <Stack spacing="xl" w={900}>
-                <PageHeader>
+                <Group position="apart" mt="xs">
                     <PageBreadcrumbs
                         items={[{ href: '/home', title: 'Home' }]}
                         mt="xs"
@@ -64,14 +61,13 @@ const SavedQueries: FC = () => {
                     !isDemo &&
                     userCanManageCharts ? (
                         <Button
-                            icon="plus"
-                            intent="primary"
+                            leftIcon={<IconPlus size={18} />}
                             onClick={handleCreateChart}
                         >
                             Create chart
                         </Button>
                     ) : undefined}
-                </PageHeader>
+                </Group>
 
                 <ResourceView
                     items={wrapResourceView(
@@ -86,18 +82,14 @@ const SavedQueries: FC = () => {
                         title: 'No charts added yet',
                         action:
                             !isDemo && userCanManageCharts ? (
-                                <Button
-                                    icon="plus"
-                                    intent="primary"
-                                    onClick={handleCreateChart}
-                                >
+                                <Button onClick={handleCreateChart}>
                                     Create chart
                                 </Button>
                             ) : undefined,
                     }}
                 />
             </Stack>
-        </Page>
+        </Center>
     );
 };
 


### PR DESCRIPTION
Closes: #4849 

### Description:
<img width="1624" alt="Screenshot 2023-03-20 at 12 17 54" src="https://user-images.githubusercontent.com/67699259/226325485-e551c686-0027-48ab-b43f-8d49908e04be.png">
<img width="1624" alt="Screenshot 2023-03-20 at 12 18 18" src="https://user-images.githubusercontent.com/67699259/226325491-9dc04dfe-659b-49f6-ba67-38f4a9bff886.png">
<img width="1624" alt="Screenshot 2023-03-20 at 12 18 29" src="https://user-images.githubusercontent.com/67699259/226325502-374676e4-30a1-4101-be02-8dbce1e0c625.png">
