### PR TITLE
feat: run underlying data query on separate endpoint

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -227,6 +227,41 @@ projectRouter.post(
 );
 
 projectRouter.post(
+    '/explores/:exploreId/runUnderlyingDataQuery',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const { body } = req;
+            const { csvLimit } = body;
+            const metricQuery: MetricQuery = {
+                dimensions: body.dimensions,
+                metrics: body.metrics,
+                filters: body.filters,
+                sorts: body.sorts,
+                limit: body.limit,
+                tableCalculations: body.tableCalculations,
+                additionalMetrics: body.additionalMetrics,
+            };
+            const results: ApiQueryResults =
+                await projectService.runUnderlyingDataQuery(
+                    req.user!,
+                    metricQuery,
+                    req.params.projectUuid,
+                    req.params.exploreId,
+                    csvLimit,
+                );
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
+projectRouter.post(
     '/explores/:exploreId/downloadCsv',
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -572,6 +572,37 @@ export class ProjectService {
         };
     }
 
+    async runUnderlyingDataQuery(
+        user: SessionUser,
+        metricQuery: MetricQuery,
+        projectUuid: string,
+        exploreName: string,
+        csvLimit: number | null | undefined,
+    ): Promise<ApiQueryResults> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { organizationUuid } =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        return this.runQueryAndFormatRows(
+            user,
+            metricQuery,
+            projectUuid,
+            exploreName,
+            csvLimit,
+        );
+    }
+
     async runQueryAndFormatRows(
         user: SessionUser,
         metricQuery: MetricQuery,

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -83,6 +83,23 @@ export const useQueryResults = () => {
     );
 };
 
+export const getUnderlyingDataResults = async ({
+    projectUuid,
+    tableId,
+    query,
+}: {
+    projectUuid: string;
+    tableId: string;
+    query: MetricQuery;
+}) => {
+    const timezoneFixQuery = convertDateFilters(query);
+    return lightdashApi<ApiQueryResults>({
+        url: `/projects/${projectUuid}/explores/${tableId}/runUnderlyingDataQuery`,
+        method: 'POST',
+        body: JSON.stringify(timezoneFixQuery),
+    });
+};
+
 export const useUnderlyingDataResults = (
     tableId: string,
     query: MetricQuery,
@@ -96,7 +113,7 @@ export const useUnderlyingDataResults = (
     return useQuery<ApiQueryResults, ApiError>({
         queryKey,
         queryFn: () =>
-            getQueryResults({
+            getUnderlyingDataResults({
                 projectUuid,
                 tableId,
                 query,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4569

### Description:

Move underlying data to a separte backeend endpoint. 

I added some permission check placeholder (same as runQuery)

![Screenshot from 2023-03-20 15-13-35](https://user-images.githubusercontent.com/1983672/226367910-4d60ac80-323d-47a7-84b5-0113171e213a.png)

