### PR TITLE
fix: broken big number chart

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -128,7 +128,7 @@ const useBigNumberConfig = (
     }, [bigNumberConfigData]);
 
     const bigNumberRaw =
-        selectedField && resultsData?.rows?.[0]?.[selectedField].value.raw;
+        selectedField && resultsData?.rows?.[0]?.[selectedField]?.value.raw;
 
     const isNumber =
         isNumericItem(item) &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5357

### Description:
<!-- Add a description of the changes proposed in the pull request. --> 

Fix big number chart when `resultsData?.rows?.[0]?.[selectedField]` is undefined. 

Before: we were getting a blank screen

Now: 

![image](https://user-images.githubusercontent.com/1983672/236156794-313765d7-ab9c-4746-bfbb-c7e49e975a8a.png)

<!-- Even better add a screenshot / gif / loom -->
