### PR TITLE
feat: add worker logs

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -5,7 +5,6 @@ import {
     isSchedulerCsvOptions,
     isSlackTarget,
     LightdashPage,
-    MetricQuery,
     NotificationPayloadBase,
     ScheduledDeliveryPayload,
     Scheduler,
@@ -14,7 +13,6 @@ import {
     SlackNotificationPayload,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
-import { Job } from 'graphile-worker';
 import { nanoid } from 'nanoid';
 import { analytics } from '../analytics/client';
 import {
@@ -344,7 +342,6 @@ export const sendSlackNotification = async (
             status: SchedulerJobStatus.COMPLETED,
         });
     } catch (e) {
-        Logger.error(`Unable to complete job "${jobId}": ${JSON.stringify(e)}`);
         analytics.track({
             event: 'scheduler_notification_job.failed',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -401,9 +398,7 @@ export const downloadCsv = async (
             status: SchedulerJobStatus.ERROR,
             details: { createdByUserUuid: payload.userUuid, error: e },
         });
-
-        // do not throw error to avoid retrying
-        Logger.error(`Unable to complete job "${jobId}": ${JSON.stringify(e)}`);
+        throw e; // Cascade error to it can be retried by graphile
     }
 };
 
@@ -535,7 +530,6 @@ export const sendEmailNotification = async (
             status: SchedulerJobStatus.COMPLETED,
         });
     } catch (e) {
-        Logger.error(`Unable to complete job "${jobId}": ${JSON.stringify(e)}`);
         analytics.track({
             event: 'scheduler_notification_job.failed',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -634,7 +628,6 @@ export const handleScheduledDelivery = async (
             },
         });
     } catch (e) {
-        Logger.error(`Unable to complete job "${jobId}": ${JSON.stringify(e)}`);
         analytics.track({
             event: 'scheduler_job.failed',
             anonymousId: LightdashAnalytics.anonymousId,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1,4 +1,3 @@
-import { SchedulerJobStatus } from '@lightdash/common';
 import { getSchedule, stringToArray } from 'cron-converter';
 import {
     JobHelpers,
@@ -17,6 +16,7 @@ import {
     sendEmailNotification,
     sendSlackNotification,
 } from './SchedulerTask';
+import schedulerWorkerEventEmitter from './SchedulerWorkerEventEmitter';
 
 type SchedulerWorkerDependencies = {
     lightdashConfig: LightdashConfig;
@@ -40,9 +40,8 @@ export const getDailyDatesFromCron = (
     return dailyDates;
 };
 
-const workerLogger = new GraphileLogger((scope) => (level, message, meta) => {
-    const sanitizedLevel = level === 'warning' ? 'warn' : level;
-    Logger[sanitizedLevel](message, meta, scope);
+const workerLogger = new GraphileLogger((scope) => (_, message, meta) => {
+    Logger.debug(message, meta, scope);
 });
 
 export class SchedulerWorker {
@@ -57,6 +56,7 @@ export class SchedulerWorker {
         await schedulerClient.graphileUtils;
         // Run a worker to execute jobs:
         Logger.info('Running scheduler');
+
         const runner = await runGraphileWorker({
             connectionString: this.lightdashConfig.database.connectionUri,
             logger: workerLogger,
@@ -74,13 +74,7 @@ export class SchedulerWorker {
                 },
             ]),
             taskList: {
-                generateDailyJobs: async (
-                    payload: any,
-                    helpers: JobHelpers,
-                ) => {
-                    Logger.info(
-                        `Processing generateDailyJobs job "${helpers.job.id}"`,
-                    );
+                generateDailyJobs: async () => {
                     const schedulers =
                         await schedulerService.getAllSchedulers();
                     const promises = schedulers.map(async (scheduler) => {
@@ -95,10 +89,6 @@ export class SchedulerWorker {
                     payload: any,
                     helpers: JobHelpers,
                 ) => {
-                    Logger.info(
-                        `Processing handleScheduledDelivery job "${helpers.job.id}"`,
-                        payload,
-                    );
                     await handleScheduledDelivery(
                         helpers.job.id,
                         helpers.job.run_at,
@@ -109,27 +99,15 @@ export class SchedulerWorker {
                     payload: any,
                     helpers: JobHelpers,
                 ) => {
-                    Logger.info(
-                        `Processing sendSlackNotification job "${helpers.job.id}"`,
-                        payload,
-                    );
                     await sendSlackNotification(helpers.job.id, payload);
                 },
                 sendEmailNotification: async (
                     payload: any,
                     helpers: JobHelpers,
                 ) => {
-                    Logger.info(
-                        `Processing sendEmailNotification job "${helpers.job.id}"`,
-                        payload,
-                    );
                     await sendEmailNotification(helpers.job.id, payload);
                 },
                 downloadCsv: async (payload: any, helpers: JobHelpers) => {
-                    Logger.info(
-                        `Processing downloadCsv job "${helpers.job.id}"`,
-                        payload,
-                    );
                     await downloadCsv(
                         helpers.job.id,
                         helpers.job.run_at,
@@ -137,6 +115,7 @@ export class SchedulerWorker {
                     );
                 },
             },
+            events: schedulerWorkerEventEmitter,
         });
 
         await runner.promise;

--- a/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.ts
@@ -1,0 +1,51 @@
+import EventEmitter from 'events';
+import { WorkerEvents } from 'graphile-worker';
+import Logger from '../logger';
+
+const schedulerWorkerEventEmitter: WorkerEvents = new EventEmitter();
+
+// Handle worker events
+schedulerWorkerEventEmitter.on('worker:create', ({ worker }) => {
+    Logger.info(`Worker ${worker.workerId} was created`);
+});
+
+schedulerWorkerEventEmitter.on('worker:stop', ({ worker, error }) => {
+    Logger.info(`Worker ${worker.workerId} was stopped. ${error ?? ''}`);
+});
+
+schedulerWorkerEventEmitter.on('worker:fatalError', ({ worker, error }) => {
+    Logger.info(`Worker ${worker.workerId} has fatal error. ${error}`);
+});
+
+// Handle job events
+schedulerWorkerEventEmitter.on('job:start', ({ worker, job }) => {
+    Logger.info(
+        `Worker ${worker.workerId} started job ${job.id} (${job.task_identifier}). Attempt ${job.attempts} of ${job.max_attempts}`,
+    );
+});
+
+schedulerWorkerEventEmitter.on('job:success', ({ worker, job }) => {
+    Logger.info(
+        `Worker ${worker.workerId} successfully executed job ${job.id} (${job.task_identifier})`,
+    );
+});
+
+schedulerWorkerEventEmitter.on('job:error', ({ worker, job, error }) => {
+    Logger.info(
+        `Worker ${worker.workerId} errored job ${job.id} (${job.task_identifier}). ${error}`,
+    );
+});
+
+schedulerWorkerEventEmitter.on('job:failed', ({ worker, job, error }) => {
+    Logger.info(
+        `Worker ${worker.workerId} failed job ${job.id} (${job.task_identifier}). ${error}`,
+    );
+});
+
+schedulerWorkerEventEmitter.on('job:complete', ({ worker, job }) => {
+    Logger.info(
+        `Worker ${worker.workerId} concluded job ${job.id} (${job.task_identifier})`,
+    );
+});
+
+export default schedulerWorkerEventEmitter;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5122 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- record info logs based on graphile events 
- record graphile logs as debug logs
- remove existing start/error logs inside the job execution


Example logs starting the server and executing a scheduled delivery:
```
2023-04-18 15:56:20 [Lightdash] info: Running scheduler
2023-04-18 15:56:20 [Lightdash] info: Worker worker-59fe5542fd7a76c661 was created
2023-04-18 15:56:20 [Lightdash] info: Worker worker-59fe5542fd7a76c661 started job 16 (handleScheduledDelivery). Attempt 1 of 1
2023-04-18 15:56:20 [Lightdash] info: Creating 1 notification jobs for scheduler 78b90b67-9302-443d-b254-9295ab0d44e4
2023-04-18 15:56:20 [Lightdash] info: Worker worker-59fe5542fd7a76c661 successfully executed job 16 (handleScheduledDelivery)
2023-04-18 15:56:20 [Lightdash] info: Worker worker-59fe5542fd7a76c661 concluded job 16 (handleScheduledDelivery)
2023-04-18 15:56:20 [Lightdash] info: Worker worker-59fe5542fd7a76c661 started job 499 (sendEmailNotification). Attempt 1 of 1
2023-04-18 15:56:22 [Lightdash] info: Worker worker-59fe5542fd7a76c661 successfully executed job 499 (sendEmailNotification)
2023-04-18 15:56:22 [Lightdash] info: Worker worker-59fe5542fd7a76c661 concluded job 499 (sendEmailNotification)
2023-04-18 15:56:48 [Lightdash] info: Worker worker-59fe5542fd7a76c661 was stopped. 
```
