### PR TITLE
fix: check for fk constraint on error for scheduler_uuid

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -453,7 +453,13 @@ export class SchedulerModel {
         } catch (error) {
             const FOREIGN_KEY_VIOLATION_ERROR_CODE = '23503';
 
-            if (error.code !== FOREIGN_KEY_VIOLATION_ERROR_CODE) throw error;
+            if (
+                !(
+                    error.code === FOREIGN_KEY_VIOLATION_ERROR_CODE &&
+                    error.constraint === 'scheduler_log_scheduler_uuid_foreign'
+                )
+            )
+                throw error;
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash/pull/5184

Closes: #4861 

### Description:

After discussing with @owlas & @rephus, I've added another check for the `scheduler_uuid` FK error. Not only we check for the `code` but also the `constraint` to specifically target that.  

<!-- Even better add a screenshot / gif / loom -->
