### PR TITLE
feat: about footer migrated to Mantine

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
         "@mantine/hooks": "^6.0.4",
         "@sentry/react": "^7.37.2",
         "@sentry/tracing": "^7.37.2",
-        "@tabler/icons-react": "^2.1.1",
+        "@tabler/icons-react": "^2.11.0",
         "@tanstack/react-table": "^8.5.11",
         "@tanstack/react-virtual": "^3.0.0-alpha.0",
         "@testing-library/jest-dom": "^5.16.2",

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -42,8 +42,8 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
             >
                 <Group
                     h={80}
-                    miw={!minimal ? 768 : '100%'}
-                    maw={maxWidth || 768}
+                    miw={!minimal ? 900 : '100%'}
+                    maw={maxWidth || 900}
                     position="apart"
                     align="center"
                     mx="auto"

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -71,9 +71,14 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                         )}
                     </Button>
                     {minimal ? (
-                        <ActionIcon color="gray.7" p="xs" size="lg">
-                            <IconBook size={19} />
-                        </ActionIcon>
+                        <Anchor
+                            href="https://docs.lightdash.com/"
+                            target="_blank"
+                        >
+                            <ActionIcon color="gray.7" p="xs" size="lg">
+                                <IconBook size={19} />
+                            </ActionIcon>
+                        </Anchor>
                     ) : (
                         <MantineLinkButton
                             href="https://docs.lightdash.com/"

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -140,9 +140,6 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                                     href="https://docs.lightdash.com/"
                                     target="_blank"
                                     variant="default"
-                                    rightIcon={
-                                        <IconShare3 size={18} color="gray" />
-                                    }
                                 >
                                     Docs
                                 </MantineLinkButton>
@@ -150,9 +147,6 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                                     href="https://github.com/lightdash/lightdash"
                                     target="_blank"
                                     variant="default"
-                                    rightIcon={
-                                        <IconShare3 size={18} color="gray" />
-                                    }
                                 >
                                     Github
                                 </MantineLinkButton>

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -1,20 +1,23 @@
-import {
-    AnchorButton,
-    Button,
-    Callout,
-    Classes,
-    Colors,
-    Dialog,
-    H5,
-    Intent,
-    Tag,
-} from '@blueprintjs/core';
 import { LightdashMode } from '@lightdash/common';
+import {
+    ActionIcon,
+    Alert,
+    Anchor,
+    Badge,
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { IconBook, IconInfoCircle, IconShare3 } from '@tabler/icons-react';
 import React, { FC, useState } from 'react';
 import { useApp } from '../providers/AppProvider';
 import { TrackPage, TrackSection } from '../providers/TrackingProvider';
 import { ReactComponent as Logo } from '../svgs/grey-icon-logo.svg';
 import { PageName, PageType, SectionName } from '../types/Events';
+import MantineLinkButton from './common/MantineLinkButton';
 
 const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
     minimal,
@@ -30,117 +33,134 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
 
     return (
         <TrackSection name={SectionName.PAGE_FOOTER}>
-            <div
+            <Group
+                w="100%"
+                mt="lg"
                 style={{
-                    width: '100%',
-                    borderTop: `1px solid ${Colors.LIGHT_GRAY2}`,
-                    display: 'flex',
-                    justifyContent: 'center',
-                    marginTop: '20px',
+                    borderTop: '1px solid lightgray',
                 }}
             >
-                <footer
-                    style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        width: '100%',
-                        maxWidth: maxWidth || 768,
-                        height: 80,
-                    }}
+                <Group
+                    h={80}
+                    miw={!minimal ? 768 : '100%'}
+                    maw={maxWidth || 768}
+                    position="apart"
+                    align="center"
+                    mx="auto"
                 >
                     <Button
-                        minimal
-                        icon={<Logo />}
-                        onClick={() => setIsOpen(true)}
-                        style={{
-                            whiteSpace: 'nowrap',
-                        }}
+                        variant={minimal ? 'subtle' : 'light'}
+                        color="gray.7"
+                        p="xs"
+                        fw="500"
+                        leftIcon={<Logo />}
                         loading={healthState.isLoading}
+                        onClick={() => setIsOpen(true)}
                     >
                         {!minimal && 'Lightdash - '}
                         {healthState.data && `v${healthState.data.version}`}
                         {hasUpdate && !isCloud && (
-                            <Tag
-                                minimal
-                                intent={Intent.PRIMARY}
-                                style={{ marginLeft: 5 }}
+                            <Badge
+                                variant="light"
+                                ml="xs"
+                                radius="xs"
+                                size="xs"
                             >
                                 New version available!
-                            </Tag>
+                            </Badge>
                         )}
                     </Button>
-                    <div>
-                        <AnchorButton
+                    {minimal ? (
+                        <ActionIcon color="gray.7" p="xs" size="lg">
+                            <IconBook size={19} />
+                        </ActionIcon>
+                    ) : (
+                        <MantineLinkButton
                             href="https://docs.lightdash.com/"
                             target="_blank"
-                            minimal
-                            icon="manual"
+                            leftIcon={<IconBook size={19} />}
+                            variant="light"
+                            color="gray.7"
+                            fw="500"
+                            p="xs"
                         >
-                            {!minimal && 'Documentation'}
-                        </AnchorButton>
-                    </div>
-                </footer>
-                <Dialog
-                    isOpen={isOpen}
+                            Documentation
+                        </MantineLinkButton>
+                    )}
+                </Group>
+                <Modal
+                    opened={isOpen}
                     onClose={() => setIsOpen(false)}
-                    icon="info-sign"
-                    title="About Lightdash"
+                    title={
+                        <Group align="center" position="left" spacing="xs">
+                            <IconInfoCircle size={17} color="gray" /> About
+                            Lightdash
+                        </Group>
+                    }
                 >
                     <TrackPage
                         name={PageName.ABOUT_LIGHTDASH}
                         type={PageType.MODAL}
                     >
-                        <div className={Classes.DIALOG_BODY}>
-                            <H5>
+                        <Stack mx="xs">
+                            <Title order={5} fw={500}>
                                 <b>Version:</b>{' '}
                                 {healthState.data
                                     ? `v${healthState.data.version}`
                                     : 'n/a'}
-                            </H5>
+                            </Title>
                             {hasUpdate && !isCloud && (
-                                <Callout
+                                <Alert
                                     title="New version available!"
-                                    intent={Intent.PRIMARY}
+                                    color="blue"
+                                    icon={<IconInfoCircle size={17} />}
                                 >
-                                    The version v
-                                    {healthState.data?.latest.version} is now
-                                    available. Please follow the instructions in
-                                    the{' '}
-                                    <a
-                                        href="https://docs.lightdash.com/references/update-lightdash/"
-                                        target="_blank"
-                                        rel="noreferrer"
-                                    >
-                                        How to update version
-                                    </a>{' '}
-                                    documentation.
-                                </Callout>
+                                    <Text color="blue">
+                                        The version v
+                                        {healthState.data?.latest.version} is
+                                        now available. Please follow the
+                                        instructions in the{' '}
+                                        <Anchor
+                                            href="https://docs.lightdash.com/references/update-lightdash/"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            style={{
+                                                textDecoration: 'underline',
+                                            }}
+                                        >
+                                            How to update version
+                                        </Anchor>{' '}
+                                        documentation.
+                                    </Text>
+                                </Alert>
                             )}
-                        </div>
-                        <div className={Classes.DIALOG_FOOTER}>
-                            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                                <AnchorButton
+
+                            <Group position="right">
+                                <MantineLinkButton
                                     href="https://docs.lightdash.com/"
                                     target="_blank"
-                                    outlined
-                                    rightIcon="share"
+                                    variant="default"
+                                    rightIcon={
+                                        <IconShare3 size={18} color="gray" />
+                                    }
                                 >
                                     Docs
-                                </AnchorButton>
-                                <AnchorButton
+                                </MantineLinkButton>
+                                <MantineLinkButton
                                     href="https://github.com/lightdash/lightdash"
                                     target="_blank"
-                                    outlined
-                                    rightIcon="share"
+                                    variant="default"
+                                    rightIcon={
+                                        <IconShare3 size={18} color="gray" />
+                                    }
                                 >
                                     Github
-                                </AnchorButton>
-                            </div>
-                        </div>
+                                </MantineLinkButton>
+                            </Group>
+                        </Stack>
                     </TrackPage>
-                </Dialog>
-            </div>
+                </Modal>
+            </Group>
         </TrackSection>
     );
 };

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -1,7 +1,6 @@
 import { assertUnreachable } from '@lightdash/common';
 import {
     Box,
-    Button,
     Divider,
     Group,
     Paper,


### PR DESCRIPTION
Closes: #4894 

### Description:
1. modals with/without update
<img width="545" alt="Screenshot 2023-03-27 at 17 20 51" src="https://user-images.githubusercontent.com/67699259/227986961-4e34c123-1aea-4bc9-af1a-5a30e6f40ab1.png">
<img width="493" alt="Screenshot 2023-03-27 at 17 21 19" src="https://user-images.githubusercontent.com/67699259/227986962-678f781c-633b-4e9b-bd3a-85a26bbf53a1.png">
2. footer on pages
<img width="1359" alt="Screenshot 2023-03-27 at 17 18 33" src="https://user-images.githubusercontent.com/67699259/227986956-37f7625c-1e0a-4f83-8cfe-09622648d998.png">
<img width="1495" alt="Screenshot 2023-03-27 at 17 15 22" src="https://user-images.githubusercontent.com/67699259/227986946-386f1968-9683-42be-bd2e-488a7b3b60f0.png">
3. footer on sidebar (SQL runner)
<img width="391" alt="Screenshot 2023-03-27 at 17 15 44" src="https://user-images.githubusercontent.com/67699259/227986953-5127eb50-9264-4636-a413-c99e6f1bf293.png">
<img width="422" alt="Screenshot 2023-03-27 at 17 25 55" src="https://user-images.githubusercontent.com/67699259/227987580-d615b382-a4e8-421a-9a1a-e64802f1d1c1.png">
