### PR TITLE
feat: new interactive viewer role

### DIFF
--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -15,28 +15,31 @@ import JoinWorkspace from './assets/join-workspace-prompt.png';
 Project Admins can invite users to their project and assign the following roles. Note that projects may also be 
 accessible by users with organization roles.
 
-| Action                                  | Project Admin | Project Editor | Project Viewer |
-|:----------------------------------------|:-------------:|:--------------:|:--------------:|
-| View charts and dashboards              |       ✅       |       ✅        |       ✅        |
-| Run metric queries                      |       ✅       |       ✅        |       ✅        |
-| Create/edit charts and dashboards       |       ✅       |       ✅        |       ❌        |
-| Use the SQL runner                      |       ✅       |       ✅        |       ❌        |
-| Manage project access and permissions   |       ✅       |       ❌        |       ❌        |
-| Delete project                          |       ✅       |       ❌        |       ❌        |
+| Action                                  | Project Admin | Project Editor | Project Interactive Viewer | Project Viewer |
+|:----------------------------------------|:-------------:|:--------------:|:--------------:|:--------------:|
+| View charts and dashboards              |       ✅       |       ✅        |       ✅        |       ✅        | 
+| Run metric queries                      |       ✅       |       ✅        |       ✅        |       ✅        | 
+| Use the explorer                        |       ✅       |       ✅        |       ✅        |       ❌        |
+| Export CSVs                             |       ✅       |       ✅        |       ✅        |       ❌        |
+| View underlying data                    |       ✅       |       ✅        |       ✅        |       ❌        |     
+| Create/edit charts and dashboards       |       ✅       |       ✅        |       ❌        |       ❌        |
+| Use the SQL runner                      |       ✅       |       ✅        |       ❌        |       ❌        |
+| Manage project access and permissions   |       ✅       |       ❌        |       ❌        |       ❌        |
+| Delete project                          |       ✅       |       ❌        |       ❌        |       ❌        |
 
 ### Organization Roles
 
 Organization Admins can assign roles to organization members, which gives access to all projects in the organization.
 
-| Action                                     | Organization Admin | Organization Editor | Organization Viewer | Organization Member |
-|:-------------------------------------------|:------------------:|:-------------------:|:-------------------:|:-------------------:|
-| Create Personal access tokens              |         ✅          |          ✅          |          ✅          |          ✅          |
-| Create new projects                        |         ✅          |          ✅          |          ✅          |          ✅          |
-| View **all** projects                      |         ✅          |          ✅          |          ✅          |          ❌          |
-| Edit **all** projects                      |         ✅          |          ✅          |          ❌          |          ❌          |
-| Admin for **all** projects                 |         ✅          |          ❌          |          ❌          |          ❌          |
-| Invite users to organization               |         ✅          |          ❌          |          ❌          |          ❌          |
-| Manage organization access and permissions |         ✅          |          ❌          |          ❌          |          ❌          |
+| Action                                     | Organization Admin | Organization Editor | Organization Viewer | Organization Viewer | Organization Member |
+|:-------------------------------------------|:------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
+| Create Personal access tokens              |         ✅          |          ✅          |          ✅          |          ✅          |          ✅          |
+| View **all** projects                      |         ✅          |          ✅          |          ✅          |          ✅          |          ❌          |
+| Create new projects                        |         ✅          |          ✅          |          ✅          |          ❌          |          ❌          |
+| Edit **all** projects                      |         ✅          |          ✅          |          ❌          |          ❌          |          ❌          |
+| Admin for **all** projects                 |         ✅          |          ❌          |          ❌          |          ❌          |          ❌          |
+| Invite users to organization               |         ✅          |          ❌          |          ❌          |          ❌          |          ❌          |
+| Manage organization access and permissions |         ✅          |          ❌          |          ❌          |          ❌          |          ❌          |
 
 ### Space Roles
 

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -31,7 +31,7 @@ accessible by users with organization roles.
 
 Organization Admins can assign roles to organization members, which gives access to all projects in the organization.
 
