### PR TITLE
fix: disable browser retries

### DIFF
--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -168,7 +168,6 @@ export class SlackService {
                         details.pageType,
                         imageId,
                         authUserUuid,
-                        3, // up to 3 retries
                     );
 
                     if (imageUrl) {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -106,7 +106,6 @@ export const getNotificationPageData = async (
             pageType,
             `slack-image-notification-${nanoid()}`,
             userUuid,
-            3, // up to 3 retries
         );
         if (imageUrl === undefined) {
             throw new Error('Unable to unfurl image');

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -167,14 +167,14 @@ export class UnfurlService {
 
             return imageBuffer;
         } catch (e) {
-            if (browser) await browser.close();
-
             Sentry.captureException(e);
 
             Logger.error(
                 `Unable to fetch screenshots from headless chrome ${e.message}`,
             );
             throw e;
+        } finally {
+            if (browser) await browser.close();
         }
     }
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -98,7 +98,6 @@ export class UnfurlService {
         cookie: string,
         url: string,
         lightdashPage: LightdashPage,
-        retries: number = 0,
     ): Promise<Buffer | undefined> {
         let browser;
 
@@ -170,31 +169,12 @@ export class UnfurlService {
         } catch (e) {
             if (browser) await browser.close();
 
-            if (retries > 0) {
-                Logger.warn(
-                    `Retrying (${retries}) to fetch screenshots from headless chrome ${e.message}`,
-                );
-                const delay = (ms: number) =>
-                    new Promise((res) => {
-                        setTimeout(res, ms);
-                    });
-                await delay(10000); // Wait 10 seconds before retrying
-                return await this.saveScreenshot(
-                    imageId,
-                    cookie,
-                    url,
-                    lightdashPage,
-                    retries - 1,
-                );
-            }
             Sentry.captureException(e);
 
             Logger.error(
                 `Unable to fetch screenshots from headless chrome ${e.message}`,
             );
             throw e;
-        } finally {
-            if (browser) await browser.close();
         }
     }
 
@@ -368,7 +348,6 @@ export class UnfurlService {
         lightdashPage: LightdashPage,
         imageId: string,
         authUserUuid: string,
-        retries: number = 0,
     ): Promise<string | undefined> {
         const cookie = await this.getUserCookie(authUserUuid);
 
@@ -377,7 +356,6 @@ export class UnfurlService {
             cookie,
             url,
             lightdashPage,
-            retries,
         );
 
         let imageUrl;
@@ -418,7 +396,6 @@ export class UnfurlService {
             pageType,
             `${snakeCaseName(name)}_${useNanoid()}`,
             user.userUuid,
-            3, // up to 3 retries
         );
         if (imageUrl === undefined) {
             throw new Error('Unable to unfurl image');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

I think this retry could be blocking the worker when an error happens..

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
