### PR TITLE
chore: rename useDeleteUserMutation hook to useDeleteOrganizationUserMutation

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -12,11 +12,11 @@ import {
     OrganizationMemberProfile,
     OrganizationMemberRole,
 } from '@lightdash/common';
-import React, { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import {
-    useDeleteUserMutation,
+    useDeleteOrganizationUserMutation,
     useOrganizationUsers,
     useUpdateUserMutation,
 } from '../../../hooks/useOrganizationUsers';
@@ -64,7 +64,8 @@ const UserListItem: FC<{
     },
 }) => {
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-    const { mutate, isLoading: isDeleting } = useDeleteUserMutation();
+    const { mutate, isLoading: isDeleting } =
+        useDeleteOrganizationUserMutation();
     const inviteLink = useCreateInviteLinkMutation();
     const { track } = useTracking();
     const { user, health } = useApp();

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -42,7 +42,7 @@ export const useOrganizationUsers = () => {
     });
 };
 
-export const useDeleteUserMutation = () => {
+export const useDeleteOrganizationUserMutation = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteUserQuery, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5139 

### Description:

Increase detail of `useDeleteUserMutation` for an organization by renaming it to `useDeleteOrganizationUserMutation`. This is necessary to avoid confusion between this hook and the newly-added hook `useUserDeleteMutation` added on #5141 
