### PR TITLE
fix: metric labels pivot table

### DIFF
--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -1,4 +1,4 @@
-import { Field, FieldType, TableCalculation } from './field';
+import { FieldType } from './field';
 
 export type PivotValue = null | {
     raw: unknown;
@@ -22,5 +22,4 @@ export interface PivotData {
 
     columnTotals?: PivotValue[];
     rowTotals?: PivotValue[];
-    itemsMap: Record<string, Field | TableCalculation>;
 }

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -1,4 +1,4 @@
-import { FieldType } from './field';
+import { Field, FieldType, TableCalculation } from './field';
 
 export type PivotValue = null | {
     raw: unknown;
@@ -22,4 +22,5 @@ export interface PivotData {
 
     columnTotals?: PivotValue[];
     rowTotals?: PivotValue[];
+    itemsMap: Record<string, Field | TableCalculation>;
 }

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -37,6 +37,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
             conditionalFormattings,
             hideRowNumbers,
             pivotTableData,
+            getDefaultColumnLabel,
         },
         isSqlRunner,
         explore,
@@ -57,7 +58,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
     if (pivotTableData) {
         return (
             <Box w="100%" h="100%" p="xs" sx={{ overflowX: 'scroll' }}>
-                <PivotTable w="100%" data={pivotTableData} />
+                <PivotTable
+                    w="100%"
+                    data={pivotTableData}
+                    getMetricLabel={getDefaultColumnLabel}
+                />
             </Box>
         );
     }

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -78,7 +78,10 @@ const useTableConfig = (
     }, [explore, resultsData]);
 
     const getDefaultColumnLabel = useCallback(
-        (fieldId: string) => {
+        (fieldId: string | null | undefined) => {
+            if (fieldId === null || fieldId === undefined) {
+                return '';
+            }
             const item = itemsMap[fieldId] as
                 | typeof itemsMap[number]
                 | undefined;
@@ -116,8 +119,7 @@ const useTableConfig = (
             resultsData?.metricQuery &&
             resultsData.metricQuery.metrics.length &&
             resultsData.rows.length &&
-            pivotDimensions?.length &&
-            metricsAsRows
+            pivotDimensions?.length
         ) {
             // Pivot V2. This will always trigger when the above conditions are met.
             // The old pivot below will always trigger. So currently we pivot twice when the above conditions are met.

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -119,7 +119,8 @@ const useTableConfig = (
             resultsData?.metricQuery &&
             resultsData.metricQuery.metrics.length &&
             resultsData.rows.length &&
-            pivotDimensions?.length
+            pivotDimensions?.length &&
+            metricsAsRows
         ) {
             // Pivot V2. This will always trigger when the above conditions are met.
             // The old pivot below will always trigger. So currently we pivot twice when the above conditions are met.

--- a/packages/frontend/src/pages/PivotingPOC/HeaderCell.tsx
+++ b/packages/frontend/src/pages/PivotingPOC/HeaderCell.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { useStyles } from './UseStyles';
+
+type HeaderCellProps = {
+    label: string | undefined;
+};
+const HeaderCell: FC<HeaderCellProps> = ({ label }) => {
+    const { classes } = useStyles();
+    return <th className={classes.header}>{label || '-'}</th>;
+};
+
+export default HeaderCell;

--- a/packages/frontend/src/pages/PivotingPOC/IndexCell.tsx
+++ b/packages/frontend/src/pages/PivotingPOC/IndexCell.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { useStyles } from './UseStyles';
+
+type IndexCellProps = {
+    label: string | undefined;
+};
+const IndexCell: FC<IndexCellProps> = ({ label }) => {
+    const { classes } = useStyles();
+    return <td className={classes.header}>{label || '-'}</td>;
+};
+
+export default IndexCell;

--- a/packages/frontend/src/pages/PivotingPOC/PivotTable.tsx
+++ b/packages/frontend/src/pages/PivotingPOC/PivotTable.tsx
@@ -8,7 +8,7 @@ import { useStyles } from './UseStyles';
 type PivotTableProps = TableProps &
     React.RefAttributes<HTMLTableElement> & {
         data: PivotData;
-        getMetricLabel: (fieldId: string | null | undefined) => string;
+        getMetricLabel?: (fieldId: string | null | undefined) => string;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
@@ -30,7 +30,7 @@ const PivotTable: FC<PivotTableProps> = ({
         >
             <thead>
                 {data.headerValueTypes.map(
-                    (_headerValueType, headerValueTypeIndex) => {
+                    (headerValueType, headerValueTypeIndex) => {
                         const headerValues =
                             data.headerValues[headerValueTypeIndex];
 
@@ -47,8 +47,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                     {headerValues.map(
                                         (headerValue, headerValueIndex) => {
                                             const label =
-                                                _headerValueType.type ===
-                                                FieldType.METRIC
+                                                headerValueType.type ===
+                                                    FieldType.METRIC &&
+                                                getMetricLabel
                                                     ? getMetricLabel(
                                                           headerValue?.formatted,
                                                       )
@@ -73,13 +74,13 @@ const PivotTable: FC<PivotTableProps> = ({
                     <tr key={i}>
                         <>
                             {data.indexValueTypes.map(
-                                (_indexValueType, indexValueTypeIndex) => {
+                                (indexValueType, indexValueTypeIndex) => {
                                     const d =
                                         data.indexValues[i][indexValueTypeIndex]
                                             ?.formatted;
                                     const label =
-                                        _indexValueType.type ===
-                                        FieldType.METRIC
+                                        indexValueType.type ===
+                                            FieldType.METRIC && getMetricLabel
                                             ? getMetricLabel(d)
                                             : d;
                                     return (

--- a/packages/frontend/src/pages/PivotingPOC/PivotTable.tsx
+++ b/packages/frontend/src/pages/PivotingPOC/PivotTable.tsx
@@ -1,26 +1,19 @@
-import { PivotData } from '@lightdash/common';
-import { createStyles, Table, TableProps } from '@mantine/core';
-import { FC } from 'react';
-
-const useStyles = createStyles((theme) => ({
-    table: {
-        '& td, & th': {
-            whiteSpace: 'nowrap',
-        },
-    },
-    header: {
-        fontWeight: 'bold',
-        backgroundColor: theme.colors.gray[0],
-    },
-}));
+import { FieldType, PivotData } from '@lightdash/common';
+import { Table, TableProps } from '@mantine/core';
+import React, { FC } from 'react';
+import HeaderCell from './HeaderCell';
+import IndexCell from './IndexCell';
+import { useStyles } from './UseStyles';
 
 type PivotTableProps = TableProps &
     React.RefAttributes<HTMLTableElement> & {
         data: PivotData;
+        getMetricLabel: (fieldId: string | null | undefined) => string;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
     data,
+    getMetricLabel,
     className,
     ...tableProps
 }) => {
@@ -52,14 +45,21 @@ const PivotTable: FC<PivotTableProps> = ({
                                     )}
 
                                     {headerValues.map(
-                                        (headerValue, headerValueIndex) => (
-                                            <th
-                                                key={headerValueIndex}
-                                                className={classes.header}
-                                            >
-                                                {headerValue?.formatted}
-                                            </th>
-                                        ),
+                                        (headerValue, headerValueIndex) => {
+                                            const label =
+                                                _headerValueType.type ===
+                                                FieldType.METRIC
+                                                    ? getMetricLabel(
+                                                          headerValue?.formatted,
+                                                      )
+                                                    : headerValue?.formatted;
+                                            return (
+                                                <HeaderCell
+                                                    label={label}
+                                                    key={headerValueIndex}
+                                                />
+                                            );
+                                        },
                                     )}
                                 </>
                             </tr>
@@ -74,6 +74,20 @@ const PivotTable: FC<PivotTableProps> = ({
                         <>
                             {data.indexValueTypes.map(
                                 (_indexValueType, indexValueTypeIndex) => {
+                                    const d =
+                                        data.indexValues[i][indexValueTypeIndex]
+                                            ?.formatted;
+                                    const label =
+                                        _indexValueType.type ===
+                                        FieldType.METRIC
+                                            ? getMetricLabel(d)
+                                            : d;
+                                    return (
+                                        <IndexCell
+                                            key={indexValueTypeIndex}
+                                            label={label}
+                                        />
+                                    );
                                     return (
                                         <td
                                             key={indexValueTypeIndex}

--- a/packages/frontend/src/pages/PivotingPOC/UseStyles.tsx
+++ b/packages/frontend/src/pages/PivotingPOC/UseStyles.tsx
@@ -1,0 +1,13 @@
+import { createStyles } from '@mantine/core';
+
+export const useStyles = createStyles((theme) => ({
+    table: {
+        '& td, & th': {
+            whiteSpace: 'nowrap',
+        },
+    },
+    header: {
+        fontWeight: 'bold',
+        backgroundColor: theme.colors.gray[0],
+    },
+}));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Metric labels are formatted correctly: 

<img width="1277" alt="Screenshot 2023-03-31 at 11 58 59" src="https://user-images.githubusercontent.com/11660098/229102736-c937a513-0686-4422-bc1d-c858d59d861b.png">