-| Action                                     | Organization Admin | Organization Editor | Organization Viewer | Organization Viewer | Organization Member |
+| Action                                     | Organization Admin | Organization Editor | Organization Interactive Viewer | Organization Viewer | Organization Member |
 |:-------------------------------------------|:------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
 | Create Personal access tokens              |         ✅          |          ✅          |          ✅          |          ✅          |          ✅          |
 | View **all** projects                      |         ✅          |          ✅          |          ✅          |          ✅          |          ❌          |

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -148,6 +148,7 @@ export default class EmailClient {
         let roleAction = 'view';
         switch (projectMember.role) {
             case ProjectMemberRole.VIEWER:
+            case ProjectMemberRole.INTERACTIVE_VIEWER:
                 roleAction = 'view';
                 break;
             case ProjectMemberRole.EDITOR:

--- a/packages/backend/src/controllers/authenticationRoles.ts
+++ b/packages/backend/src/controllers/authenticationRoles.ts
@@ -12,6 +12,8 @@ const inheritedProjectRoleFromOrgRole = (
             return null;
         case OrganizationMemberRole.VIEWER:
             return ProjectMemberRole.VIEWER;
+        case OrganizationMemberRole.INTERACTIVE_VIEWER:
+            return ProjectMemberRole.INTERACTIVE_VIEWER;
         case OrganizationMemberRole.EDITOR:
             return ProjectMemberRole.EDITOR;
         case OrganizationMemberRole.ADMIN:

--- a/packages/backend/src/database/migrations/20230322102401_add_interactive_viewer_role.ts
+++ b/packages/backend/src/database/migrations/20230322102401_add_interactive_viewer_role.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+const organizationMembershipsTableName = 'organization_memberships';
+const organizationMembershipRolesTableName = 'organization_membership_roles';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex(organizationMembershipRolesTableName).insert({
+        role: 'interactive_viewer',
+    });
+    await knex(organizationMembershipsTableName)
+        .update('role', 'interactive_viewer')
+        .where('role', 'viewer');
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(organizationMembershipsTableName)
+        .update('role', 'viewer')
+        .where('role', 'interactive_viewer');
+    await knex(organizationMembershipRolesTableName)
+        .where('role', 'interactive_viewer')
+        .delete();
+}

--- a/packages/backend/src/database/migrations/20230322102401_add_interactive_viewer_role.ts
+++ b/packages/backend/src/database/migrations/20230322102401_add_interactive_viewer_role.ts
@@ -2,8 +2,17 @@ import { Knex } from 'knex';
 
 const organizationMembershipsTableName = 'organization_memberships';
 const organizationMembershipRolesTableName = 'organization_membership_roles';
+const projectMembershipRolesTableName = 'project_membership_roles';
+const projectMembershipsTableName = 'organization_memberships';
 
 export async function up(knex: Knex): Promise<void> {
+    await knex(projectMembershipRolesTableName).insert({
+        role: 'interactive_viewer',
+    });
+    await knex(projectMembershipsTableName)
+        .update('role', 'interactive_viewer')
+        .where('role', 'viewer');
+
     await knex(organizationMembershipRolesTableName).insert({
         role: 'interactive_viewer',
     });
@@ -13,6 +22,13 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex(projectMembershipsTableName)
+        .update('role', 'viewer')
+        .where('role', 'interactive_viewer');
+    await knex(projectMembershipRolesTableName)
+        .where('role', 'interactive_viewer')
+        .delete();
+
     await knex(organizationMembershipsTableName)
         .update('role', 'viewer')
         .where('role', 'interactive_viewer');

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -111,34 +111,7 @@ app.use(morganMiddleware);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-if (process.env.NODE_ENV === 'development') {
-    app.use(
-        OpenApiValidator.middleware({
-            apiSpec: path.join(
-                __dirname,
-                '../../common/src/openapibundle.json',
-            ),
-            // apiSpec,
-            validateRequests: true,
-            ignoreUndocumented: true,
-            validateResponses: {
-                removeAdditional: 'failing',
-                onError: (error, body, req) => {
-                    Logger.warn(
-                        `[${req.method}] ${
-                            req.originalUrl
-                        } Response body fails validation:\n${
-                            error.message
-                        }\n${JSON.stringify(body, null, 4)}`,
-                    );
-                },
-            },
-            validateSecurity: false,
-            validateApiSpec: true,
-            operationHandlers: false,
-        }),
-    );
-}
+
 app.use(
     expressSession({
         secret: lightdashConfig.lightdashSecret,

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -126,7 +126,9 @@ export class AnalyticsModel {
         return {
             numberUsers: usersInProject.length,
             numberViewers: usersInProject.filter(
-                (user) => user.role === OrganizationMemberRole.VIEWER,
+                (user) =>
+                    user.role === OrganizationMemberRole.VIEWER ||
+                    user.role === OrganizationMemberRole.INTERACTIVE_VIEWER,
             ).length,
             numberEditors: usersInProject.filter(
                 (user) => user.role === OrganizationMemberRole.EDITOR,

--- a/packages/backend/src/routers/analyticsRouter.ts
+++ b/packages/backend/src/routers/analyticsRouter.ts
@@ -3,7 +3,7 @@ import {
     allowApiKeyAuthentication,
     isAuthenticated,
 } from '../controllers/authentication';
-import { analyticsService, projectService } from '../services/services';
+import { analyticsService } from '../services/services';
 
 export const analyticsRouter = express.Router({ mergeParams: true });
 

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -216,7 +216,7 @@ projectRouter.post(
                 additionalMetrics: body.additionalMetrics,
             };
             const results: ApiQueryResults =
-                await projectService.runQueryAndFormatRows(
+                await projectService.runViewChartQuery(
                     req.user!,
                     metricQuery,
                     req.params.projectUuid,
@@ -251,7 +251,7 @@ projectRouter.post(
                 additionalMetrics: body.additionalMetrics,
             };
             const results: ApiQueryResults =
-                await projectService.runQueryAndFormatRows(
+                await projectService.runExploreQuery(
                     req.user!,
                     metricQuery,
                     req.params.projectUuid,
@@ -321,7 +321,7 @@ projectRouter.post(
                 additionalMetrics: body.additionalMetrics,
             };
             const results: ApiQueryResults =
-                await projectService.runQueryAndFormatRows(
+                await projectService.runViewChartQuery(
                     req.user!,
                     metricQuery,
                     req.params.projectUuid,

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -1,9 +1,11 @@
+import { subject } from '@casl/ability';
 import {
     ApiCompiledQueryResults,
     ApiExploreResults,
     ApiExploresResults,
     ApiQueryResults,
     ApiSqlQueryResults,
+    ForbiddenError,
     getItemMap,
     getRequestMethod,
     LightdashRequestMethodHeader,
@@ -284,6 +286,17 @@ projectRouter.post(
         };
 
         try {
+            const { organizationUuid } = req.user!;
+            const { projectUuid } = req.params;
+            if (
+                req.user!.ability.cannot(
+                    'manage',
+                    subject('ExportCsv', { organizationUuid, projectUuid }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+
             const { body } = req;
             const {
                 csvLimit,

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -791,6 +791,18 @@ projectRouter.post(
             storage: s3Service.isEnabled() ? 's3' : 'local',
         };
         try {
+            const { organizationUuid } = req.user!;
+            const { projectUuid } = req.params;
+
+            if (
+                req.user!.ability.cannot(
+                    'manage',
+                    subject('ExportCsv', { organizationUuid, projectUuid }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+
             analytics.track({
                 event: 'download_results.started',
                 userId: req.user?.userUuid!,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -587,7 +587,7 @@ export class ProjectService {
 
         if (
             user.ability.cannot(
-                'manage',
+                'view',
                 subject('UnderlyingData', { organizationUuid, projectUuid }),
             )
         ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -674,8 +674,8 @@ export class ProjectService {
 
         if (
             user.ability.cannot(
-                'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -587,8 +587,8 @@ export class ProjectService {
 
         if (
             user.ability.cannot(
-                'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                'manage',
+                subject('UnderlyingData', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -77,8 +77,18 @@ export class SearchService {
             return itemSpace && hasSpaceAccess(itemSpace, user.userUuid);
         };
 
+        const hasExploreAccess = user.ability.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+
         const filteredResults = {
             ...results,
+            tables: hasExploreAccess ? results.tables : [],
+            fields: hasExploreAccess ? results.fields : [],
             dashboards: results.dashboards.filter(filterItem),
             savedCharts: results.savedCharts.filter(filterItem),
             spaces: results.spaces.filter(filterItem),

--- a/packages/common/src/authorization/organizationMemberAbility.mock.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.mock.ts
@@ -17,6 +17,10 @@ export const ORGANIZATION_VIEWER: OrganizationMemberProfile = {
     ...ORGANIZATION_MEMBER,
     role: OrganizationMemberRole.VIEWER,
 };
+export const ORGANIZATION_INTERACTIVE_VIEWER: OrganizationMemberProfile = {
+    ...ORGANIZATION_MEMBER,
+    role: OrganizationMemberRole.INTERACTIVE_VIEWER,
+};
 export const ORGANIZATION_EDITOR: OrganizationMemberProfile = {
     ...ORGANIZATION_MEMBER,
     role: OrganizationMemberRole.EDITOR,

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -4,6 +4,7 @@ import { organizationMemberAbilities } from './organizationMemberAbility';
 import {
     ORGANIZATION_ADMIN,
     ORGANIZATION_EDITOR,
+    ORGANIZATION_INTERACTIVE_VIEWER,
     ORGANIZATION_MEMBER,
     ORGANIZATION_VIEWER,
 } from './organizationMemberAbility.mock';
@@ -139,9 +140,14 @@ describe('Organization member permissions', () => {
         it('can create invitations', () => {
             expect(ability.can('create', 'InviteLink')).toEqual(false);
         });
-        it('can create Project', () => {
-            expect(ability.can('create', 'Project')).toEqual(true);
+        it('cannot create Project', () => {
+            const org = { organizationUuid: '456' };
+
+            expect(ability.can('create', subject('Project', org))).toEqual(
+                false,
+            );
         });
+
         it('cannot create any resource', () => {
             expect(ability.can('create', 'Space')).toEqual(false);
             expect(ability.can('create', 'Dashboard')).toEqual(false);
@@ -231,6 +237,131 @@ describe('Organization member permissions', () => {
                 ability.can(
                     'view',
                     subject('Job', { userUuid: ORGANIZATION_VIEWER.userUuid }),
+                ),
+            ).toEqual(false);
+        });
+        it('cannot view jobs from another user', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Job', { userUuid: 'another-user-uuid' }),
+                ),
+            ).toEqual(false);
+        });
+    });
+    describe('when user is an interactive viewer', () => {
+        beforeEach(() => {
+            ability = defineAbilityForOrganizationMember(
+                ORGANIZATION_INTERACTIVE_VIEWER,
+            );
+        });
+        it('can view member profiles', () => {
+            expect(ability.can('view', 'OrganizationMemberProfile')).toEqual(
+                true,
+            );
+        });
+        it('can create invitations', () => {
+            expect(ability.can('create', 'InviteLink')).toEqual(false);
+        });
+        it('can create Project', () => {
+            expect(ability.can('create', 'Job')).toEqual(true);
+            const org = { organizationUuid: '456' };
+            expect(ability.can('create', subject('Project', org))).toEqual(
+                true,
+            );
+        });
+
+        it('cannot create any resource', () => {
+            expect(ability.can('create', 'Space')).toEqual(false);
+            expect(ability.can('create', 'Dashboard')).toEqual(false);
+            expect(ability.can('create', 'SavedChart')).toEqual(false);
+            expect(ability.can('create', 'Organization')).toEqual(false);
+        });
+        it('cannot run SQL queries', () => {
+            expect(ability.can('manage', 'SqlRunner')).toEqual(false);
+        });
+        it('cannot update any resource', () => {
+            expect(ability.can('update', 'Space')).toEqual(false);
+            expect(ability.can('update', 'Dashboard')).toEqual(false);
+            expect(ability.can('update', 'SavedChart')).toEqual(false);
+            expect(ability.can('update', 'Project')).toEqual(false);
+            expect(ability.can('update', 'Organization')).toEqual(false);
+            expect(ability.can('update', 'InviteLink')).toEqual(false);
+        });
+        it('cannot delete any resource', () => {
+            expect(ability.can('delete', 'Space')).toEqual(false);
+            expect(ability.can('delete', 'Dashboard')).toEqual(false);
+            expect(ability.can('delete', 'SavedChart')).toEqual(false);
+            expect(ability.can('delete', 'Project')).toEqual(false);
+            expect(ability.can('delete', 'Organization')).toEqual(false);
+            expect(ability.can('delete', 'InviteLink')).toEqual(false);
+        });
+        it('can view their own organization', () => {
+            const org = { organizationUuid: '456' };
+            expect(ability.can('view', subject('Organization', org))).toEqual(
+                true,
+            );
+        });
+        it('cannot view another organization', () => {
+            const org = { organizationUuid: '789' };
+            expect(ability.can('view', subject('Organization', org))).toEqual(
+                false,
+            );
+        });
+
+        it('can view dashboards from their own organization', () => {
+            const org = { organizationUuid: '456' };
+            expect(ability.can('view', subject('Dashboard', org))).toEqual(
+                true,
+            );
+        });
+        it('cannot view dashboards from another organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', { organizationUuid: '789' }),
+                ),
+            ).toEqual(false);
+        });
+        it('can view savedCharts from their own organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('SavedChart', { organizationUuid: '456' }),
+                ),
+            ).toEqual(true);
+        });
+        it('cannot view savedCharts from another organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('SavedChart', { organizationUuid: '789' }),
+                ),
+            ).toEqual(false);
+        });
+        it('can view projects from their own organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Project', { organizationUuid: '456' }),
+                ),
+            ).toEqual(true);
+        });
+        it('cannot view projects from another organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Project', { organizationUuid: '789' }),
+                ),
+            ).toEqual(false);
+        });
+        it('can view their own jobs', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Job', {
+                        userUuid: ORGANIZATION_INTERACTIVE_VIEWER.userUuid,
+                    }),
                 ),
             ).toEqual(true);
         });

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -44,6 +44,24 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
     },
+    interactive_viewer(member, { can }) {
+        organizationMemberAbilities.member(member, { can });
+        can('view', 'Dashboard', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'Space', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'SavedChart', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'Project', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'Organization', {
+            organizationUuid: member.organizationUuid,
+        });
+    },
     editor(member, { can }) {
         organizationMemberAbilities.viewer(member, { can });
         can('manage', 'Dashboard', {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -20,11 +20,6 @@ export const organizationMemberAbilities: Record<
         can('view', 'OrganizationMemberProfile', {
             organizationUuid: member.organizationUuid,
         });
-        can('create', 'Project', {
-            organizationUuid: member.organizationUuid,
-        });
-        can('create', 'Job');
-        can('view', 'Job', { userUuid: member.userUuid });
     },
     viewer(member, { can }) {
         organizationMemberAbilities.member(member, { can });
@@ -45,25 +40,24 @@ export const organizationMemberAbilities: Record<
         });
     },
     interactive_viewer(member, { can }) {
-        organizationMemberAbilities.member(member, { can });
-        can('view', 'Dashboard', {
+        organizationMemberAbilities.viewer(member, { can });
+        can('create', 'Project', {
             organizationUuid: member.organizationUuid,
         });
-        can('view', 'Space', {
+        can('create', 'Job');
+        can('view', 'Job', { userUuid: member.userUuid });
+        can('view', 'UnderlyingData', {
             organizationUuid: member.organizationUuid,
         });
-        can('view', 'SavedChart', {
+        can('manage', 'ExportCsv', {
             organizationUuid: member.organizationUuid,
         });
-        can('view', 'Project', {
-            organizationUuid: member.organizationUuid,
-        });
-        can('view', 'Organization', {
+        can('manage', 'Explore', {
             organizationUuid: member.organizationUuid,
         });
     },
     editor(member, { can }) {
-        organizationMemberAbilities.viewer(member, { can });
+        organizationMemberAbilities.interactive_viewer(member, { can });
         can('manage', 'Dashboard', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.mock.ts
+++ b/packages/common/src/authorization/projectMemberAbility.mock.ts
@@ -12,6 +12,11 @@ export const PROJECT_VIEWER: ProjectMemberProfile = {
     lastName: '',
 };
 
+export const PROJECT_INTERACTIVE_VIEWER: ProjectMemberProfile = {
+    ...PROJECT_VIEWER,
+    role: ProjectMemberRole.INTERACTIVE_VIEWER,
+};
+
 export const PROJECT_EDITOR: ProjectMemberProfile = {
     ...PROJECT_VIEWER,
     role: ProjectMemberRole.EDITOR,

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -4,6 +4,7 @@ import { projectMemberAbilities } from './projectMemberAbility';
 import {
     PROJECT_ADMIN,
     PROJECT_EDITOR,
+    PROJECT_INTERACTIVE_VIEWER,
     PROJECT_VIEWER,
 } from './projectMemberAbility.mock';
 import { MemberAbility } from './types';
@@ -124,6 +125,11 @@ describe('Project member permissions', () => {
                 ability.can('manage', subject('Project', { projectUuid })),
             ).toEqual(false);
         });
+        it('can download CSV', () => {
+            expect(
+                ability.can('manage', subject('ExportCsv', { projectUuid })),
+            ).toEqual(true);
+        });
     });
 
     describe('when user is a viewer', () => {
@@ -187,6 +193,100 @@ describe('Project member permissions', () => {
             expect(
                 ability.can('manage', subject('SqlRunner', { projectUuid })),
             ).toEqual(false);
+        });
+        it('cannot download CSV', () => {
+            expect(
+                ability.can('manage', subject('ExportCsv', { projectUuid })),
+            ).toEqual(false);
+        });
+        it('cannot Explore', () => {
+            expect(
+                ability.can('manage', subject('Explore', { projectUuid })),
+            ).toEqual(false);
+        });
+        it('cannot view underlying data', () => {
+            expect(
+                ability.can('view', subject('UnderlyingData', { projectUuid })),
+            ).toEqual(false);
+        });
+    });
+
+    describe('when user is a interactive viewer', () => {
+        beforeEach(() => {
+            ability = defineAbilityForProjectMember(PROJECT_INTERACTIVE_VIEWER);
+        });
+
+        it('can view resources', () => {
+            expect(
+                ability.can('view', subject('SavedChart', { projectUuid })),
+            ).toEqual(true);
+            expect(
+                ability.can('view', subject('Dashboard', { projectUuid })),
+            ).toEqual(true);
+            expect(
+                ability.can('view', subject('Space', { projectUuid })),
+            ).toEqual(true);
+            expect(
+                ability.can('view', subject('Project', { projectUuid })),
+            ).toEqual(true);
+        });
+        it('cannot view resources from another project', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('SavedChart', { projectUuid: '5678' }),
+                ),
+            ).toEqual(false);
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', { projectUuid: '5678' }),
+                ),
+            ).toEqual(false);
+            expect(
+                ability.can('view', subject('Space', { projectUuid: '5678' })),
+            ).toEqual(false);
+            expect(
+                ability.can(
+                    'view',
+                    subject('Project', { projectUuid: '5678' }),
+                ),
+            ).toEqual(false);
+        });
+        it('cannot manage resources', () => {
+            expect(
+                ability.can('manage', subject('SavedChart', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can('manage', subject('Dashboard', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can('manage', subject('Space', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can('manage', subject('Project', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can('manage', subject('Job', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can('manage', subject('SqlRunner', { projectUuid })),
+            ).toEqual(false);
+        });
+        it('can download CSV', () => {
+            expect(
+                ability.can('manage', subject('ExportCsv', { projectUuid })),
+            ).toEqual(true);
+        });
+        it('can Explore', () => {
+            expect(
+                ability.can('manage', subject('Explore', { projectUuid })),
+            ).toEqual(true);
+        });
+        it('can view underlying data', () => {
+            expect(
+                ability.can('view', subject('UnderlyingData', { projectUuid })),
+            ).toEqual(true);
         });
     });
 });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -28,7 +28,9 @@ export const projectMemberAbilities: Record<
         });
     },
     interactive_viewer(member, { can }) {
-        can('manage', 'UnderlyingData', {
+        projectMemberAbilities.viewer(member, { can });
+
+        can('view', 'UnderlyingData', {
             projectUuid: member.projectUuid,
         });
         can('manage', 'ExportCsv', {
@@ -39,7 +41,7 @@ export const projectMemberAbilities: Record<
         });
     },
     editor(member, { can }) {
-        projectMemberAbilities.viewer(member, { can });
+        projectMemberAbilities.interactive_viewer(member, { can });
         can('manage', 'Dashboard', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -27,6 +27,17 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
     },
+    interactive_viewer(member, { can }) {
+        can('manage', 'UnderlyingData', {
+            projectUuid: member.projectUuid,
+        });
+        can('manage', 'ExportCsv', {
+            projectUuid: member.projectUuid,
+        });
+        can('manage', 'Explore', {
+            projectUuid: member.projectUuid,
+        });
+    },
     editor(member, { can }) {
         projectMemberAbilities.viewer(member, { can });
         can('manage', 'Dashboard', {

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -26,6 +26,9 @@ type Subject =
     | 'Job'
     | 'SqlRunner'
     | 'Analytics'
+    | 'Explore'
+    | 'UnderlyingData'
+    | 'ExportCsv'
     | 'all';
 
 type PossibleAbilities = [

--- a/packages/common/src/openapi/openapi.json
+++ b/packages/common/src/openapi/openapi.json
@@ -61,15 +61,6 @@
         "/projects/{projectUuid}/explores/{tableId}/runQuery": {
             "$ref": "./paths/projectRunQuery.json"
         },
-        "/projects/{projectUuid}/explores/{tableId}/runDashboardTileQuery": {
-            "$ref": "./paths/projectRunQuery.json"
-        },
-        "/projects/{projectUuid}/explores/{tableId}/runViewChartQuery": {
-            "$ref": "./paths/projectRunQuery.json"
-        },
-        "/projects/{projectUuid}/explores/{tableId}/runUnderlyingDataQuery": {
-            "$ref": "./paths/projectRunQuery.json"
-        },
         "/projects/{projectUuid}/catalog": {
             "$ref": "./paths/projectCatalog.json"
         },

--- a/packages/common/src/openapi/openapi.json
+++ b/packages/common/src/openapi/openapi.json
@@ -61,6 +61,15 @@
         "/projects/{projectUuid}/explores/{tableId}/runQuery": {
             "$ref": "./paths/projectRunQuery.json"
         },
+        "/projects/{projectUuid}/explores/{tableId}/runDashboardTileQuery": {
+            "$ref": "./paths/projectRunQuery.json"
+        },
+        "/projects/{projectUuid}/explores/{tableId}/runViewChartQuery": {
+            "$ref": "./paths/projectRunQuery.json"
+        },
+        "/projects/{projectUuid}/explores/{tableId}/runUnderlyingDataQuery": {
+            "$ref": "./paths/projectRunQuery.json"
+        },
         "/projects/{projectUuid}/catalog": {
             "$ref": "./paths/projectCatalog.json"
         },

--- a/packages/common/src/openapi/schemas/Dashboard.json
+++ b/packages/common/src/openapi/schemas/Dashboard.json
@@ -33,7 +33,7 @@
             "type": "string"
         },
         "updatedByUser": {
-            "$ref": "../Schemas/UpdatedByUser.json"
+            "$ref": "./UpdatedByUser.json"
         },
         "pinnedListUuid": {
             "type": "string"

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -618,282 +618,6 @@
                 }
             }
         },
-        "/projects/{projectUuid}/explores/{tableId}/runDashboardTileQuery": {
-            "post": {
-                "summary": "Run query",
-                "description": "Run a query on project",
-                "tags": ["project"],
-                "operationId": "runQuery",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "path",
-                        "name": "tableId",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "requestBody": {
-                    "description": "query",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "metrics": {
-                                        "type": "array"
-                                    },
-                                    "dimensions": {
-                                        "type": "array"
-                                    },
-                                    "limit": {
-                                        "type": "number"
-                                    },
-                                    "sorts": {
-                                        "type": "array"
-                                    },
-                                    "tableCalculations": {
-                                        "type": "array"
-                                    }
-                                },
-                                "required": ["metrics", "dimensions"]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successfully ran query",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/Success"
-                                        },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "results": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "rows": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "$ref": "#/components/schemas/QueryResult"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "required": ["results"]
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "$ref": "#/components/responses/ErrorResponse"
-                    }
-                }
-            }
-        },
-        "/projects/{projectUuid}/explores/{tableId}/runViewChartQuery": {
-            "post": {
-                "summary": "Run query",
-                "description": "Run a query on project",
-                "tags": ["project"],
-                "operationId": "runQuery",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "path",
-                        "name": "tableId",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "requestBody": {
-                    "description": "query",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "metrics": {
-                                        "type": "array"
-                                    },
-                                    "dimensions": {
-                                        "type": "array"
-                                    },
-                                    "limit": {
-                                        "type": "number"
-                                    },
-                                    "sorts": {
-                                        "type": "array"
-                                    },
-                                    "tableCalculations": {
-                                        "type": "array"
-                                    }
-                                },
-                                "required": ["metrics", "dimensions"]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successfully ran query",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/Success"
-                                        },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "results": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "rows": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "$ref": "#/components/schemas/QueryResult"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "required": ["results"]
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "$ref": "#/components/responses/ErrorResponse"
-                    }
-                }
-            }
-        },
-        "/projects/{projectUuid}/explores/{tableId}/runUnderlyingDataQuery": {
-            "post": {
-                "summary": "Run query",
-                "description": "Run a query on project",
-                "tags": ["project"],
-                "operationId": "runQuery",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "required": true
-                    },
-                    {
-                        "in": "path",
-                        "name": "tableId",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    }
-                ],
-                "requestBody": {
-                    "description": "query",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "metrics": {
-                                        "type": "array"
-                                    },
-                                    "dimensions": {
-                                        "type": "array"
-                                    },
-                                    "limit": {
-                                        "type": "number"
-                                    },
-                                    "sorts": {
-                                        "type": "array"
-                                    },
-                                    "tableCalculations": {
-                                        "type": "array"
-                                    }
-                                },
-                                "required": ["metrics", "dimensions"]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successfully ran query",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/Success"
-                                        },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "results": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "rows": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "$ref": "#/components/schemas/QueryResult"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "required": ["results"]
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "$ref": "#/components/responses/ErrorResponse"
-                    }
-                }
-            }
-        },
         "/projects/{projectUuid}/catalog": {
             "get": {
                 "summary": "Get project catalog",
@@ -2267,6 +1991,13 @@
                     "spaceName": {
                         "type": "string"
                     },
+                    "views": {
+                        "type": "number"
+                    },
+                    "firstViewedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "updatedByUser": {
                         "$ref": "#/components/schemas/UpdatedByUser"
                     },
@@ -2432,6 +2163,13 @@
                     },
                     "pinnedListUuid": {
                         "type": "string"
+                    },
+                    "views": {
+                        "type": "number"
+                    },
+                    "firstViewedAt": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [

--- a/packages/common/src/openapibundle.json
+++ b/packages/common/src/openapibundle.json
@@ -618,6 +618,282 @@
                 }
             }
         },
+        "/projects/{projectUuid}/explores/{tableId}/runDashboardTileQuery": {
+            "post": {
+                "summary": "Run query",
+                "description": "Run a query on project",
+                "tags": ["project"],
+                "operationId": "runQuery",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "tableId",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "requestBody": {
+                    "description": "query",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "metrics": {
+                                        "type": "array"
+                                    },
+                                    "dimensions": {
+                                        "type": "array"
+                                    },
+                                    "limit": {
+                                        "type": "number"
+                                    },
+                                    "sorts": {
+                                        "type": "array"
+                                    },
+                                    "tableCalculations": {
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["metrics", "dimensions"]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successfully ran query",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "results": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "rows": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/QueryResult"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/projects/{projectUuid}/explores/{tableId}/runViewChartQuery": {
+            "post": {
+                "summary": "Run query",
+                "description": "Run a query on project",
+                "tags": ["project"],
+                "operationId": "runQuery",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "tableId",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "requestBody": {
+                    "description": "query",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "metrics": {
+                                        "type": "array"
+                                    },
+                                    "dimensions": {
+                                        "type": "array"
+                                    },
+                                    "limit": {
+                                        "type": "number"
+                                    },
+                                    "sorts": {
+                                        "type": "array"
+                                    },
+                                    "tableCalculations": {
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["metrics", "dimensions"]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successfully ran query",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "results": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "rows": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/QueryResult"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
+        "/projects/{projectUuid}/explores/{tableId}/runUnderlyingDataQuery": {
+            "post": {
+                "summary": "Run query",
+                "description": "Run a query on project",
+                "tags": ["project"],
+                "operationId": "runQuery",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "tableId",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "requestBody": {
+                    "description": "query",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "metrics": {
+                                        "type": "array"
+                                    },
+                                    "dimensions": {
+                                        "type": "array"
+                                    },
+                                    "limit": {
+                                        "type": "number"
+                                    },
+                                    "sorts": {
+                                        "type": "array"
+                                    },
+                                    "tableCalculations": {
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["metrics", "dimensions"]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successfully ran query",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Success"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "results": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "rows": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/QueryResult"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "required": ["results"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/ErrorResponse"
+                    }
+                }
+            }
+        },
         "/projects/{projectUuid}/catalog": {
             "get": {
                 "summary": "Get project catalog",
@@ -1991,13 +2267,6 @@
                     "spaceName": {
                         "type": "string"
                     },
-                    "views": {
-                        "type": "number"
-                    },
-                    "firstViewedAt": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "updatedByUser": {
                         "$ref": "#/components/schemas/UpdatedByUser"
                     },
@@ -2163,13 +2432,6 @@
                     },
                     "pinnedListUuid": {
                         "type": "string"
-                    },
-                    "views": {
-                        "type": "number"
-                    },
-                    "firstViewedAt": {
-                        "type": "string",
-                        "nullable": true
                     }
                 },
                 "required": [

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -1,6 +1,7 @@
 export enum OrganizationMemberRole {
     MEMBER = 'member',
     VIEWER = 'viewer',
+    INTERACTIVE_VIEWER = 'interactive_viewer',
     EDITOR = 'editor',
     ADMIN = 'admin',
 }

--- a/packages/common/src/types/projectMemberProfile.ts
+++ b/packages/common/src/types/projectMemberProfile.ts
@@ -1,5 +1,6 @@
 export enum ProjectMemberRole {
     VIEWER = 'viewer',
+    INTERACTIVE_VIEWER = 'interactive_viewer',
     EDITOR = 'editor',
     ADMIN = 'admin',
 }

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -226,3 +226,138 @@ describe('Lightdash API organization permission tests', () => {
         );
     });
 });
+
+describe('Lightdash API tests for viewer org user', () => {
+    let email;
+
+    before(() => {
+        cy.loginWithPermissions('viewer', []).then((e) => {
+            email = e;
+        });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
+    });
+    it('Should identify user', () => {
+        cy.request(`${apiUrl}/user`).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.have.property('email', email);
+            expect(resp.body.results).to.have.property('role', 'viewer');
+        });
+    });
+
+    it('Should get success response (200) from GET public endpoints', () => {
+        const endpoints = ['/livez', '/health', '/flash'];
+        endpoints.forEach((endpoint) => {
+            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body).to.have.property('status', 'ok');
+            });
+        });
+    });
+
+    it('Should get success response (200) from GET org', () => {
+        const endpoint = `${apiUrl}/org/`;
+
+        cy.request({
+            url: endpoint,
+            headers: { 'Content-type': 'application/json' },
+            method: 'GET',
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+        });
+    });
+
+    it('Should get a forbidden (403) from POST project', () => {
+        const endpoint = `${apiUrl}/org/projects/`;
+
+        cy.request({
+            url: endpoint,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: {},
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(403);
+        });
+    });
+
+    it('Should get success response (200) from GET userRouter endpoints', () => {
+        const endpoints = [`/user`, `/user/identities`];
+        endpoints.forEach((endpoint) => {
+            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body).to.have.property('status', 'ok');
+            });
+        });
+    });
+});
+
+describe('Lightdash API tests for interactive_viewer org user', () => {
+    let email;
+
+    before(() => {
+        cy.loginWithPermissions('interactive_viewer', []).then((e) => {
+            email = e;
+        });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
+    });
+    it('Should identify user', () => {
+        cy.request(`${apiUrl}/user`).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.have.property('email', email);
+            expect(resp.body.results).to.have.property(
+                'role',
+                'interactive_viewer',
+            );
+        });
+    });
+
+    it('Should get success response (200) from GET public endpoints', () => {
+        const endpoints = ['/livez', '/health', '/flash'];
+        endpoints.forEach((endpoint) => {
+            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body).to.have.property('status', 'ok');
+            });
+        });
+    });
+
+    it('Should get success response (200) from GET org', () => {
+        const endpoint = `${apiUrl}/org/`;
+
+        cy.request({
+            url: endpoint,
+            headers: { 'Content-type': 'application/json' },
+            method: 'GET',
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+        });
+    });
+
+    it('Should get a credentials error (500) from POST project', () => {
+        const endpoint = `${apiUrl}/org/projects/`;
+
+        cy.request({
+            url: endpoint,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: {},
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(500);
+        });
+    });
+
+    it('Should get success response (200) from GET userRouter endpoints', () => {
+        const endpoints = [`/user`, `/user/identities`];
+        endpoints.forEach((endpoint) => {
+            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body).to.have.property('status', 'ok');
+            });
+        });
+    });
+});

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -557,7 +557,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
             expect(resp.body).to.have.property('status', 'ok');
         });
     });
