### PR TITLE
fix: single word long space names overflows

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -152,7 +152,12 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
                         <ResourceIcon item={item} />
 
                         <Stack spacing={4} sx={{ flexGrow: 1, flexShrink: 1 }}>
-                            <Text lineClamp={1} fz="sm" fw={600}>
+                            <Text
+                                lineClamp={1}
+                                fz="sm"
+                                fw={600}
+                                sx={{ overflowWrap: 'anywhere' }}
+                            >
                                 {item.data.name}
                             </Text>
 

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -165,7 +165,11 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                         }
                                         position="top-start"
                                     >
-                                        <Text fw={600} lineClamp={1}>
+                                        <Text
+                                            fw={600}
+                                            lineClamp={1}
+                                            sx={{ overflowWrap: 'anywhere' }}
+                                        >
                                             {item.data.name}
                                         </Text>
                                     </Tooltip>


### PR DESCRIPTION
Closes: 
### Description:
found this bug
<img width="350" alt="Screenshot 2023-04-04 at 15 13 49" src="https://user-images.githubusercontent.com/67699259/229809113-8b6ee303-f9ab-480b-9dfb-9aee6228d856.png">
fixed it
<img width="389" alt="Screenshot 2023-04-04 at 15 30 48" src="https://user-images.githubusercontent.com/67699259/229809144-282bb215-10f6-4f07-b67d-a431f0e13e73.png">
