### PR TITLE
chore: add strict eslint rules

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         project: './tsconfig.json',
         createDefaultProgram: true,
     },
-    ignorePatterns: [ '**/styles/*.css' ],
+    ignorePatterns: ['**/styles/*.css'],
     extends: [
         './../../.eslintrc.js',
         'plugin:@typescript-eslint/recommended',
@@ -45,7 +45,6 @@ module.exports = {
         '@typescript-eslint/no-inferrable-types': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-throw-literal': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
         'import/no-extraneous-dependencies': 'off',
         'import/no-named-as-default': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -3,6 +3,7 @@ const restrictedGlobals = require('confusing-browser-globals');
 const unusedVarExceptions = {
     argsIgnorePattern: '^_',
     destructuredArrayIgnorePattern: '^_',
+    ignoreRestSiblings: true,
 };
 
 module.exports = {

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
                 leadingUnderscore: 'allow',
             },
         ],
+        'react-hooks/exhaustive-deps': 'error',
 
         // TODO: enable these rules once the codebase is fixed
         '@typescript-eslint/ban-ts-comment': 'off',

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -1,5 +1,10 @@
 const restrictedGlobals = require('confusing-browser-globals');
 
+const unusedVarExceptions = {
+    argsIgnorePattern: '^_',
+    destructuredArrayIgnorePattern: '^_',
+};
+
 module.exports = {
     parserOptions: {
         project: './tsconfig.json',
@@ -37,6 +42,17 @@ module.exports = {
     rules: {
         'no-restricted-globals': ['error'].concat(restrictedGlobals),
         'react/prop-types': 'off',
+        'no-unused-vars': ['error', unusedVarExceptions],
+        '@typescript-eslint/no-unused-vars': ['error', unusedVarExceptions],
+        '@typescript-eslint/naming-convention': [
+            'error',
+            {
+                selector: 'variable',
+                format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+                leadingUnderscore: 'allow',
+            },
+        ],
+
         // TODO: enable these rules once the codebase is fixed
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/ban-types': 'off',

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -11,8 +11,9 @@ import {
     Text,
     Title,
 } from '@mantine/core';
-import { IconBook, IconInfoCircle, IconShare3 } from '@tabler/icons-react';
-import React, { FC, useState } from 'react';
+import { IconBook, IconInfoCircle } from '@tabler/icons-react';
+import { FC, useState } from 'react';
+
 import { useApp } from '../providers/AppProvider';
 import { TrackPage, TrackSection } from '../providers/TrackingProvider';
 import { ReactComponent as Logo } from '../svgs/grey-icon-logo.svg';

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -31,7 +31,6 @@ import {
     MinMaxContainer,
     MinMaxInput,
     MinMaxWrapper,
-    SectionTitle,
     Wrapper,
 } from './ChartConfigPanel.styles';
 import FieldLayoutOptions from './FieldLayoutOptions';
@@ -343,7 +342,7 @@ const ChartConfigTabs: FC = () => {
                                         dirtyLayout?.flipAxes ? 'Y' : 'X'
                                     }-axis`}
                                     checked={!!dirtyLayout?.showGridX}
-                                    onChange={(e) => {
+                                    onChange={() => {
                                         setShowGridX(!dirtyLayout?.showGridX);
                                     }}
                                 />
@@ -357,7 +356,7 @@ const ChartConfigTabs: FC = () => {
                                             ? dirtyLayout?.showGridY
                                             : true
                                     }
-                                    onChange={(e) => {
+                                    onChange={() => {
                                         setShowGridY(
                                             dirtyLayout?.showGridY !== undefined
                                                 ? !dirtyLayout?.showGridY

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/Legend.styles.tsx
@@ -1,4 +1,4 @@
-import { Colors, Label } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const SectionTitle = styled.p`

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.styles.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.styles.tsx
@@ -1,4 +1,4 @@
-import { Button, Collapse, Colors } from '@blueprintjs/core';
+import { Collapse, Colors } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import styled from 'styled-components';
 

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -1,13 +1,11 @@
 import { Button, FormGroup, InputGroup } from '@blueprintjs/core';
 import { DateInput2 } from '@blueprintjs/datetime2';
 import {
-    AdditionalMetric,
     CompiledDimension,
     Field,
     fieldId as getFieldId,
     formatDate,
     getDateFormat,
-    isAdditionalMetric,
     isDateItem,
     isDimension,
     isField,
@@ -19,6 +17,7 @@ import {
 import debounce from 'lodash/debounce';
 import moment from 'moment';
 import { FC, useCallback, useMemo, useState } from 'react';
+
 import FieldAutoComplete from '../../common/Filters/FieldAutoComplete';
 import MonthAndYearInput from '../../common/MonthAndYearInput';
 import { ReferenceLineField } from '../../common/ReferenceLine';
@@ -170,7 +169,7 @@ export const ReferenceLine: FC<Props> = ({
     removeReferenceLine,
 }) => {
     const {
-        cartesianConfig: { dirtyLayout, dirtyEchartsConfig },
+        cartesianConfig: { dirtyLayout },
     } = useVisualizationContext();
 
     const fieldsInAxes = useMemo(() => {

--- a/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -9,6 +9,7 @@ import {
 } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+
 import { useProject } from '../../../hooks/useProject';
 import { ReferenceLineField } from '../../common/ReferenceLine';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
@@ -26,7 +27,6 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
             dirtyLayout,
             dirtyEchartsConfig,
             updateSeries,
-            updateSingleSeries,
             referenceLines,
             setReferenceLines,
         },

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
@@ -4,6 +4,7 @@ import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
 import { FC } from 'react';
 import { BlockPicker, ColorResult } from 'react-color';
 import { useToggle } from 'react-use';
+
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { ColorButton, ColorButtonInner } from './Series.styles';
 
@@ -14,7 +15,7 @@ type Props = {
 
 const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
     const [isOpen, toggle] = useToggle(false);
-    const { isLoading: isOrgLoading, data } = useOrganization();
+    const { data } = useOrganization();
 
     const colors = data?.chartColors || ECHARTS_DEFAULT_COLORS;
     return (

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -10,6 +10,7 @@ import { Classes, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     ApiScheduledDownloadCsv,
+    assertUnreachable,
     ChartType,
     getCustomLabelsFromColumnProperties,
 } from '@lightdash/common';
@@ -150,8 +151,7 @@ export const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                 downloadJson(echartsInstance.getOption());
                 break;
             default: {
-                const never: never = type;
-                throw new Error(`Unexpected download type: ${type}`);
+                assertUnreachable(type, `Unexpected download type: ${type}`);
             }
         }
     }, [chartRef, type]);

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -32,6 +32,7 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
+
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
 import useSavedQueryWithDashboardFilters from '../../hooks/dashboard/useSavedQueryWithDashboardFilters';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
@@ -45,9 +46,9 @@ import { useApp } from '../../providers/AppProvider';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
+import { Can } from '../common/Authorization';
 import { getConditionalRuleLabel } from '../common/Filters/configs';
 import LinkMenuItem from '../common/LinkMenuItem';
-import { TableColumn } from '../common/Table/types';
 import { FilterValues } from '../DashboardFilter/ActiveFilters/ActiveFilters.styles';
 import ExportCSVModal from '../ExportCSV/ExportCSVModal';
 import LightdashVisualization from '../LightdashVisualization';
@@ -65,8 +66,6 @@ import {
     GlobalTileStyles,
 } from './TileBase/TileBase.styles';
 
-import { Can } from '../common/Authorization';
-import DashboardFilter from '../DashboardFilter';
 interface ExportResultAsCSVModalProps {
     projectUuid: string;
     savedChart: SavedChart;
@@ -75,7 +74,6 @@ interface ExportResultAsCSVModalProps {
 }
 
 const ExportResultAsCSVModal: FC<ExportResultAsCSVModalProps> = ({
-    projectUuid,
     savedChart,
     onClose,
     onConfirm,
@@ -126,13 +124,7 @@ const ValidDashboardChartTile: FC<{
         e: EchartSeriesClickEvent,
         series: EChartSeries[],
     ) => void;
-}> = ({
-    tileUuid,
-    isTitleHidden = false,
-    data,
-    project,
-    onSeriesContextMenu,
-}) => {
+}> = ({ tileUuid, isTitleHidden = false, data, onSeriesContextMenu }) => {
     const { data: resultData, isLoading } = useChartResults(
         data.uuid,
         data.metricQuery.filters,
@@ -183,9 +175,8 @@ const ValidDashboardChartTileMinimal: FC<{
     tileUuid: string;
     isTitleHidden?: boolean;
     data: SavedChart;
-    project: string;
     dashboardFilters?: DashboardFilters;
-}> = ({ tileUuid, data, project, dashboardFilters, isTitleHidden = false }) => {
+}> = ({ tileUuid, data, dashboardFilters, isTitleHidden = false }) => {
     const filters =
         dashboardFilters !== undefined
             ? convertDashboardFiltersToFilters(dashboardFilters)

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -689,7 +689,6 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     tileUuid={tileUuid}
                     isTitleHidden={hideTitle}
                     data={data}
-                    project={projectUuid}
                     dashboardFilters={dashboardFilters}
                 />
             ) : (

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -1,4 +1,4 @@
-import { Card, Colors, H5 } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import styled, { createGlobalStyle, css } from 'styled-components';
 
 interface HeaderContainerProps {

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -1,10 +1,10 @@
 import { subject } from '@casl/ability';
 import { IconTelescope } from '@tabler/icons-react';
 import { useMemo } from 'react';
+
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useApp } from '../../providers/AppProvider';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
-import LinkButton from '../common/LinkButton';
 import { StyledLinkButton } from '../Home/LandingPanel/LandingPanel.styles';
 
 const ExploreFromHereButton = () => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import { StyledSwitch } from './ShowTotalsToggle.styles';
 
@@ -15,7 +16,7 @@ const ShowTotalsToggle: FC = () => {
             label="Show column total"
             alignIndicator="right"
             checked={showColumnCalculation}
-            onChange={(e) => {
+            onChange={() => {
                 setShowColumnCalculation(!showColumnCalculation);
             }}
         />

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@lightdash/common';
 import { FC, memo, useCallback, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { downloadCsv } from '../../../hooks/useDownloadCsv';
 import { useExplore } from '../../../hooks/useExplore';

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Colors, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import {
+    assertUnreachable,
     CartesianSeriesType,
     ChartType,
     isSeriesWithMixedChartTypes,
@@ -134,8 +135,10 @@ const VisualizationCardOptions: FC = memo(() => {
                             ),
                         };
                     default:
-                        const never: never = cartesianType;
-                        throw new Error('Cartesian type not supported');
+                        return assertUnreachable(
+                            cartesianType,
+                            `Unknown cartesian type ${cartesianType}`,
+                        );
                 }
             }
             case ChartType.TABLE:
@@ -159,8 +162,10 @@ const VisualizationCardOptions: FC = memo(() => {
                     ),
                 };
             default: {
-                const never: never = chartType;
-                throw new Error('Chart type not supported');
+                return assertUnreachable(
+                    chartType,
+                    `Unknown chart type ${chartType}`,
+                );
             }
         }
     }, [
@@ -169,6 +174,7 @@ const VisualizationCardOptions: FC = memo(() => {
         cartesianType,
         chartType,
         setStacking,
+        disabled,
     ]);
 
     return (

--- a/packages/frontend/src/components/ExportCSV/ExportCSVModal.tsx
+++ b/packages/frontend/src/components/ExportCSV/ExportCSVModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogFooter, DialogProps } from '@blueprintjs/core';
+import { Button, Dialog, DialogProps } from '@blueprintjs/core';
 import { FC } from 'react';
 import ExportCSV, { ExportCSVProps } from '.';
 

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { Group, Stack, Text, Title } from '@mantine/core';
-import { IconTable } from '@tabler/icons-react';
 import { FC } from 'react';
+
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
 import MantineLinkButton from '../../common/MantineLinkButton';

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -1,11 +1,12 @@
 import {
     ApiQueryResults,
+    assertUnreachable,
     ChartConfig,
     ChartType,
     Explore,
 } from '@lightdash/common';
 import EChartsReact from 'echarts-for-react';
-import React, {
+import {
     createContext,
     FC,
     RefObject,
@@ -16,6 +17,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
+
 import useCartesianChartConfig from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
 import useTableConfig from '../../hooks/tableVisualization/useTableConfig';
@@ -175,8 +177,10 @@ export const VisualizationProvider: FC<Props> = ({
                 validConfig = validTableConfig;
                 break;
             default:
-                const never: never = chartType;
-                throw new Error(`Unexpected chart type: ${chartType}`);
+                assertUnreachable(
+                    chartType,
+                    `Unexpected chart type: ${chartType}`,
+                );
         }
         onChartConfigChange?.(validConfig);
     }, [

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -18,7 +18,6 @@ import { setLastProject, useProjects } from '../../hooks/useProjects';
 import { useErrorLogs } from '../../providers/ErrorLogsProvider';
 import { ReactComponent as Logo } from '../../svgs/logo-icon.svg';
 import { ErrorLogsDrawer } from '../ErrorLogsDrawer';
-import NavLink from '../NavLink';
 import { ShowErrorsButton } from '../ShowErrorsButton';
 import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -2,7 +2,8 @@ import { subject } from '@casl/ability';
 import { PinnedItems, ResourceViewItemType } from '@lightdash/common';
 import { Card, Group, Text } from '@mantine/core';
 import { IconPin } from '@tabler/icons-react';
-import React, { FC, useMemo } from 'react';
+import { FC } from 'react';
+
 import { useApp } from '../../providers/AppProvider';
 import MantineIcon from '../common/MantineIcon';
 import MantineLinkButton from '../common/MantineLinkButton';

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -1,10 +1,12 @@
 import {
+    assertUnreachable,
     DbtProjectType,
     DbtProjectTypeLabels,
     WarehouseTypes,
 } from '@lightdash/common';
 import { FC, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+
 import { useApp } from '../../providers/AppProvider';
 import FormSection from '../ReactHookForm/FormSection';
 import Input from '../ReactHookForm/Input';
@@ -94,8 +96,10 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
             case DbtProjectType.NONE:
                 return <DbtNoneForm disabled={disabled} />;
             default: {
-                const never: never = type;
-                return null;
+                return assertUnreachable(
+                    type,
+                    `Unknown dbt project type ${type}`,
+                );
             }
         }
     }, [disabled, type, resetField]);

--- a/packages/frontend/src/components/ReactHookForm/ArrayInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/ArrayInput.tsx
@@ -1,6 +1,6 @@
 import { FormGroup, Icon } from '@blueprintjs/core';
-import React, { useState } from 'react';
-import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+import { useState } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import DocumentationHelpButton from '../DocumentationHelpButton';
 import { LabelInfoToggleButton } from './FromGroup.styles';
 

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@lightdash/common';
 import { FC, useCallback, useState } from 'react';
 import { v4 as uuid4 } from 'uuid';
+
 import {
     appendNewTilesToBottom,
     useCreateMutation,
@@ -171,6 +172,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
         isCreatingNewDashboard,
         isCreatingNewSpace,
         onClose,
+        newDashboardDescription,
     ]);
 
     if (isLoadingDashboards || !dashboards || isLoadingSpaces || !spaces) {

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -13,6 +13,7 @@ import { Anchor } from '@mantine/core';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import useHealth from '../../../hooks/health/useHealth';
+
 import { useSlackChannels } from '../../../hooks/slack/useSlackChannels';
 import { useGetSlack } from '../../../hooks/useSlack';
 import { isInvalidCronExpression } from '../../../utils/fieldValidators';
@@ -98,7 +99,7 @@ const SlackErrorContent: FC<{ slackState: SlackStates }> = ({
 
 const SchedulerOptions: FC<
     { disabled: boolean } & React.ComponentProps<typeof Form>
-> = ({ disabled, methods, ...rest }) => {
+> = ({ disabled: _disabled, methods, ...rest }) => {
     const [format, setFormat] = useState(
         methods.getValues()?.options?.formatted === false
             ? Values.RAW

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/index.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/index.tsx
@@ -7,7 +7,7 @@ const SchedulersModalBase: FC<
     { name: string } & React.ComponentProps<typeof SchedulersModalContent>
 > = ({
     resourceUuid,
-    name,
+    name: _name,
     schedulersQuery,
     createMutation,
     ...modalProps

--- a/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
@@ -1,14 +1,4 @@
-import {
-    Button,
-    Card,
-    Collapse,
-    Colors,
-    H3,
-    HTMLSelect,
-    Icon,
-    Tag,
-} from '@blueprintjs/core';
-import { IconLayoutDashboard } from '@tabler/icons-react';
+import { Card, H3 } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
 export const Header = styled.div`

--- a/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
+++ b/packages/frontend/src/components/TableCalculationModels/TableCalculationModal.tsx
@@ -1,13 +1,10 @@
 import { Button, Callout, Classes, Intent } from '@blueprintjs/core';
-import {
-    hasSpecialCharacters,
-    snakeCaseName,
-    TableCalculation,
-} from '@lightdash/common';
+import { snakeCaseName, TableCalculation } from '@lightdash/common';
 import { Anchor } from '@mantine/core';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useToggle } from 'react-use';
+
 import useToaster from '../../hooks/toaster/useToaster';
 import { useExplorerAceEditorCompleter } from '../../hooks/useExplorerAceEditorCompleter';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
@@ -70,9 +67,7 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const [isFullscreen, toggleFullscreen] = useToggle(false);
     const { showToastError } = useToaster();
-    const tableName = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableName,
-    );
+
     const dimensions = useExplorerContext(
         (context) => context.state.unsavedChartVersion.metricQuery.dimensions,
     );
@@ -83,6 +78,7 @@ const TableCalculationModal: FC<Props> = ({
         (context) =>
             context.state.unsavedChartVersion.metricQuery.tableCalculations,
     );
+
     const { setAceEditor } = useExplorerAceEditorCompleter();
     const methods = useForm<TableCalculationFormInputs>({
         mode: 'onSubmit',

--- a/packages/frontend/src/components/TableConfigPanel/ConditionalFormatting.styles.ts
+++ b/packages/frontend/src/components/TableConfigPanel/ConditionalFormatting.styles.ts
@@ -1,4 +1,4 @@
-import { Button, Colors } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const ConditionalFormattingListWrapper = styled.div`

--- a/packages/frontend/src/components/UserSettings/AppearancePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearancePanel/index.tsx
@@ -2,6 +2,7 @@ import { Intent, Spinner } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
 import { FC, useCallback, useEffect, useState } from 'react';
+
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
 import { InputWrapper } from '../../ChartConfigPanel/ChartConfigPanel.styles';
@@ -24,7 +25,11 @@ const AppearancePanel: FC = () => {
 
     const update = useCallback(() => {
         if (data) {
-            const { needsProject, organizationUuid, ...params } = data;
+            const {
+                needsProject: _needsProject,
+                organizationUuid: _organizationUuid,
+                ...params
+            } = data;
             updateMutation.mutate({
                 ...params,
                 chartColors: colors,

--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles.ts
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles.ts
@@ -1,4 +1,4 @@
-import { Button, Card, Colors, H5, Menu } from '@blueprintjs/core';
+import { Card, Colors, H5 } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
 export const Title = styled(H5)`

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingsPanel.styles.ts
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingsPanel.styles.ts
@@ -1,4 +1,4 @@
-import { AnchorButton, Button, Callout, Colors } from '@blueprintjs/core';
+import { Callout, Colors } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const SlackSettingsWrapper = styled.div`

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,10 +1,5 @@
 import { NonIdealState } from '@blueprintjs/core';
-import {
-    AuthorizationError,
-    ForbiddenError,
-    LightdashError,
-    NotExistsError,
-} from '@lightdash/common';
+import { LightdashError } from '@lightdash/common';
 import { ComponentProps, FC, useMemo } from 'react';
 import styled from 'styled-components';
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { Colors, Menu, Spinner } from '@blueprintjs/core';
+import { Menu, Spinner } from '@blueprintjs/core';
 import { MenuItem2, Popover2Props } from '@blueprintjs/popover2';
 import { MultiSelect2 } from '@blueprintjs/select';
 import { FilterableItem } from '@lightdash/common';
@@ -6,6 +6,7 @@ import { Highlight } from '@mantine/core';
 import Fuse from 'fuse.js';
 import React, { FC, useCallback, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+
 import {
     MAX_AUTOCOMPLETE_RESULTS,
     useFieldValues,

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -54,7 +54,6 @@ const StickyMenuDivider: FC<StickyMenuDividerProps> = ({ index, title }) => {
 const renderFilterList = <T extends Field | TableCalculation>({
     items,
     itemsParentRef,
-    query,
     renderItem,
 }: ItemListRendererProps<T>) => {
     const getGroupedItems = (filteredItems: typeof items) => {

--- a/packages/frontend/src/components/common/PageBreadcrumbs.tsx
+++ b/packages/frontend/src/components/common/PageBreadcrumbs.tsx
@@ -3,7 +3,6 @@ import {
     Breadcrumbs,
     BreadcrumbsProps,
     MantineSize,
-    Text,
     Tooltip,
     TooltipProps,
 } from '@mantine/core';

--- a/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
@@ -3,7 +3,6 @@ import {
     Field,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
-    PivotValue,
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
@@ -17,6 +16,7 @@ import {
     useMemo,
     useState,
 } from 'react';
+
 import { readableColor } from '../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../Filters/configs';
 import { usePivotTableCellStyles } from './tableStyles';

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -1,14 +1,10 @@
 import { subject } from '@casl/ability';
-import {
-    Field,
-    PivotValue,
-    ResultValue,
-    TableCalculation,
-} from '@lightdash/common';
+import { Field, ResultValue, TableCalculation } from '@lightdash/common';
 import { Menu, MenuProps } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
+
 import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';

--- a/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
@@ -32,7 +32,7 @@ interface IconBoxProps extends MantineIconProps {
 const IconBox: FC<IconBoxProps> = ({
     color,
     icon,
-    size = 'xl',
+    size = 'lg',
     ...mantineIconProps
 }) => (
     <Paper
@@ -50,7 +50,7 @@ const IconBox: FC<IconBoxProps> = ({
             color={color}
             fill={color}
             fillOpacity={0.1}
-            size="lg"
+            size={size}
             {...mantineIconProps}
         />
     </Paper>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -3,7 +3,6 @@ import {
     Box,
     Flex,
     Group,
-    Overlay,
     Paper,
     Popover,
     Stack,
@@ -20,6 +19,7 @@ import {
     IconUsers,
 } from '@tabler/icons-react';
 import { FC, useMemo } from 'react';
+
 import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
 } from '../ResourceActionMenu';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -1,8 +1,9 @@
 import { assertUnreachable, ResourceViewItemType } from '@lightdash/common';
 import { Anchor, SimpleGrid, Stack, Text } from '@mantine/core';
-import { FC, useMemo, useState } from 'react';
+import { FC, useMemo } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { Link, useParams } from 'react-router-dom';
+
 import { ResourceViewCommonProps } from '..';
 import { ResourceViewItemActionState } from '../ResourceActionHandlers';
 import { getResourceName, getResourceUrl } from '../resourceUtils';
@@ -47,9 +48,9 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
             .filter((group) => group.items.length > 0);
     }, [groups, items]);
 
-    const [draggableItems, setDraggableItems] = useState(
-        groupedItems.map((g) => g.items),
-    );
+    // const [draggableItems, setDraggableItems] = useState(
+    //     groupedItems.map((g) => g.items),
+    // );
     const handleOnDragEnd = (result: any) => {
         // here we can implement the order logic with a mutation hook
         // Mantine use-list hook could be useful here

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -7,6 +7,7 @@ import {
     Space,
 } from '@lightdash/common';
 import { FC, useCallback, useMemo, useState } from 'react';
+
 import { useProjectAccess } from '../../../hooks/useProjectAccess';
 import { useAddSpaceShareMutation } from '../../../hooks/useSpaces';
 import {
@@ -80,7 +81,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     );
 
     const renderUserShare: ItemRenderer<string> = useCallback(
-        (userUuid, { modifiers, handleClick, query }) => {
+        (userUuid, { modifiers, handleClick }) => {
             if (!modifiers.matchesPredicate) {
                 return null;
             }

--- a/packages/frontend/src/components/common/SpaceActionModal/CreateSpaceSelectAccessType.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/CreateSpaceSelectAccessType.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@blueprintjs/core';
 import { Select2 } from '@blueprintjs/select';
 import { FC } from 'react';
-import { useParams } from 'react-router-dom';
+
 import { useProject } from '../../../hooks/useProject';
 import {
     AccessRole,

--- a/packages/frontend/src/components/common/SpaceActionModal/SpaceActionModal.style.ts
+++ b/packages/frontend/src/components/common/SpaceActionModal/SpaceActionModal.style.ts
@@ -1,4 +1,4 @@
-import { Button, Colors } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
 export const RadioDescription = styled.p`

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,9 +1,9 @@
-import { Colors } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { isField } from '@lightdash/common';
 import { flexRender } from '@tanstack/react-table';
 import React, { FC } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
+
 import {
     TABLE_HEADER_BG,
     Th,

--- a/packages/frontend/src/components/common/UnitInput/index.tsx
+++ b/packages/frontend/src/components/common/UnitInput/index.tsx
@@ -32,7 +32,6 @@ const UnitInput = forwardRef<HTMLInputElement, UnitInputProps>(
             units,
             value: valueWithUnit,
             defaultValue: defaultValueWithUnit,
-            fallbackValue,
             onChange,
             ...rest
         },

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -29,7 +29,6 @@ interface ChartCreateModalProps extends DialogProps {
 const ChartCreateModal: FC<ChartCreateModalProps> = ({
     savedData,
     onClose,
-    onConfirm,
     ...modalProps
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -9,7 +9,7 @@ import {
     InputGroup,
     Intent,
 } from '@blueprintjs/core';
-import { Dashboard } from '@lightdash/common';
+import { Dashboard, Space } from '@lightdash/common';
 import { FC, useCallback, useState } from 'react';
 import { useCreateMutation } from '../../../hooks/dashboard/useDashboard';
 import {
@@ -73,20 +73,20 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     };
 
     const handleConfirm = useCallback(async () => {
+        let newSpace: Space | undefined;
+
         if (isCreatingNewSpace) {
-            const newSpace = await createSpace({
+            newSpace = await createSpace({
                 name: newSpaceName,
                 isPrivate: false,
                 access: [],
             });
-
-            spaceUuid = newSpace.uuid;
         }
 
         const dashboard = await createDashboard({
             name: dashboardName,
             description: dashboardDescription,
-            spaceUuid,
+            spaceUuid: newSpace?.uuid || selectedSpaceUuid,
             tiles: [],
         });
         onConfirm?.(dashboard);
@@ -97,9 +97,9 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
         selectedSpaceUuid,
         dashboardName,
         newSpaceName,
-        isCreatingDashboard,
         isCreatingNewSpace,
-        onClose,
+        dashboardDescription,
+        onConfirm,
     ]);
 
     if (user.data?.ability?.cannot('manage', 'Dashboard')) return null;

--- a/packages/frontend/src/hooks/analytics/useUserActivity.tsx
+++ b/packages/frontend/src/hooks/analytics/useUserActivity.tsx
@@ -1,21 +1,7 @@
-import {
-    ApiError,
-    CreateDashboard,
-    Dashboard,
-    DashboardTile,
-    FilterableField,
-    isDashboardChartTileType,
-    UpdateDashboard,
-    UpdateDashboardDetails,
-    UserActivity,
-} from '@lightdash/common';
-import { useMemo, useState } from 'react';
-import { useMutation, useQueries, useQuery, useQueryClient } from 'react-query';
-import { UseQueryOptions, UseQueryResult } from 'react-query/types/react/types';
-import { useHistory, useParams } from 'react-router-dom';
-import { useDeepCompareEffect } from 'react-use';
+import { ApiError, UserActivity } from '@lightdash/common';
+import { useQuery } from 'react-query';
+
 import { lightdashApi } from '../../api';
-import useToaster from '../toaster/useToaster';
 import useQueryError from '../useQueryError';
 
 const getUserActivity = async (projectUuid: string) =>

--- a/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
+++ b/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
@@ -9,7 +9,7 @@ import {
     useQueryClient,
     UseQueryOptions,
 } from 'react-query';
-import { useParams } from 'react-router-dom';
+
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 

--- a/packages/frontend/src/hooks/pinning/usePinnedItems.ts
+++ b/packages/frontend/src/hooks/pinning/usePinnedItems.ts
@@ -1,5 +1,6 @@
-import { ApiError, ApiPinnedItems, PinnedItems } from '@lightdash/common';
-import { useQuery, useQueryClient } from 'react-query';
+import { ApiError, PinnedItems } from '@lightdash/common';
+import { useQuery } from 'react-query';
+
 import { lightdashApi } from '../../api';
 
 const getPinnedItems = async (projectUuid: string, pinnedlistUuid: string) =>

--- a/packages/frontend/src/hooks/scheduler/useSchedulersUpdateMutation.ts
+++ b/packages/frontend/src/hooks/scheduler/useSchedulersUpdateMutation.ts
@@ -26,7 +26,7 @@ export const useSchedulersUpdateMutation = (schedulerUuid: string) => {
         UpdateSchedulerAndTargetsWithoutId
     >((data) => updateScheduler(schedulerUuid, data), {
         mutationKey: ['update_scheduler'],
-        onSuccess: async (space) => {
+        onSuccess: async () => {
             await queryClient.invalidateQueries('chart_schedulers');
             await queryClient.invalidateQueries('dashboard_schedulers');
             await queryClient.invalidateQueries(['scheduler', schedulerUuid]);

--- a/packages/frontend/src/hooks/tableVisualization/getPivotDataAndColumns.ts
+++ b/packages/frontend/src/hooks/tableVisualization/getPivotDataAndColumns.ts
@@ -1,4 +1,3 @@
-import { Colors } from '@blueprintjs/core';
 import {
     ApiQueryResults,
     Field,

--- a/packages/frontend/src/hooks/useAccessToken.ts
+++ b/packages/frontend/src/hooks/useAccessToken.ts
@@ -62,7 +62,7 @@ export const useCreateAccessToken = () => {
     >((data) => createAccessToken(data), {
         mutationKey: ['personal_access_tokens'],
         retry: 3,
-        onSuccess: async (data) => {
+        onSuccess: async () => {
             await queryClient.invalidateQueries('personal_access_tokens');
         },
         onError: (error) => {

--- a/packages/frontend/src/hooks/useEmailVerification.tsx
+++ b/packages/frontend/src/hooks/useEmailVerification.tsx
@@ -36,7 +36,7 @@ export const useEmailStatus = (enabled = true) =>
 
 export const useOneTimePassword = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastError } = useToaster();
     return useMutation<EmailStatusExpiring, ApiError>(
         () => sendOneTimePasscodeQuery(),
         {

--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -1,9 +1,4 @@
-import {
-    ApiError,
-    CreateInviteLink,
-    formatTimestamp,
-    InviteLink,
-} from '@lightdash/common';
+import { ApiError, CreateInviteLink, InviteLink } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
@@ -69,7 +64,7 @@ export const useCreateInviteLinkMutation = () => {
                 subtitle: rest.join('\n'),
             });
         },
-        onSuccess: async (data) => {
+        onSuccess: async () => {
             await queryClient.invalidateQueries(['onboarding-status']);
             await queryClient.refetchQueries(['organization_users']);
             showToastSuccess({

--- a/packages/frontend/src/hooks/useProjectAccess.tsx
+++ b/packages/frontend/src/hooks/useProjectAccess.tsx
@@ -75,7 +75,7 @@ export const useCreateProjectAccessMutation = (projectUuid: string) => {
         (data) => createProjectAccessQuery(projectUuid, data),
         {
             mutationKey: ['project_access_create'],
-            onSuccess: async (data) => {
+            onSuccess: async () => {
                 await queryClient.refetchQueries(['project_access_users']);
                 showToastSuccess({
                     title: 'Created new project access',
@@ -112,7 +112,7 @@ export const useUpdateProjectAccessMutation = (projectUuid: string) => {
         UpdateProjectMember & { userUuid: string }
     >((data) => updateProjectAccessQuery(projectUuid, data.userUuid, data), {
         mutationKey: ['project_access_update'],
-        onSuccess: async (data) => {
+        onSuccess: async () => {
             await queryClient.refetchQueries(['project_access_users']);
             showToastSuccess({
                 title: 'Updated project access role',

--- a/packages/frontend/src/hooks/useShare.ts
+++ b/packages/frontend/src/hooks/useShare.ts
@@ -28,8 +28,8 @@ export const useCreateShareMutation = () => {
         (data) => createShareUrl(data),
         {
             //mutationKey: ['share'],
-            onSuccess: async (space) => {},
-            onError: (error) => {},
+            onSuccess: async () => {},
+            onError: () => {},
         },
     );
 };

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -182,7 +182,7 @@ export const useAddSpaceShareMutation = (
         (userUuid) => addSpaceShare(projectUuid, spaceUuid, userUuid),
         {
             mutationKey: ['space_share', projectUuid, spaceUuid],
-            onSuccess: async (space) => {
+            onSuccess: async () => {
                 await queryClient.refetchQueries(['spaces', projectUuid]);
                 await queryClient.refetchQueries([
                     'space',

--- a/packages/frontend/src/hooks/user/useJoinOrganizationMutation.ts
+++ b/packages/frontend/src/hooks/user/useJoinOrganizationMutation.ts
@@ -1,11 +1,7 @@
-import {
-    ApiError,
-    CreateOrganization,
-    UpdateOrganization,
-} from '@lightdash/common';
+import { ApiError } from '@lightdash/common';
 import { useMutation, useQueryClient } from 'react-query';
+
 import { lightdashApi } from '../../api';
-import useToaster from '../toaster/useToaster';
 
 const joinOrgQuery = async (orgUuid: string) =>
     lightdashApi<undefined>({

--- a/packages/frontend/src/hooks/user/usePassword.ts
+++ b/packages/frontend/src/hooks/user/usePassword.ts
@@ -1,5 +1,4 @@
-import { Ability } from '@casl/ability';
-import { ApiError, LightdashUserWithAbilityRules } from '@lightdash/common';
+import { ApiError } from '@lightdash/common';
 import { useQuery } from 'react-query';
 import { lightdashApi } from '../../api';
 

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { Alert, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
 import {
+    assertUnreachable,
     Dashboard as IDashboard,
     DashboardTile,
     DashboardTileTypes,
@@ -15,6 +16,7 @@ import React, {
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
 import { Helmet } from 'react-helmet';
 import { useHistory, useParams } from 'react-router-dom';
+
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import ErrorState from '../components/common/ErrorState';
 import Page from '../components/common/Page/Page';
@@ -118,8 +120,8 @@ const GridTile: FC<
         case DashboardTileTypes.LOOM:
             return <LoomTile {...props} tile={tile} />;
         default: {
-            const never: never = tile;
-            throw new Error(
+            return assertUnreachable(
+                tile,
                 `Dashboard tile type "${props.tile.type}" not recognised`,
             );
         }
@@ -202,6 +204,7 @@ const Dashboard: FC = () => {
         reset,
         setDashboardTemporaryFilters,
         setHaveFiltersChanged,
+        setHaveTilesChanged,
     ]);
 
     const handleUpdateTiles = useCallback(
@@ -230,7 +233,7 @@ const Dashboard: FC = () => {
 
             setHaveTilesChanged(true);
         },
-        [setDashboardTiles],
+        [setDashboardTiles, setHaveTilesChanged],
     );
 
     const handleAddTiles = useCallback(
@@ -241,7 +244,7 @@ const Dashboard: FC = () => {
 
             setHaveTilesChanged(true);
         },
-        [setDashboardTiles],
+        [setDashboardTiles, setHaveTilesChanged],
     );
 
     const handleDeleteTile = useCallback(
@@ -254,7 +257,7 @@ const Dashboard: FC = () => {
 
             setHaveTilesChanged(true);
         },
-        [setDashboardTiles],
+        [setDashboardTiles, setHaveTilesChanged],
     );
 
     const handleEditTiles = useCallback(
@@ -266,7 +269,7 @@ const Dashboard: FC = () => {
             );
             setHaveTilesChanged(true);
         },
-        [setDashboardTiles],
+        [setDashboardTiles, setHaveTilesChanged],
     );
 
     const handleCancel = useCallback(() => {
@@ -285,6 +288,7 @@ const Dashboard: FC = () => {
         setDashboardTiles,
         setHaveFiltersChanged,
         setDashboardFilters,
+        setHaveTilesChanged,
     ]);
 
     const handleMoveDashboardToSpace = (spaceUuid: string) => {

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -17,7 +17,7 @@ import {
     useProjectSavedChartStatus,
 } from '../hooks/useOnboardingStatus';
 import { useProject } from '../hooks/useProject';
-import { useSavedCharts, useSpaces } from '../hooks/useSpaces';
+import { useSavedCharts } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
 const Home: FC = () => {

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -16,8 +16,8 @@ import {
     TextInput,
     Title,
 } from '@mantine/core';
-import { isNotEmpty, useForm } from '@mantine/form';
-import React, { FC, useEffect } from 'react';
+import { useForm } from '@mantine/form';
+import { FC, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useMutation } from 'react-query';
 import { Redirect, useLocation } from 'react-router-dom';

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -5,22 +5,19 @@ import {
 } from '@lightdash/common';
 import { FC, useMemo } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
 import LoomTile from '../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../components/DashboardTiles/DashboardMarkdownTile';
 import { useDashboardQuery } from '../hooks/dashboard/useDashboard';
-import {
-    DashboardProvider,
-    useDashboardContext,
-} from '../providers/DashboardProvider';
-
-import { useMount } from 'react-use';
-import '../styles/react-grid.css';
+import { DashboardProvider } from '../providers/DashboardProvider';
 import {
     getReactGridLayoutConfig,
     RESPONSIVE_GRID_LAYOUT_PROPS,
 } from './Dashboard';
+
+import '../styles/react-grid.css';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,17 +1,13 @@
 import { NonIdealState, Spinner, Tab, Tabs } from '@blueprintjs/core';
-import { subject } from '@casl/ability';
-import { Anchor, Breadcrumbs, Text } from '@mantine/core';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import {
-    Link,
     Redirect,
     Route,
     Switch,
     useHistory,
     useParams,
 } from 'react-router-dom';
-import { Can } from '../components/common/Authorization';
 import ErrorState from '../components/common/ErrorState';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import DbtCloudSettings from '../components/DbtCloudSettings';

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -8,13 +8,12 @@ import { Button, Center, Group, Stack, Tooltip } from '@mantine/core';
 import { IconLayoutDashboard, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { Redirect, useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import LoadingState from '../components/common/LoadingState';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { useCreateMutation } from '../hooks/dashboard/useDashboard';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
 import { useSpaces } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
@@ -27,13 +26,6 @@ const SavedDashboards = () => {
     const { isLoading, data: dashboards = [] } = useDashboards(projectUuid);
     const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
         useState<boolean>(false);
-
-    const {
-        isLoading: isCreatingDashboard,
-        isSuccess: hasCreatedDashboard,
-        mutate: createDashboard,
-        data: newDashboard,
-    } = useCreateMutation(projectUuid);
 
     const { user, health } = useApp();
     const isDemo = health.data?.mode === LightdashMode.DEMO;
@@ -50,15 +42,6 @@ const SavedDashboards = () => {
 
     if (isLoading || isLoadingSpaces) {
         return <LoadingState title="Loading dashboards" />;
-    }
-
-    if (hasCreatedDashboard && newDashboard) {
-        return (
-            <Redirect
-                push
-                to={`/projects/${projectUuid}/dashboards/${newDashboard.uuid}`}
-            />
-        );
     }
 
     const handleCreateDashboard = () => {
@@ -87,7 +70,6 @@ const SavedDashboards = () => {
                         !isDemo && (
                             <Button
                                 leftIcon={<IconPlus size={18} />}
-                                loading={isCreatingDashboard}
                                 onClick={handleCreateDashboard}
                                 disabled={hasNoSpaces}
                             >
@@ -131,7 +113,6 @@ const SavedDashboards = () => {
                                     <div>
                                         <Button
                                             leftIcon={<IconPlus size={18} />}
-                                            loading={isCreatingDashboard}
                                             onClick={handleCreateDashboard}
                                             disabled={hasNoSpaces}
                                         >
@@ -142,7 +123,6 @@ const SavedDashboards = () => {
                             ) : userCanManageDashboards && !isDemo ? (
                                 <Button
                                     leftIcon={<IconPlus size={18} />}
-                                    loading={isCreatingDashboard}
                                     onClick={handleCreateDashboard}
                                     disabled={hasNoSpaces}
                                 >

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'react-router-dom';
 import { Transition } from 'react-transition-group';
 import ErrorState from '../components/common/ErrorState';
 import {
-    CardContent,
     Drawer,
     PageContentContainer,
     PageWrapper,

--- a/packages/frontend/src/pages/Settings.styles.tsx
+++ b/packages/frontend/src/pages/Settings.styles.tsx
@@ -1,4 +1,4 @@
-import { Card, H5 } from '@blueprintjs/core';
+import { Card } from '@blueprintjs/core';
 import styled, { css } from 'styled-components';
 
 const Layout = css`

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -8,7 +8,7 @@ import { IconUsers } from '@tabler/icons-react';
 import EChartsReact from 'echarts-for-react';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -31,7 +31,7 @@ import {
 const showTableBodyWithUsers = (key: string, userList: UserWithCount[]) => {
     return (
         <tbody>
-            {userList.map((user, index) => {
+            {userList.map((user) => {
                 return (
                     <tr key={`${key}-${user.userUuid}`}>
                         <td>{user.firstName} </td>
@@ -125,7 +125,6 @@ const chartWeeklyAverageQueries = (
 });
 
 const UserActivity: FC = () => {
-    const history = useHistory();
     const params = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(params.projectUuid);
     const { user: sessionUser } = useApp();

--- a/packages/frontend/src/types/table-core.d.ts
+++ b/packages/frontend/src/types/table-core.d.ts
@@ -1,10 +1,9 @@
 import { Field, PivotReference, TableCalculation } from '@lightdash/common';
-import { RowData } from '@tanstack/react-table';
 import { MouseEventHandler } from 'react';
 import { Sort } from '../components/common/Table/types';
 
 declare module '@tanstack/table-core' {
-    interface ColumnMeta<TData extends RowData, TValue> {
+    interface ColumnMeta {
         isInvalidItem?: boolean;
         width?: number;
         draggable?: boolean;

--- a/packages/frontend/src/utils/dateFilter.ts
+++ b/packages/frontend/src/utils/dateFilter.ts
@@ -6,7 +6,6 @@ import {
     getFilterGroupItemsPropertyName,
     getItemsFromFilterGroup,
     isFilterGroup,
-    MetricQuery,
 } from '@lightdash/common';
 import moment from 'moment';
 

--- a/packages/frontend/src/utils/fieldValidators.ts
+++ b/packages/frontend/src/utils/fieldValidators.ts
@@ -66,9 +66,9 @@ export const isOnlyNumbers: FieldValidator<string> = (fieldName) => (value) =>
         : undefined;
 
 export const isValidGithubToken: FieldValidator<string> =
-    (fieldName) => (value) => {
+    (_fieldName) => (value) => {
         if (value) {
-            const [isValid, error] = validateGithubToken(value);
+            const [_isValid, error] = validateGithubToken(value);
             return error;
         }
     };


### PR DESCRIPTION
Closes: #5336 

### Description:

adds strict checks on:

- [x] `react-hooks/exhaustive-deps`
- [x] `no-unused-vars`
- [x] `@typescript-eslint/no-unused-vars`


unused variables are ignored if:

- function argument starts with `_`: `array.filter(_elem, index)`
- array destructure variable starts with `_`: `[_first, second] = array`
- object destructure has a spread variable: `{ name, ...personWithoutName } = person`


- [x] removes eslint errors and fixes build


⚠️ only affects frontend builds