### PR TITLE
feat: send slack message for empty csv results

### DIFF
--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -70,7 +70,7 @@ type GetChartCsvResultsBlocksArgs = {
     title: string;
     description: string | undefined;
     ctaUrl: string;
-    csvUrl: string;
+    csvUrl?: string;
     footerMarkdown?: string;
 };
 export const getChartCsvResultsBlocks = ({
@@ -105,7 +105,9 @@ export const getChartCsvResultsBlocks = ({
                 action_id: 'button-action',
             },
         },
-        {
+    ];
+    if (csvUrl) {
+        blocks.push({
             type: 'actions',
             elements: [
                 {
@@ -119,8 +121,16 @@ export const getChartCsvResultsBlocks = ({
                     action_id: 'download-results',
                 },
             ],
-        },
-    ];
+        });
+    } else {
+        blocks.push({
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: '*_This query returned no results_*',
+            },
+        });
+    }
     if (footerMarkdown) {
         blocks.push({
             type: 'context',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -291,14 +291,16 @@ export const sendSlackNotification = async (
                     throw new Error('Missing CSV URL');
                 }
                 if (csvUrl.path === '#no-results') {
-                    // Slack doesn't like URL blocks with no URL, so we are capturing this case and not sending a message
+                    // Slack doesn't like URL blocks with no URL, so we are capturing this case
                     Logger.error(`No CSV results for chart ${savedChartUuid}`);
-                    return; // Do not retry
+
+                    blocks = getChartCsvResultsBlocks(getBlocksArgs);
+                } else {
+                    blocks = getChartCsvResultsBlocks({
+                        ...getBlocksArgs,
+                        csvUrl: csvUrl.path,
+                    });
                 }
-                blocks = getChartCsvResultsBlocks({
-                    ...getBlocksArgs,
-                    csvUrl: csvUrl.path,
-                });
             } else if (dashboardUuid) {
                 if (csvUrls === undefined) {
                     throw new Error('Missing CSV URLS');

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -290,17 +290,12 @@ export const sendSlackNotification = async (
                 if (csvUrl === undefined) {
                     throw new Error('Missing CSV URL');
                 }
-                if (csvUrl.path === '#no-results') {
-                    // Slack doesn't like URL blocks with no URL, so we are capturing this case
-                    Logger.error(`No CSV results for chart ${savedChartUuid}`);
 
-                    blocks = getChartCsvResultsBlocks(getBlocksArgs);
-                } else {
-                    blocks = getChartCsvResultsBlocks({
-                        ...getBlocksArgs,
-                        csvUrl: csvUrl.path,
-                    });
-                }
+                blocks = getChartCsvResultsBlocks({
+                    ...getBlocksArgs,
+                    csvUrl:
+                        csvUrl.path !== '#no-results' ? csvUrl.path : undefined,
+                });
             } else if (dashboardUuid) {
                 if (csvUrls === undefined) {
                     throw new Error('Missing CSV URLS');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5118 

### Description:

Send Slack message when there are no results from query and therefore no CSV URL. 

Example of query with no results:

![Screenshot 2023-04-19 at 15 53 32](https://user-images.githubusercontent.com/7611706/233116003-f6c43d7a-bdc0-4acb-b138-080c9845ec30.png)


Slack message example: 

<img width="1167" alt="Screenshot 2023-04-19 at 15 53 47" src="https://user-images.githubusercontent.com/7611706/233115946-d3810fc7-f240-4466-a4ac-effd35653f87.png">


<!-- Even better add a screenshot / gif / loom -->