-    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+    it('Should get success response (200) from POST runDashboardTileQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         const endpoint = `/projects/${projectUuid}/explores/customers/runDashboardTileQuery`;
@@ -572,7 +572,20 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         });
     });
 
-    // TODO add view mode endpoint
+    it('Should get success response (200) from POST runViewChartQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runViewChartQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
 
     it('Should get forbidden (403) from POST sqlQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
@@ -749,7 +762,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         });
     });
 
-    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+    it('Should get success response (200) from POST runDashboardTileQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         const endpoint = `/projects/${projectUuid}/explores/customers/runDashboardTileQuery`;
@@ -763,8 +776,20 @@ describe('Lightdash API tests for member user with viewer project permissions', 
             expect(resp.body).to.have.property('status', 'ok');
         });
     });
+    it('Should get success response (200) from POST runViewChartQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
 
-    // TODO add view mode endpoint
+        const endpoint = `/projects/${projectUuid}/explores/customers/runViewChartQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
 
     it('Should get forbidden (403) from POST sqlQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -14,7 +14,7 @@ const runqueryBody = {
 const sqlQueryBody = { sql: 'select 1' };
 describe('Lightdash API tests for member user with admin project permissions', () => {
     let email;
-    beforeEach(() => {
+    before(() => {
         cy.loginWithPermissions('member', [
             {
                 role: 'admin',
@@ -23,6 +23,9 @@ describe('Lightdash API tests for member user with admin project permissions', (
         ]).then((e) => {
             email = e;
         });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
     });
     it('Should identify user', () => {
         cy.request(`${apiUrl}/user`).then((resp) => {
@@ -92,6 +95,20 @@ describe('Lightdash API tests for member user with admin project permissions', (
         });
     });
 
+    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runUnderlyingDataQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
     it('Should get success response (200) from POST sqlQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
@@ -236,7 +253,8 @@ describe('Lightdash API tests for member user with admin project permissions', (
 
 describe('Lightdash API tests for member user with editor project permissions', () => {
     let email;
-    beforeEach(() => {
+
+    before(() => {
         cy.loginWithPermissions('member', [
             {
                 role: 'editor',
@@ -245,6 +263,9 @@ describe('Lightdash API tests for member user with editor project permissions', 
         ]).then((e) => {
             email = e;
         });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
     });
     it('Should identify user', () => {
         cy.request(`${apiUrl}/user`).then((resp) => {
@@ -313,7 +334,21 @@ describe('Lightdash API tests for member user with editor project permissions', 
             expect(resp.body).to.have.property('status', 'ok');
         });
     });
+    it('Should get success response (200) from POST downloadCsv', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
 
+        const endpoint = `/projects/${projectUuid}/explores/customers/downloadCsv`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            cy.log(`resp.body ${JSON.stringify(resp.body)}`);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
     it('Should get success response (200) from POST sqlQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
@@ -456,9 +491,142 @@ describe('Lightdash API tests for member user with editor project permissions', 
     });
 });
 
+describe('Lightdash API tests for member user with interactive_viewer project permissions', () => {
+    let email;
+
+    before(() => {
+        cy.loginWithPermissions('member', [
+            {
+                role: 'interactive_viewer',
+                projectUuid: SEED_PROJECT.project_uuid,
+            },
+        ]).then((e) => {
+            email = e;
+        });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
+    });
+    it('Should identify user', () => {
+        cy.request(`${apiUrl}/user`).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.have.property('email', email);
+            expect(resp.body.results).to.have.property('role', 'member');
+        });
+    });
+
+    it('Should get success response (200) from POST runQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
+    it('Should get success response (200) from POST downloadCsv', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/downloadCsv`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
+    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runUnderlyingDataQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
+    // TODO add dashboard endpoint
+    // TODO add view mode endpoint
+
+    it('Should get forbidden (403) from POST sqlQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/sqlQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: sqlQueryBody,
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(403);
+        });
+    });
+
+    it('Should get a forbidden (403) from PATCH project', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `${apiUrl}/projects/${projectUuid}`;
+
+        // Fetch the existing project first and patching with the same data
+        cy.request(endpoint).then((projectResponse) => {
+            expect(projectResponse.status).to.eq(200);
+
+            cy.request({
+                url: endpoint,
+                headers: { 'Content-type': 'application/json' },
+                method: 'PATCH',
+                body: projectResponse.body.results,
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(403);
+            });
+        });
+    });
+
+    it('Should get a forbidden (403) from PATCH dashboard', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        cy.request(`${apiUrl}/projects/${projectUuid}/dashboards`).then(
+            (projectResponse) => {
+                expect(projectResponse.status).to.eq(200);
+
+                const dashboardUuid = projectResponse.body.results[0].uuid;
+                const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
+
+                cy.request({
+                    url: endpoint,
+                    headers: { 'Content-type': 'application/json' },
+                    method: 'PATCH',
+                    body: {
+                        name: 'test',
+                        tiles: [],
+                        filters: { dimensions: [], metrics: [] },
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(403);
+                });
+            },
+        );
+    });
+});
+
 describe('Lightdash API tests for member user with viewer project permissions', () => {
     let email;
-    beforeEach(() => {
+
+    before(() => {
         cy.loginWithPermissions('member', [
             {
                 role: 'viewer',
@@ -467,6 +635,9 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         ]).then((e) => {
             email = e;
         });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
     });
     it('Should identify user', () => {
         cy.request(`${apiUrl}/user`).then((resp) => {
@@ -521,7 +692,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         );
     });
 
-    it('Should get success response (200) from POST runQuery', () => {
+    it('Should get forbidden (403) from POST runQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         const endpoint = `/projects/${projectUuid}/explores/customers/runQuery`;
@@ -530,11 +701,41 @@ describe('Lightdash API tests for member user with viewer project permissions', 
             headers: { 'Content-type': 'application/json' },
             method: 'POST',
             body: runqueryBody,
+            failOnStatusCode: false,
         }).then((resp) => {
-            expect(resp.status).to.eq(200);
-            expect(resp.body).to.have.property('status', 'ok');
+            expect(resp.status).to.eq(403);
         });
     });
+    it('Should get forbidden (403) from POST downloadCsv', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/downloadCsv`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(403);
+        });
+    });
+    it('Should get forbidden (403) from POST runUnderlyingDataQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runUnderlyingDataQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(403);
+        });
+    });
+    // TODO add dashboard endpoint
+    // TODO add view mode endpoint
 
     it('Should get forbidden (403) from POST sqlQuery', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
@@ -572,7 +773,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         });
     });
 
-    it('Should get success response (200) from PATCH dashboard', () => {
+    it('Should get a forbidden (403) from PATCH dashboard', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         cy.request(`${apiUrl}/projects/${projectUuid}/dashboards`).then(
             (projectResponse) => {
@@ -671,10 +872,14 @@ describe('Lightdash API tests for member user with viewer project permissions', 
 
 describe('Lightdash API tests for member user with NO project permissions', () => {
     let email;
-    beforeEach(() => {
+
+    before(() => {
         cy.loginWithPermissions('member', []).then((e) => {
             email = e;
         });
+    });
+    beforeEach(() => {
+        cy.loginWithEmail(email);
     });
     it('Should identify user', () => {
         cy.request(`${apiUrl}/user`).then((resp) => {

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -557,7 +557,21 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
             expect(resp.body).to.have.property('status', 'ok');
         });
     });
-    // TODO add dashboard endpoint
+    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runDashboardTileQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
+
     // TODO add view mode endpoint
 
     it('Should get forbidden (403) from POST sqlQuery', () => {
@@ -734,7 +748,22 @@ describe('Lightdash API tests for member user with viewer project permissions', 
             expect(resp.status).to.eq(403);
         });
     });
-    // TODO add dashboard endpoint
+
+    it('Should get success response (200) from POST runUnderlyingDataQuery', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `/projects/${projectUuid}/explores/customers/runDashboardTileQuery`;
+        cy.request({
+            url: `${apiUrl}${endpoint}`,
+            headers: { 'Content-type': 'application/json' },
+            method: 'POST',
+            body: runqueryBody,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.have.property('status', 'ok');
+        });
+    });
+
     // TODO add view mode endpoint
 
     it('Should get forbidden (403) from POST sqlQuery', () => {

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -47,6 +47,7 @@ declare global {
                 orgRole,
                 projectPermissions,
             ): Chainable<Element>;
+            loginWithEmail: (email) => Chainable<Element>;
             getApiToken(): Chainable<string>;
         }
     }
@@ -214,6 +215,24 @@ Cypress.Commands.add(
     },
 );
 
+Cypress.Commands.add('loginWithEmail', (email: string) => {
+    cy.session(
+        email,
+        () => {
+            cy.request({
+                url: 'api/v1/login',
+                method: 'POST',
+                body: {
+                    email,
+                    password: 'test',
+                },
+            })
+                .its('status')
+                .should('eq', 200);
+        },
+        {},
+    );
+});
 Cypress.Commands.add('getApiToken', () => {
     cy.request({
         url: `api/v1/user/me/personal-access-tokens`,

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -7,6 +7,7 @@ import {
     PopoverPosition,
 } from '@blueprintjs/core';
 import { Classes, Popover2 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import {
     ChartType,
     getCustomLabelsFromColumnProperties,
@@ -15,6 +16,8 @@ import EChartsReact from 'echarts-for-react';
 import JsPDF from 'jspdf';
 import React, { memo, RefObject, useCallback, useState } from 'react';
 import useEcharts from '../hooks/echarts/useEcharts';
+import { useApp } from '../providers/AppProvider';
+import { Can } from './common/Authorization';
 import ExportCSV from './ExportCSV';
 import { useVisualizationContext } from './LightdashVisualization/VisualizationProvider';
 
@@ -225,33 +228,41 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             chartType === ChartType.BIG_NUMBER ||
             (chartType === ChartType.CARTESIAN && !eChartsOptions);
 
+        const { user } = useApp();
         return chartType === ChartType.TABLE && getCsvLink ? (
-            <Popover2
-                lazy
-                position={PopoverPosition.BOTTOM_LEFT}
-                popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-                content={
-                    <ExportCSV
-                        getCsvLink={async (
-                            limit: number | null,
-                            onlyRaw: boolean,
-                        ) =>
-                            getCsvLink(
-                                limit,
-                                onlyRaw,
-                                showTableNames,
-                                columnOrder,
-                                getCustomLabelsFromColumnProperties(
-                                    columnProperties,
-                                ),
-                            )
-                        }
-                        rows={rows}
-                    />
-                }
+            <Can
+                I="manage"
+                this={subject('ExportCsv', {
+                    organizationUuid: user.data?.organizationUuid,
+                })}
             >
-                <Button text="Export CSV" rightIcon="caret-down" minimal />
-            </Popover2>
+                <Popover2
+                    lazy
+                    position={PopoverPosition.BOTTOM_LEFT}
+                    popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+                    content={
+                        <ExportCSV
+                            getCsvLink={async (
+                                limit: number | null,
+                                onlyRaw: boolean,
+                            ) =>
+                                getCsvLink(
+                                    limit,
+                                    onlyRaw,
+                                    showTableNames,
+                                    columnOrder,
+                                    getCustomLabelsFromColumnProperties(
+                                        columnProperties,
+                                    ),
+                                )
+                            }
+                            rows={rows}
+                        />
+                    }
+                >
+                    <Button text="Export CSV" rightIcon="caret-down" minimal />
+                </Popover2>
+            </Can>
         ) : chartType === ChartType.TABLE && !getCsvLink ? null : (
             <Popover2
                 lazy

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -5,6 +5,7 @@ import {
     Popover2TargetProps,
     Tooltip2,
 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import {
     ChartType,
     DashboardChartTile as IDashboardChartTile,
@@ -61,6 +62,7 @@ import {
     GlobalTileStyles,
 } from './TileBase/TileBase.styles';
 
+import { Can } from '../common/Authorization';
 interface ExportResultAsCSVModalProps {
     projectUuid: string;
     savedChart: SavedChart;
@@ -421,7 +423,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 description={savedQueryWithDashboardFilters?.description}
                 isLoading={isLoading || isLoadingExplore}
                 extraMenuItems={
-                    savedChartUuid !== null && (
+                    savedChartUuid !== null &&
+                    user.data?.ability?.can('manage', 'Explore') && (
                         <>
                             {user.data?.ability?.can(
                                 'manage',
@@ -482,64 +485,85 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                 />
                                             </CopyToClipboard>
                                         )}
-
-                                        <MenuItem2
-                                            text={`View underlying data`}
-                                            icon={'layers'}
-                                            onClick={(e) => {
-                                                if (
-                                                    viewUnderlyingDataOptions !==
-                                                    undefined
-                                                ) {
-                                                    const {
-                                                        value,
-                                                        meta,
-                                                        row,
-                                                        dimensions,
-                                                        pivotReference,
-                                                    } = viewUnderlyingDataOptions;
-                                                    openUnderlyingDataModel(
-                                                        value,
-                                                        meta,
-                                                        row,
-                                                        dimensions,
-                                                        pivotReference,
-                                                        dashboardFiltersThatApplyToChart,
-                                                    );
-                                                    track({
-                                                        name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                                        properties: {
-                                                            organizationId:
-                                                                user?.data
-                                                                    ?.organizationUuid,
-                                                            userId: user?.data
-                                                                ?.userUuid,
-                                                            projectId:
-                                                                projectUuid,
-                                                        },
-                                                    });
-                                                }
-                                            }}
-                                        />
-                                        <DrillDownMenuItem
-                                            row={viewUnderlyingDataOptions?.row}
-                                            selectedItem={
-                                                viewUnderlyingDataOptions?.meta
-                                                    ?.item
-                                            }
-                                            pivotReference={
-                                                viewUnderlyingDataOptions?.pivotReference
-                                            }
-                                            dashboardFilters={
-                                                dashboardFiltersThatApplyToChart
-                                            }
-                                            trackingData={{
-                                                organizationId:
+                                        <Can
+                                            I="view"
+                                            this={subject('UnderlyingData', {
+                                                organizationUuid:
                                                     user.data?.organizationUuid,
-                                                userId: user.data?.userUuid,
-                                                projectId: projectUuid,
-                                            }}
-                                        />
+                                                projectUuid: projectUuid,
+                                            })}
+                                        >
+                                            <MenuItem2
+                                                text={`View underlying data`}
+                                                icon={'layers'}
+                                                onClick={(e) => {
+                                                    if (
+                                                        viewUnderlyingDataOptions !==
+                                                        undefined
+                                                    ) {
+                                                        const {
+                                                            value,
+                                                            meta,
+                                                            row,
+                                                            dimensions,
+                                                            pivotReference,
+                                                        } = viewUnderlyingDataOptions;
+                                                        openUnderlyingDataModel(
+                                                            value,
+                                                            meta,
+                                                            row,
+                                                            dimensions,
+                                                            pivotReference,
+                                                            dashboardFiltersThatApplyToChart,
+                                                        );
+                                                        track({
+                                                            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+                                                            properties: {
+                                                                organizationId:
+                                                                    user?.data
+                                                                        ?.organizationUuid,
+                                                                userId: user
+                                                                    ?.data
+                                                                    ?.userUuid,
+                                                                projectId:
+                                                                    projectUuid,
+                                                            },
+                                                        });
+                                                    }
+                                                }}
+                                            />
+                                        </Can>
+                                        <Can
+                                            I="manage"
+                                            this={subject('Explore', {
+                                                organizationUuid:
+                                                    user.data?.organizationUuid,
+                                                projectUuid: projectUuid,
+                                            })}
+                                        >
+                                            <DrillDownMenuItem
+                                                row={
+                                                    viewUnderlyingDataOptions?.row
+                                                }
+                                                selectedItem={
+                                                    viewUnderlyingDataOptions
+                                                        ?.meta?.item
+                                                }
+                                                pivotReference={
+                                                    viewUnderlyingDataOptions?.pivotReference
+                                                }
+                                                dashboardFilters={
+                                                    dashboardFiltersThatApplyToChart
+                                                }
+                                                trackingData={{
+                                                    organizationId:
+                                                        user.data
+                                                            ?.organizationUuid,
+                                                    userId: user.data?.userUuid,
+                                                    projectId: projectUuid,
+                                                }}
+                                            />
+                                        </Can>
                                         <MenuItem2
                                             icon="filter"
                                             text="Filter dashboard to..."

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -1,4 +1,5 @@
 import { Intent, NonIdealState, PopoverPosition } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
 import { Dashboard } from '@lightdash/common';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
@@ -6,6 +7,7 @@ import { useSavedCharts } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
+import { Can } from '../../common/Authorization';
 import AddTileButton from '../AddTileButton';
 import {
     ButtonWrapper,
@@ -75,6 +77,8 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     const savedCharts = savedChartsRequest.data || [];
     const hasSavedCharts = savedCharts.length > 0;
 
+    const { user } = useApp();
+
     return (
         <TrackSection name={SectionName.EMPTY_RESULTS_TABLE}>
             <div style={{ padding: '50px 0' }}>
@@ -91,7 +95,16 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
                     }
                     action={
                         !hasSavedCharts ? (
-                            <RunQueryButton projectId={projectUuid} />
+                            <Can
+                                I="manage"
+                                this={subject('Explore', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid: projectUuid,
+                                })}
+                            >
+                                <RunQueryButton projectId={projectUuid} />
+                            </Can>
                         ) : undefined
                     }
                 />

--- a/packages/frontend/src/components/DownloadCsvButton/index.tsx
+++ b/packages/frontend/src/components/DownloadCsvButton/index.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
 import { ResultRow } from '@lightdash/common';
 import { FC, memo } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
+import { useApp } from '../../providers/AppProvider';
 
 type Props = {
     disabled: boolean;

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -1,5 +1,7 @@
+import { subject } from '@casl/ability';
 import { useMemo } from 'react';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import { useApp } from '../../providers/AppProvider';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
 import LinkButton from '../common/LinkButton';
 import { StyledLinkButton } from '../Home/LandingPanel/LandingPanel.styles';
@@ -19,6 +21,15 @@ const ExploreFromHereButton = () => {
         }
     }, [savedChart]);
 
+    const { user } = useApp();
+    const cannotManageExplore = user.data?.ability.cannot(
+        'manage',
+        subject('Explore', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid: savedChart?.projectUuid,
+        }),
+    );
+    if (cannotManageExplore) return null;
     if (!exploreFromHereUrl) return null;
 
     return (

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,15 +1,18 @@
 import { Button, PopoverPosition } from '@blueprintjs/core';
 import { Classes, Popover2 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { getResultValues } from '@lightdash/common';
 import { FC, memo, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { downloadCsv } from '../../../hooks/useDownloadCsv';
 import { getQueryResults } from '../../../hooks/useQueryResults';
+import { useApp } from '../../../providers/AppProvider';
 import {
     ExplorerSection,
     useExplorerContext,
 } from '../../../providers/ExplorerProvider';
 import AddColumnButton from '../../AddColumnButton';
+import { Can } from '../../common/Authorization';
 import CollapsableCard from '../../common/CollapsableCard';
 import ExportCSV from '../../ExportCSV';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
@@ -73,6 +76,7 @@ const ResultsCard: FC = memo(() => {
         () => toggleExpandedSection(ExplorerSection.RESULTS),
         [toggleExpandedSection],
     );
+    const { user } = useApp();
     return (
         <CollapsableCard
             title="Results"
@@ -99,23 +103,33 @@ const ResultsCard: FC = memo(() => {
                 tableName && (
                     <>
                         {isEditMode && <AddColumnButton />}
-                        <Popover2
-                            lazy
-                            position={PopoverPosition.BOTTOM_LEFT}
-                            popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-                            content={
-                                <ExportCSV
-                                    rows={rows}
-                                    getCsvLink={getCsvLink}
-                                />
-                            }
+                        <Can
+                            I="manage"
+                            this={subject('ExportCsv', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid: projectUuid,
+                            })}
                         >
-                            <Button
-                                text="Export CSV"
-                                rightIcon="caret-down"
-                                minimal
-                            />
-                        </Popover2>
+                            <Popover2
+                                lazy
+                                position={PopoverPosition.BOTTOM_LEFT}
+                                popoverClassName={
+                                    Classes.POPOVER2_CONTENT_SIZING
+                                }
+                                content={
+                                    <ExportCSV
+                                        rows={rows}
+                                        getCsvLink={getCsvLink}
+                                    />
+                                }
+                            >
+                                <Button
+                                    text="Export CSV"
+                                    rightIcon="caret-down"
+                                    minimal
+                                />
+                            </Popover2>
+                        </Can>
                     </>
                 )
             }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -4,6 +4,7 @@ import {
     Popover2,
     Popover2TargetProps,
 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { getItemMap } from '@lightdash/common';
 import React, {
     FC,
@@ -22,6 +23,7 @@ import { useApp } from '../../../providers/AppProvider';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
+import { Can } from '../../common/Authorization';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../../MetricQueryData/DrillDownMenuItem';
 import {
@@ -119,22 +121,30 @@ export const SeriesContextMenu: FC<{
             content={
                 <div onContextMenu={cancelContextMenu}>
                     <Menu>
-                        <MenuItem2
-                            text={`View underlying data`}
-                            icon={'layers'}
-                            onClick={() => {
-                                onViewUnderlyingData();
-                                track({
-                                    name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                    properties: {
-                                        organizationId:
-                                            user?.data?.organizationUuid,
-                                        userId: user?.data?.userUuid,
-                                        projectId: projectUuid,
-                                    },
-                                });
-                            }}
-                        />
+                        <Can
+                            I="view"
+                            this={subject('UnderlyingData', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid: projectUuid,
+                            })}
+                        >
+                            <MenuItem2
+                                text={`View underlying data`}
+                                icon={'layers'}
+                                onClick={() => {
+                                    onViewUnderlyingData();
+                                    track({
+                                        name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+                                        properties: {
+                                            organizationId:
+                                                user?.data?.organizationUuid,
+                                            userId: user?.data?.userUuid,
+                                            projectId: projectUuid,
+                                        },
+                                    });
+                                }}
+                            />
+                        </Can>
                         {underlyingData?.value && (
                             <CopyToClipboard
                                 text={underlyingData.value.formatted}
@@ -147,17 +157,25 @@ export const SeriesContextMenu: FC<{
                                 <MenuItem2 text="Copy value" icon="duplicate" />
                             </CopyToClipboard>
                         )}
-
-                        <DrillDownMenuItem
-                            row={underlyingData?.row}
-                            selectedItem={underlyingData?.meta?.item}
-                            pivotReference={underlyingData?.pivotReference}
-                            trackingData={{
-                                organizationId: user?.data?.organizationUuid,
-                                userId: user?.data?.userUuid,
-                                projectId: projectUuid,
-                            }}
-                        />
+                        <Can
+                            I="view"
+                            this={subject('Explore', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid: projectUuid,
+                            })}
+                        >
+                            <DrillDownMenuItem
+                                row={underlyingData?.row}
+                                selectedItem={underlyingData?.meta?.item}
+                                pivotReference={underlyingData?.pivotReference}
+                                trackingData={{
+                                    organizationId:
+                                        user?.data?.organizationUuid,
+                                    userId: user?.data?.userUuid,
+                                    projectId: projectUuid,
+                                }}
+                            />
+                        </Can>
                     </Menu>
                 </div>
             }

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,6 +1,9 @@
+import { subject } from '@casl/ability';
 import { Group, Stack, Text, Title } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
 import { FC } from 'react';
+import { useApp } from '../../../providers/AppProvider';
+import { Can } from '../../common/Authorization';
 import MantineLinkButton from '../../common/MantineLinkButton';
 
 interface Props {
@@ -9,6 +12,7 @@ interface Props {
 }
 
 const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
+    const { user } = useApp();
     return (
         <Group position="apart" my="xl" pt="xl">
             <Stack justify="flex-start" spacing="xs">
@@ -21,9 +25,17 @@ const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
                     below:
                 </Text>
             </Stack>
-            <MantineLinkButton href={`/projects/${projectUuid}/tables`}>
-                Run a query
-            </MantineLinkButton>
+            <Can
+                I="manage"
+                this={subject('Explore', {
+                    organizationUuid: user.data?.organizationUuid,
+                    projectUuid: projectUuid,
+                })}
+            >
+                <MantineLinkButton href={`/projects/${projectUuid}/tables`}>
+                    Run a query
+                </MantineLinkButton>
+            </Can>
         </Group>
     );
 };

--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -43,146 +43,161 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
 
     return (
         <>
-            <Popover2
-                isOpen={isOpen}
-                interactionKind={PopoverInteractionKind.CLICK}
-                onClose={() => setIsOpen(false)}
-                content={
-                    <Menu large>
-                        <LargeMenuItem
-                            icon={
-                                <LargeMenuItemIconWrapper>
-                                    <IconTable size={22} color={Colors.WHITE} />
-                                </LargeMenuItemIconWrapper>
-                            }
-                            href={`/projects/${projectUuid}/tables`}
-                            text={
-                                <>
-                                    <LargeMenuItemText>
-                                        Query from tables
-                                    </LargeMenuItemText>
-                                    <LargeMenuItemSubText>
-                                        Build queries and save them as charts.
-                                    </LargeMenuItemSubText>
-                                </>
-                            }
-                        />
-                        <Can
-                            I="manage"
-                            this={subject('SqlRunner', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <LargeMenuItem
-                                icon={
-                                    <LargeMenuItemIconWrapper>
-                                        <IconTerminal2
-                                            size={22}
-                                            color={Colors.WHITE}
-                                        />
-                                    </LargeMenuItemIconWrapper>
-                                }
-                                href={`/projects/${projectUuid}/sqlRunner`}
-                                onClick={() => setIsOpen(false)}
-                                text={
-                                    <>
-                                        <LargeMenuItemText>
-                                            Query using SQL runner
-                                        </LargeMenuItemText>
-                                        <LargeMenuItemSubText>
-                                            Access your database to run ad-hoc
-                                            queries.
-                                        </LargeMenuItemSubText>
-                                    </>
-                                }
-                            />
-                        </Can>
-                        <Can
-                            I="manage"
-                            this={subject('Dashboard', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <LargeMenuItem
-                                icon={
-                                    <LargeMenuItemIconWrapper>
-                                        <IconLayoutDashboard
-                                            size={22}
-                                            color={Colors.WHITE}
-                                        />
-                                    </LargeMenuItemIconWrapper>
-                                }
-                                onClick={() => {
-                                    setIsOpen(false);
-                                    setIsCreateDashboardOpen(true);
-                                }}
-                                text={
-                                    <>
-                                        <LargeMenuItemText>
-                                            Dashboard
-                                        </LargeMenuItemText>
-                                        <LargeMenuItemSubText>
-                                            Arrange multiple charts into a
-                                            single view.
-                                        </LargeMenuItemSubText>
-                                    </>
-                                }
-                            />
-                        </Can>
-                        <Can
-                            I="manage"
-                            this={subject('Space', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <LargeMenuItem
-                                icon={
-                                    <LargeMenuItemIconWrapper>
-                                        <IconFolder
-                                            size={22}
-                                            color={Colors.WHITE}
-                                        />
-                                    </LargeMenuItemIconWrapper>
-                                }
-                                onClick={() => {
-                                    setIsOpen(false);
-                                    setIsCreateSpaceOpen(true);
-                                }}
-                                text={
-                                    <>
-                                        <LargeMenuItemText>
-                                            Space
-                                        </LargeMenuItemText>
-                                        <LargeMenuItemSubText>
-                                            Organize your saved charts and
-                                            dashboards.
-                                        </LargeMenuItemSubText>
-                                    </>
-                                }
-                            />
-                        </Can>
-                    </Menu>
-                }
-                position={Position.BOTTOM_RIGHT}
+            {' '}
+            <Can
+                I="manage"
+                this={subject('Explore', {
+                    organizationUuid: user.data?.organizationUuid,
+                    projectUuid,
+                })}
             >
-                <Button
-                    minimal
-                    icon={
-                        <IconSquareRoundedPlus
-                            size={20}
-                            color={Colors.GRAY4}
-                            style={{ marginRight: '6px' }}
-                        />
+                <Popover2
+                    isOpen={isOpen}
+                    interactionKind={PopoverInteractionKind.CLICK}
+                    onClose={() => setIsOpen(false)}
+                    content={
+                        <Menu large>
+                            <LargeMenuItem
+                                icon={
+                                    <LargeMenuItemIconWrapper>
+                                        <IconTable
+                                            size={22}
+                                            color={Colors.WHITE}
+                                        />
+                                    </LargeMenuItemIconWrapper>
+                                }
+                                href={`/projects/${projectUuid}/tables`}
+                                text={
+                                    <>
+                                        <LargeMenuItemText>
+                                            Query from tables
+                                        </LargeMenuItemText>
+                                        <LargeMenuItemSubText>
+                                            Build queries and save them as
+                                            charts.
+                                        </LargeMenuItemSubText>
+                                    </>
+                                }
+                            />
+                            <Can
+                                I="manage"
+                                this={subject('SqlRunner', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <LargeMenuItem
+                                    icon={
+                                        <LargeMenuItemIconWrapper>
+                                            <IconTerminal2
+                                                size={22}
+                                                color={Colors.WHITE}
+                                            />
+                                        </LargeMenuItemIconWrapper>
+                                    }
+                                    href={`/projects/${projectUuid}/sqlRunner`}
+                                    onClick={() => setIsOpen(false)}
+                                    text={
+                                        <>
+                                            <LargeMenuItemText>
+                                                Query using SQL runner
+                                            </LargeMenuItemText>
+                                            <LargeMenuItemSubText>
+                                                Access your database to run
+                                                ad-hoc queries.
+                                            </LargeMenuItemSubText>
+                                        </>
+                                    }
+                                />
+                            </Can>
+                            <Can
+                                I="manage"
+                                this={subject('Dashboard', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <LargeMenuItem
+                                    icon={
+                                        <LargeMenuItemIconWrapper>
+                                            <IconLayoutDashboard
+                                                size={22}
+                                                color={Colors.WHITE}
+                                            />
+                                        </LargeMenuItemIconWrapper>
+                                    }
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        setIsCreateDashboardOpen(true);
+                                    }}
+                                    text={
+                                        <>
+                                            <LargeMenuItemText>
+                                                Dashboard
+                                            </LargeMenuItemText>
+                                            <LargeMenuItemSubText>
+                                                Arrange multiple charts into a
+                                                single view.
+                                            </LargeMenuItemSubText>
+                                        </>
+                                    }
+                                />
+                            </Can>
+                            <Can
+                                I="manage"
+                                this={subject('Space', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <LargeMenuItem
+                                    icon={
+                                        <LargeMenuItemIconWrapper>
+                                            <IconFolder
+                                                size={22}
+                                                color={Colors.WHITE}
+                                            />
+                                        </LargeMenuItemIconWrapper>
+                                    }
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        setIsCreateSpaceOpen(true);
+                                    }}
+                                    text={
+                                        <>
+                                            <LargeMenuItemText>
+                                                Space
+                                            </LargeMenuItemText>
+                                            <LargeMenuItemSubText>
+                                                Organize your saved charts and
+                                                dashboards.
+                                            </LargeMenuItemSubText>
+                                        </>
+                                    }
+                                />
+                            </Can>
+                        </Menu>
                     }
-                    onClick={() => setIsOpen(!isOpen)}
+                    position={Position.BOTTOM_RIGHT}
                 >
-                    New
-                </Button>
-            </Popover2>
-
+                    <Button
+                        minimal
+                        icon={
+                            <IconSquareRoundedPlus
+                                size={20}
+                                color={Colors.GRAY4}
+                                style={{ marginRight: '6px' }}
+                            />
+                        }
+                        onClick={() => setIsOpen(!isOpen)}
+                    >
+                        New
+                    </Button>
+                </Popover2>
+            </Can>
             {isCreateSpaceOpen && (
                 <SpaceActionModal
                     projectUuid={projectUuid}
@@ -199,7 +214,6 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     }}
                 />
             )}
-
             <DashboardCreateModal
                 projectUuid={projectUuid}
                 isOpen={isCreateDashboardOpen}

--- a/packages/frontend/src/components/NavBar/SettingsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu/index.tsx
@@ -26,15 +26,14 @@ const SettingsMenu: FC = () => {
         }),
     );
 
-    const userCanViewCurrentProject = user.ability.can(
-        'view',
+    const userCanCreateProject = user.ability.can(
+        'create',
         subject('Project', {
             organizationUuid: user.organizationUuid,
-            projectUuid: activeProjectUuid,
         }),
     );
 
-    if (!userCanViewOrganization && !userCanViewCurrentProject) {
+    if (!userCanViewOrganization && !userCanCreateProject) {
         return null;
     }
 
@@ -44,7 +43,7 @@ const SettingsMenu: FC = () => {
             position={PopoverPosition.BOTTOM_RIGHT}
             content={
                 <Menu>
-                    {activeProjectUuid && userCanViewCurrentProject && (
+                    {activeProjectUuid && userCanCreateProject && (
                         <LinkMenuItem
                             text="Project settings"
                             icon={<IconDatabase size={17} />}

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -82,7 +82,7 @@ const UserListItem: FC<{
                                 options={Object.values(ProjectMemberRole).map(
                                     (orgMemberRole) => ({
                                         value: orgMemberRole,
-                                        label: orgMemberRole,
+                                        label: orgMemberRole.replace('_', ' '),
                                     }),
                                 )}
                                 required

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -147,6 +147,11 @@ const relevantOrgRolesForProjectRole: Record<
     OrganizationMemberRole[]
 > = {
     [ProjectMemberRole.VIEWER]: [
+        OrganizationMemberRole.INTERACTIVE_VIEWER,
+        OrganizationMemberRole.EDITOR,
+        OrganizationMemberRole.ADMIN,
+    ],
+    [ProjectMemberRole.INTERACTIVE_VIEWER]: [
         OrganizationMemberRole.EDITOR,
         OrganizationMemberRole.ADMIN,
     ],

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessCreation/index.tsx
@@ -213,7 +213,7 @@ const ProjectAccessCreation: FC<ProjectAccessCreationProps> = ({
                         options={Object.values(ProjectMemberRole).map(
                             (orgMemberRole) => ({
                                 value: orgMemberRole,
-                                label: orgMemberRole,
+                                label: orgMemberRole.replace('_', ' '),
                             }),
                         )}
                         rules={{

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { ResultRow } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -9,6 +10,7 @@ import { useExplore } from '../../hooks/useExplore';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
+import { Can } from '../common/Authorization';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../MetricQueryData/MetricQueryDataProvider';
@@ -88,23 +90,38 @@ export const BigNumberContextMenu: FC<BigNumberContextMenuProps> = ({
                             <MenuItem2 text="Copy value" icon="duplicate" />
                         </CopyToClipboard>
                     )}
-
-                    <MenuItem2
-                        text="View underlying data"
-                        icon="layers"
-                        onClick={() => {
-                            viewUnderlyingData();
-                        }}
-                    />
-                    <DrillDownMenuItem
-                        row={resultsData?.rows[0]}
-                        selectedItem={selectedItem}
-                        trackingData={{
-                            organizationId: user?.data?.organizationUuid,
-                            userId: user?.data?.userUuid,
-                            projectId: projectUuid,
-                        }}
-                    />
+                    <Can
+                        I="view"
+                        this={subject('UnderlyingData', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid: projectUuid,
+                        })}
+                    >
+                        <MenuItem2
+                            text="View underlying data"
+                            icon="layers"
+                            onClick={() => {
+                                viewUnderlyingData();
+                            }}
+                        />
+                    </Can>
+                    <Can
+                        I="manage"
+                        this={subject('Explore', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid: projectUuid,
+                        })}
+                    >
+                        <DrillDownMenuItem
+                            row={resultsData?.rows[0]}
+                            selectedItem={selectedItem}
+                            trackingData={{
+                                organizationId: user?.data?.organizationUuid,
+                                userId: user?.data?.userUuid,
+                                projectId: projectUuid,
+                            }}
+                        />
+                    </Can>
                 </Menu>
             }
         />

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,6 +1,8 @@
 import { Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Popover2Props } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
+import { Can } from '../common/Authorization';
+
 import { ResultRow } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -10,7 +12,6 @@ import { useExplore } from '../../hooks/useExplore';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
-import { Can } from '../common/Authorization';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../MetricQueryData/MetricQueryDataProvider';

--- a/packages/frontend/src/components/UserSettings/InvitesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/InvitesPanel/index.tsx
@@ -80,7 +80,7 @@ const InvitePanel: FC<{
                             options={Object.values(OrganizationMemberRole).map(
                                 (orgMemberRole) => ({
                                     value: orgMemberRole,
-                                    label: orgMemberRole,
+                                    label: orgMemberRole.replace('_', ' '),
                                 }),
                             )}
                             rules={{

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -125,7 +125,7 @@ const UserListItem: FC<{
                                     OrganizationMemberRole,
                                 ).map((orgMemberRole) => ({
                                     value: orgMemberRole,
-                                    label: orgMemberRole,
+                                    label: orgMemberRole.replace('_', ' '),
                                 }))}
                                 required
                                 onChange={(e) => {

--- a/packages/frontend/src/hooks/useDownloadCsv.tsx
+++ b/packages/frontend/src/hooks/useDownloadCsv.tsx
@@ -2,6 +2,7 @@ import { ApiDownloadCsv, MetricQuery } from '@lightdash/common';
 
 import { lightdashApi } from '../api';
 import { convertDateFilters } from '../utils/dateFilter';
+import useToaster from './toaster/useToaster';
 
 export const downloadCsv = async ({
     projectUuid,

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,6 +1,8 @@
 import { Card } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
 import { memo } from 'react';
 import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
 import {
     CardContent,
     PageContentContainer,
@@ -41,6 +43,8 @@ const ExplorerWithUrlParams = memo(() => {
 });
 
 const ExplorerPage = memo(() => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
     const explorerUrlState = useExplorerUrlState();
     const { sidebarRef, sidebarWidth, isResizing, startResizing } =
         useSidebarResize({
@@ -53,7 +57,21 @@ const ExplorerPage = memo(() => {
 
     const queryResults = useQueryResults();
 
-    if (user.data?.ability?.cannot('view', 'Project')) {
+    const cannotViewProject = user.data?.ability?.cannot(
+        'view',
+        subject('Project', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+    const cannotManageExplore = user.data?.ability?.cannot(
+        'manage',
+        subject('Explore', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+    if (cannotViewProject || cannotManageExplore) {
         return <ForbiddenPanel />;
     }
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { Menu } from '@blueprintjs/core';
+import { subject } from '@casl/ability';
 import {
     IconDatabase,
     IconKey,
@@ -11,6 +12,7 @@ import {
 import React, { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import { Can } from '../components/common/Authorization';
 import ErrorState from '../components/common/ErrorState';
 import Content from '../components/common/Page/Content';
 import { PageWithSidebar } from '../components/common/Page/Page.styles';
@@ -124,57 +126,64 @@ const Settings: FC = () => {
                     </Menu>
                 </MenuWrapper>
 
-                <MenuWrapper>
-                    <MenuHeader>Organization settings</MenuHeader>
+                <Can
+                    I="create"
+                    this={subject('Project', {
+                        organizationUuid: organization.organizationUuid,
+                    })}
+                >
+                    <MenuWrapper>
+                        <MenuHeader>Organization settings</MenuHeader>
 
-                    <Menu>
-                        {user.ability.can('manage', 'Organization') && (
-                            <RouterMenuItem
-                                text="General"
-                                exact
-                                to={`${basePath}/organization`}
-                                icon={<IconUserCircle size={17} />}
-                            />
-                        )}
-
-                        {user.ability.can(
-                            'view',
-                            'OrganizationMemberProfile',
-                        ) && (
-                            <RouterMenuItem
-                                text="User management"
-                                to={`${basePath}/userManagement`}
-                                icon={<IconUserPlus size={17} />}
-                            />
-                        )}
-
-                        {organization &&
-                            !organization.needsProject &&
-                            user.ability.can('view', 'Project') && (
+                        <Menu>
+                            {user.ability.can('manage', 'Organization') && (
                                 <RouterMenuItem
-                                    text="Projects"
-                                    to={`${basePath}/projectManagement`}
-                                    icon={<IconDatabase size={17} />}
-                                />
-                            )}
-
-                        <RouterMenuItem
-                            text="Appearance"
-                            exact
-                            to={`${basePath}/appearance`}
-                            icon={<IconPalette size={17} />}
-                        />
-                        {health.hasSlack &&
-                            user.ability.can('manage', 'Organization') && (
-                                <RouterMenuItem
-                                    text="Integrations"
+                                    text="General"
                                     exact
-                                    to={`${basePath}/integrations/slack`}
-                                    icon={<IconPlug size={17} />}
+                                    to={`${basePath}/organization`}
+                                    icon={<IconUserCircle size={17} />}
                                 />
                             )}
-                    </Menu>
-                </MenuWrapper>
+
+                            {user.ability.can(
+                                'view',
+                                'OrganizationMemberProfile',
+                            ) && (
+                                <RouterMenuItem
+                                    text="User management"
+                                    to={`${basePath}/userManagement`}
+                                    icon={<IconUserPlus size={17} />}
+                                />
+                            )}
+
+                            {organization &&
+                                !organization.needsProject &&
+                                user.ability.can('view', 'Project') && (
+                                    <RouterMenuItem
+                                        text="Projects"
+                                        to={`${basePath}/projectManagement`}
+                                        icon={<IconDatabase size={17} />}
+                                    />
+                                )}
+
+                            <RouterMenuItem
+                                text="Appearance"
+                                exact
+                                to={`${basePath}/appearance`}
+                                icon={<IconPalette size={17} />}
+                            />
+                            {health.hasSlack &&
+                                user.ability.can('manage', 'Organization') && (
+                                    <RouterMenuItem
+                                        text="Integrations"
+                                        exact
+                                        to={`${basePath}/integrations/slack`}
+                                        icon={<IconPlug size={17} />}
+                                    />
+                                )}
+                        </Menu>
+                    </MenuWrapper>
+                </Can>
             </Sidebar>
 
             <Switch>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4427
Closes: #4860


[Screencast from 24-03-23 09:21:06.webm](https://user-images.githubusercontent.com/1983672/227464202-9e96697b-1575-4898-aa76-5b693b09767e.webm)


### Acceptance criteria:

- [x] rename existing `viewer` role to `interactive viewer`
  - [x] Update copy in App: permissions, organization allowed email domains
  - [x] Update copy in the docs. 

![image](https://user-images.githubusercontent.com/1983672/227181206-e623bb55-703a-42ae-a66a-50574016f97c.png)

![image](https://user-images.githubusercontent.com/1983672/227181473-aec9d2ad-0e60-4624-95b8-8999a9b0602d.png)

- [x] create new `viewer` role 
- [x] Add `interactive viewer` and `viewer` roles as options in `organizations` and `project` permissions.
- [ ] the new role role is limited to the same actions as a viewer, but also:
    - [x] Can't explore tables (either creating a new explore from the `new` tab, or open an unsaved explore shared with them)
    - [x] Can't use the SQL runner
    - [x] Can't use "explore from here" for a chart in a dashboard
    - [x] Can't "explore from here" from a saved chart in view mode
    - [x] Can't use "drill down" from a dashboard
    - [x] Can't use "drill down" from the results table in a saved chart
    - [x] Can't use "view underlying data" from a dashboard
    - [x] CAn't use "view underlying data" from the results table in a saved chart
    - [x] Can't invite other users.
    - [x] Can't create new projects
    - [x] can't "export to .csv" from the results table

![image](https://user-images.githubusercontent.com/1983672/227183597-3515efdb-408f-4e77-9ae8-9b4f765ef3a8.png)

 - [x] The header has the `new` tab removed (since none of these actions are available to this new viewer role)

- [x] the settings button from the tab is removed (since none of these actions are available to this new viewer role)

- [x] Only `user settings` is visible in the settings menu. They can only access this menu by clicking on their profile image --> user settings.


- [x] In the `organization allowed email domains` setting, you're able to select `organization viewer`, `organization member`, `organization interactive viewer` as the default role. 
- [x] If you select `organization member`, then the copy says `project viewer access` and the users are made to be non-interactive project viewers by default. 

![Screenshot from 2023-03-23 13-32-50](https://user-images.githubusercontent.com/1983672/227204892-29a26dd7-d09a-4e90-9fe5-38994c34643f.png)
![Screenshot from 2023-03-23 13-33-22](https://user-images.githubusercontent.com/1983672/227204898-12f71d02-80b7-4bb1-a6e3-e16cf8266281.png)


- [x] New e2e tests

[Screencast from 23-03-23 13:20:26.webm](https://user-images.githubusercontent.com/1983672/227202268-87974d20-1fe3-4c8b-a47c-86b42b9ad463.webm)
