### PR TITLE
docs: minor typo in self host lightdash docs (docker-compose)

### DIFF
--- a/docs/docs/self-host/self-host-lightdash-docker-compose.mdx
+++ b/docs/docs/self-host/self-host-lightdash-docker-compose.mdx
@@ -33,7 +33,6 @@ You must set the following two environment variables:
 
 ```bash
 
-```bash
 export LIGHTDASH_SECRET="not very secret" 
 export PGPASSWORD="password"
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: (just fixing minor typo in docs - i did not create an issue for it)

### Description:

Hi, during playing around with lightdash, I discovered following minor issue in docs (```bash): 

![image](https://user-images.githubusercontent.com/18550315/235308159-c8084d29-08b1-416c-a3d2-cabc22ebbf42.png)

Here is the simple fix for it. :) 
