### PR TITLE
fix: add logger to `downloadCsv` job

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -402,7 +402,9 @@ export const downloadCsv = async (
             status: SchedulerJobStatus.ERROR,
             details: { createdByUserUuid: payload.userUuid, error: e },
         });
+
         // do not throw error to avoid retrying
+        Logger.error(`Unable to complete job "${jobId}": ${JSON.stringify(e)}`);
     }
 };
 

--- a/packages/frontend/src/components/ExportCSV/index.tsx
+++ b/packages/frontend/src/components/ExportCSV/index.tsx
@@ -91,6 +91,7 @@ const ExportCSV: FC<ExportCSVProps> = memo(
                     onSuccess: (scheduledCsvResponse) => {
                         pollCsvFileUrl(scheduledCsvResponse)
                             .then((url) => {
+                                console.log({ url });
                                 if (url) window.location.href = url;
                                 AppToaster.dismiss('exporting-csv');
                             })

--- a/packages/frontend/src/components/ExportCSV/index.tsx
+++ b/packages/frontend/src/components/ExportCSV/index.tsx
@@ -91,7 +91,6 @@ const ExportCSV: FC<ExportCSVProps> = memo(
                     onSuccess: (scheduledCsvResponse) => {
                         pollCsvFileUrl(scheduledCsvResponse)
                             .then((url) => {
-                                console.log({ url });
                                 if (url) window.location.href = url;
                                 AppToaster.dismiss('exporting-csv');
                             })


### PR DESCRIPTION
adds logger to `downloadCsv` job since it's not propagating catching errors