### PR TITLE
fix: Open sql runner code editor when a table is clicked on sidebar

### DIFF
--- a/packages/frontend/src/components/common/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree.tsx
@@ -88,12 +88,12 @@ export const Tree: React.FC<{
 }> = ({ setExpandedCards, contents, handleSelect, onNodeClick }) => {
     const [nodes, dispatch] = React.useReducer(treeReducer, contents);
 
-    const handleCardExpandOnNodeClick = (
-        card: SqlRunnerCards,
-        value: boolean,
-    ) => {
-        setExpandedCards((prev) => new Map(prev).set(card, value));
-    };
+    const handleCardExpandOnNodeClick = React.useCallback(
+        (card: SqlRunnerCards, value: boolean) => {
+            setExpandedCards((prev) => new Map(prev).set(card, value));
+        },
+        [setExpandedCards],
+    );
 
     const handleNodeClick = React.useCallback(
         (
@@ -120,7 +120,7 @@ export const Tree: React.FC<{
             }
             onNodeClick?.(node, nodePath, e);
         },
-        [handleSelect, onNodeClick],
+        [handleCardExpandOnNodeClick, handleSelect, onNodeClick],
     );
 
     const handleNodeCollapse = React.useCallback(

--- a/packages/frontend/src/components/common/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree.tsx
@@ -67,8 +67,17 @@ function treeReducer(state: TreeNodeInfo[], action: TreeAction) {
     }
 }
 
+enum SqlRunnerCards {
+    CHART = 'CHART',
+    SQL = 'SQL',
+    RESULTS = 'RESULTS',
+}
+
 // Note: this code is based on blueprint example https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples/core-examples/treeExample.tsx
 export const Tree: React.FC<{
+    setExpandedCards: React.Dispatch<
+        React.SetStateAction<Map<SqlRunnerCards, boolean>>
+    >;
     contents: TreeNodeInfo[];
     handleSelect: boolean;
     onNodeClick?: (
@@ -76,8 +85,15 @@ export const Tree: React.FC<{
         nodePath: NodePath,
         e: React.MouseEvent<HTMLElement>,
     ) => void;
-}> = ({ contents, handleSelect, onNodeClick }) => {
+}> = ({ setExpandedCards, contents, handleSelect, onNodeClick }) => {
     const [nodes, dispatch] = React.useReducer(treeReducer, contents);
+
+    const handleCardExpandOnNodeClick = (
+        card: SqlRunnerCards,
+        value: boolean,
+    ) => {
+        setExpandedCards((prev) => new Map(prev).set(card, value));
+    };
 
     const handleNodeClick = React.useCallback(
         (
@@ -85,6 +101,7 @@ export const Tree: React.FC<{
             nodePath: NodePath,
             e: React.MouseEvent<HTMLElement>,
         ) => {
+            handleCardExpandOnNodeClick(SqlRunnerCards.SQL, true);
             if (handleSelect) {
                 const originallySelected = node.isSelected;
                 if (!e.shiftKey) {

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -254,6 +254,7 @@ const SqlRunnerPage = () => {
                         ) : (
                             <>
                                 <Tree
+                                    setExpandedCards={setExpandedCards}
                                     contents={catalogTree}
                                     handleSelect={false}
                                     onNodeClick={handleNodeClick}


### PR DESCRIPTION
Closes: #813

### Description:
In this PR, I have updated the Tree component to open the SQL runner when is it collapsed and the user clicks on a table in the sidebar to show the changed query.🚀

#### Screen recording:

https://user-images.githubusercontent.com/74011196/231244031-b7aa6d8e-ee8a-4c36-8b94-0e80d939212a.mov


