### PR TITLE
feat: migrate access tokens list to mantine table

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/AccessTokens.styles.ts
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/AccessTokens.styles.ts
@@ -1,6 +1,0 @@
-import { H5 } from '@blueprintjs/core';
-import styled from 'styled-components';
-
-export const PanelTitle = styled(H5)`
-    margin: 0;
-`;

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/AccessTokens.styles.ts
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/AccessTokens.styles.ts
@@ -1,42 +1,5 @@
-import { Card, H5, Tag } from '@blueprintjs/core';
+import { H5 } from '@blueprintjs/core';
 import styled from 'styled-components';
-
-export const HeaderActions = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-`;
-
-export const AccessTokenWrapper = styled(Card)`
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 1.25em;
-    width: 100%;
-`;
-
-export const ItemContent = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-`;
-
-export const AccessTokenInfo = styled.div`
-    margin: 0;
-    flex: 1;
-    display: flex;
-    gap: 3px;
-    flex-direction: column;
-`;
-
-export const AccessTokenLabel = styled.b`
-    margin: 0;
-    margin-right: 0.625em;
-`;
-
-export const ExpireAtLabel = styled(Tag)`
-    width: fit-content;
-`;
 
 export const PanelTitle = styled(H5)`
     margin: 0;

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -1,0 +1,124 @@
+import { Button, Classes, Dialog } from '@blueprintjs/core';
+import { ApiPersonalAccessTokenResponse, formatDate } from '@lightdash/common';
+import {
+    Button as MantineButton,
+    createStyles,
+    Paper,
+    Table,
+} from '@mantine/core';
+import { FC, useState } from 'react';
+import {
+    useAccessToken,
+    useDeleteAccessToken,
+} from '../../../hooks/useAccessToken';
+
+const useTableStyles = createStyles((theme) => ({
+    root: {
+        '& thead tr': {
+            backgroundColor: theme.colors.gray[0],
+        },
+
+        '& thead tr th': {
+            color: theme.colors.gray[6],
+            fontWeight: 600,
+        },
+
+        '& thead tr th, & tbody tr td': {
+            padding: '12px 20px',
+        },
+
+        '& tr td:last-child': {
+            textAlign: 'right',
+        },
+
+        '&[data-hover] tbody tr': theme.fn.hover({
+            cursor: 'pointer',
+            backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
+        }),
+    },
+}));
+
+const TokenItem: FC<{
+    token: ApiPersonalAccessTokenResponse;
+}> = ({ token }) => {
+    const { description, expiresAt, uuid } = token;
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const { mutate, isLoading: isDeleting } = useDeleteAccessToken();
+
+    return (
+        <>
+            <tr>
+                <td>{description}</td>
+                <td>
+                    {expiresAt ? formatDate(expiresAt) : 'No expiration date'}
+                </td>
+                <td>
+                    <MantineButton
+                        variant="outline"
+                        size="xs"
+                        color="red"
+                        onClick={() => setIsDeleteDialogOpen(true)}
+                    >
+                        Delete
+                    </MantineButton>
+                </td>
+            </tr>
+            <Dialog
+                isOpen={isDeleteDialogOpen}
+                icon="delete"
+                onClose={() => !isDeleting && setIsDeleteDialogOpen(false)}
+                title={`Delete token ${description}`}
+                lazy
+            >
+                <div className={Classes.DIALOG_BODY}>
+                    <p>
+                        Are you sure ? This will permanently delete the
+                        <b> {description} </b> token.
+                    </p>
+                </div>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Button
+                            disabled={isDeleting}
+                            onClick={() => setIsDeleteDialogOpen(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            disabled={isDeleting}
+                            intent="danger"
+                            onClick={() => {
+                                mutate(uuid || '');
+                            }}
+                        >
+                            Delete
+                        </Button>
+                    </div>
+                </div>
+            </Dialog>
+        </>
+    );
+};
+
+export const TokensTable = () => {
+    const { data } = useAccessToken();
+    const { classes } = useTableStyles();
+    return (
+        <Paper withBorder>
+            <Table className={classes.root} highlightOnHover>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Expiration date</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {data?.map((token) => (
+                        <TokenItem key={token.uuid} token={token} />
+                    ))}
+                </tbody>
+            </Table>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -78,8 +78,8 @@ export const TokensTable = () => {
         },
     })();
     return (
-        <Paper withBorder>
-            <Table className={classes.root} highlightOnHover>
+        <Paper>
+            <Table withBorder className={classes.root} highlightOnHover>
                 <thead>
                     <tr>
                         <th>Name</th>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -78,8 +78,8 @@ export const TokensTable = () => {
         },
     })();
     return (
-        <Paper>
-            <Table withBorder className={classes.root} highlightOnHover>
+        <Paper withBorder sx={{ overflow: 'hidden' }}>
+            <Table className={classes.root} highlightOnHover>
                 <thead>
                     <tr>
                         <th>Name</th>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -1,42 +1,12 @@
 import { Button, Classes, Dialog } from '@blueprintjs/core';
 import { ApiPersonalAccessTokenResponse, formatDate } from '@lightdash/common';
-import {
-    Button as MantineButton,
-    createStyles,
-    Paper,
-    Table,
-} from '@mantine/core';
+import { Button as MantineButton, Paper, Table } from '@mantine/core';
 import { FC, useState } from 'react';
+import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import {
     useAccessToken,
     useDeleteAccessToken,
 } from '../../../hooks/useAccessToken';
-
-const useTableStyles = createStyles((theme) => ({
-    root: {
-        '& thead tr': {
-            backgroundColor: theme.colors.gray[0],
-        },
-
-        '& thead tr th': {
-            color: theme.colors.gray[6],
-            fontWeight: 600,
-        },
-
-        '& thead tr th, & tbody tr td': {
-            padding: '12px 20px',
-        },
-
-        '& tr td:last-child': {
-            textAlign: 'right',
-        },
-
-        '&[data-hover] tbody tr': theme.fn.hover({
-            cursor: 'pointer',
-            backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
-        }),
-    },
-}));
 
 const TokenItem: FC<{
     token: ApiPersonalAccessTokenResponse;
@@ -102,7 +72,11 @@ const TokenItem: FC<{
 
 export const TokensTable = () => {
     const { data } = useAccessToken();
-    const { classes } = useTableStyles();
+    const { classes } = useTableStyles({
+        '& tr td:last-child': {
+            textAlign: 'right',
+        },
+    })();
     return (
         <Paper withBorder>
             <Table className={classes.root} highlightOnHover>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -41,11 +41,7 @@ const TokenItem: FC<{
 export const TokensTable = () => {
     const { data } = useAccessToken();
 
-    const { classes } = useTableStyles({
-        '& tr td:last-child': {
-            textAlign: 'right',
-        },
-    })();
+    const { classes } = useTableStyles();
 
     const [tokenToDelete, setTokenToDelete] = useState<
         ApiPersonalAccessTokenResponse | undefined
@@ -61,7 +57,10 @@ export const TokensTable = () => {
     return (
         <>
             <Paper withBorder sx={{ overflow: 'hidden' }}>
-                <Table className={classes.root} highlightOnHover>
+                <Table
+                    className={`${classes.root} ${classes.alignLastTdRight}`}
+                    highlightOnHover
+                >
                     <thead>
                         <tr>
                             <th>Name</th>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -1,6 +1,6 @@
 import { Button, Classes, Dialog } from '@blueprintjs/core';
 import { ApiPersonalAccessTokenResponse, formatDate } from '@lightdash/common';
-import { Button as MantineButton, Paper, Table } from '@mantine/core';
+import { Button as MantineButton, clsx, Paper, Table } from '@mantine/core';
 import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import {
@@ -58,7 +58,7 @@ export const TokensTable = () => {
         <>
             <Paper withBorder sx={{ overflow: 'hidden' }}>
                 <Table
-                    className={`${classes.root} ${classes.alignLastTdRight}`}
+                    className={clsx(classes.root, classes.alignLastTdRight)}
                     highlightOnHover
                 >
                     <thead>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@blueprintjs/core';
-import { Flex, Title } from '@mantine/core';
+import { Button, Flex, Title } from '@mantine/core';
 import { IconKey } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { useAccessToken } from '../../../hooks/useAccessToken';

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -1,106 +1,17 @@
-import {
-    Button,
-    ButtonGroup,
-    Classes,
-    Dialog,
-    Intent,
-} from '@blueprintjs/core';
-import { ApiPersonalAccessTokenResponse, formatDate } from '@lightdash/common';
-import { Button as MantineButton, Flex } from '@mantine/core';
+import { Button } from '@blueprintjs/core';
+import { Flex, Title } from '@mantine/core';
 import { IconKey } from '@tabler/icons-react';
 import { FC, useState } from 'react';
-import {
-    useAccessToken,
-    useDeleteAccessToken,
-} from '../../../hooks/useAccessToken';
+import { useAccessToken } from '../../../hooks/useAccessToken';
 import { EmptyState } from '../../common/EmptyState';
 import MantineIcon from '../../common/MantineIcon';
 import CreateTokenPanel from '../CreateTokenPanel';
-import {
-    AccessTokenInfo,
-    AccessTokenLabel,
-    AccessTokenWrapper,
-    ExpireAtLabel,
-    HeaderActions,
-    ItemContent,
-    PanelTitle,
-} from './AccessTokens.styles';
-
-const TokenListItem: FC<{
-    token: ApiPersonalAccessTokenResponse;
-}> = ({ token }) => {
-    const { description, expiresAt, uuid } = token;
-    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-    const { mutate, isLoading: isDeleting } = useDeleteAccessToken();
-    return (
-        <AccessTokenWrapper elevation={0}>
-            <ItemContent>
-                <AccessTokenInfo>
-                    <AccessTokenLabel
-                        className={Classes.TEXT_OVERFLOW_ELLIPSIS}
-                    >
-                        {description}
-                    </AccessTokenLabel>
-                    <ExpireAtLabel intent={expiresAt ? 'warning' : 'none'}>
-                        {expiresAt
-                            ? `Expires on ${formatDate(expiresAt)}`
-                            : 'No expiration date'}
-                    </ExpireAtLabel>
-                </AccessTokenInfo>
-                <ButtonGroup>
-                    <Button
-                        icon="delete"
-                        outlined
-                        text="Delete"
-                        intent={Intent.DANGER}
-                        style={{ marginLeft: 10 }}
-                        onClick={() => setIsDeleteDialogOpen(true)}
-                    />
-                </ButtonGroup>
-            </ItemContent>
-            <Dialog
-                isOpen={isDeleteDialogOpen}
-                icon="delete"
-                onClose={() =>
-                    !isDeleting ? setIsDeleteDialogOpen(false) : undefined
-                }
-                title={`Delete token ${description}`}
-                lazy
-            >
-                <div className={Classes.DIALOG_BODY}>
-                    <p>
-                        Are you sure ? This will permanently delete the
-                        <b> {description} </b> token.
-                    </p>
-                </div>
-                <div className={Classes.DIALOG_FOOTER}>
-                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <Button
-                            disabled={isDeleting}
-                            onClick={() => setIsDeleteDialogOpen(false)}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            disabled={isDeleting}
-                            intent="danger"
-                            onClick={() => {
-                                mutate(uuid || '');
-                            }}
-                        >
-                            Delete
-                        </Button>
-                    </div>
-                </div>
-            </Dialog>
-        </AccessTokenWrapper>
-    );
-};
+import { TokensTable } from './TokensTable';
 
 const AccessTokensPanel: FC = () => {
     const { data } = useAccessToken();
     const [createTokenPanel, setCreateInvitesPanel] = useState(false);
-    const hasAvailableTokens = data && data?.length > 0;
+    const hasAvailableTokens = data && data.length > 0;
     if (createTokenPanel) {
         return (
             <CreateTokenPanel
@@ -109,30 +20,9 @@ const AccessTokensPanel: FC = () => {
         );
     }
 
-    return (
-        <Flex
-            h="100%"
-            direction="column"
-            justify={hasAvailableTokens ? 'auto' : 'center'}
-            align={hasAvailableTokens ? 'auto' : 'center'}
-        >
-            {hasAvailableTokens && (
-                <HeaderActions>
-                    <PanelTitle>Personal access tokens</PanelTitle>
-                    <Button
-                        intent="primary"
-                        onClick={() => setCreateInvitesPanel(true)}
-                        text="Generate new token"
-                    />
-                </HeaderActions>
-            )}
-            {hasAvailableTokens ? (
-                <div>
-                    {data?.map((token) => (
-                        <TokenListItem key={token.uuid} token={token} />
-                    ))}
-                </div>
-            ) : (
+    if (!hasAvailableTokens) {
+        return (
+            <Flex h="100%" direction="column" justify="center" align="center">
                 <EmptyState
                     icon={
                         <MantineIcon
@@ -145,12 +35,25 @@ const AccessTokensPanel: FC = () => {
                     title="No tokens"
                     description="You haven't generated any tokens yet!, generate your first token"
                 >
-                    <MantineButton onClick={() => setCreateInvitesPanel(true)}>
+                    <Button onClick={() => setCreateInvitesPanel(true)}>
                         Generate token
-                    </MantineButton>
+                    </Button>
                 </EmptyState>
-            )}
-        </Flex>
+            </Flex>
+        );
+    }
+
+    return (
+        <>
+            <Flex justify="space-between" align="center" mb="lg">
+                <Title order={5}>Personal access tokens</Title>
+                <Button onClick={() => setCreateInvitesPanel(true)}>
+                    Generate new token
+                </Button>
+            </Flex>
+
+            <TokensTable />
+        </>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Title } from '@mantine/core';
+import { Button, Group, Stack, Title } from '@mantine/core';
 import { IconKey } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { useAccessToken } from '../../../hooks/useAccessToken';
@@ -41,16 +41,16 @@ const AccessTokensPanel: FC = () => {
     }
 
     return (
-        <>
-            <Flex justify="space-between" align="center" mb="lg">
+        <Stack mb="lg">
+            <Group position="apart">
                 <Title order={5}>Personal access tokens</Title>
                 <Button onClick={() => setCreateInvitesPanel(true)}>
                     Generate new token
                 </Button>
-            </Flex>
+            </Group>
 
             <TokensTable />
-        </>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -21,24 +21,22 @@ const AccessTokensPanel: FC = () => {
 
     if (!hasAvailableTokens) {
         return (
-            <Flex h="100%" direction="column" justify="center" align="center">
-                <EmptyState
-                    icon={
-                        <MantineIcon
-                            icon={IconKey}
-                            color="gray.6"
-                            stroke={1}
-                            size="5xl"
-                        />
-                    }
-                    title="No tokens"
-                    description="You haven't generated any tokens yet!, generate your first token"
-                >
-                    <Button onClick={() => setCreateInvitesPanel(true)}>
-                        Generate token
-                    </Button>
-                </EmptyState>
-            </Flex>
+            <EmptyState
+                icon={
+                    <MantineIcon
+                        icon={IconKey}
+                        color="gray.6"
+                        stroke={1}
+                        size="5xl"
+                    />
+                }
+                title="No tokens"
+                description="You haven't generated any tokens yet!, generate your first token"
+            >
+                <Button onClick={() => setCreateInvitesPanel(true)}>
+                    Generate token
+                </Button>
+            </EmptyState>
         );
     }
 

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/ProjectManagementPanel.styles.ts
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/ProjectManagementPanel.styles.ts
@@ -1,4 +1,4 @@
-import { Card, Tag } from '@blueprintjs/core';
+import { Card, H5, Tag } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const ProjectManagementPanelWrapper = styled.div`
@@ -43,4 +43,8 @@ export const ProjectName = styled.b`
 export const ProjectTag = styled(Tag)`
     width: fit-content;
     margin-top: 0.3em;
