### PR TITLE
feat: migrating space page buttons and wrappers to Mantine

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -1,16 +1,14 @@
-import { Classes, Dialog } from '@blueprintjs/core';
+import { Dialog } from '@blueprintjs/core';
 import { Space } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconLock, IconUsers } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useApp } from '../../../providers/AppProvider';
 import { ShareSpaceAccessType } from './ShareSpaceAccessType';
 import { ShareSpaceAddUser } from './ShareSpaceAddUser';
-import {
-    DialogBody,
-    DialogFooter,
-    OpenShareModal,
-} from './ShareSpaceModal.style';
+import { DialogBody, DialogFooter } from './ShareSpaceModal.style';
 import {
     AccessOption,
     SpaceAccessOptions,
@@ -34,17 +32,21 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
 
     return (
         <>
-            <OpenShareModal
-                icon={
-                    selectedAccess.value === SpaceAccessType.PRIVATE
-                        ? 'lock'
-                        : 'people'
+            <Button
+                leftIcon={
+                    selectedAccess.value === SpaceAccessType.PRIVATE ? (
+                        <IconLock size={18} />
+                    ) : (
+                        <IconUsers size={18} />
+                    )
                 }
-                text="Share"
-                onClick={(e) => {
+                onClick={() => {
                     setIsOpen(true);
                 }}
-            />
+                variant="default"
+            >
+                Share
+            </Button>
 
             <Dialog
                 style={{

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -78,7 +78,7 @@ const Space: FC = () => {
         );
     };
 
-    const renderUpdateSpaceModel = () => {
+    const renderUpdateSpaceModal = () => {
         return (
             updateSpace && (
                 <SpaceActionModal
@@ -150,7 +150,7 @@ const Space: FC = () => {
                                 projectUuid={projectUuid}
                             />
                             {renderSpaceBrowserMenu()}
-                            {renderUpdateSpaceModel()}
+                            {renderUpdateSpaceModal()}
                             {renderDeleteSpaceModal()}
                         </Can>
                     </Group>

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -1,57 +1,163 @@
-import { NonIdealState, Spinner } from '@blueprintjs/core';
-import React, { FC } from 'react';
+import { Intent, NonIdealState } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
+import { ActionIcon, Center, Group, Stack } from '@mantine/core';
+import { IconDots } from '@tabler/icons-react';
+import React, { FC, useCallback, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { Can } from '../components/common/Authorization';
 import ErrorState from '../components/common/ErrorState';
-import Page from '../components/common/Page/Page';
+import LoadingState from '../components/common/LoadingState';
+import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
+import ShareSpaceModal from '../components/common/ShareSpaceModal';
+import SpaceActionModal, {
+    ActionType,
+} from '../components/common/SpaceActionModal';
+import { SpaceBrowserMenu } from '../components/Explorer/SpaceBrowser/SpaceBrowserMenu';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import SpacePanel from '../components/SpacePanel';
+import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
 import { useSpace } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
 const Space: FC = () => {
-    const params = useParams<{ projectUuid: string; spaceUuid: string }>();
-    const { data, isLoading, error } = useSpace(
-        params.projectUuid,
-        params.spaceUuid,
-    );
+    const { projectUuid, spaceUuid } = useParams<{
+        projectUuid: string;
+        spaceUuid: string;
+    }>();
+    const { data: space, isLoading, error } = useSpace(projectUuid, spaceUuid);
+    const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
     const { user } = useApp();
+
+    const history = useHistory();
+    const location = useLocation();
+
+    const [updateSpace, setUpdateSpace] = useState<boolean>(false);
+    const [deleteSpace, setDeleteSpace] = useState<boolean>(false);
+
+    const handlePinToggleSpace = useCallback(
+        (spaceId: string) => pinSpace(spaceId),
+        [pinSpace],
+    );
 
     if (user.data?.ability?.cannot('view', 'SavedChart')) {
         return <ForbiddenPanel />;
     }
 
     if (isLoading) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <NonIdealState title="Loading..." icon={<Spinner />} />
-            </div>
-        );
+        return <LoadingState title="Loading items" />;
     }
 
     if (error) {
         return <ErrorState error={error.error} />;
     }
 
-    if (data === undefined) {
+    if (space === undefined) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <NonIdealState
                     title="Space does not exist"
-                    description={`We could not find space with uuid ${params.spaceUuid}`}
+                    description={`We could not find space with uuid ${spaceUuid}`}
                 />
             </div>
         );
     }
 
-    return (
-        <Page>
-            <Helmet>
-                <title>{data?.name} - Lightdash</title>
-            </Helmet>
+    const renderSpaceBrowserMenu = () => {
+        return (
+            <SpaceBrowserMenu
+                onRename={() => setUpdateSpace(true)}
+                onDelete={() => setDeleteSpace(true)}
+                onTogglePin={() => handlePinToggleSpace(space?.uuid)}
+                isPinned={!!space?.pinnedListUuid}
+            >
+                <ActionIcon variant="default" size={36}>
+                    <IconDots size={20} />
+                </ActionIcon>
+            </SpaceBrowserMenu>
+        );
+    };
 
-            <SpacePanel space={data}></SpacePanel>
-        </Page>
+    const renderUpdateSpaceModel = () => {
+        return (
+            updateSpace && (
+                <SpaceActionModal
+                    projectUuid={projectUuid}
+                    spaceUuid={space?.uuid}
+                    actionType={ActionType.UPDATE}
+                    title="Update space"
+                    confirmButtonLabel="Update"
+                    icon="folder-close"
+                    onClose={() => setUpdateSpace(false)}
+                />
+            )
+        );
+    };
+
+    const renderDeleteSpaceModal = () => {
+        return (
+            deleteSpace && (
+                <SpaceActionModal
+                    projectUuid={projectUuid}
+                    spaceUuid={space?.uuid}
+                    actionType={ActionType.DELETE}
+                    title="Delete space"
+                    confirmButtonLabel="Delete"
+                    confirmButtonIntent={Intent.DANGER}
+                    icon="folder-close"
+                    onSubmitForm={() => {
+                        if (location.pathname.includes(space?.uuid)) {
+                            //Redirect to home if we are on the space we are deleting
+                            history.push(`/projects/${projectUuid}/home`);
+                        }
+                    }}
+                    onClose={() => {
+                        setDeleteSpace(false);
+                    }}
+                />
+            )
+        );
+    };
+
+    return (
+        <Center my="md">
+            <Helmet>
+                <title>{space?.name} - Lightdash</title>
+            </Helmet>
+            <Stack spacing="xl" w={900}>
+                <Group position="apart" mt="xs">
+                    <PageBreadcrumbs
+                        items={[
+                            {
+                                href: `/projects/${projectUuid}/spaces`,
+                                title: 'Spaces',
+                            },
+                        ]}
+                        mt="xs"
+                    >
+                        {space.name}
+                    </PageBreadcrumbs>
+                    <Group spacing="xs">
+                        <Can
+                            I="manage"
+                            this={subject('Space', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            <ShareSpaceModal
+                                space={space!}
+                                projectUuid={projectUuid}
+                            />
+                            {renderSpaceBrowserMenu()}
+                            {renderUpdateSpaceModel()}
+                            {renderDeleteSpaceModal()}
+                        </Can>
+                    </Group>
+                </Group>
+                <SpacePanel space={space} />
+            </Stack>
+        </Center>
     );
 };
 

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -63,101 +63,94 @@ const Space: FC = () => {
         );
     }
 
-    const renderSpaceBrowserMenu = () => {
-        return (
-            <SpaceBrowserMenu
-                onRename={() => setUpdateSpace(true)}
-                onDelete={() => setDeleteSpace(true)}
-                onTogglePin={() => handlePinToggleSpace(space?.uuid)}
-                isPinned={!!space?.pinnedListUuid}
-            >
-                <ActionIcon variant="default" size={36}>
-                    <IconDots size={20} />
-                </ActionIcon>
-            </SpaceBrowserMenu>
-        );
-    };
-
-    const renderUpdateSpaceModal = () => {
-        return (
-            updateSpace && (
-                <SpaceActionModal
-                    projectUuid={projectUuid}
-                    spaceUuid={space?.uuid}
-                    actionType={ActionType.UPDATE}
-                    title="Update space"
-                    confirmButtonLabel="Update"
-                    icon="folder-close"
-                    onClose={() => setUpdateSpace(false)}
-                />
-            )
-        );
-    };
-
-    const renderDeleteSpaceModal = () => {
-        return (
-            deleteSpace && (
-                <SpaceActionModal
-                    projectUuid={projectUuid}
-                    spaceUuid={space?.uuid}
-                    actionType={ActionType.DELETE}
-                    title="Delete space"
-                    confirmButtonLabel="Delete"
-                    confirmButtonIntent={Intent.DANGER}
-                    icon="folder-close"
-                    onSubmitForm={() => {
-                        if (location.pathname.includes(space?.uuid)) {
-                            //Redirect to home if we are on the space we are deleting
-                            history.push(`/projects/${projectUuid}/home`);
-                        }
-                    }}
-                    onClose={() => {
-                        setDeleteSpace(false);
-                    }}
-                />
-            )
-        );
-    };
-
     return (
-        <Center my="md">
+        <>
             <Helmet>
                 <title>{space?.name} - Lightdash</title>
             </Helmet>
-            <Stack spacing="xl" w={900}>
-                <Group position="apart" mt="xs">
-                    <PageBreadcrumbs
-                        items={[
-                            {
-                                href: `/projects/${projectUuid}/spaces`,
-                                title: 'Spaces',
-                            },
-                        ]}
-                        mt="xs"
-                    >
-                        {space.name}
-                    </PageBreadcrumbs>
-                    <Group spacing="xs">
-                        <Can
-                            I="manage"
-                            this={subject('Space', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
+            <Center my="md">
+                <Stack spacing="xl" w={900}>
+                    <Group position="apart" mt="xs">
+                        <PageBreadcrumbs
+                            items={[
+                                {
+                                    href: `/projects/${projectUuid}/spaces`,
+                                    title: 'Spaces',
+                                },
+                            ]}
+                            mt="xs"
                         >
-                            <ShareSpaceModal
-                                space={space!}
-                                projectUuid={projectUuid}
-                            />
-                            {renderSpaceBrowserMenu()}
-                            {renderUpdateSpaceModal()}
-                            {renderDeleteSpaceModal()}
-                        </Can>
+                            {space.name}
+                        </PageBreadcrumbs>
+                        <Group spacing="xs">
+                            <Can
+                                I="manage"
+                                this={subject('Space', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <ShareSpaceModal
+                                    space={space!}
+                                    projectUuid={projectUuid}
+                                />
+                                <SpaceBrowserMenu
+                                    onRename={() => setUpdateSpace(true)}
+                                    onDelete={() => setDeleteSpace(true)}
+                                    onTogglePin={() =>
+                                        handlePinToggleSpace(space?.uuid)
+                                    }
+                                    isPinned={!!space?.pinnedListUuid}
+                                >
+                                    <ActionIcon variant="default" size={36}>
+                                        <IconDots size={20} />
+                                    </ActionIcon>
+                                </SpaceBrowserMenu>
+                                {updateSpace && (
+                                    <SpaceActionModal
+                                        projectUuid={projectUuid}
+                                        spaceUuid={space?.uuid}
+                                        actionType={ActionType.UPDATE}
+                                        title="Update space"
+                                        confirmButtonLabel="Update"
+                                        icon="folder-close"
+                                        onClose={() => setUpdateSpace(false)}
+                                    />
+                                )}
+                                {deleteSpace && (
+                                    <SpaceActionModal
+                                        projectUuid={projectUuid}
+                                        spaceUuid={space?.uuid}
+                                        actionType={ActionType.DELETE}
+                                        title="Delete space"
+                                        confirmButtonLabel="Delete"
+                                        confirmButtonIntent={Intent.DANGER}
+                                        icon="folder-close"
+                                        onSubmitForm={() => {
+                                            if (
+                                                location.pathname.includes(
+                                                    space?.uuid,
+                                                )
+                                            ) {
+                                                //Redirect to home if we are on the space we are deleting
+                                                history.push(
+                                                    `/projects/${projectUuid}/home`,
+                                                );
+                                            }
+                                        }}
+                                        onClose={() => {
+                                            setDeleteSpace(false);
+                                        }}
+                                    />
+                                )}
+                            </Can>
+                        </Group>
                     </Group>
-                </Group>
-                <SpacePanel space={space} />
-            </Stack>
-        </Center>
+                    <SpacePanel space={space} />
+                </Stack>
+            </Center>
+        </>
     );
 };
 


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
migrated to Mantine
```
wrappers
breadcrumbs
Share button
Three dots button
```
refactored
```
Page header components (i.e. breadcrumbs, share button, three dots button) 
previously in SpacePanel are now in SpacePage
```

<img width="1624" alt="Screenshot 2023-03-21 at 13 01 54" src="https://user-images.githubusercontent.com/67699259/226600311-b52305cf-4705-4159-ac2e-b678a1ceaf38.png">
<img width="1624" alt="Screenshot 2023-03-21 at 13 02 19" src="https://user-images.githubusercontent.com/67699259/226600320-26842713-2da1-40d1-8157-54bf22fa9327.png">
