### PR TITLE
feat: add ui logic for pivot metric rows

### DIFF
--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
@@ -1,6 +1,6 @@
 import { MetricQuery, ResultRow } from '@lightdash/common';
 
-export const METRIC_QUERY: Pick<
+export const METRIC_QUERY_2DIM_2METRIC: Pick<
     MetricQuery,
     'metrics' | 'dimensions' | 'tableCalculations' | 'additionalMetrics'
 > = {
@@ -9,7 +9,7 @@ export const METRIC_QUERY: Pick<
     tableCalculations: [],
 };
 
-export const RESULT_ROWS: ResultRow[] = [
+export const RESULT_ROWS_2DIM_2METRIC: ResultRow[] = [
     {
         page: { value: { raw: '/home', formatted: '/home' } },
         site: { value: { raw: 'blog', formatted: 'Blog' } },
@@ -39,5 +39,32 @@ export const RESULT_ROWS: ResultRow[] = [
         site: { value: { raw: 'docs', formatted: 'Docs' } },
         views: { value: { raw: 2, formatted: '2.0' } },
         devices: { value: { raw: 13, formatted: '13.0' } },
+    },
+];
+
+export const METRIC_QUERY_1DIM_2METRIC: Pick<
+    MetricQuery,
+    'metrics' | 'dimensions' | 'tableCalculations' | 'additionalMetrics'
+> = {
+    metrics: ['views', 'devices'],
+    dimensions: ['page'],
+    tableCalculations: [],
+};
+
+export const RESULT_ROWS_1DIM_2METRIC: ResultRow[] = [
+    {
+        page: { value: { raw: '/home', formatted: '/home' } },
+        views: { value: { raw: 6, formatted: '6.0' } },
+        devices: { value: { raw: 7, formatted: '7.0' } },
+    },
+    {
+        page: { value: { raw: '/about', formatted: '/about' } },
+        views: { value: { raw: 12, formatted: '12.0' } },
+        devices: { value: { raw: 0, formatted: '0.0' } },
+    },
+    {
+        page: { value: { raw: '/first-post', formatted: '/first-post' } },
+        views: { value: { raw: 11, formatted: '11.0' } },
+        devices: { value: { raw: 1, formatted: '1.0' } },
     },
 ];

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
@@ -1,0 +1,43 @@
+import { MetricQuery, ResultRow } from '@lightdash/common';
+
+export const METRIC_QUERY: Pick<
+    MetricQuery,
+    'metrics' | 'dimensions' | 'tableCalculations' | 'additionalMetrics'
+> = {
+    metrics: ['views', 'devices'],
+    dimensions: ['page', 'site'],
+    tableCalculations: [],
+};
+
+export const RESULT_ROWS: ResultRow[] = [
+    {
+        page: { value: { raw: '/home', formatted: '/home' } },
+        site: { value: { raw: 'blog', formatted: 'Blog' } },
+        views: { value: { raw: 6, formatted: '6.0' } },
+        devices: { value: { raw: 7, formatted: '7.0' } },
+    },
+    {
+        page: { value: { raw: '/about', formatted: '/about' } },
+        site: { value: { raw: 'blog', formatted: 'Blog' } },
+        views: { value: { raw: 12, formatted: '12.0' } },
+        devices: { value: { raw: 0, formatted: '0.0' } },
+    },
+    {
+        page: { value: { raw: '/first-post', formatted: '/first-post' } },
+        site: { value: { raw: 'blog', formatted: 'Blog' } },
+        views: { value: { raw: 11, formatted: '11.0' } },
+        devices: { value: { raw: 1, formatted: '1.0' } },
+    },
+    {
+        page: { value: { raw: '/home', formatted: '/home' } },
+        site: { value: { raw: 'docs', formatted: 'Docs' } },
+        views: { value: { raw: 2, formatted: '2.0' } },
+        devices: { value: { raw: 10, formatted: '10.0' } },
+    },
+    {
+        page: { value: { raw: '/about', formatted: '/about' } },
+        site: { value: { raw: 'docs', formatted: 'Docs' } },
+        views: { value: { raw: 2, formatted: '2.0' } },
+        devices: { value: { raw: 13, formatted: '13.0' } },
+    },
+];

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.mock.ts
@@ -68,3 +68,19 @@ export const RESULT_ROWS_1DIM_2METRIC: ResultRow[] = [
         devices: { value: { raw: 1, formatted: '1.0' } },
     },
 ];
+
+export const METRIC_QUERY_0DIM_2METRIC: Pick<
+    MetricQuery,
+    'metrics' | 'dimensions' | 'tableCalculations' | 'additionalMetrics'
+> = {
+    metrics: ['views', 'devices'],
+    dimensions: [],
+    tableCalculations: [],
+};
+
+export const RESULT_ROWS_0DIM_2METRIC: ResultRow[] = [
+    {
+        views: { value: { raw: 6, formatted: '6.0' } },
+        devices: { value: { raw: 7, formatted: '7.0' } },
+    },
+];

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
@@ -1,0 +1,80 @@
+import { pivotQueryResults } from './pivotQueryResults';
+import { METRIC_QUERY, RESULT_ROWS } from './pivotQueryResults.mock';
+
+const pivotConfig = {
+    pivotDimensions: ['site'],
+    metricsAsRows: true,
+};
+
+describe('Should pivot data', () => {
+    it('with metrics as rows and one pivot dimension', () => {
+        const expected = {
+            headerValueTypes: [{ type: 'dimension', field: 'site' }],
+            headerValues: [
+                [
+                    { raw: 'blog', formatted: 'Blog' },
+                    { raw: 'docs', formatted: 'Docs' },
+                ],
+            ],
+            indexValueTypes: [
+                { type: 'dimension', field: 'page' },
+                { type: 'metrics' },
+            ],
+            indexValues: [
+                [
+                    { raw: '/home', formatted: '/home' },
+                    { raw: 'views', formatted: 'views' },
+                ],
+                [
+                    { raw: '/home', formatted: '/home' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+                [
+                    { raw: '/about', formatted: '/about' },
+                    { raw: 'views', formatted: 'views' },
+                ],
+                [
+                    { raw: '/about', formatted: '/about' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+                [
+                    { raw: '/first-post', formatted: '/first-post' },
+                    { raw: 'views', formatted: 'views' },
+                ],
+                [
+                    { raw: '/first-post', formatted: '/first-post' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+            ],
+            dataColumnCount: 2,
+            metrics: {},
+            dimensions: {},
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 2, formatted: '2.0' },
+                ],
+                [
+                    { raw: 7, formatted: '7.0' },
+                    { raw: 10, formatted: '10.0' },
+                ],
+                [
+                    { raw: 12, formatted: '12.0' },
+                    { raw: 2, formatted: '2.0' },
+                ],
+                [
+                    { raw: 0, formatted: '0.0' },
+                    { raw: 13, formatted: '13.0' },
+                ],
+                [{ raw: 11, formatted: '11.0' }, null],
+                [{ raw: 1, formatted: '1.0' }, null],
+            ],
+        };
+        const results = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY,
+            rows: RESULT_ROWS,
+        });
+        expect(results).toStrictEqual(expected);
+    });
+});

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
@@ -1,8 +1,148 @@
 import { pivotQueryResults } from './pivotQueryResults';
-import { METRIC_QUERY, RESULT_ROWS } from './pivotQueryResults.mock';
+import {
+    METRIC_QUERY_1DIM_2METRIC,
+    METRIC_QUERY_2DIM_2METRIC,
+    RESULT_ROWS_1DIM_2METRIC,
+    RESULT_ROWS_2DIM_2METRIC,
+} from './pivotQueryResults.mock';
 
 describe('Should pivot data', () => {
-    it('with metrics as columns and one pivot dimension', () => {
+    it.skip('with 1 dimension, pivoted, metrics as cols (everything on columns)', () => {
+        const pivotConfig = {
+            pivotDimensions: ['page'],
+            metricsAsRows: false,
+        };
+        const expected = {
+            headerValueTypes: [
+                { type: 'dimension', field: 'page' },
+                { type: 'metrics' },
+            ],
+            headerValues: [
+                [
+                    { raw: '/home', formatted: '/home' },
+                    { raw: '/home', formatted: '/home' },
+                    { raw: '/about', formatted: '/about' },
+                    { raw: '/about', formatted: '/about' },
+                    { raw: '/first-post', formatted: '/first-post' },
+                    { raw: '/first-post', formatted: '/first-post' },
+                ],
+                [
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+            ],
+            indexValueTypes: [],
+            indexValues: [],
+            dataColumns: 6,
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 7, formatted: '7.0' },
+                    { raw: 12, formatted: '12.0' },
+                    { raw: 0, formatted: '0.0' },
+                    { raw: 11, formatted: '11.0' },
+                    { raw: 1, formatted: '1.0' },
+                ],
+            ],
+        };
+        const result = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY_1DIM_2METRIC,
+            rows: RESULT_ROWS_1DIM_2METRIC,
+        });
+        expect(result).toEqual(expected);
+    });
+    it('with 1 dimension, metrics as cols', () => {
+        const pivotConfig = {
+            pivotDimensions: [],
+            metricsAsRows: false,
+        };
+        const expected = {
+            headerValueTypes: [{ type: 'metrics' }],
+            headerValues: [
+                [
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+            ],
+            indexValueTypes: [{ type: 'dimension', field: 'page' }],
+            indexValues: [
+                [{ raw: '/home', formatted: '/home' }],
+                [{ raw: '/about', formatted: '/about' }],
+                [{ raw: '/first-post', formatted: '/first-post' }],
+            ],
+            dataColumnCount: 2,
+            dimensions: {},
+            metrics: {},
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 7, formatted: '7.0' },
+                ],
+                [
+                    { raw: 12, formatted: '12.0' },
+                    { raw: 0, formatted: '0.0' },
+                ],
+                [
+                    { raw: 11, formatted: '11.0' },
+                    { raw: 1, formatted: '1.0' },
+                ],
+            ],
+        };
+        const result = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY_1DIM_2METRIC,
+            rows: RESULT_ROWS_1DIM_2METRIC,
+        });
+        expect(result).toEqual(expected);
+    });
+    it('with 1 dimension, 1 pivoted, metrics as rows', () => {
+        const pivotConfig = {
+            pivotDimensions: ['page'],
+            metricsAsRows: true,
+        };
+        const expected = {
+            headerValueTypes: [{ type: 'dimension', field: 'page' }],
+            headerValues: [
+                [
+                    { raw: '/home', formatted: '/home' },
+                    { raw: '/about', formatted: '/about' },
+                    { raw: '/first-post', formatted: '/first-post' },
+                ],
+            ],
+            indexValueTypes: [{ type: 'metrics' }],
+            indexValues: [
+                [{ raw: 'views', formatted: 'views' }],
+                [{ raw: 'devices', formatted: 'devices' }],
+            ],
+            dataColumnCount: 3,
+            metrics: {},
+            dimensions: {},
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 12, formatted: '12.0' },
+                    { raw: 11, formatted: '11.0' },
+                ],
+                [
+                    { raw: 7, formatted: '7.0' },
+                    { raw: 0, formatted: '0.0' },
+                    { raw: 1, formatted: '1.0' },
+                ],
+            ],
+        };
+        const result = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY_1DIM_2METRIC,
+            rows: RESULT_ROWS_1DIM_2METRIC,
+        });
+        expect(result).toEqual(expected);
+    });
+    it('with 2 dimensions, 1 pivoted, metrics as columns', () => {
         const pivotConfig = {
             pivotDimensions: ['site'],
             metricsAsRows: false,
@@ -58,12 +198,12 @@ describe('Should pivot data', () => {
         };
         const result = pivotQueryResults({
             pivotConfig,
-            metricQuery: METRIC_QUERY,
-            rows: RESULT_ROWS,
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
         });
         expect(result).toEqual(expected);
     });
-    it('with metrics as rows and one pivot dimension', () => {
+    it('with 2 dimensions, 1 pivoted, metrics as rows', () => {
         const pivotConfig = {
             pivotDimensions: ['site'],
             metricsAsRows: true,
@@ -132,8 +272,8 @@ describe('Should pivot data', () => {
         };
         const results = pivotQueryResults({
             pivotConfig,
-            metricQuery: METRIC_QUERY,
-            rows: RESULT_ROWS,
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
         });
         expect(results).toStrictEqual(expected);
     });

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
@@ -1,7 +1,9 @@
 import { pivotQueryResults } from './pivotQueryResults';
 import {
+    METRIC_QUERY_0DIM_2METRIC,
     METRIC_QUERY_1DIM_2METRIC,
     METRIC_QUERY_2DIM_2METRIC,
+    RESULT_ROWS_0DIM_2METRIC,
     RESULT_ROWS_1DIM_2METRIC,
     RESULT_ROWS_2DIM_2METRIC,
 } from './pivotQueryResults.mock';
@@ -274,6 +276,38 @@ describe('Should pivot data', () => {
             pivotConfig,
             metricQuery: METRIC_QUERY_2DIM_2METRIC,
             rows: RESULT_ROWS_2DIM_2METRIC,
+        });
+        expect(results).toStrictEqual(expected);
+    });
+    it.skip('with 0 dimensions and 2 metrics as columns', () => {
+        const pivotConfig = {
+            pivotDimensions: [],
+            metricsAsRows: false,
+        };
+        const expected = {
+            headerValueTypes: [{ type: 'metrics' }],
+            headerValues: [
+                [
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+            ],
+            indexValueTypes: [],
+            indexValues: [],
+            dataColumnCount: 2,
+            metrics: {},
+            dimensions: {},
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 7, formatted: '7.0' },
+                ],
+            ],
+        };
+        const results = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY_0DIM_2METRIC,
+            rows: RESULT_ROWS_0DIM_2METRIC,
         });
         expect(results).toStrictEqual(expected);
     });

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
@@ -1,13 +1,73 @@
 import { pivotQueryResults } from './pivotQueryResults';
 import { METRIC_QUERY, RESULT_ROWS } from './pivotQueryResults.mock';
 
