### PR TITLE
fix: append dashboard filters

### DIFF
--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -26,6 +26,33 @@ describe('Dashboard', () => {
         cy.get('thead th').should('have.length', 6); // Table chart
     });
 
+    it.only('Should use dashboard filters', () => {
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
+
+        // wiat for the dashboard to load
+        cy.findByText('Loading dashboards').should('not.exist');
+
+        cy.contains('a', 'Jaffle dashboard').click();
+
+        cy.contains('How much revenue');
+
+        cy.findAllByText('Loading chart').should('have.length', 0); // Finish loading
+
+        cy.contains('bank_transfer').should('have.length', 1);
+
+        // Add filter
+        cy.contains('Add filter').click();
+
+        cy.findByPlaceholderText('Search field...').click();
+        cy.contains('Payments Payment method').click();
+        cy.findByPlaceholderText('Start typing to filter results').type(
+            'credit_card{enter}{esc}',
+        );
+        cy.contains('Apply').click();
+
+        cy.contains('bank_transfer').should('have.length', 0);
+    });
+
     it('Should create dashboard with tiles', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 

--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -26,7 +26,7 @@ describe('Dashboard', () => {
         cy.get('thead th').should('have.length', 6); // Table chart
     });
 
-    it.only('Should use dashboard filters', () => {
+    it('Should use dashboard filters', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         // wiat for the dashboard to load


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4968
### Description:
Changes: 

- Added new e2e dashboard filter 
- updated the backend to `append` filters from request to existing chart filters. 

There is no need to update the frontend to change its logic. 

[Screencast from 31-03-23 10:08:15.webm](https://user-images.githubusercontent.com/1983672/229068269-00a8a827-8fa1-48f8-bebf-213c9f834938.webm)

How I tested it: 

- I created a chart with filter orderId = 5 
- I added that chart to the dashboard
- As a viewer, I can add filters, they will be appended to the orderId = 5 (the frontend stills sends the chart filter anyway) 
- I tried to hack the request using CURL by replacing orderId = 5 with orderId = 1
- I can see in the backend that the filters are appended
- On the CURL response, I get 0 results now 


![Screenshot from 2023-03-31 10-25-08](https://user-images.githubusercontent.com/1983672/229068326-54d5e641-4995-4d19-8917-f02cd167c2e5.png)


![Screenshot from 2023-03-31 10-25-24](https://user-images.githubusercontent.com/1983672/229068306-11a717ef-757c-4cb5-b8c6-97cc405a3283.png)

