### PR TITLE
chore: rename organization spelling in common package

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -181,7 +181,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Organisation: {
+    Organization: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -203,7 +203,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                results: { ref: 'Organisation', required: true },
+                results: { ref: 'Organization', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -222,7 +222,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Organisation.name_': {
+    'Pick_Organization.name_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -233,10 +233,10 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateOrganization: {
         dataType: 'refAlias',
-        type: { ref: 'Pick_Organisation.name_', validators: {} },
+        type: { ref: 'Pick_Organization.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Omit_Organisation.organizationUuid-or-needsProject__': {
+    'Partial_Omit_Organization.organizationUuid-or-needsProject__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -254,7 +254,7 @@ const models: TsoaRoute.Models = {
     UpdateOrganization: {
         dataType: 'refAlias',
         type: {
-            ref: 'Partial_Omit_Organisation.organizationUuid-or-needsProject__',
+            ref: 'Partial_Omit_Organization.organizationUuid-or-needsProject__',
             validators: {},
         },
     },

--- a/packages/backend/src/models/InviteLinkModel.ts
+++ b/packages/backend/src/models/InviteLinkModel.ts
@@ -29,7 +29,7 @@ export class InviteLinkModel {
             inviteCode,
             expiresAt: data.expires_at,
             inviteUrl: InviteLinkModel.transformInviteCodeToUrl(inviteCode),
-            organisationUuid: data.organization_uuid,
+            organizationUuid: data.organization_uuid,
             userUuid: data.user_uuid,
             email: data.email,
         };

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -1,7 +1,7 @@
 import {
     CreateOrganization,
     NotFoundError,
-    Organisation,
+    Organization,
     UpdateOrganization,
     UserAllowedOrganization,
 } from '@lightdash/common';
@@ -20,7 +20,7 @@ export class OrganizationModel {
         this.database = database;
     }
 
-    static mapDBObjectToOrganization(data: DbOrganization): Organisation {
+    static mapDBObjectToOrganization(data: DbOrganization): Organization {
         return {
             organizationUuid: data.organization_uuid,
             name: data.organization_name,
@@ -35,7 +35,7 @@ export class OrganizationModel {
         return orgs.length > 0;
     }
 
-    async get(organizationUuid: string): Promise<Organisation> {
+    async get(organizationUuid: string): Promise<Organization> {
         const [org] = await this.database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)
             .select('*');
@@ -45,7 +45,7 @@ export class OrganizationModel {
         return OrganizationModel.mapDBObjectToOrganization(org);
     }
 
-    async create(data: CreateOrganization): Promise<Organisation> {
+    async create(data: CreateOrganization): Promise<Organization> {
         const [org] = await this.database(OrganizationTableName)
             .insert({
                 organization_name: data.name,
@@ -57,7 +57,7 @@ export class OrganizationModel {
     async update(
         organizationUuid: string,
         data: UpdateOrganization,
-    ): Promise<Organisation> {
+    ): Promise<Organization> {
         // Undefined values are ignored by .update (it DOES NOT set null)
         const [org] = await this.database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -1,7 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     LightdashMode,
-    Organisation,
+    Organization,
     OrganizationMemberRole,
     SessionUser,
 } from '@lightdash/common';
@@ -27,7 +27,7 @@ export const user: SessionUser = {
     abilityRules: [],
 };
 
-export const organization: Organisation = {
+export const organization: Organization = {
     organizationUuid: 'organizationUuid',
     name: 'Lightdash',
 };

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -7,7 +7,7 @@ import {
     LightdashMode,
     NotExistsError,
     OnbordingRecord,
-    Organisation,
+    Organization,
     OrganizationMemberProfile,
     OrganizationMemberProfileUpdate,
     OrganizationMemberRole,
@@ -72,7 +72,7 @@ export class OrganizationService {
             organizationAllowedEmailDomainsModel;
     }
 
-    async get(user: SessionUser): Promise<Organisation> {
+    async get(user: SessionUser): Promise<Organization> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -50,7 +50,7 @@ import { FieldValueSearchResult } from './types/fieldMatch';
 import {
     AllowedEmailDomains,
     OnboardingStatus,
-    Organisation,
+    Organization,
     OrganizationProject,
     UpdateAllowedEmailDomains,
 } from './types/organization';
@@ -62,10 +62,7 @@ import {
     ProjectType,
     WarehouseCredentials,
 } from './types/projects';
-import {
-    NotificationPayloadBase,
-    SchedulerAndTargets,
-} from './types/scheduler';
+import { SchedulerAndTargets } from './types/scheduler';
 import { SlackChannel } from './types/slack';
 import { Space } from './types/space';
 import { TableBase } from './types/table';
@@ -431,7 +428,7 @@ export type InviteLink = {
     expiresAt: Date;
     inviteCode: string;
     inviteUrl: string;
-    organisationUuid: string;
+    organizationUuid: string;
     userUuid: string;
     email: string;
 };
@@ -453,7 +450,7 @@ type ApiResults =
     | ApiStatusResults
     | ApiRefreshResults
     | ApiHealthResults
-    | Organisation
+    | Organization
     | LightdashUser
     | SavedChart
     | SavedChart[]

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -4,14 +4,14 @@ import { ProjectType } from './projects';
 /**
  * Details of a user's Organization
  */
-export type Organisation = {
+export type Organization = {
     /**
-     * The unique identifier of the organisation
+     * The unique identifier of the organization
      * @format uuid
      */
     organizationUuid: string;
     /**
-     * The name of the organisation
+     * The name of the organization
      */
     name: string;
 
@@ -25,15 +25,15 @@ export type Organisation = {
     needsProject?: boolean;
 };
 
-export type CreateOrganization = Pick<Organisation, 'name'>;
+export type CreateOrganization = Pick<Organization, 'name'>;
 
 export type UpdateOrganization = Partial<
-    Omit<Organisation, 'organizationUuid' | 'needsProject'>
+    Omit<Organization, 'organizationUuid' | 'needsProject'>
 >;
 
 export type ApiOrganization = {
     status: 'ok';
-    results: Organisation;
+    results: Organization;
 };
 
 /**

--- a/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Intent } from '@blueprintjs/core';
-import { Organisation } from '@lightdash/common';
+import { Organization } from '@lightdash/common';
 import { FC, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
@@ -12,7 +12,7 @@ const OrganizationPanel: FC = () => {
     const { isLoading: isOrgLoading, data } = useOrganization();
     const updateMutation = useOrganizationUpdateMutation();
     const isLoading = updateMutation.isLoading || isOrgLoading;
-    const methods = useForm<Organisation>({
+    const methods = useForm<Organization>({
         mode: 'onSubmit',
     });
     const { setValue } = methods;
@@ -23,7 +23,7 @@ const OrganizationPanel: FC = () => {
         }
     }, [data, setValue]);
 
-    const handleUpdate = (value: Organisation) => {
+    const handleUpdate = (value: Organization) => {
         updateMutation.mutate(value);
     };
 

--- a/packages/frontend/src/hooks/organization/useOrganization.ts
+++ b/packages/frontend/src/hooks/organization/useOrganization.ts
@@ -1,19 +1,19 @@
-import { ApiError, Organisation } from '@lightdash/common';
+import { ApiError, Organization } from '@lightdash/common';
 import { useQuery } from 'react-query';
 import { UseQueryOptions } from 'react-query/types/react/types';
 import { lightdashApi } from '../../api';
 
 const getOrganization = async () =>
-    lightdashApi<Organisation>({
+    lightdashApi<Organization>({
         url: `/org`,
         method: 'GET',
         body: undefined,
     });
 
 export const useOrganization = (
-    useQueryOptions?: UseQueryOptions<Organisation, ApiError>,
+    useQueryOptions?: UseQueryOptions<Organization, ApiError>,
 ) =>
-    useQuery<Organisation, ApiError>({
+    useQuery<Organization, ApiError>({
         queryKey: ['organization'],
         queryFn: getOrganization,
         ...useQueryOptions,


### PR DESCRIPTION
Finalises work done on: 
* https://github.com/lightdash/lightdash/pull/5142
* https://github.com/lightdash/lightdash/pull/5145
* https://github.com/lightdash/lightdash/pull/5147

Closes: #5143 

### Description:

Rename all instances of `organisation` to `organization` in `packages/common` and update references in `packages/backend` and `packages/frontend`. 

We now only have 3 files that reference the word `organisation` which don't need to be changed 🎉 
![image](https://user-images.githubusercontent.com/7611706/233124730-c044bfb3-b8d6-4952-83a9-144c1423e8b4.png)

