### PR TITLE
fix: minimal page big number chart font sizes

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,5 +1,6 @@
 import clamp from 'lodash-es/clamp';
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, HTMLAttributes, useMemo } from 'react';
+import { useResizeObserver } from '../../hooks/useResizeObserver';
 import {
     TILE_HEADER_HEIGHT,
     TILE_HEADER_MARGIN_BOTTOM,
@@ -14,7 +15,7 @@ import {
     BigNumberLabel,
 } from './SimpleStatistics.styles';
 
-interface SimpleStatisticsProps extends React.HTMLAttributes<HTMLDivElement> {
+interface SimpleStatisticsProps extends HTMLAttributes<HTMLDivElement> {
     minimal?: boolean;
     isDashboard?: boolean;
     isTitleHidden?: boolean;
@@ -39,65 +40,6 @@ const calculateFontSize = (
             ((fontSizeMax - fontSizeMin) * (boundWidth - BOX_MIN_WIDTH)) /
                 (BOX_MAX_WIDTH - BOX_MIN_WIDTH),
     );
-
-type ObserverRect = Omit<DOMRectReadOnly, 'toJSON'>;
-
-const defaultState: ObserverRect = {
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-};
-
-export function useResizeObserver<T extends HTMLElement = any>() {
-    const frameID = useRef(0);
-    const [ref, setState] = useState<T | null>(null);
-
-    const [rect, setRect] = useState<ObserverRect>(defaultState);
-
-    const observer = useMemo(
-        () =>
-            typeof window !== 'undefined'
-                ? new ResizeObserver((entries: any) => {
-                      const entry = entries[0];
-
-                      console.log(entry, 'this happens');
-
-                      if (entry) {
-                          cancelAnimationFrame(frameID.current);
-
-                          frameID.current = requestAnimationFrame(() => {
-                              if (ref) {
-                                  setRect(entry.contentRect);
-                              }
-                          });
-                      }
-                  })
-                : null,
-        [ref],
-    );
-
-    useEffect(() => {
-        if (ref) {
-            console.log('observe', ref, observer);
-            observer?.observe(ref);
-        }
-
-        return () => {
-            observer?.disconnect();
-
-            if (frameID.current) {
-                cancelAnimationFrame(frameID.current);
-            }
-        };
-    }, [ref, observer]);
-
-    return [setState, rect] as const;
-}
 
 const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     minimal = false,
@@ -138,15 +80,6 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             labelFontSize: labelSize,
         };
     }, [observerElementSize]);
-
-    // const [count, setCount] = useState(0);
-    // useEffect(() => {
-    //     const timer = setTimeout(() => {
-    //         setCount(count + 1);
-    //     }, 1000);
-
-    //     return () => clearTimeout(timer);
-    // }, [resizeObserverRef, resizeObserverRef.current]);
 
     const validData = bigNumber && resultsData?.rows.length;
 

--- a/packages/frontend/src/hooks/useResizeObserver/index.ts
+++ b/packages/frontend/src/hooks/useResizeObserver/index.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type ObserverRect = Omit<DOMRectReadOnly, 'toJSON'>;
+
+const defaultState: ObserverRect = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+};
+
+/**
+ * Implementation taken from: https://github.com/mantinedev/mantine/blob/master/src/mantine-hooks/src/use-resize-observer/use-resize-observer.ts
+ * But dependencies of useMemo and useEffect react to changes to ref - which is crucial for this hook's usage
+ */
+export const useResizeObserver = <T extends HTMLElement = any>() => {
+    const frameID = useRef(0);
+    const [ref, setState] = useState<T | null>(null);
+
+    const [rect, setRect] = useState<ObserverRect>(defaultState);
+
+    const observer = useMemo(
+        () =>
+            typeof window !== 'undefined'
+                ? new ResizeObserver((entries: any) => {
+                      const entry = entries[0];
+
+                      if (entry) {
+                          cancelAnimationFrame(frameID.current);
+
+                          frameID.current = requestAnimationFrame(() => {
+                              if (ref) {
+                                  setRect(entry.contentRect);
+                              }
+                          });
+                      }
+                  })
+                : null,
+        [ref],
+    );
+
+    useEffect(() => {
+        if (ref) {
+            observer?.observe(ref);
+        }
+
+        return () => {
+            observer?.disconnect();
+
+            if (frameID.current) {
+                cancelAnimationFrame(frameID.current);
+            }
+        };
+    }, [ref, observer]);
+
+    return [setState, rect] as const;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4921 

### Description:

Fix /minimal page Big Number chart size when capturing a screenshot to be sent on a Scheduled Delivery. Tested with Render-deployed environment. 

Thanks @IrakliJani for pairing with me on this and identifying the underlying issue with Mantine's `useResizeObserver` hook that didn't track `ref` changes and therefore didn't allow us to do the necessary calculations.

Before
![Screenshot 2023-04-20 at 17 22 19](https://user-images.githubusercontent.com/7611706/233429684-188fab7a-e6f1-4be3-9ef3-7d7500d3bc42.png)

After
![Screenshot 2023-04-20 at 17 29 32](https://user-images.githubusercontent.com/7611706/233429823-f6e0f95d-0af4-4f23-95ae-1a9321b0d759.png)

