### PR TITLE
fix: handle undefined scheduler_uuid when logging

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -438,27 +438,23 @@ export class SchedulerModel {
     }
 
     async logSchedulerJob(log: SchedulerLog): Promise<void> {
-        if (log.schedulerUuid) {
-            const schedulersList = await this.database(SchedulerTableName)
-                .select('scheduler_uuid')
-                .where('scheduler_uuid', log.schedulerUuid);
+        try {
+            await this.database(SchedulerLogTableName).insert({
+                task: log.task,
+                scheduler_uuid: log.schedulerUuid,
+                status: log.status,
+                job_id: log.jobId,
+                job_group: log.jobGroup,
+                scheduled_time: log.scheduledTime,
+                target: log.target || null,
+                target_type: log.targetType || null,
+                details: log.details || null,
+            });
+        } catch (error) {
+            const FOREIGN_KEY_VIOLATION_ERROR_CODE = '23503';
 
-            if (schedulersList.length === 0) {
-                return;
-            }
+            if (error.code !== FOREIGN_KEY_VIOLATION_ERROR_CODE) throw error;
         }
-
-        await this.database(SchedulerLogTableName).insert({
-            task: log.task,
-            scheduler_uuid: log.schedulerUuid,
-            status: log.status,
-            job_id: log.jobId,
-            job_group: log.jobGroup,
-            scheduled_time: log.scheduledTime,
-            target: log.target || null,
-            target_type: log.targetType || null,
-            details: log.details || null,
-        });
     }
 
     async deleteScheduledLogs(schedulerUuid: string): Promise<void> {

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -438,6 +438,16 @@ export class SchedulerModel {
     }
 
     async logSchedulerJob(log: SchedulerLog): Promise<void> {
+        if (log.schedulerUuid) {
+            const schedulersList = await this.database(SchedulerTableName)
+                .select('scheduler_uuid')
+                .where('scheduler_uuid', log.schedulerUuid);
+
+            if (schedulersList.length === 0) {
+                return;
+            }
+        }
+
         await this.database(SchedulerLogTableName).insert({
             task: log.task,
             scheduler_uuid: log.schedulerUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4861

### Description:

Linked issue already explains this, but essentially this PR handles a potential `scheduler_uuid` value missing  when handling the logging of a Scheduled Job. 

(Thanks @ZeRego for pairing with me on this 🎉 )
