### PR TITLE
fix: multiple model selection

### DIFF
--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -42,7 +42,11 @@ const optionsToArgs = (options: DbtCompileOptions): string[] =>
         if (value !== undefined && dbtCompileArgs.includes(key)) {
             const argKey = `--${camelToSnakeCase(key)}`;
             if (typeof value !== 'boolean') {
-                return [...acc, argKey, value.toString()];
+                return [
+                    ...acc,
+                    argKey,
+                    Array.isArray(value) ? value.join(' ') : value,
+                ];
             }
             return [...acc, argKey];
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5287 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

dbt model selection should use white spaces instead of commas.

Before:
```
node ./packages/cli/dist/index.js compile -s orders payments customers --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles

15:10:31  Running with dbt=1.4.5
15:10:31  Found 7 models, 20 tests, 0 snapshots, 0 analyses, 291 macros, 0 operations, 4 seed files, 0 sources, 0 exposures, 4 metrics
15:10:31  The selection criterion 'orders,payments,customers' does not match any nodes
15:10:31  
15:10:31  Nothing to do. Try checking your model configs and model specification args
15:10:31  Done.

Compiled 0 explores, SUCCESS=0 ERRORS=0
```

After:
```
root@ffba7d503c68:/usr/app# node ./packages/cli/dist/index.js compile -s orders payments customers --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles          
15:13:25  Running with dbt=1.4.5
15:13:25  Found 7 models, 20 tests, 0 snapshots, 0 analyses, 291 macros, 0 operations, 4 seed files, 0 sources, 0 exposures, 4 metrics
15:13:25  
15:13:25  Concurrency: 1 threads (target='jaffle')
15:13:25  
15:13:26  Done.


- SUCCESS> payments 
- SUCCESS> customers 
- SUCCESS> orders 

Compiled 3 explores, SUCCESS=3 ERRORS=0

Successfully compiled project
Done 🕶
```

