### PR TITLE
chore: use casl for space access checks

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -313,19 +313,23 @@ export class UserModel {
 
     private async getUserProjectRoles(
         userId: number,
-    ): Promise<Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[]> {
+    ): Promise<
+        Pick<ProjectMemberProfile, 'projectUuid' | 'role' | 'userUuid'>[]
+    > {
         const projectMemberships = await this.database('project_memberships')
-            .leftJoin(
+            .innerJoin(
                 'projects',
                 'project_memberships.project_id',
                 'projects.project_id',
             )
-            .select('*')
+            .innerJoin('users', 'project_memberships.user_id', 'users.user_id')
+            .select(['project_uuid', 'role', 'user_uuid'])
             .where('user_id', userId);
 
         return projectMemberships.map((membership) => ({
             projectUuid: membership.project_uuid,
             role: membership.role,
+            userUuid: membership.user_uuid,
         }));
     }
 

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -11,7 +11,6 @@ import { analytics } from '../../analytics/client';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
-import { hasSpaceAccess } from '../SpaceService/SpaceService';
 
 type Dependencies = {
     searchModel: SearchModel;
@@ -74,7 +73,16 @@ export class SearchService {
             const spaceUuid: string =
                 'spaceUuid' in item ? item.spaceUuid : item.uuid;
             const itemSpace = spaces.find((s) => s.uuid === spaceUuid);
-            return itemSpace && hasSpaceAccess(itemSpace, user.userUuid);
+            const hasSpaceAccess = user.ability.can(
+                'view',
+                subject('Space', {
+                    organizationUuid: itemSpace?.organizationUuid,
+                    projectUuid: itemSpace?.projectUuid,
+                    isPrivate: itemSpace?.isPrivate,
+                    access: itemSpace?.access.map((a) => a.userUuid),
+                }),
+            );
+            return itemSpace && hasSpaceAccess;
         };
 
         const hasExploreAccess = user.ability.can(

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -17,13 +17,6 @@ type Dependencies = {
     pinnedListModel: PinnedListModel;
 };
 
-export const hasSpaceAccess = (space: Space, userUuid: string): boolean =>
-    !space.isPrivate ||
-    space.access.find(
-        (userAccess) =>
-            userAccess.userUuid === userUuid && userAccess.role !== null,
-    ) !== undefined;
-
 export class SpaceService {
     private readonly projectModel: ProjectModel;
 
@@ -42,15 +35,16 @@ export class SpaceService {
         user: SessionUser,
     ): Promise<Space[]> {
         const spaces = await this.spaceModel.getAllSpaces(projectUuid);
-        return spaces.filter(
-            (space) =>
-                user.ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: space.organizationUuid,
-                        projectUuid,
-                    }),
-                ) && hasSpaceAccess(space, user.userUuid),
+        return spaces.filter((space) =>
+            user.ability.can(
+                'view',
+                subject('SavedChart', {
+                    organizationUuid: space.organizationUuid,
+                    projectUuid: space.projectUuid,
+                    isPrivate: space.isPrivate,
+                    access: space.access.map((a) => a.userUuid),
+                }),
+            ),
         );
     }
 
@@ -66,10 +60,11 @@ export class SpaceService {
                 'view',
                 subject('Space', {
                     organizationUuid: space.organizationUuid,
-                    projectUuid,
+                    projectUuid: space.projectUuid,
+                    isPrivate: space.isPrivate,
+                    access: space.access.map((a) => a.userUuid),
                 }),
-            ) ||
-            !hasSpaceAccess(space, user.userUuid)
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -134,9 +129,10 @@ export class SpaceService {
                 subject('Space', {
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
+                    isPrivate: space.isPrivate,
+                    access: space.access.map((a) => a.userUuid),
                 }),
-            ) ||
-            !hasSpaceAccess(space, user.userUuid)
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -173,10 +169,11 @@ export class SpaceService {
                 'delete',
                 subject('Space', {
                     organizationUuid: space.organizationUuid,
+                    isPrivate: space.isPrivate,
                     projectUuid: space.projectUuid,
+                    access: space.access.map((a) => a.userUuid),
                 }),
-            ) ||
-            !hasSpaceAccess(space, user.userUuid)
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -205,9 +202,10 @@ export class SpaceService {
                 subject('Space', {
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
+                    isPrivate: space.isPrivate,
+                    access: space.access.map((a) => a.userUuid),
                 }),
-            ) ||
-            !hasSpaceAccess(space, user.userUuid)
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -227,9 +225,10 @@ export class SpaceService {
                 subject('Space', {
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
+                    isPrivate: space.isPrivate,
+                    access: space.access.map((a) => a.userUuid),
                 }),
-            ) ||
-            !hasSpaceAccess(space, user.userUuid)
+            )
         ) {
             throw new ForbiddenError();
         }

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -7,7 +7,10 @@ import { MemberAbility } from './types';
 
 export const getUserAbilityBuilder = (
     user: Pick<LightdashUser, 'role' | 'organizationUuid' | 'userUuid'>,
-    projectProfiles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[],
+    projectProfiles: Pick<
+        ProjectMemberProfile,
+        'projectUuid' | 'role' | 'userUuid'
+    >[],
 ) => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     if (user.role && user.organizationUuid) {
@@ -30,7 +33,10 @@ export const getUserAbilityBuilder = (
 
 export const defineUserAbility = (
     user: Pick<LightdashUser, 'role' | 'organizationUuid' | 'userUuid'>,
-    projectProfiles: Pick<ProjectMemberProfile, 'projectUuid' | 'role'>[],
+    projectProfiles: Pick<
+        ProjectMemberProfile,
+        'projectUuid' | 'role' | 'userUuid'
+    >[],
 ): MemberAbility => {
     const builder = getUserAbilityBuilder(user, projectProfiles);
     return builder.build();

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -82,7 +82,7 @@ describe('Organization member permissions', () => {
         it('can view dashboards', () => {
             expect(ability.can('view', 'Dashboard')).toEqual(true);
         });
-        it('cannot manage dashboards from their own organization', () => {
+        it('can manage dashboards from their own organization', () => {
             expect(
                 ability.can(
                     'manage',
@@ -108,6 +108,50 @@ describe('Organization member permissions', () => {
         });
         it('cannot run SQL Queries', () => {
             expect(ability.can('manage', 'SqlRunner')).toEqual(false);
+        });
+        it('can manage public spaces', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Space', {
+                        organizationUuid: '456',
+                        isPrivate: false,
+                    }),
+                ),
+            ).toEqual(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Space', {
+                        organizationUuid: '456',
+                        isPrivate: false,
+                        access: ['random-uuid'],
+                    }),
+                ),
+            ).toEqual(true);
+        });
+        it('cannot manage private spaces', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Space', {
+                        organizationUuid: '456',
+                        isPrivate: true,
+                    }),
+                ),
+            ).toEqual(false);
+        });
+        it('can manage space if granted access', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Space', {
+                        organizationUuid: '456',
+                        isPrivate: true,
+                        access: [ORGANIZATION_EDITOR.userUuid],
+                    }),
+                ),
+            ).toEqual(true);
         });
     });
     describe('when user is an developer', () => {
@@ -143,6 +187,43 @@ describe('Organization member permissions', () => {
     describe('when user is a viewer', () => {
         beforeEach(() => {
             ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
+        });
+        it('can view spaces', () => {
+            expect(ability.can('view', 'Space')).toEqual(true);
+        });
+        it('can view public spaces in their organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Space', {
+                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
+                        isPrivate: false,
+                    }),
+                ),
+            ).toEqual(true);
+        });
+        it('cannot view private spaces in their organization', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Space', {
+                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
+                        isPrivate: true,
+                    }),
+                ),
+            ).toEqual(false);
+        });
+        it('can view private spaces in their organization if they have access', () => {
+            expect(
+                ability.can(
+                    'view',
+                    subject('Space', {
+                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
+                        isPrivate: true,
+                        access: [ORGANIZATION_VIEWER.userUuid],
+                    }),
+                ),
+            ).toEqual(true);
         });
         it('can view member profiles', () => {
             expect(ability.can('view', 'OrganizationMemberProfile')).toEqual(

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -31,6 +31,12 @@ export const organizationMemberAbilities: Record<
         });
         can('view', 'Space', {
             organizationUuid: member.organizationUuid,
+            isPrivate: false,
+        });
+        can('view', 'Space', {
+            organizationUuid: member.organizationUuid,
+            isPrivate: true,
+            access: member.userUuid,
         });
         can('view', 'SavedChart', {
             organizationUuid: member.organizationUuid,
@@ -66,6 +72,12 @@ export const organizationMemberAbilities: Record<
         });
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,
+            isPrivate: false,
+        });
+        can('manage', 'Space', {
+            organizationUuid: member.organizationUuid,
+            isPrivate: true,
+            access: member.userUuid,
         });
         can('manage', 'SavedChart', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -13,7 +13,9 @@ import { MemberAbility } from './types';
 const { projectUuid } = PROJECT_VIEWER;
 
 const defineAbilityForProjectMember = (
-    member: Pick<ProjectMemberProfile, 'role' | 'projectUuid'> | undefined,
+    member:
+        | Pick<ProjectMemberProfile, 'role' | 'projectUuid' | 'userUuid'>
+        | undefined,
 ): MemberAbility => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     if (member) {

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -9,7 +9,7 @@ import { MemberAbility } from './types';
 export const projectMemberAbilities: Record<
     ProjectMemberRole,
     (
-        member: Pick<ProjectMemberProfile, 'role' | 'projectUuid'>,
+        member: Pick<ProjectMemberProfile, 'role' | 'projectUuid' | 'userUuid'>,
         builder: Pick<AbilityBuilder<MemberAbility>, 'can'>,
     ) => void
 > = {
@@ -19,6 +19,12 @@ export const projectMemberAbilities: Record<
         });
         can('view', 'Space', {
             projectUuid: member.projectUuid,
+            isPrivate: false,
+        });
+        can('view', 'Space', {
+            projectUuid: member.projectUuid,
+            isPrivate: true,
+            access: member.userUuid,
         });
         can('view', 'SavedChart', {
             projectUuid: member.projectUuid,
@@ -47,6 +53,12 @@ export const projectMemberAbilities: Record<
         });
         can('manage', 'Space', {
             projectUuid: member.projectUuid,
+            isPrivate: false,
+        });
+        can('manage', 'Space', {
+            projectUuid: member.projectUuid,
+            isPrivate: true,
+            access: member.userUuid,
         });
         can('manage', 'SavedChart', {
             projectUuid: member.projectUuid,


### PR DESCRIPTION
We make multiple round trips on the DB to determine space access.

This is an example of pushing that logic into CASL, which is then executed against a `Space`

I've added:
- tests to show how CASL checks work with array properties (in this case the `access` array)
- replaced the `hasSpaceAccess`


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
