### PR TITLE
fix: limit and index scheduler logs

### DIFF
--- a/packages/backend/src/database/migrations/20230421072202_scheduler_log_index.ts
+++ b/packages/backend/src/database/migrations/20230421072202_scheduler_log_index.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const SchedulerLogTableName = 'scheduler_log';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(SchedulerLogTableName)) {
+        await knex.schema.alterTable(SchedulerLogTableName, (table) => {
+            table.index(['scheduler_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(SchedulerLogTableName)) {
+        await knex.schema.alterTable(SchedulerLogTableName, (table) => {
+            table.dropIndex(['scheduler_uuid']);
+        });
+    }
+}

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -432,7 +432,9 @@ export class SchedulerModel {
         const logs = await this.database(SchedulerLogTableName)
 
             .select()
-            .whereIn(`scheduler_uuid`, uniqueSchedulerUuids);
+            .whereIn(`scheduler_uuid`, uniqueSchedulerUuids)
+            .limit(1500);
+
         const schedulerLogs: SchedulerLog[] = logs.map(
             SchedulerModel.parseSchedulerLog,
         );

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -433,7 +433,8 @@ export class SchedulerModel {
 
             .select()
             .whereIn(`scheduler_uuid`, uniqueSchedulerUuids)
-            .limit(1500);
+            .orderBy('created_at', 'desc')
+            .limit(100);
 
         const schedulerLogs: SchedulerLog[] = logs.map(
             SchedulerModel.parseSchedulerLog,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5176

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
currently on analytics it takes 2 seconds to get the data from the backend
We load 13624 rows 
and takes 10+ seconds to render. 

I think limiting results will fix the issue. 1500 results means more than 1 every minute in a day (60*24=1440) 

I added also an index on scheduler_uuid to make it scale better. 

Another harder improvements we could implement : 
- lazy loading
- Pagination

## Possible side effect edge case of this quick fix: 
 If you have a scheduled delivery that runs once a week , and you have another delivery that runs every hour. It is possibl ethat all the logs are about the noisy scheduler. So on the scheduler dashboard it will look like it never run
 
 This should be fixed here https://github.com/lightdash/lightdash/issues/5175
 Or The fix for this would be to make a separate request per schedulerUuid... so I guess we don't need to handle it for now 