### PR TITLE
fix: unify loading states for home page

### DIFF
--- a/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
@@ -9,6 +9,7 @@ import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { FC, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useApp } from '../../../providers/AppProvider';
+import MantineIcon from '../../common/MantineIcon';
 import MantineLinkButton from '../../common/MantineLinkButton';
 import ResourceView from '../../common/ResourceView';
 import {
@@ -113,7 +114,7 @@ const RecentlyUpdatedPanel: FC<Props> = ({ data, projectUuid }) => {
                     : undefined
             }
             emptyStateProps={{
-                icon: <IconChartBar size={30} />,
+                icon: <MantineIcon icon={IconChartBar} size={30} />,
                 title: userCanManageCharts
                     ? 'Feels a little bit empty over here'
                     : 'No items added yet',
@@ -123,7 +124,7 @@ const RecentlyUpdatedPanel: FC<Props> = ({ data, projectUuid }) => {
                 action:
                     !isDemo && userCanManageCharts ? (
                         <Button
-                            leftIcon={<IconPlus size={18} />}
+                            leftIcon={<MantineIcon icon={IconPlus} size={18} />}
                             onClick={handleCreateChart}
                         >
                             Create chart

--- a/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
@@ -1,12 +1,15 @@
-import { AnchorButton, Button } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
-import { IconChartBar, IconEye, IconStar } from '@tabler/icons-react';
+import {
+    DashboardBasicDetails,
+    LightdashMode,
+    SpaceQuery,
+} from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { FC, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useDashboards } from '../../../hooks/dashboard/useDashboards';
-import { useSavedCharts } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
+import MantineLinkButton from '../../common/MantineLinkButton';
 import ResourceView from '../../common/ResourceView';
 import {
     isResourceViewSpaceItem,
@@ -15,31 +18,30 @@ import {
 } from '../../common/ResourceView/resourceTypeUtils';
 
 interface Props {
+    data: {
+        dashboards: DashboardBasicDetails[];
+        savedCharts: SpaceQuery[];
+    };
     projectUuid: string;
 }
 
-const RecentlyUpdatedPanel: FC<Props> = ({ projectUuid }) => {
+const RecentlyUpdatedPanel: FC<Props> = ({ data, projectUuid }) => {
     const history = useHistory();
     const { user, health } = useApp();
-    const { data: dashboards = [], isLoading: isDashboardsLoading } =
-        useDashboards(projectUuid);
-    const { data: savedCharts = [], isLoading: isChartsLoading } =
-        useSavedCharts(projectUuid);
 
     const recentItems = useMemo(() => {
         return [
-            ...wrapResourceView(dashboards, ResourceViewItemType.DASHBOARD),
-            ...wrapResourceView(savedCharts, ResourceViewItemType.CHART),
+            ...wrapResourceView(
+                data.dashboards,
+                ResourceViewItemType.DASHBOARD,
+            ),
+            ...wrapResourceView(data.savedCharts, ResourceViewItemType.CHART),
         ];
-    }, [dashboards, savedCharts]);
+    }, [data]);
 
     const handleCreateChart = () => {
         history.push(`/projects/${projectUuid}/tables`);
     };
-
-    if (isDashboardsLoading || isChartsLoading) {
-        return null;
-    }
 
     const isDemo = health.data?.mode === LightdashMode.DEMO;
 
@@ -97,25 +99,31 @@ const RecentlyUpdatedPanel: FC<Props> = ({ projectUuid }) => {
                     ? {
                           title: 'Charts and Dashboards',
                           action: (
-                              <AnchorButton
-                                  text="Learn"
-                                  minimal
+                              <MantineLinkButton
+                                  color="gray.6"
+                                  compact
+                                  variant="subtle"
                                   target="_blank"
                                   href="https://docs.lightdash.com/get-started/exploring-data/intro"
-                              />
+                              >
+                                  Learn
+                              </MantineLinkButton>
                           ),
                       }
                     : undefined
             }
             emptyStateProps={{
                 icon: <IconChartBar size={30} />,
-                title: 'Feels a little bit empty over here...',
-                description: 'get started by creating some charts',
+                title: userCanManageCharts
+                    ? 'Feels a little bit empty over here'
+                    : 'No items added yet',
+                description: userCanManageCharts
+                    ? 'get started by creating some charts'
+                    : undefined,
                 action:
                     !isDemo && userCanManageCharts ? (
                         <Button
-                            icon="plus"
-                            intent="primary"
+                            leftIcon={<IconPlus size={18} />}
                             onClick={handleCreateChart}
                         >
                             Create chart

--- a/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu/index.tsx
@@ -19,6 +19,7 @@ import { FC, memo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
+import MantineIcon from '../../common/MantineIcon';
 import DashboardCreateModal from '../../common/modal/DashboardCreateModal';
 import SpaceActionModal, { ActionType } from '../../common/SpaceActionModal';
 import {
@@ -60,9 +61,10 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             <LargeMenuItem
                                 icon={
                                     <LargeMenuItemIconWrapper>
-                                        <IconTable
+                                        <MantineIcon
+                                            icon={IconTable}
                                             size={22}
-                                            color={Colors.WHITE}
+                                            color="gray.0"
                                         />
                                     </LargeMenuItemIconWrapper>
                                 }
@@ -90,9 +92,10 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 <LargeMenuItem
                                     icon={
                                         <LargeMenuItemIconWrapper>
-                                            <IconTerminal2
+                                            <MantineIcon
+                                                icon={IconTerminal2}
                                                 size={22}
-                                                color={Colors.WHITE}
+                                                color="gray.0"
                                             />
                                         </LargeMenuItemIconWrapper>
                                     }
@@ -122,9 +125,10 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 <LargeMenuItem
                                     icon={
                                         <LargeMenuItemIconWrapper>
-                                            <IconLayoutDashboard
+                                            <MantineIcon
+                                                icon={IconLayoutDashboard}
                                                 size={22}
-                                                color={Colors.WHITE}
+                                                color="gray.0"
                                             />
                                         </LargeMenuItemIconWrapper>
                                     }
@@ -156,9 +160,10 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 <LargeMenuItem
                                     icon={
                                         <LargeMenuItemIconWrapper>
-                                            <IconFolder
+                                            <MantineIcon
+                                                icon={IconFolder}
                                                 size={22}
-                                                color={Colors.WHITE}
+                                                color="gray.0"
                                             />
                                         </LargeMenuItemIconWrapper>
                                     }
@@ -186,9 +191,10 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     <Button
                         minimal
                         icon={
-                            <IconSquareRoundedPlus
+                            <MantineIcon
+                                icon={IconSquareRoundedPlus}
                                 size={20}
-                                color={Colors.GRAY4}
+                                color="gray.5"
                                 style={{ marginRight: '6px' }}
                             />
                         }

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,9 +1,8 @@
 import { subject } from '@casl/ability';
+import { DashboardBasicDetails, Space, SpaceQuery } from '@lightdash/common';
 import { Card, Group, Text } from '@mantine/core';
 import { IconPin } from '@tabler/icons-react';
 import React, { FC, useMemo } from 'react';
-import { useDashboards } from '../../hooks/dashboard/useDashboards';
-import { useSavedCharts, useSpaces } from '../../hooks/useSpaces';
 import { useApp } from '../../providers/AppProvider';
 import MantineIcon from '../common/MantineIcon';
 import MantineLinkButton from '../common/MantineLinkButton';
@@ -14,16 +13,21 @@ import {
 } from '../common/ResourceView/resourceTypeUtils';
 
 interface Props {
+    data: {
+        dashboards: DashboardBasicDetails[];
+        savedCharts: SpaceQuery[];
+        spaces: Space[];
+    };
     projectUuid: string;
     organizationUuid: string;
 }
 
-const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
+const PinnedItemsPanel: FC<Props> = ({
+    data,
+    projectUuid,
+    organizationUuid,
+}) => {
     const { user } = useApp();
-    const { data: dashboards = [] } = useDashboards(projectUuid);
-    const { data: savedCharts = [] } = useSavedCharts(projectUuid);
-    const { data: spaces = [] } = useSpaces(projectUuid);
-
     const userCanUpdateProject = user.data?.ability.can(
         'update',
         subject('Project', { organizationUuid, projectUuid }),
@@ -31,13 +35,16 @@ const PinnedItemsPanel: FC<Props> = ({ projectUuid, organizationUuid }) => {
 
     const pinnedItems = useMemo(() => {
         return [
-            ...wrapResourceView(dashboards, ResourceViewItemType.DASHBOARD),
-            ...wrapResourceView(savedCharts, ResourceViewItemType.CHART),
-            ...wrapResourceView(spaces, ResourceViewItemType.SPACE),
+            ...wrapResourceView(
+                data.dashboards,
+                ResourceViewItemType.DASHBOARD,
+            ),
+            ...wrapResourceView(data.savedCharts, ResourceViewItemType.CHART),
+            ...wrapResourceView(data.spaces, ResourceViewItemType.SPACE),
         ].filter((item) => {
             return !!item.data.pinnedListUuid;
         });
-    }, [dashboards, savedCharts, spaces]);
+    }, [data]);
 
     return pinnedItems.length > 0 ? (
         <ResourceView

--- a/packages/frontend/src/components/common/MantineIcon/index.tsx
+++ b/packages/frontend/src/components/common/MantineIcon/index.tsx
@@ -28,7 +28,7 @@ const MantineIcon: FC<MantineIconProps> = ({
         size: typeof size === 'string' ? theme.spacing[size] : size,
         stroke: typeof stroke === 'string' ? theme.spacing[stroke] : stroke,
         color: color ? theme.fn.themeColor(color) : undefined,
-        fill: fill ? theme.fn.themeColor(fill) : undefined,
+        fill: fill ? theme.fn.themeColor(fill) : 'none',
     };
 
     return <TablerIcon {...mantineOverridedProps} {...rest} />;

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -18,6 +18,7 @@ import { FC } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useSpaces } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
+import MantineIcon from '../MantineIcon';
 import {
     ResourceViewItemAction,
     ResourceViewItemActionState,
@@ -239,7 +240,12 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 <Menu.Item
                                     component="button"
                                     role="menuitem"
-                                    icon={<IconPlus size={18} />}
+                                    icon={
+                                        <MantineIcon
+                                            icon={IconPlus}
+                                            size={18}
+                                        />
+                                    }
                                     onClick={() => {
                                         onAction({
                                             type: ResourceViewItemAction.CREATE_SPACE,
@@ -260,7 +266,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     component="button"
                     role="menuitem"
                     color="red"
-                    icon={<IconTrash size={18} />}
+                    icon={<MantineIcon icon={IconTrash} size={18} />}
                     onClick={() => {
                         onAction({
                             type: ResourceViewItemAction.DELETE,

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -10,11 +10,13 @@ import OnboardingPanel from '../components/Home/OnboardingPanel/index';
 import RecentlyUpdatedPanel from '../components/Home/RecentlyUpdatedPanel';
 import PageSpinner from '../components/PageSpinner';
 import PinnedItemsPanel from '../components/PinnedItemsPanel';
+import { useDashboards } from '../hooks/dashboard/useDashboards';
 import {
     useOnboardingStatus,
     useProjectSavedChartStatus,
 } from '../hooks/useOnboardingStatus';
 import { useProject } from '../hooks/useProject';
+import { useSavedCharts, useSpaces } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
 const Home: FC = () => {
@@ -24,10 +26,22 @@ const Home: FC = () => {
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
 
+    const { data: dashboards = [], isLoading: dashboardsLoading } =
+        useDashboards(selectedProjectUuid);
+    const { data: savedCharts = [], isLoading: chartsLoading } =
+        useSavedCharts(selectedProjectUuid);
+    const { data: spaces = [], isLoading: spacesLoading } =
+        useSpaces(selectedProjectUuid);
+
     const { user } = useApp();
 
     const isLoading =
-        onboarding.isLoading || project.isLoading || savedChartStatus.isLoading;
+        onboarding.isLoading ||
+        project.isLoading ||
+        savedChartStatus.isLoading ||
+        dashboardsLoading ||
+        chartsLoading ||
+        spacesLoading;
     const error = onboarding.error || project.error || savedChartStatus.error;
 
     useUnmount(() => onboarding.remove());
@@ -64,11 +78,12 @@ const Home: FC = () => {
                             projectUuid={project.data.projectUuid}
                         />
                         <PinnedItemsPanel
+                            data={{ dashboards, savedCharts, spaces }}
                             projectUuid={project.data.projectUuid}
                             organizationUuid={project.data.organizationUuid}
                         />
-
                         <RecentlyUpdatedPanel
+                            data={{ dashboards, savedCharts }}
                             projectUuid={project.data.projectUuid}
                         />
                     </>


### PR DESCRIPTION
Closes: #4979 

### Description:
#### changes (technical):
- passing data to `RecentlyUpdatedPanel` and `PinnedItemsPanel` as props, making them dumb components
- all loading states are now in `Home.tsx`
- migrated to Mantine `RecentlyUpdatedPanel`'s empty state (now EVERYTHING on home page is Mantified 🎉 )

#### on the UI:
- the page shows the `PageSpinner` until all data on the home page is retrieved

https://user-images.githubusercontent.com/67699259/230393088-a381c1ac-da16-4884-9a2e-34d6c51f7da5.mov

`-`
- empty state for viewers updated to make sense 😅 here's a before/after
<img width="1624" alt="Screenshot 2023-04-06 at 15 01 57" src="https://user-images.githubusercontent.com/67699259/230393546-6d81172c-f658-4777-83a3-e76a69f28e65.png">
<img width="1624" alt="Screenshot 2023-04-06 at 15 06 01" src="https://user-images.githubusercontent.com/67699259/230393565-54d6cc62-1598-4d5d-8bd0-351aed61af2e.png">


