### PR TITLE
chore: add db query for ResourceViewItemSpace

### DIFF
--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -1,0 +1,57 @@
+import { ResourceViewItemType, ResourceViewSpaceItem } from '@lightdash/common';
+import { Knex } from 'knex';
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class ResourceViewItemModel {
+    database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+
+    async getSpacesByPinnedListUuid(
+        pinnedListUuid: string,
+    ): Promise<ResourceViewSpaceItem[]> {
+        const rows = await this.database.raw<Record<string, any>[]>(
+            `
+select
+    pl.project_uuid,
+    pl.pinned_list_uuid,
+    ps.space_uuid,
+    MAX(s.name) as name,
+    BOOL_OR(s.is_private) as is_private,
+    COUNT(DISTINCT ss.user_id) as access_list_length,
+    COUNT(DISTINCT d.dashboard_id) as dashboard_count,
+    COUNT(DISTINCT sq.saved_query_id) as chart_count
+from pinned_list pl
+inner join pinned_space ps on pl.pinned_list_uuid = ps.pinned_list_uuid
+    and ps.pinned_list_uuid = :pinnedListUuid
+inner join spaces s on ps.space_uuid = s.space_uuid
+left join space_share ss on s.space_id = ss.space_id
+left join dashboards d on s.space_id = d.space_id
+left join saved_queries sq on s.space_id = sq.space_id
+group by 1, 2, 3;
+        `,
+            { pinnedListUuid },
+        );
+        const resourceType: ResourceViewItemType.SPACE =
+            ResourceViewItemType.SPACE;
+        const items = rows.map((row) => ({
+            type: resourceType,
+            data: {
+                projectUuid: row.project_uuid,
+                pinnedListUuid: row.pinned_list_uuid,
+                uuid: row.space_uuid,
+                name: row.name,
+                isPrivate: row.is_private,
+                accessListLength: row.access_list_length,
+                dashboardCount: row.dashboard_count,
+                chartCount: row.saved_query_count,
+            },
+        }));
+        return items;
+    }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -107,6 +107,7 @@ export * from './types/pinning';
 export * from './types/pivot';
 export * from './types/projectMemberProfile';
 export * from './types/projects';
+export * from './types/resourceViewItem';
 export * from './types/results';
 export * from './types/savedCharts';
 export * from './types/scheduler';

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -1,9 +1,7 @@
-import {
-    assertUnreachable,
-    DashboardBasicDetails,
-    Space,
-    SpaceQuery,
-} from '@lightdash/common';
+import assertUnreachable from '../utils/assertUnreachable';
+import { DashboardBasicDetails } from './dashboard';
+import { SpaceQuery } from './savedCharts';
+import { Space } from './space';
 
 export enum ResourceViewItemType {
     CHART = 'chart',
@@ -18,7 +16,18 @@ export type ResourceViewChartItem = {
 
 export type ResourceViewDashboardItem = {
     type: ResourceViewItemType.DASHBOARD;
-    data: DashboardBasicDetails;
+    data: Pick<
+        DashboardBasicDetails,
+        | 'uuid'
+        | 'spaceUuid'
+        | 'description'
+        | 'name'
+        | 'views'
+        | 'firstViewedAt'
+        | 'pinnedListUuid'
+        | 'updatedAt'
+        | 'updatedByUser'
+    >;
 };
 
 export type ResourceViewSpaceItem = {
@@ -75,9 +84,8 @@ export const wrapResource = <T extends ResourceViewAcceptedItems>(
 export const wrapResourceView = (
     resources: ResourceViewAcceptedItems[],
     type: ResourceViewItemType,
-): ResourceViewItem[] => {
-    return resources.map((resource) => wrapResource(resource, type));
-};
+): ResourceViewItem[] =>
+    resources.map((resource) => wrapResource(resource, type));
 
 export const spaceToResourceViewItem = (
     space: Space,

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -8,6 +8,7 @@ import { useApp } from '../../../providers/AppProvider';
 import ResourceView, { ResourceViewType } from '../../common/ResourceView';
 import {
     ResourceViewItemType,
+    spaceToResourceViewItem,
     wrapResourceView,
 } from '../../common/ResourceView/resourceTypeUtils';
 import SpaceActionModal, { ActionType } from '../../common/SpaceActionModal';
@@ -36,7 +37,10 @@ const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         <>
             <ResourceView
                 view={ResourceViewType.GRID}
-                items={wrapResourceView(spaces, ResourceViewItemType.SPACE)}
+                items={wrapResourceView(
+                    spaces.map(spaceToResourceViewItem),
+                    ResourceViewItemType.SPACE,
+                )}
                 headerProps={{
                     title: 'Spaces',
 

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/index.tsx
@@ -1,16 +1,16 @@
 import { AnchorButton, Button } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    ResourceViewItemType,
+    spaceToResourceViewItem,
+    wrapResourceView,
+} from '@lightdash/common';
 import { IconFolders } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { useSpaces } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import ResourceView, { ResourceViewType } from '../../common/ResourceView';
-import {
-    ResourceViewItemType,
-    spaceToResourceViewItem,
-    wrapResourceView,
-} from '../../common/ResourceView/resourceTypeUtils';
 import SpaceActionModal, { ActionType } from '../../common/SpaceActionModal';
 
 const SpaceBrowser: FC<{ projectUuid: string }> = ({ projectUuid }) => {

--- a/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/RecentlyUpdatedPanel/index.tsx
@@ -1,8 +1,11 @@
 import { subject } from '@casl/ability';
 import {
     DashboardBasicDetails,
+    isResourceViewSpaceItem,
     LightdashMode,
+    ResourceViewItemType,
     SpaceQuery,
+    wrapResourceView,
 } from '@lightdash/common';
 import { Button } from '@mantine/core';
 import { IconChartBar, IconPlus } from '@tabler/icons-react';
@@ -12,11 +15,6 @@ import { useApp } from '../../../providers/AppProvider';
 import MantineIcon from '../../common/MantineIcon';
 import MantineLinkButton from '../../common/MantineLinkButton';
 import ResourceView from '../../common/ResourceView';
-import {
-    isResourceViewSpaceItem,
-    ResourceViewItemType,
-    wrapResourceView,
-} from '../../common/ResourceView/resourceTypeUtils';
 
 interface Props {
     data: {

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,5 +1,12 @@
 import { subject } from '@casl/ability';
-import { DashboardBasicDetails, Space, SpaceQuery } from '@lightdash/common';
+import {
+    DashboardBasicDetails,
+    ResourceViewItemType,
+    Space,
+    SpaceQuery,
+    spaceToResourceViewItem,
+    wrapResourceView,
+} from '@lightdash/common';
 import { Card, Group, Text } from '@mantine/core';
 import { IconPin } from '@tabler/icons-react';
 import React, { FC, useMemo } from 'react';
@@ -7,11 +14,6 @@ import { useApp } from '../../providers/AppProvider';
 import MantineIcon from '../common/MantineIcon';
 import MantineLinkButton from '../common/MantineLinkButton';
 import ResourceView, { ResourceViewType } from '../common/ResourceView';
-import {
-    ResourceViewItemType,
-    spaceToResourceViewItem,
-    wrapResourceView,
-} from '../common/ResourceView/resourceTypeUtils';
 
 interface Props {
     data: {

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -9,6 +9,7 @@ import MantineLinkButton from '../common/MantineLinkButton';
 import ResourceView, { ResourceViewType } from '../common/ResourceView';
 import {
     ResourceViewItemType,
+    spaceToResourceViewItem,
     wrapResourceView,
 } from '../common/ResourceView/resourceTypeUtils';
 
@@ -40,7 +41,10 @@ const PinnedItemsPanel: FC<Props> = ({
                 ResourceViewItemType.DASHBOARD,
             ),
             ...wrapResourceView(data.savedCharts, ResourceViewItemType.CHART),
-            ...wrapResourceView(data.spaces, ResourceViewItemType.SPACE),
+            ...wrapResourceView(
+                data.spaces.map(spaceToResourceViewItem),
+                ResourceViewItemType.SPACE,
+            ),
         ].filter((item) => {
             return !!item.data.pinnedListUuid;
         });

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -1,4 +1,11 @@
-import { assertUnreachable, Space } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ResourceViewChartItem,
+    ResourceViewDashboardItem,
+    ResourceViewItem,
+    ResourceViewItemType,
+    Space,
+} from '@lightdash/common';
 import { FC, useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import {
@@ -18,12 +25,6 @@ import ChartUpdateModal from '../modal/ChartUpdateModal';
 import DashboardDeleteModal from '../modal/DashboardDeleteModal';
 import DashboardUpdateModal from '../modal/DashboardUpdateModal';
 import SpaceActionModal, { ActionType } from '../SpaceActionModal';
-import {
-    ResourceViewChartItem,
-    ResourceViewDashboardItem,
-    ResourceViewItem,
-    ResourceViewItemType,
-} from './resourceTypeUtils';
 
 export enum ResourceViewItemAction {
     CLOSE,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { assertUnreachable } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ResourceViewItem,
+    ResourceViewItemType,
+} from '@lightdash/common';
 import { ActionIcon, Box, Menu } from '@mantine/core';
 import {
     IconCheck,
@@ -23,7 +27,6 @@ import {
     ResourceViewItemAction,
     ResourceViewItemActionState,
 } from './ResourceActionHandlers';
-import { ResourceViewItem, ResourceViewItemType } from './resourceTypeUtils';
 
 export interface ResourceViewActionMenuCommonProps {
     onAction: (newAction: ResourceViewItemActionState) => void;

--- a/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
@@ -1,4 +1,9 @@
-import { assertUnreachable, ChartKind } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ChartKind,
+    ResourceViewItem,
+    ResourceViewItemType,
+} from '@lightdash/common';
 import { Center, Paper } from '@mantine/core';
 import {
     IconChartArea,
@@ -14,7 +19,6 @@ import {
 } from '@tabler/icons-react';
 import { FC } from 'react';
 import MantineIcon from '../MantineIcon';
-import { ResourceViewItem, ResourceViewItemType } from './resourceTypeUtils';
 
 interface ResourceIconProps {
     item: ResourceViewItem;

--- a/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
@@ -2,11 +2,11 @@ import { Text, Tooltip } from '@mantine/core';
 import moment from 'moment';
 import { FC } from 'react';
 
-import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import {
     ResourceViewChartItem,
     ResourceViewDashboardItem,
-} from './resourceTypeUtils';
+} from '@lightdash/common';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
 
 interface ResourceLastEditedProps {
     item: ResourceViewChartItem | ResourceViewDashboardItem;

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -1,3 +1,4 @@
+import { ResourceViewChartItem } from '@lightdash/common';
 import {
     Box,
     Flex,
@@ -14,7 +15,6 @@ import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
 } from '../ResourceActionMenu';
 import { ResourceIcon } from '../ResourceIcon';
-import { ResourceViewChartItem } from '../resourceTypeUtils';
 import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 
 interface ResourceViewGridChartItemProps

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -1,3 +1,4 @@
+import { ResourceViewDashboardItem } from '@lightdash/common';
 import {
     Box,
     Flex,
@@ -14,7 +15,6 @@ import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
 } from '../ResourceActionMenu';
 import { ResourceIcon } from '../ResourceIcon';
-import { ResourceViewDashboardItem } from '../resourceTypeUtils';
 import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 
 interface ResourceViewGridDashboardItemProps

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -1,4 +1,4 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, ResourceViewSpaceItem } from '@lightdash/common';
 import {
     Box,
     Flex,
@@ -24,7 +24,6 @@ import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
 } from '../ResourceActionMenu';
 import { ResourceIcon } from '../ResourceIcon';
-import { ResourceViewSpaceItem } from '../resourceTypeUtils';
 
 interface ResourceViewGridSpaceItemProps
     extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -40,7 +40,7 @@ enum ResourceAccess {
 const getResourceAccessType = (item: ResourceViewSpaceItem): ResourceAccess => {
     if (!item.data.isPrivate) {
         return ResourceAccess.Public;
-    } else if (item.data.access.length > 1) {
+    } else if (item.data.accessListLength > 1) {
         return ResourceAccess.Shared;
     } else {
         return ResourceAccess.Private;
@@ -116,8 +116,8 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
             case ResourceAccess.Public:
                 return 'Everyone in this project has access';
             case ResourceAccess.Shared:
-                return `Shared with ${item.data.access.length} user${
-                    item.data.access.length > 1 ? 's' : ''
+                return `Shared with ${item.data.accessListLength} user${
+                    item.data.accessListLength > 1 ? 's' : ''
                 }`;
             default:
                 return assertUnreachable(
@@ -203,11 +203,11 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
                     <Group>
                         <AttributeCount
                             Icon={IconLayoutDashboard}
-                            count={item.data.dashboards.length}
+                            count={item.data.dashboardCount}
                         />
                         <AttributeCount
                             Icon={IconChartBar}
-                            count={item.data.queries.length}
+                            count={item.data.chartCount}
                         />
                     </Group>
                 </Stack>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -1,10 +1,9 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, ResourceViewItemType } from '@lightdash/common';
 import { Anchor, SimpleGrid, Stack, Text } from '@mantine/core';
 import { FC, useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
 import { ResourceViewItemActionState } from '../ResourceActionHandlers';
-import { ResourceViewItemType } from '../resourceTypeUtils';
 import { getResourceName, getResourceUrl } from '../resourceUtils';
 import ResourceViewGridChartItem from './ResourceViewGridChartItem';
 import ResourceViewGridDashboardItem from './ResourceViewGridDashboardItem';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -1,18 +1,17 @@
-import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
-import { createStyles } from '@mantine/styles';
-import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
-import moment from 'moment';
-import React, { FC, useMemo, useState } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
-import { ResourceViewCommonProps } from '..';
-import { useSpaces } from '../../../../hooks/useSpaces';
-import { ResourceIcon } from '../ResourceIcon';
 import {
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     isResourceViewSpaceItem,
     ResourceViewItem,
-} from '../resourceTypeUtils';
+} from '@lightdash/common';
+import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
+import { createStyles } from '@mantine/styles';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import React, { FC, useMemo, useState } from 'react';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { ResourceViewCommonProps } from '..';
+import { useSpaces } from '../../../../hooks/useSpaces';
+import { ResourceIcon } from '../ResourceIcon';
 import {
     getResourceTypeName,
     getResourceUrl,

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -1,4 +1,4 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, ResourceViewItem } from '@lightdash/common';
 import {
     Box,
     Divider,
@@ -19,7 +19,6 @@ import ResourceActionHandlers, {
 import ResourceEmptyState, {
     ResourceEmptyStateProps,
 } from './ResourceEmptyState';
-import { ResourceViewItem } from './resourceTypeUtils';
 import ResourceViewGrid, {
     ResourceViewGridCommonProps,
 } from './ResourceViewGrid';

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -1,6 +1,10 @@
-import { assertUnreachable, ChartKind } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ChartKind,
+    ResourceViewItem,
+    ResourceViewItemType,
+} from '@lightdash/common';
 import moment from 'moment';
-import { ResourceViewItem, ResourceViewItemType } from './resourceTypeUtils';
 
 export const getResourceTypeName = (item: ResourceViewItem) => {
     switch (item.type) {

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    ResourceViewItemType,
+    wrapResourceView,
+} from '@lightdash/common';
 import { Button, Center, Group, Stack, Tooltip } from '@mantine/core';
 import { IconLayoutDashboard, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -9,10 +13,6 @@ import LoadingState from '../components/common/LoadingState';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
-import {
-    ResourceViewItemType,
-    wrapResourceView,
-} from '../components/common/ResourceView/resourceTypeUtils';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
 import { useCreateMutation } from '../hooks/dashboard/useDashboard';
 import { useDashboards } from '../hooks/dashboard/useDashboards';

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    ResourceViewItemType,
+    wrapResourceView,
+} from '@lightdash/common';
 import { Button, Center, Group, Stack } from '@mantine/core';
 import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { FC } from 'react';
@@ -8,10 +12,6 @@ import { useHistory, useParams } from 'react-router-dom';
 import LoadingState from '../components/common/LoadingState';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
-import {
-    ResourceViewItemType,
-    wrapResourceView,
-} from '../components/common/ResourceView/resourceTypeUtils';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
 import { useSavedCharts } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -7,7 +7,11 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    ResourceViewItemType,
+    wrapResourceView,
+} from '@lightdash/common';
 import { ActionIcon, Center, Group, Stack } from '@mantine/core';
 import {
     IconChartAreaLine,
@@ -25,10 +29,6 @@ import DashboardCreateModal from '../components/common/modal/DashboardCreateModa
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { ResourceTypeIcon } from '../components/common/ResourceView/ResourceIcon';
-import {
-    ResourceViewItemType,
-    wrapResourceView,
-} from '../components/common/ResourceView/resourceTypeUtils';
 import ShareSpaceModal from '../components/common/ShareSpaceModal';
 import SpaceActionModal, {
     ActionType,

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -1,6 +1,11 @@
 import { AnchorButton } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    ResourceViewItemType,
+    spaceToResourceViewItem,
+    wrapResourceView,
+} from '@lightdash/common';
 import { Button, Center, Group, Stack } from '@mantine/core';
 import { IconFolders, IconPlus } from '@tabler/icons-react';
 import { FC, useState } from 'react';
@@ -11,11 +16,6 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView, {
     ResourceViewType,
 } from '../components/common/ResourceView';
-import {
-    ResourceViewItemType,
-    spaceToResourceViewItem,
-    wrapResourceView,
-} from '../components/common/ResourceView/resourceTypeUtils';
 import SpaceActionModal, {
     ActionType,
 } from '../components/common/SpaceActionModal';

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -13,6 +13,7 @@ import ResourceView, {
 } from '../components/common/ResourceView';
 import {
     ResourceViewItemType,
+    spaceToResourceViewItem,
     wrapResourceView,
 } from '../components/common/ResourceView/resourceTypeUtils';
 import SpaceActionModal, {
@@ -83,7 +84,10 @@ const Spaces: FC = () => {
                 </Group>
                 <ResourceView
                     view={ResourceViewType.GRID}
-                    items={wrapResourceView(spaces, ResourceViewItemType.SPACE)}
+                    items={wrapResourceView(
+                        spaces.map(spaceToResourceViewItem),
+                        ResourceViewItemType.SPACE,
+                    )}
                     headerProps={{
                         title: 'Spaces',
                     }}


### PR DESCRIPTION
Part of a group of PRs to make a new API endpoint to get ResourceViewItems used by the frontend. Need for pinning.

* Moves `resourceViewUtils` to `@lightdash/common` (most file changes are import updates)
* Updates the `ResourceViewItemSpace` type to only include required fields
* Adds a new db query to get `ResourceViewItemSpaces` by a pinned list uuid (not used yet)