### PR TITLE
feat: move compile project to scheduler

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -146,6 +146,8 @@ export class DbtCliClient implements DbtClient {
             });
             return DbtCliClient.parseDbtJsonLogs(dbtProcess.all);
         } catch (e) {
+            Logger.error(`Error running dbt command  ${e}`);
+
             throw new DbtError(
                 `Failed to run "dbt ${command.join(' ')}"`,
                 DbtCliClient.parseDbtJsonLogs(e.all),

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -308,7 +308,7 @@ projectRouter.post(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
-            const results = await projectService.compileProject(
+            const results = await projectService.scheduleCompileProject(
                 req.user!,
                 req.params.projectUuid,
                 getRequestMethod(req.header(LightdashRequestMethodHeader)),

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -59,7 +59,7 @@ projectRouter.patch(
     unauthorisedInDemo,
     async (req, res, next) => {
         projectService
-            .update(
+            .updateAndScheduleAsyncWork(
                 req.params.projectUuid,
                 req.user!,
                 req.body,

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -293,7 +293,7 @@ export class SchedulerClient {
             jobId,
             scheduledTime: now,
             status: SchedulerJobStatus.SCHEDULED,
-            details: { createdByUserUuid: payload.userUuid },
+            details: { createdByUserUuid: payload.createdByUserUuid },
         });
 
         return { jobId };
@@ -315,7 +315,7 @@ export class SchedulerClient {
             jobId,
             scheduledTime: now,
             status: SchedulerJobStatus.SCHEDULED,
-            details: { createdByUserUuid: payload.userUuid },
+            details: { createdByUserUuid: payload.createdByUserUuid },
         });
 
         return { jobId };

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -298,4 +298,26 @@ export class SchedulerClient {
 
         return { jobId };
     }
+
+    async testAndCompileProject(payload: CompileProjectPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            'testAndCompileProject',
+            payload,
+            {
+                runAt: now, // now
+                maxAttempts: 1,
+            },
+        );
+        await this.schedulerModel.logSchedulerJob({
+            task: 'testAndCompileProject',
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: { createdByUserUuid: payload.userUuid },
+        });
+
+        return { jobId };
+    }
 }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1,4 +1,5 @@
 import {
+    CompileProjectPayload,
     DownloadCsvPayload,
     EmailNotificationPayload,
     isSlackTarget,
@@ -267,6 +268,28 @@ export class SchedulerClient {
         );
         await this.schedulerModel.logSchedulerJob({
             task: 'downloadCsv',
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: { createdByUserUuid: payload.userUuid },
+        });
+
+        return { jobId };
+    }
+
+    async compileProject(payload: CompileProjectPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            'compileProject',
+            payload,
+            {
+                runAt: now, // now
+                maxAttempts: 1,
+            },
+        );
+        await this.schedulerModel.logSchedulerJob({
+            task: 'compileProject',
             jobId,
             scheduledTime: now,
             status: SchedulerJobStatus.SCHEDULED,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -372,11 +372,13 @@ export const testAndCompileProject = async (
         scheduledTime,
     };
     try {
-        const user = await userService.getSessionByUserUuid(payload.userUuid);
+        const user = await userService.getSessionByUserUuid(
+            payload.createdByUserUuid,
+        );
 
         schedulerService.logSchedulerJob({
             ...baseLog,
-            details: { createdByUserUuid: payload.userUuid },
+            details: { createdByUserUuid: payload.createdByUserUuid },
             status: SchedulerJobStatus.STARTED,
         });
 
@@ -395,7 +397,7 @@ export const testAndCompileProject = async (
         schedulerService.logSchedulerJob({
             ...baseLog,
             status: SchedulerJobStatus.ERROR,
-            details: { createdByUserUuid: payload.userUuid, error: e },
+            details: { createdByUserUuid: payload.createdByUserUuid, error: e },
         });
         throw e;
     }
@@ -412,11 +414,13 @@ export const compileProject = async (
         scheduledTime,
     };
     try {
-        const user = await userService.getSessionByUserUuid(payload.userUuid);
+        const user = await userService.getSessionByUserUuid(
+            payload.createdByUserUuid,
+        );
 
         schedulerService.logSchedulerJob({
             ...baseLog,
-            details: { createdByUserUuid: payload.userUuid },
+            details: { createdByUserUuid: payload.createdByUserUuid },
             status: SchedulerJobStatus.STARTED,
         });
 
@@ -435,7 +439,7 @@ export const compileProject = async (
         schedulerService.logSchedulerJob({
             ...baseLog,
             status: SchedulerJobStatus.ERROR,
-            details: { createdByUserUuid: payload.userUuid, error: e },
+            details: { createdByUserUuid: payload.createdByUserUuid, error: e },
         });
         throw e;
     }

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -17,6 +17,7 @@ import {
     handleScheduledDelivery,
     sendEmailNotification,
     sendSlackNotification,
+    testAndCompileProject,
 } from './SchedulerTask';
 import schedulerWorkerEventEmitter from './SchedulerWorkerEventEmitter';
 
@@ -122,6 +123,16 @@ export class SchedulerWorker {
                 },
                 compileProject: async (payload: any, helpers: JobHelpers) => {
                     await compileProject(
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                    );
+                },
+                testAndCompileProject: async (
+                    payload: any,
+                    helpers: JobHelpers,
+                ) => {
+                    await testAndCompileProject(
                         helpers.job.id,
                         helpers.job.run_at,
                         payload,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -12,6 +12,7 @@ import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logger';
 import { schedulerService } from '../services/services';
 import {
+    compileProject,
     downloadCsv,
     handleScheduledDelivery,
     sendEmailNotification,
@@ -114,6 +115,13 @@ export class SchedulerWorker {
                 },
                 downloadCsv: async (payload: any, helpers: JobHelpers) => {
                     await downloadCsv(
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                    );
+                },
+                compileProject: async (payload: any, helpers: JobHelpers) => {
+                    await compileProject(
                         helpers.job.id,
                         helpers.job.run_at,
                         payload,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1176,7 +1176,7 @@ export class ProjectService {
         await this.jobModel.create(job);
 
         await schedulerClient.compileProject({
-            userUuid: user.userUuid,
+            createdByUserUuid: user.userUuid,
             projectUuid,
             requestMethod,
             jobUuid: job.jobUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -373,7 +373,7 @@ export class ProjectService {
 
         if (savedProject.dbtConnection.type !== DbtProjectType.NONE) {
             await schedulerClient.testAndCompileProject({
-                userUuid: user.userUuid,
+                createdByUserUuid: user.userUuid,
                 projectUuid,
                 requestMethod: method,
                 jobUuid: job.jobUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -22,7 +22,8 @@ export type SchedulerLog = {
         | 'sendEmailNotification'
         | 'sendSlackNotification'
         | 'downloadCsv'
-        | 'compileProject';
+        | 'compileProject'
+        | 'testAndCompileProject';
     schedulerUuid?: string;
     jobId: string;
     jobGroup?: string;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -238,7 +238,7 @@ export type ApiCsvUrlResponse = {
 };
 
 export type CompileProjectPayload = {
-    userUuid: string;
+    createdByUserUuid: string;
     projectUuid: string;
     requestMethod: string;
     jobUuid: string;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -21,7 +21,8 @@ export type SchedulerLog = {
         | 'handleScheduledDelivery'
         | 'sendEmailNotification'
         | 'sendSlackNotification'
-        | 'downloadCsv';
+        | 'downloadCsv'
+        | 'compileProject';
     schedulerUuid?: string;
     jobId: string;
     jobGroup?: string;
@@ -233,4 +234,11 @@ export type ApiCsvUrlResponse = {
         url: string;
         status: string;
     };
+};
+
+export type CompileProjectPayload = {
+    userUuid: string;
+    projectUuid: string;
+    requestMethod: string;
+    jobUuid: string;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5165

### Description:

Note: I haven't updated the logic for any of these methods, I'm just moving the async stuff inside scheduler. But these methods are still using the old Job table method , we'll have to refactor the backend and frontend to move this to the new sheduler log details (like csv) . I created separated tickets for this 


Moves both : 
- "Dbt refresh" -> Compile project 
- "Test and compile " (settings) -> TestAndCOmpile project

IMO these 2 functions could be merged together . But I have added a separate ticket for that . 


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

![image](https://user-images.githubusercontent.com/1983672/235663472-bd219a24-705a-4f1e-b9ba-5c8b33c1fa0a.png)

```
2023-05-02 14:12:34 [Lightdash] info: Worker worker-05e44e4151677f91f2 was created
2023-05-02 14:12:34 [Lightdash] debug: Spawned
2023-05-02 14:12:34 [Lightdash] debug: Worker connected and looking for jobs... (task names: 'generateDailyJobs', 'handleScheduledDelivery', 'sendSlackNotification', 'sendEmailNotification', 'downloadCsv', 'compileProject')
2023-05-02 14:12:37 [Lightdash] info: Worker worker-05e44e4151677f91f2 started job 14881 (compileProject). Attempt 1 of 1
2023-05-02 14:12:37 [Lightdash] debug: Found task 14881 (compileProject)
2023-05-02 14:12:37 [Lightdash] http: POST /api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/refresh 200 - 37.062 ms

2023-05-02 14:12:37 [Lightdash] debug: Initialize warehouse client of type postgres
...
2023-05-02 14:12:41 [Lightdash] debug: Convert explores
2023-05-02 14:12:41 [Lightdash] debug: Destroy local project adapter
2023-05-02 14:12:41 [Lightdash] debug: Destroy base project adapter
2023-05-02 14:12:42 [Lightdash] http: GET /api/v1/jobs/e9fb9129-2316-4b79-bfe2-d6574675c0e6 200 - 11.299 ms

2023-05-02 14:12:42 [Lightdash] info: Worker worker-05e44e4151677f91f2 successfully executed job 14881 (compileProject)
2023-05-02 14:12:42 [Lightdash] debug: Completed task 14881 (compileProject) with success (4462.50ms)
2023-05-02 14:12:42 [Lightdash] info: Worker worker-05e44e4151677f91f2 concluded job 14881 (compileProject)
2023-05-02 14:12:42 [Lightdash] http: GET /api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/explores?filtered=true 200 - 16.745 ms
```

WITH CLI (no test) 
[Screencast from 02-05-23 15:53:55.webm](https://user-images.githubusercontent.com/1983672/235696789-c5235e00-9c19-46fc-9bd5-bc38b7eefbf4.webm)

With Local (test + compile) 
[Screencast from 02-05-23 16:19:19.webm](https://user-images.githubusercontent.com/1983672/235696864-18fdf00f-80ee-46a0-8046-6e75225ef32a.webm)


![Screenshot from 2023-05-02 16-19-53](https://user-images.githubusercontent.com/1983672/235696715-610a7577-5b0d-4077-ac36-1e8de007fedf.png)
