### PR TITLE
style: improve visuals of dashboard and chart headers

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
+import { IconPencil } from '@tabler/icons-react';
 import { FC, useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
@@ -180,17 +181,22 @@ const SavedChartsHeader: FC = () => {
                                         <Button icon="info-sign" minimal />
                                     </Tooltip2>
                                 )}
-                                {user.data?.ability?.can(
-                                    'manage',
-                                    'SavedChart',
-                                ) && (
-                                    <Button
-                                        icon="edit"
-                                        disabled={updateSavedChart.isLoading}
-                                        onClick={() => setIsRenamingChart(true)}
-                                        minimal
-                                    />
-                                )}
+                                {isEditMode &&
+                                    user.data?.ability?.can(
+                                        'manage',
+                                        'SavedChart',
+                                    ) && (
+                                        <Button
+                                            icon={<IconPencil size={16} />}
+                                            disabled={
+                                                updateSavedChart.isLoading
+                                            }
+                                            onClick={() =>
+                                                setIsRenamingChart(true)
+                                            }
+                                            minimal
+                                        />
+                                    )}
                                 <ChartUpdateModal
                                     isOpen={isRenamingChart}
                                     uuid={savedChart.uuid}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Divider, Intent, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Dashboard, Space, UpdatedByUser } from '@lightdash/common';
+import { IconPencil } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
@@ -114,9 +115,9 @@ const DashboardHeader = ({
                         </Tooltip2>
                     )}
 
-                    {userCanManageDashboard && (
+                    {isEditMode && userCanManageDashboard && (
                         <Button
-                            icon="edit"
+                            icon={<IconPencil size={16} />}
                             disabled={isSaving}
                             onClick={handleEditClick}
                             minimal

--- a/packages/frontend/src/components/common/PageHeader/index.tsx
+++ b/packages/frontend/src/components/common/PageHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Colors, H3, Icon } from '@blueprintjs/core';
+import { Colors, H4, Icon } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const PAGE_HEADER_HEIGHT = 80;
@@ -21,8 +21,8 @@ export const PageTitleAndDetailsContainer = styled.div`
     flex: 1;
 `;
 
-export const PageTitle = styled(H3)`
-    margin: 0 5px 0 0;
+export const PageTitle = styled(H4)`
+    margin: 4px 5px 4px 0;
 `;
 
 export const PageTitleContainer = styled.div`


### PR DESCRIPTION
Closes: #4997 

### Description:
 
- [x] Change the dashboard/chart name to 18px font-size
- [x] The edit icon next to the dashboard/chart name should only appear when the user is in edit mode
- [x] Change the edit icon to the equivalent Tabler version

#### Screen recording:

https://user-images.githubusercontent.com/74011196/231140365-79d1f42a-cb53-43f7-8657-e84a50a75bea.mov

