### PR TITLE
fix: keep date group on joined tables

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -105,17 +105,23 @@ export class ExploreCompiler {
                     join.label ||
                     (join.alias && friendlyName(join.alias)) ||
                     tables[join.table].label;
+
+                const tableDimensions = tables[join.table].dimensions;
                 return {
                     ...prev,
                     [join.alias || join.table]: {
                         ...tables[join.table],
                         name: joinTableName,
                         label: joinTableLabel,
-                        dimensions: Object.keys(tables[join.table].dimensions)
+                        dimensions: Object.keys(tableDimensions)
                             .filter(
                                 (d) =>
                                     join.fields === undefined ||
-                                    join.fields.includes(d),
+                                    join.fields.includes(d) ||
+                                    (tableDimensions[d].group !== undefined &&
+                                        join.fields.includes(
+                                            tableDimensions[d].group!,
+                                        )),
                             )
                             .reduce<Record<string, Dimension>>(
                                 (prevDimensions, dimensionKey) => ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #5077

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
What happened: 

When we select fields on `sql_on` join, we basically filter the fields that are not in the list, that includes `_DAY, _MONTH` etc.

![image](https://user-images.githubusercontent.com/1983672/235617728-0488bfc8-5192-4de1-817e-e9fb0747e2eb.png)

I now include groups too. 

Before: 
![Screenshot from 2023-05-02 10-24-17](https://user-images.githubusercontent.com/1983672/235617758-ecf99fe5-6405-4775-86da-75000be3c194.png)


Now:
![Screenshot from 2023-05-02 10-24-44](https://user-images.githubusercontent.com/1983672/235617767-2892ed26-4827-4824-8e25-c855fdfc3aaa.png)



