### PR TITLE
fix: docker-compose PGHOST env variable (local deployment)

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ SITE_URL=http://localhost:3000
 
 DOCKERFILE_TARGET=dev
 
-PGHOST=db-dev
+PGHOST=db
 PGPORT=5432
 PGUSER=postgres
 PGPASSWORD=password


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5291 

### Description:

As described in the issue, if you want to run Lightdash via `docker-compose`, it ends up with error `error: Error starting standalone scheduler worker getaddrinfo ENOTFOUND db-dev`. The issue is that `PGHOST` env variable is configured to `db-dev`, which means that PostgreSQL runs on host `db-dev` but services expect to be `db`. 

To be honest, I am not sure if this change will not break "development environment" for `docker-compose.dev.yml` but I think that `docker-compose.yml` should not use development environments by default. Please check it and we can discuss other possible solutions. :)  
