### PR TITLE
fix: uncaught rejection in useQueryResults.tsx

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -75,7 +75,7 @@ export const useQueryResults = (props?: {
     const { mutateAsync } = mutation;
 
     const mutateAsyncOverride = useCallback(
-        (tableName: string, metricQuery: MetricQuery) => {
+        async (tableName: string, metricQuery: MetricQuery) => {
             const fields = new Set([
                 ...metricQuery.dimensions,
                 ...metricQuery.metrics,
@@ -83,7 +83,7 @@ export const useQueryResults = (props?: {
             ]);
             const isValidQuery = fields.size > 0;
             if (!!tableName && isValidQuery) {
-                mutateAsync({
+                await mutateAsync({
                     projectUuid,
                     tableId: tableName,
                     query: metricQuery,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/5085

Fixes sentry error "Non-Error promise rejection captured"

<img width="1269" alt="Screenshot 2023-04-21 at 09 14 35" src="https://user-images.githubusercontent.com/11660098/233581581-c1924d99-bf5e-4c35-942d-8fea8ca8e135.png">

This happened for two reasons:

- `lightdashApi` throws raw objects instead of errors (but refactoring this will change 200 usages around the app)
- `useQueryResults` used `mutate` without awaiting, so when it rejected it was uncaught and the resulting response (a non-error from `lightdashApi`) was thrown to sentry. 

This only happened for errors when the user got an error when hitting the `runQuery` button

Side effects:

- `await` means that the errors will now propagate up, but this is fine because the only usage is in `ExploreProvider` and is wrapped in a `try{} catch{console.error()}` so behaviour in the app is unchanged

