### PR TITLE
fix: handle default scheduler when headless browser is disabled

### DIFF
--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -10,7 +10,7 @@ import {
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { CreateSchedulerAndTargetsWithoutIds } from '@lightdash/common';
 import React, { FC, useEffect, useMemo, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import useHealth from '../../../hooks/health/useHealth';
 import { useSlackChannels } from '../../../hooks/slack/useSlackChannels';
 import { useGetSlack } from '../../../hooks/useSlack';
@@ -176,12 +176,11 @@ const SchedulerOptions: FC<
     );
 };
 
-const SchedulerForm: FC<
-    {
-        disabled: boolean;
-        methods: UseFormReturn<CreateSchedulerAndTargetsWithoutIds, object>;
-    } & Omit<React.ComponentProps<typeof Form>, 'methods'>
-> = ({ disabled, methods, ...rest }) => {
+const SchedulerForm: FC<{
+    disabled: boolean;
+}> = ({ disabled }) => {
+    const methods = useFormContext<CreateSchedulerAndTargetsWithoutIds>();
+
     const slackQuery = useGetSlack();
     const slackState = useMemo(() => {
         if (slackQuery.isLoading) {
@@ -220,7 +219,7 @@ const SchedulerForm: FC<
         useState<boolean>(true);
 
     return (
-        <Form name="scheduler" methods={methods} {...rest}>
+        <Form name="scheduler" methods={methods}>
             <FormGroup label={<Title>1. Name the delivery</Title>}>
                 <Input
                     name="name"

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -8,7 +8,9 @@ import {
     RadioGroup,
 } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
+import { CreateSchedulerAndTargetsWithoutIds } from '@lightdash/common';
 import React, { FC, useEffect, useMemo, useState } from 'react';
+import { UseFormReturn } from 'react-hook-form';
 import useHealth from '../../../hooks/health/useHealth';
 import { useSlackChannels } from '../../../hooks/slack/useSlackChannels';
 import { useGetSlack } from '../../../hooks/useSlack';
@@ -16,14 +18,13 @@ import { isInvalidCronExpression } from '../../../utils/fieldValidators';
 import { ArrayInput } from '../../ReactHookForm/ArrayInput';
 import AutoComplete from '../../ReactHookForm/AutoComplete';
 import CronInput from '../../ReactHookForm/CronInput';
-import Form from '../../ReactHookForm/Form';
-import Input from '../../ReactHookForm/Input';
-
 import {
     InlinedInputs,
     InlinedLabel,
     InlineIcon,
 } from '../../ReactHookForm/CronInput/CronInput.styles';
+import Form from '../../ReactHookForm/Form';
+import Input from '../../ReactHookForm/Input';
 import { hasRequiredScopes } from '../../UserSettings/SlackSettingsPanel';
 import {
     EmailIcon,
@@ -176,7 +177,10 @@ const SchedulerOptions: FC<
 };
 
 const SchedulerForm: FC<
-    { disabled: boolean } & React.ComponentProps<typeof Form>
+    {
+        disabled: boolean;
+        methods: UseFormReturn<CreateSchedulerAndTargetsWithoutIds, object>;
+    } & Omit<React.ComponentProps<typeof Form>, 'methods'>
 > = ({ disabled, methods, ...rest }) => {
     const slackQuery = useGetSlack();
     const slackState = useMemo(() => {
@@ -210,10 +214,11 @@ const SchedulerForm: FC<
     const isAddEmailDisabled = disabled || !health.data?.hasEmailClient;
     const isImageDisabled = !health.data?.hasHeadlessBrowser;
 
-    const format = methods.watch('format');
+    const format = methods.watch('format', isImageDisabled ? 'csv' : 'image');
 
     const [showDestinationLabel, setShowDestinationLabel] =
         useState<boolean>(true);
+
     return (
         <Form name="scheduler" methods={methods} {...rest}>
             <FormGroup label={<Title>1. Name the delivery</Title>}>
@@ -246,19 +251,21 @@ const SchedulerForm: FC<
                         <InlinedLabel>Format</InlinedLabel>
 
                         <StyledSelect
-                            name="format"
-                            value={format}
-                            onChange={(e) => {
-                                methods.setValue(
-                                    'format',
-                                    e.currentTarget.value,
-                                );
+                            {...methods.register('format', {
+                                value: format,
 
-                                const isCsvValue =
-                                    e.currentTarget.value === 'csv';
-                                if (!isCsvValue)
-                                    methods.setValue('options', {});
-                            }}
+                                onChange: (e) => {
+                                    methods.setValue(
+                                        'format',
+                                        e.currentTarget.value,
+                                    );
+
+                                    const isCsvValue =
+                                        e.currentTarget.value === 'csv';
+                                    if (!isCsvValue)
+                                        methods.setValue('options', {});
+                                },
+                            })}
                             options={[
                                 {
                                     value: 'image',
@@ -314,8 +321,8 @@ const SchedulerForm: FC<
                             renderRow={(key, index, remove) => {
                                 setShowDestinationLabel(false);
                                 const isSlack =
-                                    methods.getValues()?.targets?.[index]
-                                        ?.channel !== undefined;
+                                    'channel' in
+                                    methods.getValues()?.targets?.[index];
 
                                 if (isSlack) {
                                     return (

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -36,6 +36,12 @@ import {
     Title,
 } from './SchedulerModalBase.styles';
 
+const isSlack = (
+    target: CreateSchedulerAndTargetsWithoutIds['targets'][number],
+): target is {
+    channel: string;
+} => 'channel' in target && target.channel !== undefined;
+
 export enum Limit {
     TABLE = 'table',
     ALL = 'all',
@@ -319,11 +325,11 @@ const SchedulerForm: FC<{
                             disabled={disabled}
                             renderRow={(key, index, remove) => {
                                 setShowDestinationLabel(false);
-                                const isSlack =
-                                    'channel' in
+
+                                const target =
                                     methods.getValues()?.targets?.[index];
 
-                                if (isSlack) {
+                                if (isSlack(target)) {
                                     return (
                                         <TargetRow key={key}>
                                             <SlackIcon />

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalContent.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalContent.tsx
@@ -12,7 +12,7 @@ import {
     SchedulerAndTargets,
     UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
-import React, { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import {
     UseMutationResult,
@@ -70,9 +70,6 @@ const CreateStateContent: FC<{
 }> = ({ resourceUuid, createMutation, onBack }) => {
     const methods = useForm<CreateSchedulerAndTargetsWithoutIds>({
         mode: 'onSubmit',
-        defaultValues: {
-            targets: [],
-        },
     });
     useEffect(() => {
         if (createMutation.isSuccess) {

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalContent.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerModalContent.tsx
@@ -13,7 +13,7 @@ import {
     UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
 import { FC, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import {
     UseMutationResult,
     UseQueryResult,
@@ -83,10 +83,9 @@ const CreateStateContent: FC<{
     return (
         <>
             <DialogBody>
-                <SchedulerForm
-                    disabled={createMutation.isLoading}
-                    methods={methods}
-                />
+                <FormProvider {...methods}>
+                    <SchedulerForm disabled={createMutation.isLoading} />
+                </FormProvider>
             </DialogBody>
             <DialogFooter
                 actions={
@@ -156,10 +155,9 @@ const UpdateStateContent: FC<{
     return (
         <>
             <DialogBody>
-                <SchedulerForm
-                    disabled={mutation.isLoading}
-                    methods={methods}
-                />
+                <FormProvider {...methods}>
+                    <SchedulerForm disabled={mutation.isLoading} />
+                </FormProvider>
             </DialogBody>
             <DialogFooter
                 actions={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4890 

### Description:

Currently if headless browser is disabled (no screenshot functionality available) and user creates a scheduled delivery it will ignore the `image` format field being disabled and still set it as the `format` value for the Scheduled Delivery, when it should actually be `csv`.

This PR ensures the `format` is set to `csv` when the `image` option is disabled

Current behaviour:

https://user-images.githubusercontent.com/7611706/233314288-bd141ff7-548c-4cf6-a443-992db7e889ea.mov

Solution: 

https://user-images.githubusercontent.com/7611706/233314344-f363dd60-7574-42ba-a118-012a0a8ad763.mov


