### PR TITLE
chore: rename organization spelling in backend

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -149,7 +149,7 @@ type TrackOrganizationEvent = BaseTrack & {
     };
 };
 
-type OrganisationAllowedEmailDomainUpdatedEvent = BaseTrack & {
+type OrganizationAllowedEmailDomainUpdatedEvent = BaseTrack & {
     event: 'organization_allowed_email_domains.updated';
     properties: {
         organizationId: string;
@@ -610,7 +610,7 @@ type Track =
     | CreateDashboardOrVersionEvent
     | ProjectTablesConfigurationEvent
     | TrackOrganizationEvent
-    | OrganisationAllowedEmailDomainUpdatedEvent
+    | OrganizationAllowedEmailDomainUpdatedEvent
     | LoginEvent
     | IdentityLinkedEvent
     | SqlExecutedEvent

--- a/packages/backend/src/database/migrations/20220125142122_add_organisation_allowed_domains_column.ts
+++ b/packages/backend/src/database/migrations/20220125142122_add_organisation_allowed_domains_column.ts
@@ -1,10 +1,10 @@
 import { Knex } from 'knex';
 
-const OrganisationTableName = 'organizations';
+const OrganizationTableName = 'organizations';
 const AllowedEmailDomainsColumnName = 'allowed_email_domains';
 
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.table(OrganisationTableName, (table) => {
+    await knex.schema.table(OrganizationTableName, (table) => {
         table
             .jsonb(AllowedEmailDomainsColumnName)
             .notNullable()
@@ -15,11 +15,11 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
     if (
         await knex.schema.hasColumn(
-            OrganisationTableName,
+            OrganizationTableName,
             AllowedEmailDomainsColumnName,
         )
     ) {
-        await knex.schema.table(OrganisationTableName, (table) => {
+        await knex.schema.table(OrganizationTableName, (table) => {
             table.dropColumn(AllowedEmailDomainsColumnName);
         });
     }

--- a/packages/backend/src/database/migrations/20230308100040_remove_org_allowed_email_domains.ts
+++ b/packages/backend/src/database/migrations/20230308100040_remove_org_allowed_email_domains.ts
@@ -1,23 +1,23 @@
 import { Knex } from 'knex';
 
-const OrganisationTableName = 'organizations';
+const OrganizationTableName = 'organizations';
 const AllowedEmailDomainsColumnName = 'allowed_email_domains';
 
 export async function up(knex: Knex): Promise<void> {
     if (
         await knex.schema.hasColumn(
-            OrganisationTableName,
+            OrganizationTableName,
             AllowedEmailDomainsColumnName,
         )
     ) {
-        await knex.schema.table(OrganisationTableName, (table) => {
+        await knex.schema.table(OrganizationTableName, (table) => {
             table.dropColumn(AllowedEmailDomainsColumnName);
         });
     }
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.schema.table(OrganisationTableName, (table) => {
+    await knex.schema.table(OrganizationTableName, (table) => {
         table
             .jsonb(AllowedEmailDomainsColumnName)
             .notNullable()

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -20,7 +20,7 @@ export class OrganizationModel {
         this.database = database;
     }
 
-    static mapDBObjectToOrganisation(data: DbOrganization): Organisation {
+    static mapDBObjectToOrganization(data: DbOrganization): Organisation {
         return {
             organizationUuid: data.organization_uuid,
             name: data.organization_name,
@@ -40,9 +40,9 @@ export class OrganizationModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (org === undefined) {
-            throw new NotFoundError(`No organisation found`);
+            throw new NotFoundError(`No organization found`);
         }
-        return OrganizationModel.mapDBObjectToOrganisation(org);
+        return OrganizationModel.mapDBObjectToOrganization(org);
     }
 
     async create(data: CreateOrganization): Promise<Organisation> {
@@ -51,7 +51,7 @@ export class OrganizationModel {
                 organization_name: data.name,
             })
             .returning('*');
-        return OrganizationModel.mapDBObjectToOrganisation(org);
+        return OrganizationModel.mapDBObjectToOrganization(org);
     }
 
     async update(
@@ -66,7 +66,7 @@ export class OrganizationModel {
                 chart_colors: data.chartColors,
             })
             .returning('*');
-        return OrganizationModel.mapDBObjectToOrganisation(org);
+        return OrganizationModel.mapDBObjectToOrganization(org);
     }
 
     async deleteOrgAndUsers(
@@ -77,7 +77,7 @@ export class OrganizationModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (org === undefined) {
-            throw new NotFoundError(`No organisation found`);
+            throw new NotFoundError(`No organization found`);
         }
 
         await this.database.transaction(async (trx) => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -27,7 +27,7 @@ export const user: SessionUser = {
     abilityRules: [],
 };
 
-export const organisation: Organisation = {
+export const organization: Organisation = {
     organizationUuid: 'organizationUuid',
     name: 'Lightdash',
 };

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -9,14 +9,14 @@ import {
     userModel,
 } from '../../models/models';
 import { OrganizationService } from './OrganizationService';
-import { organisation, user } from './OrganizationService.mock';
+import { organization, user } from './OrganizationService.mock';
 
 jest.mock('../../models/models', () => ({
     projectModel: {
         hasProjects: jest.fn(async () => true),
     },
     organizationModel: {
-        get: jest.fn(async () => organisation),
+        get: jest.fn(async () => organization),
     },
     organizationAllowedEmailDomainsModel: {},
 }));
@@ -43,7 +43,7 @@ describe('organization service', () => {
 
     it('Should return needsProject false if there are projects in DB', async () => {
         expect(await organizationService.get(user)).toEqual({
-            ...organisation,
+            ...organization,
             needsProject: false,
         });
     });
@@ -52,7 +52,7 @@ describe('organization service', () => {
             async () => false,
         );
         expect(await organizationService.get(user)).toEqual({
-            ...organisation,
+            ...organization,
             needsProject: true,
         });
     });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -80,11 +80,11 @@ export class OrganizationService {
             user.organizationUuid,
         ));
 
-        const organisation = await this.organizationModel.get(
+        const organization = await this.organizationModel.get(
             user.organizationUuid,
         );
         return {
-            ...organisation,
+            ...organization,
             needsProject,
         };
     }


### PR DESCRIPTION

Relates to: #5143 (doesn't fully close it as it's a fraction of the work that needs to be done)

Similar to: https://github.com/lightdash/lightdash/pull/5145

### Description:
Rename `organisation` references to `organization` in backend package
