### PR TITLE
style: improve visuals by changing icons to tabler icons in dashboard and chart

### DIFF
--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { IconTelescope } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useApp } from '../../providers/AppProvider';
@@ -36,7 +37,7 @@ const ExploreFromHereButton = () => {
         <StyledLinkButton
             intent="primary"
             large
-            icon="series-search"
+            icon={<IconTelescope size={16} />}
             href={exploreFromHereUrl}
         >
             Explore from here

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -374,6 +374,7 @@ const SavedChartsHeader: FC = () => {
                             }
                         >
                             <Button
+                                style={{ padding: '5px 7px' }}
                                 icon={<IconDots size={16} />}
                                 disabled={!unsavedChartVersion.tableName}
                             />

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
-import { IconPencil } from '@tabler/icons-react';
+import { IconDots, IconPencil } from '@tabler/icons-react';
 import { FC, useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
@@ -237,7 +237,7 @@ const SavedChartsHeader: FC = () => {
                         {!isEditMode ? (
                             <>
                                 <Button
-                                    icon="edit"
+                                    icon={<IconPencil size={16} />}
                                     onClick={() =>
                                         history.push({
                                             pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/edit`,
@@ -374,7 +374,7 @@ const SavedChartsHeader: FC = () => {
                             }
                         >
                             <Button
-                                icon="more"
+                                icon={<IconDots size={16} />}
                                 disabled={!unsavedChartVersion.tableName}
                             />
                         </Popover2>

--- a/packages/frontend/src/components/ShareLinkButton/index.tsx
+++ b/packages/frontend/src/components/ShareLinkButton/index.tsx
@@ -1,3 +1,4 @@
+import { IconLink } from '@tabler/icons-react';
 import { FC } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import useToaster from '../../hooks/toaster/useToaster';
@@ -15,7 +16,7 @@ const ShareLinkButton: FC<{ url: string }> = ({ url }) => {
                 })
             }
         >
-            <ShareLink icon="link" />
+            <ShareLink icon={<IconLink size={16} />} />
         </CopyToClipboard>
     );
 };

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, Divider, Intent, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Dashboard, Space, UpdatedByUser } from '@lightdash/common';
-import { IconPencil } from '@tabler/icons-react';
+import { IconDots, IconPencil } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
@@ -188,7 +188,7 @@ const DashboardHeader = ({
             ) : userCanManageDashboard ? (
                 <PageActionsContainer>
                     <Button
-                        icon="edit"
+                        icon={<IconPencil size={16} />}
                         text="Edit dashboard"
                         onClick={() => {
                             history.replace(
@@ -287,7 +287,7 @@ const DashboardHeader = ({
                             </Menu>
                         }
                     >
-                        <Button icon="more" />
+                        <Button icon={<IconDots size={16} />} />
                     </Popover2>
 
                     {isCreatingNewSpace && (

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -287,7 +287,10 @@ const DashboardHeader = ({
                             </Menu>
                         }
                     >
-                        <Button icon={<IconDots size={16} />} />
+                        <Button
+                            style={{ padding: '5px 7px' }}
+                            icon={<IconDots size={16} />}
+                        />
                     </Popover2>
 
                     {isCreatingNewSpace && (

--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -1,3 +1,4 @@
+import { IconLink } from '@tabler/icons-react';
 import copy from 'copy-to-clipboard';
 import React, { FC, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -36,7 +37,7 @@ const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
                 createShareUrl(shareUrl);
             }}
             disabled={isDisabled}
-            icon="link"
+            icon={<IconLink size={16} />}
         />
     );
 };


### PR DESCRIPTION
Closes: #5053 

### Description:

- changed the edit, link, and more icons to Tabler icons
- Did not change the series-search icon near the "Explore from here" text, bcoz I could not find one in tabler icon.
### Screenshots
Dashboard:
<img width="288" alt="Screenshot 2023-04-12 at 9 49 45 PM" src="https://user-images.githubusercontent.com/74011196/231520057-3d2cc913-2239-438a-a67e-5f206b53821f.png">

Chart:
<img width="296" alt="Screenshot 2023-04-12 at 9 50 18 PM" src="https://user-images.githubusercontent.com/74011196/231520223-c42cb717-58d4-4396-9700-a1c4e5801a03.png">
