### PR TITLE
fix: remove local storage fallback and use lightdashconfig

### DIFF
--- a/packages/backend/src/clients/Aws/s3.ts
+++ b/packages/backend/src/clients/Aws/s3.ts
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import * as Sentry from '@sentry/node';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logger';
 
@@ -83,6 +84,8 @@ export class S3Service {
             return url;
         } catch (error) {
             Logger.error(`Failed to upload file to s3. ${error}`);
+            Sentry.captureException(error);
+
             throw error;
         }
     }

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import { lightdashConfig } from '../../config/lightdashConfig';
 import {
     dashboardModel,
     savedChartModel,
@@ -25,6 +26,7 @@ jest.mock('../services', () => ({
 
 describe('Csv service', () => {
     const csvService = new CsvService({
+        lightdashConfig,
         userModel,
         projectService,
         s3Service,

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -144,6 +144,7 @@ export const schedulerService = new SchedulerService({
 });
 
 export const csvService = new CsvService({
+    lightdashConfig,
     userModel,
     s3Service,
     projectService,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5161

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
I found some errors on gcloud logs (not in sentry though) 

![image](https://user-images.githubusercontent.com/1983672/235635222-5cf3f89e-c834-4f39-9f98-f4734132017f.png)

S3 does not have any retry method, so I don't know how to make it more resilient without knowing what the error is. 

I removed the fallback 

and I configured LightdashConfig properly. I think it was not picking up the right SITE_URL 
