### PR TITLE
fix: minimal chart padding

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Colors } from '@blueprintjs/core';
 import { Ability } from '@casl/ability';
+import { Stack } from '@mantine/core';
 import { Helmet } from 'react-helmet';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -101,13 +102,12 @@ const App = () => (
                                                         <PrivateRoute path="/minimal">
                                                             <Switch>
                                                                 <Route path="/minimal/projects/:projectUuid/saved/:savedQueryUuid">
-                                                                    <div
-                                                                        style={{
-                                                                            height: '100vh',
-                                                                        }}
+                                                                    <Stack
+                                                                        p="lg"
+                                                                        h="100vh"
                                                                     >
                                                                         <MinimalSavedExplorer />
-                                                                    </div>
+                                                                    </Stack>
                                                                 </Route>
 
                                                                 <Route path="/minimal/projects/:projectUuid/dashboards/:dashboardUuid">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5022 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before:
![before](https://user-images.githubusercontent.com/9117144/233127663-11967428-6813-475f-a48e-a103aef44075.png)



After: there is some space now around the image. You can notice it between the label and the top of the image (grey line)
![after](https://user-images.githubusercontent.com/9117144/233127601-f0d01437-e5ce-4dcd-9161-44a01c5d5f28.png)