+`;
+
+export const PanelTitle = styled(H5)`
+    margin: 0;
 `;

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@blueprintjs/core';
 import { subject } from '@casl/ability';
 import { OrganizationProject, ProjectType } from '@lightdash/common';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { Redirect, useHistory } from 'react-router-dom';
 import {
     deleteLastProject,
@@ -18,10 +18,10 @@ import {
 import { useApp } from '../../../providers/AppProvider';
 import { Can } from '../../common/Authorization';
 import LinkButton from '../../common/LinkButton';
-import { PanelTitle } from '../AccessTokensPanel/AccessTokens.styles';
 import {
     HeaderActions,
     ItemContent,
+    PanelTitle,
     ProjectInfo,
     ProjectListItemWrapper,
     ProjectManagementPanelWrapper,

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -72,11 +72,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
     defaultSort,
     onAction,
 }) => {
-    const { classes } = useTableStyles({
-        '& thead tr th': {
-            fontSize: '12px',
-        },
-    })();
+    const { classes } = useTableStyles();
 
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -333,7 +329,10 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
     }, [items, columnSorts, columns]);
 
     return (
-        <Table className={classes.root} highlightOnHover>
+        <Table
+            className={`${classes.root} ${classes.smallHeaderText}`}
+            highlightOnHover
+        >
             <thead>
                 <tr>
                     {visibleColumns.map((column) => {

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -5,11 +5,11 @@ import {
     ResourceViewItem,
 } from '@lightdash/common';
 import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
-import { createStyles } from '@mantine/styles';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import React, { FC, useMemo, useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
+import { useTableStyles } from '../../../../hooks/styles/useTableStyles';
 import { useSpaces } from '../../../../hooks/useSpaces';
 import { ResourceIcon } from '../ResourceIcon';
 import {
@@ -64,29 +64,6 @@ const getNextSortDirection = (current: SortingState): SortingState => {
     return sortOrder.concat(sortOrder[0])[currentIndex + 1];
 };
 
-const useTableStyles = createStyles((theme) => ({
-    root: {
-        '& thead tr': {
-            backgroundColor: theme.colors.gray[0],
-        },
-
-        '& thead tr th': {
-            color: theme.colors.gray[6],
-            fontWeight: 600,
-            fontSize: '12px',
-        },
-
-        '& thead tr th, & tbody tr td': {
-            padding: '12px 20px',
-        },
-
-        '&[data-hover] tbody tr': theme.fn.hover({
-            cursor: 'pointer',
-            backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
-        }),
-    },
-}));
-
 const ResourceViewList: FC<ResourceViewListProps> = ({
     items,
     enableSorting: enableSortingProp = true,
@@ -95,7 +72,11 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
     defaultSort,
     onAction,
 }) => {
-    const { classes } = useTableStyles();
+    const { classes } = useTableStyles({
+        '& thead tr th': {
+            fontSize: '12px',
+        },
+    })();
 
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -4,7 +4,16 @@ import {
     isResourceViewSpaceItem,
     ResourceViewItem,
 } from '@lightdash/common';
-import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
+import {
+    Anchor,
+    Box,
+    clsx,
+    Group,
+    Stack,
+    Table,
+    Text,
+    Tooltip,
+} from '@mantine/core';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import React, { FC, useMemo, useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
@@ -330,7 +339,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
 
     return (
         <Table
-            className={`${classes.root} ${classes.smallHeaderText}`}
+            className={clsx(classes.root, classes.smallHeaderText)}
             highlightOnHover
         >
             <thead>

--- a/packages/frontend/src/hooks/styles/useTableStyles.tsx
+++ b/packages/frontend/src/hooks/styles/useTableStyles.tsx
@@ -1,39 +1,33 @@
-import { createStyles, CSSObject } from '@mantine/core';
+import { createStyles } from '@mantine/core';
 
-export const useTableStyles = (overrideStyles?: Record<string, CSSObject>) =>
-    createStyles((theme) => {
-        const defaultStyles: Record<string, CSSObject> = {
-            '& thead tr': {
-                backgroundColor: theme.colors.gray[0],
-            },
+export const useTableStyles = createStyles((theme) => ({
+    root: {
+        '& thead tr': {
+            backgroundColor: theme.colors.gray[0],
+        },
 
-            '& thead tr th': {
-                color: theme.colors.gray[6],
-                fontWeight: 600,
-            },
+        '& thead tr th': {
+            color: theme.colors.gray[6],
+            fontWeight: 600,
+        },
 
-            '& thead tr th, & tbody tr td': {
-                padding: '12px 20px',
-            },
+        '& thead tr th, & tbody tr td': {
+            padding: `${theme.spacing.sm} ${theme.spacing.lg}`,
+        },
 
-            '&[data-hover] tbody tr': theme.fn.hover({
-                cursor: 'pointer',
-                backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
-            }),
-        };
-
-        if (overrideStyles) {
-            Object.keys(overrideStyles).forEach((key) => {
-                if (key in defaultStyles) {
-                    defaultStyles[key] = {
-                        ...defaultStyles[key],
-                        ...overrideStyles[key],
-                    };
-                } else {
-                    defaultStyles[key] = overrideStyles[key];
-                }
-            });
-        }
-
-        return { root: defaultStyles };
-    });
+        '&[data-hover] tbody tr': theme.fn.hover({
+            cursor: 'pointer',
+            backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
+        }),
+    },
+    smallHeaderText: {
+        '& thead tr th': {
+            fontSize: theme.fontSizes.xs,
+        },
+    },
+    alignLastTdRight: {
+        '& tr td:last-child': {
+            textAlign: 'right',
+        },
+    },
+}));

--- a/packages/frontend/src/hooks/styles/useTableStyles.tsx
+++ b/packages/frontend/src/hooks/styles/useTableStyles.tsx
@@ -1,0 +1,39 @@
+import { createStyles, CSSObject } from '@mantine/core';
+
+export const useTableStyles = (overrideStyles?: Record<string, CSSObject>) =>
+    createStyles((theme) => {
+        const defaultStyles: Record<string, CSSObject> = {
+            '& thead tr': {
+                backgroundColor: theme.colors.gray[0],
+            },
+
+            '& thead tr th': {
+                color: theme.colors.gray[6],
+                fontWeight: 600,
+            },
+
+            '& thead tr th, & tbody tr td': {
+                padding: '12px 20px',
+            },
+
+            '&[data-hover] tbody tr': theme.fn.hover({
+                cursor: 'pointer',
+                backgroundColor: theme.fn.rgba(theme.colors.gray[0], 0.5),
+            }),
+        };
+
+        if (overrideStyles) {
+            Object.keys(overrideStyles).forEach((key) => {
+                if (key in defaultStyles) {
+                    defaultStyles[key] = {
+                        ...defaultStyles[key],
+                        ...overrideStyles[key],
+                    };
+                } else {
+                    defaultStyles[key] = overrideStyles[key];
+                }
+            });
+        }
+
+        return { root: defaultStyles };
+    });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5329 

### Description:

Change PATs List view to a `<Table>`
Create styles hook `useTableStyles` to be shared across the app. This hook also allows overrides with CSS selectors+styling

NOTE: this work does not include `Delete token` modal layout


before: 
![image](https://user-images.githubusercontent.com/7611706/236166889-f891dc00-6363-4b1b-a4ca-26d759942c80.png)
after:
![image](https://user-images.githubusercontent.com/7611706/236166701-5d074c61-22f9-4374-b907-07aea5f9cd07.png)

Resource List component still looks as it did before:
![image](https://user-images.githubusercontent.com/7611706/236167411-09a3fd15-ba80-433a-9e6b-0419b6ca4c80.png)

