### PR TITLE
chore: unused exports git hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+yarn workspace frontend unused-exports

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
     "lint-staged": {
         "packages/frontend/src/**/*.(ts|tsx|json|css)": [
             "yarn workspace frontend linter --fix",
-            "yarn workspace frontend formatter --write",
-            "yarn workspace frontend unused-exports"
+            "yarn workspace frontend formatter --write"
         ],
         "packages/backend/src/**/*.(ts|tsx|json)": [
             "yarn workspace backend linter --fix",


### PR DESCRIPTION
follow up for: #5339 

### Description:
lint-staged passes only changed pathes to the unused-exports while it should run on entire frontend project

moved `unused-exports` check directly to git hooks
