### PR TITLE
feat: migrate `login` form to Mantine

### DIFF
--- a/packages/e2e/cypress/e2e/login.cy.ts
+++ b/packages/e2e/cypress/e2e/login.cy.ts
@@ -19,19 +19,28 @@ describe('Login', () => {
         cy.get('[data-cy="signin-button"]').click();
         cy.url().should('include', '/home');
     });
-    it('Should display error message when credentials are invalid', () => {
+    it('Should display error message when email is invalid', () => {
         cy.logout();
         cy.visit('/login');
         cy.findByPlaceholderText('Your email address').type('test-email');
         cy.findByPlaceholderText('Your password').type('test-password');
         cy.get('[data-cy="signin-button"]').click();
-        cy.findByText('Email and password not recognized').should('be.visible');
+        cy.findByText('Your email address is not valid').should('be.visible');
     });
-    it('Should display error message when one field is empty', () => {
+    it('Should display error message when credentials are invalid', () => {
         cy.logout();
         cy.visit('/login');
-        cy.findByPlaceholderText('Your email address').type('test-email');
+        cy.findByPlaceholderText('Your email address').type('test@emaill.com');
+        cy.findByPlaceholderText('Your password').type('test-password');
         cy.get('[data-cy="signin-button"]').click();
-        cy.findByText('Required field').should('be.visible');
+        cy.findByText('Email and password not recognized').should('be.visible');
     });
+    // FIXME: Please fill out this field is a tooltip and Cy can't find it on the UI
+    // it('Should display error message when one field is empty', () => {
+    //     cy.logout();
+    //     cy.visit('/login');
+    //     cy.findByPlaceholderText('Your email address').type('test@mail.com');
+    //     cy.get('[data-cy="signin-button"]').click();
+    //     cy.findByText('Please fill out this field.').should('be.visible');
+    // });
 });

--- a/packages/e2e/cypress/e2e/login.cy.ts
+++ b/packages/e2e/cypress/e2e/login.cy.ts
@@ -10,28 +10,28 @@ describe('Login', () => {
     it('Should login successfully', () => {
         cy.logout();
         cy.visit('/login');
-        cy.findByLabelText('Email address *').type(
+        cy.findByPlaceholderText('Your email address').type(
             SEED_ORG_1_ADMIN_EMAIL.email,
         );
-        cy.findByLabelText('Password *').type(
+        cy.findByPlaceholderText('Your password').type(
             SEED_ORG_1_ADMIN_PASSWORD.password,
         );
-        cy.get('[data-cy="login-button"]').click();
+        cy.get('form').findByText('Sign in').click();
         cy.url().should('include', '/home');
     });
     it('Should display error message when credentials are invalid', () => {
         cy.logout();
         cy.visit('/login');
-        cy.findByLabelText('Email address *').type('test-email');
-        cy.findByLabelText('Password *').type('test-password');
-        cy.get('[data-cy="login-button"]').click();
+        cy.findByPlaceholderText('Your email address').type('test-email');
+        cy.findByPlaceholderText('Your password').type('test-password');
+        cy.get('form').findByText('Sign in').click();
         cy.findByText('Email and password not recognized').should('be.visible');
     });
     it('Should display error message when one field is empty', () => {
         cy.logout();
         cy.visit('/login');
-        cy.findByLabelText('Email address *').type('test-email');
-        cy.get('[data-cy="login-button"]').click();
+        cy.findByPlaceholderText('Your email address').type('test-email');
+        cy.get('form').findByText('Sign in').click();
         cy.findByText('Required field').should('be.visible');
     });
 });

--- a/packages/e2e/cypress/e2e/login.cy.ts
+++ b/packages/e2e/cypress/e2e/login.cy.ts
@@ -24,7 +24,7 @@ describe('Login', () => {
         cy.visit('/login');
         cy.findByPlaceholderText('Your email address').type('test-email');
         cy.findByPlaceholderText('Your password').type('test-password');
-        cy.get('form').findByText('Sign in').click();
+        cy.get('[data-cy="signin-button"]').click();
         cy.findByText('Email and password not recognized').should('be.visible');
     });
     it('Should display error message when one field is empty', () => {

--- a/packages/e2e/cypress/e2e/login.cy.ts
+++ b/packages/e2e/cypress/e2e/login.cy.ts
@@ -16,7 +16,7 @@ describe('Login', () => {
         cy.findByPlaceholderText('Your password').type(
             SEED_ORG_1_ADMIN_PASSWORD.password,
         );
-        cy.get('form').findByText('Sign in').click();
+        cy.get('[data-cy="signin-button"]').click();
         cy.url().should('include', '/home');
     });
     it('Should display error message when credentials are invalid', () => {
@@ -31,7 +31,7 @@ describe('Login', () => {
         cy.logout();
         cy.visit('/login');
         cy.findByPlaceholderText('Your email address').type('test-email');
-        cy.get('form').findByText('Sign in').click();
+        cy.get('[data-cy="signin-button"]').click();
         cy.findByText('Required field').should('be.visible');
     });
 });

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,6 +15,7 @@
         "@hookform/error-message": "^2.0.0",
         "@lightdash/common": "^0.479.0",
         "@mantine/core": "^5.10.4",
+        "@mantine/form": "^6.0.4",
         "@mantine/hooks": "^5.10.4",
         "@sentry/react": "^7.37.2",
         "@sentry/tracing": "^7.37.2",

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -135,11 +135,6 @@ const Login: FC = () => {
                     required
                     {...form.getInputProps('email')}
                     disabled={isLoading || isSuccess}
-                    styles={{
-                        label: {
-                            marginBottom: '5px',
-                        },
-                    }}
                 />
                 <PasswordInput
                     label="Password"
@@ -148,11 +143,6 @@ const Login: FC = () => {
                     required
                     {...form.getInputProps('password')}
                     disabled={isLoading || isSuccess}
-                    styles={{
-                        label: {
-                            marginBottom: '5px',
-                        },
-                    }}
                 />
                 <Button
                     type="submit"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -6,7 +6,7 @@ import {
     SEED_ORG_1_ADMIN_PASSWORD,
 } from '@lightdash/common';
 import { Anchor, Button, PasswordInput, Stack, TextInput } from '@mantine/core';
-import { useForm } from '@mantine/form';
+import { isNotEmpty, useForm } from '@mantine/form';
 import React, { FC, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useMutation } from 'react-query';
@@ -50,6 +50,10 @@ const Login: FC = () => {
         initialValues: {
             email: '',
             password: '',
+        },
+        validate: {
+            email: isNotEmpty('Required field'),
+            password: isNotEmpty('Required field'),
         },
     });
 
@@ -142,11 +146,7 @@ const Login: FC = () => {
                     {...form.getInputProps('password')}
                     disabled={isLoading}
                 />
-                <Button
-                    type="submit"
-                    disabled={!form.values.email || !form.values.password}
-                    loading={isLoading}
-                >
+                <Button type="submit" loading={isLoading}>
                     Sign in
                 </Button>
                 {health.data?.hasEmailClient && (

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -126,10 +126,7 @@ const Login: FC = () => {
     );
 
     const passwordLogin = allowPasswordAuthentication && (
-        <form
-            name="login"
-            onSubmit={form.onSubmit((values: LoginParams) => mutate(values))}
-        >
+        <form name="login" onSubmit={form.onSubmit((values) => mutate(values))}>
             <Stack spacing="lg">
                 <TextInput
                     label="Email address"
@@ -137,7 +134,7 @@ const Login: FC = () => {
                     placeholder="Your email address"
                     required
                     {...form.getInputProps('email')}
-                    disabled={isLoading}
+                    disabled={isLoading || isSuccess}
                     styles={{
                         label: {
                             marginBottom: '5px',
@@ -150,7 +147,7 @@ const Login: FC = () => {
                     placeholder="Your password"
                     required
                     {...form.getInputProps('password')}
-                    disabled={isLoading}
+                    disabled={isLoading || isSuccess}
                     styles={{
                         label: {
                             marginBottom: '5px',

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -5,7 +5,16 @@ import {
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
 } from '@lightdash/common';
-import { Anchor, Button, PasswordInput, Stack, TextInput } from '@mantine/core';
+import {
+    Anchor,
+    Button,
+    Card,
+    Image,
+    PasswordInput,
+    Stack,
+    TextInput,
+    Title,
+} from '@mantine/core';
 import { isNotEmpty, useForm } from '@mantine/form';
 import React, { FC, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
@@ -23,15 +32,7 @@ import useToaster from '../hooks/toaster/useToaster';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
-import {
-    CardWrapper,
-    Divider,
-    DividerWrapper,
-    FormWrapper,
-    Logo,
-    LogoWrapper,
-    Title,
-} from './SignUp.styles';
+import { Divider, DividerWrapper } from './SignUp.styles';
 
 type LoginParams = { email: string; password: string };
 
@@ -122,7 +123,6 @@ const Login: FC = () => {
             {health.data?.auth.oneLogin.enabled && <OneLoginLoginButton />}
         </>
     );
-    console.log(form.values);
 
     const passwordLogin = allowPasswordAuthentication && (
         <form
@@ -177,15 +177,22 @@ const Login: FC = () => {
             <Helmet>
                 <title>Login - Lightdash</title>
             </Helmet>
-            <FormWrapper>
-                <LogoWrapper>
-                    <Logo src={LightdashLogo} alt="lightdash logo" />
-                </LogoWrapper>
-                <CardWrapper elevation={2}>
-                    <Title>Sign in</Title>
+            <Stack w={400} px="lg" mt="xl">
+                <Image
+                    src={LightdashLogo}
+                    alt="lightdash logo"
+                    width={130}
+                    mx="auto"
+                    mt="xl"
+                    mb="md"
+                />
+                <Card p="xl" radius="xs" withBorder shadow="xs">
+                    <Title order={3} ta="center" mb="md">
+                        Sign in
+                    </Title>
                     {logins}
-                </CardWrapper>
-            </FormWrapper>
+                </Card>
+            </Stack>
         </Page>
     );
 };

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import {
     LightdashUser,
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
+    validateEmail,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -53,14 +54,14 @@ const Login: FC = () => {
             password: '',
         },
         validate: {
-            email: isNotEmpty('Required field'),
-            password: isNotEmpty('Required field'),
+            email: (value) =>
+                validateEmail(value) ? null : 'Your email address is not valid',
         },
     });
 
     const { identify } = useTracking();
 
-    const { isIdle, isLoading, mutate } = useMutation<
+    const { isIdle, isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
         ApiError,
         LoginParams
@@ -129,12 +130,12 @@ const Login: FC = () => {
             name="login"
             onSubmit={form.onSubmit((values: LoginParams) => mutate(values))}
         >
-            <Stack spacing="md">
+            <Stack spacing="lg">
                 <TextInput
                     label="Email address"
                     name="email"
                     placeholder="Your email address"
-                    withAsterisk
+                    required
                     {...form.getInputProps('email')}
                     disabled={isLoading}
                 />
@@ -142,13 +143,13 @@ const Login: FC = () => {
                     label="Password"
                     name="password"
                     placeholder="Your password"
-                    withAsterisk
+                    required
                     {...form.getInputProps('password')}
                     disabled={isLoading}
                 />
                 <Button
                     type="submit"
-                    loading={isLoading}
+                    loading={isLoading || isSuccess}
                     data-cy="signin-button"
                 >
                     Sign in
@@ -181,14 +182,13 @@ const Login: FC = () => {
             <Helmet>
                 <title>Login - Lightdash</title>
             </Helmet>
-            <Stack w={400} px="lg" mt="xl">
+            <Stack w={400} mt="xl" pt="lg">
                 <Image
                     src={LightdashLogo}
                     alt="lightdash logo"
                     width={130}
                     mx="auto"
-                    mt="xl"
-                    mb="md"
+                    my="lg"
                 />
                 <Card p="xl" radius="xs" withBorder shadow="xs">
                     <Title order={3} ta="center" mb="md">

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -138,6 +138,11 @@ const Login: FC = () => {
                     required
                     {...form.getInputProps('email')}
                     disabled={isLoading}
+                    styles={{
+                        label: {
+                            marginBottom: '5px',
+                        },
+                    }}
                 />
                 <PasswordInput
                     label="Password"
@@ -146,6 +151,11 @@ const Login: FC = () => {
                     required
                     {...form.getInputProps('password')}
                     disabled={isLoading}
+                    styles={{
+                        label: {
+                            marginBottom: '5px',
+                        },
+                    }}
                 />
                 <Button
                     type="submit"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -146,7 +146,11 @@ const Login: FC = () => {
                     {...form.getInputProps('password')}
                     disabled={isLoading}
                 />
-                <Button type="submit" loading={isLoading}>
+                <Button
+                    type="submit"
+                    loading={isLoading}
+                    data-cy="signin-button"
+                >
                     Sign in
                 </Button>
                 {health.data?.hasEmailClient && (


### PR DESCRIPTION
Closes: #4812 

### Description:
what this POC revealed
```
- we can use Mantine useForm hook to replace react-use-form
- it's fairly straightforward to migrate forms, given they are well built
- in order to completely migrate the Sign in Page, we need to migrate: 
SSO login buttons, AboutFooter, Page component
```
<img width="1624" alt="Screenshot 2023-03-23 at 10 51 21" src="https://user-images.githubusercontent.com/67699259/227166590-c9f1dabd-9a1b-4532-888d-fcd3cdef8b8f.png">