-const pivotConfig = {
-    pivotDimensions: ['site'],
-    metricsAsRows: true,
-};
-
 describe('Should pivot data', () => {
+    it('with metrics as columns and one pivot dimension', () => {
+        const pivotConfig = {
+            pivotDimensions: ['site'],
+            metricsAsRows: false,
+        };
+        const expected = {
+            headerValueTypes: [
+                { type: 'dimension', field: 'site' },
+                { type: 'metrics' },
+            ],
+            headerValues: [
+                [
+                    { raw: 'blog', formatted: 'Blog' },
+                    { raw: 'blog', formatted: 'Blog' },
+                    { raw: 'docs', formatted: 'Docs' },
+                    { raw: 'docs', formatted: 'Docs' },
+                ],
+                [
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                    { raw: 'views', formatted: 'views' },
+                    { raw: 'devices', formatted: 'devices' },
+                ],
+            ],
+            indexValueTypes: [{ type: 'dimension', field: 'page' }],
+            indexValues: [
+                [{ raw: '/home', formatted: '/home' }],
+                [{ raw: '/about', formatted: '/about' }],
+                [{ raw: '/first-post', formatted: '/first-post' }],
+            ],
+            dataColumnCount: 4,
+            metrics: {},
+            dimensions: {},
+            dataValues: [
+                [
+                    { raw: 6, formatted: '6.0' },
+                    { raw: 7, formatted: '7.0' },
+                    { raw: 2, formatted: '2.0' },
+                    { raw: 10, formatted: '10.0' },
+                ],
+                [
+                    { raw: 12, formatted: '12.0' },
+                    { raw: 0, formatted: '0.0' },
+                    { raw: 2, formatted: '2.0' },
+                    { raw: 13, formatted: '13.0' },
+                ],
+                [
+                    { raw: 11, formatted: '11.0' },
+                    { raw: 1, formatted: '1.0' },
+                    null,
+                    null,
+                ],
+            ],
+        };
+        const result = pivotQueryResults({
+            pivotConfig,
+            metricQuery: METRIC_QUERY,
+            rows: RESULT_ROWS,
+        });
+        expect(result).toEqual(expected);
+    });
     it('with metrics as rows and one pivot dimension', () => {
+        const pivotConfig = {
+            pivotDimensions: ['site'],
+            metricsAsRows: true,
+        };
         const expected = {
             headerValueTypes: [{ type: 'dimension', field: 'site' }],
             headerValues: [

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -1,0 +1,183 @@
+import { MetricQuery, ResultRow } from '@lightdash/common';
+
+type PivotConfig = {
+    pivotDimensions: string[];
+    metricsAsRows: boolean;
+};
+
+type PivotQueryResultsArgs = {
+    pivotConfig: PivotConfig;
+    metricQuery: Pick<
+        MetricQuery,
+        'dimensions' | 'metrics' | 'tableCalculations' | 'additionalMetrics'
+    >;
+    rows: ResultRow[];
+};
+
+const setKeyIfNotExists = (obj: any, keys: string[], value: any): boolean => {
+    const [key, ...rest] = keys;
+    if (rest.length === 0) {
+        if (obj[key] === undefined) {
+            obj[key] = value;
+            return true;
+        }
+        return false;
+    }
+    if (obj[key] === undefined) {
+        obj[key] = {};
+    }
+    return setKeyIfNotExists(obj[key], rest, value);
+};
+
+const getByKey = (obj: any, keys: string[]): any => {
+    const [key, ...rest] = keys;
+    if (rest.length === 0) {
+        return obj[key];
+    }
+    return getByKey(obj[key], rest);
+};
+
+type Value = {
+    raw: unknown;
+    formatted: string;
+};
+
+export const pivotQueryResults = ({
+    pivotConfig,
+    metricQuery,
+    rows,
+}: PivotQueryResultsArgs) => {
+    // Headers (column index)
+    const headerDimensions = metricQuery.dimensions.filter((d) =>
+        pivotConfig.pivotDimensions.includes(d),
+    );
+    const headerValueTypes = [
+        ...headerDimensions.map((d) => ({ type: 'dimension', field: d })),
+        ...(pivotConfig.metricsAsRows ? [] : [{ type: 'metrics' }]),
+    ];
+
+    // Indices (row index)
+    const indexDimensions = metricQuery.dimensions.filter(
+        (d) => !pivotConfig.pivotDimensions.includes(d),
+    );
+    const indexValueTypes = [
+        ...indexDimensions.map((d) => ({ type: 'dimension', field: d })),
+        ...(pivotConfig.metricsAsRows ? [{ type: 'metrics' }] : []),
+    ];
+
+    // Metrics
+    const metrics = [
+        ...metricQuery.metrics,
+        ...(metricQuery.additionalMetrics || []).map((m) => m.name),
+        ...metricQuery.tableCalculations.map((tc) => tc.name),
+    ].map((m) => ({ raw: m, formatted: m }));
+
+    const N_ROWS = rows.length;
+
+    // For every row in the results, check the index dimensions to compute the length of the new result set
+    const indexValues: Value[][] = [];
+    const headerValuesT: Value[][] = [];
+    let dimensionRowIndices = {};
+    let dimensionColIndices = {};
+    let rowCount = 0;
+    let columnCount = 0;
+    for (let nRow = 0; nRow < N_ROWS; nRow++) {
+        const row = rows[nRow];
+
+        // Compute index and header values in pivot table
+        const indexDimensionValues = indexDimensions.map((d) => row[d].value);
+        const headerDimensionValues = headerDimensions.map((d) => row[d].value);
+
+        // Write the index values
+        if (
+            setKeyIfNotExists(
+                dimensionRowIndices,
+                indexDimensionValues.map((r) => r.raw),
+                rowCount,
+            )
+        ) {
+            rowCount++;
+            if (!pivotConfig.metricsAsRows) {
+                indexValues.push(indexDimensionValues);
+            } else {
+                for (let nMetric = 0; nMetric < metrics.length; nMetric++) {
+                    indexValues.push([
+                        ...indexDimensionValues,
+                        metrics[nMetric],
+                    ]);
+                }
+            }
+        }
+
+        // Write the header values
+        if (
+            setKeyIfNotExists(
+                dimensionColIndices,
+                headerDimensionValues.map((r) => r.raw),
+                columnCount,
+            )
+        ) {
+            columnCount++;
+            if (!pivotConfig.metricsAsRows) {
+                for (let nMetric = 0; nMetric < metrics.length; nMetric++) {
+                    headerValuesT.push([
+                        ...headerDimensionValues,
+                        metrics[nMetric],
+                    ]);
+                }
+            } else {
+                headerValuesT.push(headerDimensionValues);
+            }
+        }
+    }
+
+    const headerValues = headerValuesT[0].map((_, colIndex) =>
+        headerValuesT.map((row) => row[colIndex]),
+    );
+
+    // Compute the data values
+    const N_DATA_ROWS =
+        rowCount * (pivotConfig.metricsAsRows ? metrics.length : 1);
+    const N_DATA_COLUMNS =
+        columnCount * (pivotConfig.metricsAsRows ? 1 : metrics.length);
+    const dataValues: Value[][] = [...Array(N_DATA_ROWS)].map((e) =>
+        Array(N_DATA_COLUMNS).fill(null),
+    );
+
+    // Compute pivoted data
+    for (let nRow = 0; nRow < N_ROWS; nRow++) {
+        const row = rows[nRow];
+        let dimRowIndex = getByKey(
+            dimensionRowIndices,
+            indexDimensions.map((d) => row[d].value.raw),
+        );
+        let dimColIndex = getByKey(
+            dimensionColIndices,
+            headerDimensions.map((d) => row[d].value.raw),
+        );
+        for (let nMetric = 0; nMetric < metrics.length; nMetric++) {
+            const metric = metrics[nMetric];
+            const value = row[metric.raw].value;
+            if (pivotConfig.metricsAsRows) {
+                dataValues[dimRowIndex * metrics.length + nMetric][
+                    dimColIndex
+                ] = value;
+            } else {
+                dataValues[dimRowIndex][
+                    dimColIndex * metrics.length + nMetric
+                ] = value;
+            }
+        }
+    }
+
+    return {
+        metrics: {},
+        dimensions: {},
+        headerValueTypes: headerValueTypes,
+        headerValues,
+        indexValueTypes: indexValueTypes,
+        indexValues,
+        dataColumnCount: N_DATA_COLUMNS,
+        dataValues,
+    };
+};

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -53,6 +53,9 @@ export const pivotQueryResults = ({
     metricQuery,
     rows,
 }: PivotQueryResultsArgs) => {
+    if (rows.length === 0) {
+        throw new Error('Cannot pivot results with no rows');
+    }
     // Headers (column index)
     const headerDimensions = metricQuery.dimensions.filter((d) =>
         pivotConfig.pivotDimensions.includes(d),


### PR DESCRIPTION
Transform logic to take query `ResultsRows` + `MetricQuery` to produce a table representation used by Pivot Table V2

**WIP**
add more tests for:
- metrics as cols
- edge cases (1 row + 1 col)