### PR TITLE
fix: handle error for multiple orgs registration when it's not allowed

### DIFF
--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -4,7 +4,7 @@ import {
     ApiSuccessEmpty,
     ApiUserAllowedOrganizationsResponse,
 } from '@lightdash/common';
-import { Controller, Query } from '@tsoa/runtime';
+import { Controller, Delete, Query } from '@tsoa/runtime';
 import express from 'express';
 import {
     Get,
@@ -118,6 +118,24 @@ export class UserController extends Controller {
                 resolve();
             });
         });
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Delete user
+     * @param req express request
+     */
+    @Middlewares([isAuthenticated])
+    @Delete('/me')
+    @OperationId('deleteUser')
+    async deleteUser(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        await userService.delete(req.user!, req.user!.userUuid);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2355,6 +2355,46 @@ export function RegisterRoutes(app: express.Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/user/me',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.deleteUser,
+        ),
+
+        function UserController_deleteUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new UserController();
+
+                const promise = controller.deleteUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -177,29 +177,24 @@ export class UserService {
     }
 
     async delete(user: SessionUser, userUuidToDelete: string): Promise<void> {
-        if (user.userUuid === userUuidToDelete) {
-            throw new ForbiddenError('User can not delete themself');
-        }
-        if (user.organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
-        }
+        if (user.organizationUuid) {
+            if (user.ability.cannot('delete', 'OrganizationMemberProfile')) {
+                throw new ForbiddenError();
+            }
 
-        if (user.ability.cannot('delete', 'OrganizationMemberProfile')) {
-            throw new ForbiddenError();
-        }
-
-        // Race condition between check and delete
-        const [admin, ...remainingAdmins] =
-            await this.organizationMemberProfileModel.getOrganizationAdmins(
-                user.organizationUuid,
-            );
-        if (
-            remainingAdmins.length === 0 &&
-            admin.userUuid === userUuidToDelete
-        ) {
-            throw new ForbiddenError(
-                'Organization must have at least one admin',
-            );
+            // Race condition between check and delete
+            const [admin, ...remainingAdmins] =
+                await this.organizationMemberProfileModel.getOrganizationAdmins(
+                    user.organizationUuid,
+                );
+            if (
+                remainingAdmins.length === 0 &&
+                admin.userUuid === userUuidToDelete
+            ) {
+                throw new ForbiddenError(
+                    'Organization must have at least one admin',
+                );
+            }
         }
 
         await this.sessionModel.deleteAllByUserUuid(userUuidToDelete);

--- a/packages/frontend/src/hooks/user/useUserDeleteMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserDeleteMutation.ts
@@ -1,0 +1,15 @@
+import { ApiError } from '@lightdash/common';
+import { useMutation } from 'react-query';
+import { lightdashApi } from '../../api';
+
+const deleteUserQuery = async () =>
+    lightdashApi<undefined>({
+        url: `/user/me`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useDeleteUserMutation = () =>
+    useMutation<undefined, ApiError, undefined>(deleteUserQuery, {
+        mutationKey: ['user_delete'],
+    });

--- a/packages/frontend/src/hooks/user/useUserDeleteMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserDeleteMutation.ts
@@ -10,6 +10,9 @@ const deleteUserQuery = async () =>
     });
 
 export const useDeleteUserMutation = () =>
-    useMutation<undefined, ApiError, undefined>(deleteUserQuery, {
+    useMutation<undefined, ApiError>(deleteUserQuery, {
         mutationKey: ['user_delete'],
+        onSuccess: () => {
+            window.location.href = '/login';
+        },
     });

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -1,3 +1,4 @@
+import { NonIdealState } from '@blueprintjs/core';
 import { getEmailDomain } from '@lightdash/common';
 import {
     Anchor,
@@ -18,6 +19,7 @@ import PageSpinner from '../components/PageSpinner';
 import { useOrganisationCreateMutation } from '../hooks/organisation/useOrganisationCreateMutation';
 import useAllowedOrganizations from '../hooks/user/useAllowedOrganizations';
 import { useJoinOrganizationMutation } from '../hooks/user/useJoinOrganizationMutation';
+import { useDeleteUserMutation } from '../hooks/user/useUserDeleteMutation';
 import { useApp } from '../providers/AppProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
 
@@ -30,7 +32,9 @@ export const JoinOrganizationPage: FC = () => {
         mutate: createOrg,
         isLoading: isCreatingOrg,
         isSuccess: hasCreatedOrg,
+        error: createOrgError,
     } = useOrganisationCreateMutation();
+    const { mutate: deleteUser } = useDeleteUserMutation();
     const {
         mutate: joinOrg,
         isLoading: isJoiningOrg,
@@ -45,7 +49,8 @@ export const JoinOrganizationPage: FC = () => {
             !isCreatingOrg &&
             !isLoadingAllowedOrgs &&
             !userHasOrg &&
-            !isAllowedToJoinOrgs
+            !isAllowedToJoinOrgs &&
+            !createOrgError
         ) {
             createOrg({ name: '' });
         }
@@ -56,13 +61,14 @@ export const JoinOrganizationPage: FC = () => {
         isCreatingOrg,
         user,
         isLoadingAllowedOrgs,
+        createOrgError,
     ]);
 
     useEffect(() => {
-        if (hasCreatedOrg || hasJoinedOrg) {
+        if ((hasCreatedOrg || hasJoinedOrg) && !createOrgError) {
             history.push('/');
         }
-    }, [hasCreatedOrg, hasJoinedOrg, history]);
+    }, [createOrgError, hasCreatedOrg, hasJoinedOrg, history]);
 
     if (health.isLoading || isLoadingAllowedOrgs || isCreatingOrg) {
         return <PageSpinner />;
@@ -72,83 +78,109 @@ export const JoinOrganizationPage: FC = () => {
 
     return (
         <Page isFullHeight>
-            <Helmet>
-                <title>Join a workspace - Lightdash</title>
-            </Helmet>
-            <Stack w={400} mt="4xl">
-                <Image
-                    src={LightdashLogo}
-                    alt="lightdash logo"
-                    width={130}
-                    mx="auto"
-                    my="lg"
-                />
-                <Card p="xl" radius="xs" withBorder shadow="xs">
-                    <Stack justify="center" spacing="md" mb="xs">
-                        <Title order={3} ta="center">
-                            Join a workspace
-                        </Title>
-                        <Text color="gray.6" ta="center">
-                            The workspaces below are open to anyone with a{' '}
-                            <Text span fw={600}>
-                                @{emailDomain}:
-                            </Text>{' '}
-                            domain
-                        </Text>
-                        {allowedOrgs?.map((org) => (
-                            <Card key={org.organizationUuid} withBorder>
-                                <Group position="apart">
-                                    <Group spacing="md">
-                                        <Avatar
-                                            size="md"
-                                            radius="xl"
-                                            color="gray.6"
-                                        >
-                                            {org.name[0]?.toUpperCase()}
-                                        </Avatar>
-                                        <Stack spacing="two">
-                                            <Text truncate fw={600}>
-                                                {org.name}
-                                            </Text>
-                                            <Text fz="xs" c="gray">
-                                                {org.membersCount} members
-                                            </Text>
-                                        </Stack>
-                                    </Group>
-                                    <Button
-                                        onClick={() =>
-                                            joinOrg(org.organizationUuid)
-                                        }
-                                        loading={isJoiningOrg}
-                                    >
-                                        Join
-                                    </Button>
-                                </Group>
-                            </Card>
-                        ))}
-                    </Stack>
-                </Card>
-                <Anchor
-                    component="button"
-                    onClick={() => createOrg({ name: '' })}
-                    disabled={disabled}
-                    ta="center"
-                    size="sm"
-                    sx={(theme) =>
-                        disabled
-                            ? {
-                                  color: theme.colors.gray[6],
-                                  '&:hover': {
-                                      textDecoration: 'none',
-                                      color: theme.colors.gray[6],
-                                  },
-                              }
-                            : {}
+            {createOrgError ? (
+                <NonIdealState
+                    icon="error"
+                    title="Error"
+                    description={createOrgError.error.message}
+                    action={
+                        <Button
+                            onClick={() => {
+                                console.log('delete user');
+                                // @ts-expect-error
+                                deleteUser();
+                                history.push('/register');
+                            }}
+                        >
+                            Delete user and go back
+                        </Button>
                     }
-                >
-                    Create a new workspace
-                </Anchor>
-            </Stack>
+                />
+            ) : (
+                <>
+                    <Helmet>
+                        <title>Join a workspace - Lightdash</title>
+                    </Helmet>
+                    <Stack w={400} mt="4xl">
+                        <Image
+                            src={LightdashLogo}
+                            alt="lightdash logo"
+                            width={130}
+                            mx="auto"
+                            my="lg"
+                        />
+                        <Card p="xl" radius="xs" withBorder shadow="xs">
+                            <Stack justify="center" spacing="md" mb="xs">
+                                <Title order={3} ta="center">
+                                    Join a workspace
+                                </Title>
+                                <Text color="gray.6" ta="center">
+                                    The workspaces below are open to anyone with
+                                    a{' '}
+                                    <Text span fw={600}>
+                                        @{emailDomain}:
+                                    </Text>{' '}
+                                    domain
+                                </Text>
+                                {allowedOrgs?.map((org) => (
+                                    <Card key={org.organizationUuid} withBorder>
+                                        <Group position="apart">
+                                            <Group spacing="md">
+                                                <Avatar
+                                                    size="md"
+                                                    radius="xl"
+                                                    color="gray.6"
+                                                >
+                                                    {org.name[0]?.toUpperCase()}
+                                                </Avatar>
+                                                <Stack spacing="two">
+                                                    <Text truncate fw={600}>
+                                                        {org.name}
+                                                    </Text>
+                                                    <Text fz="xs" c="gray">
+                                                        {org.membersCount}{' '}
+                                                        members
+                                                    </Text>
+                                                </Stack>
+                                            </Group>
+                                            <Button
+                                                onClick={() =>
+                                                    joinOrg(
+                                                        org.organizationUuid,
+                                                    )
+                                                }
+                                                loading={isJoiningOrg}
+                                            >
+                                                Join
+                                            </Button>
+                                        </Group>
+                                    </Card>
+                                ))}
+                            </Stack>
+                        </Card>
+                        <Anchor
+                            component="button"
+                            onClick={() => createOrg({ name: '' })}
+                            disabled={disabled}
+                            ta="center"
+                            size="sm"
+                            sx={(theme) =>
+                                disabled
+                                    ? {
+                                          color: theme.colors.gray[6],
+                                          '&:hover': {
+                                              textDecoration: 'none',
+                                              color: theme.colors.gray[6],
+                                          },
+                                      }
+                                    : {}
+                            }
+                        >
+                            Create a new workspace
+                        </Anchor>
+                    </Stack>
+                </>
+            )}
         </Page>
     );
 };

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -79,23 +79,18 @@ export const JoinOrganizationPage: FC = () => {
     return (
         <Page isFullHeight>
             {createOrgError ? (
-                <NonIdealState
-                    icon="error"
-                    title="Error"
-                    description={createOrgError.error.message}
-                    action={
-                        <Button
-                            onClick={() => {
-                                console.log('delete user');
-                                // @ts-expect-error
-                                deleteUser();
-                                history.push('/register');
-                            }}
-                        >
-                            Delete user and go back
-                        </Button>
-                    }
-                />
+                <Stack mt="4xl">
+                    <NonIdealState
+                        icon="error"
+                        title="Error"
+                        description={createOrgError.error.message}
+                        action={
+                            <Button onClick={() => deleteUser()}>
+                                Cancel registration
+                            </Button>
+                        }
+                    />
+                </Stack>
             ) : (
                 <>
                     <Helmet>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5114 

### Description:

Users get stuck when registering without an invite link - since the `createOrg` mutation error doesn't get handled, the page displays an intermittent page spinner + infinite calls to `createOrg` mutation through an useEffect.

Current behaviour is registered in issue #5114.

### Proposed solution

#### When organization creation fails: 

- User tries to register (with /register)
- Create Org mutation throws `403`
- Stop flow, allow user to discard current journey 
- Redirect to /login and start over

https://user-images.githubusercontent.com/7611706/233031286-25e98376-554b-4fba-8127-fa3d2c0ebbc3.mov

### Current scenarios that work as expected (no changes)

#### When multiple orgs are allowed (`ALLOW_MULTIPLE_ORGS=true`)

https://user-images.githubusercontent.com/7611706/233032322-d1a1328f-5bc8-4f4d-b8df-d105e3ed116d.mov

#### When domain (e.g. lightdash.com) is allowed through company settings:

https://user-images.githubusercontent.com/7611706/233031375-b49270f4-414a-4d6f-8249-ad6fe06b80e0.mov


Thanks @ZeRego for pairing on this 🎉 
