### PR TITLE
fix: redirect new user to first default project

### DIFF
--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -1,12 +1,14 @@
-import React, { FC } from 'react';
-import { Redirect, useParams } from 'react-router-dom';
+import { FC } from 'react';
+import { Redirect } from 'react-router-dom';
 import ErrorState from '../components/common/ErrorState';
 import PageSpinner from '../components/PageSpinner';
-import { getLastProject, useProjects } from '../hooks/useProjects';
+import { useActiveProjectUuid } from '../hooks/useProject';
+import { useProjects } from '../hooks/useProjects';
 
 export const Projects: FC = () => {
-    const params = useParams<{ projectUuid: string | undefined }>();
     const { isLoading, data, error } = useProjects();
+    const activeProjectUuid = useActiveProjectUuid();
+
     if (isLoading) {
         return <PageSpinner />;
     }
@@ -17,18 +19,5 @@ export const Projects: FC = () => {
         return <Redirect to="/no-access" />;
     }
 
-    const availableProjectUuids = data.map(({ projectUuid }) => projectUuid);
-
-    const find = (projectUuid: string | undefined) => {
-        return projectUuid && availableProjectUuids.includes(projectUuid)
-            ? projectUuid
-            : undefined;
-    };
-    const lastProject = getLastProject();
-    const projectUuid =
-        find(params.projectUuid) ||
-        find(lastProject) ||
-        availableProjectUuids[0];
-
-    return <Redirect to={`/projects/${projectUuid}/home`} />;
+    return <Redirect to={`/projects/${activeProjectUuid}/home`} />;
 };


### PR DESCRIPTION

### Description:

#### Current behaviour

Currently, users who join an org for the first time get redirected to the first project that's available (independently of its Project type: `Default` or `Preview`).

Screen recording: 

https://user-images.githubusercontent.com/7611706/232542404-7f34839c-6e48-4ab9-a77c-9a063c43ace7.mov


#### Proposed solution

Users who join an org for the first time get redirected to the first `default` Project - if it exists.

Screen recording: 

https://user-images.githubusercontent.com/7611706/232542665-cc22c90b-1ff0-4b82-894f-04287b5eb42c.mov


