### PR TITLE
fix: mantine breadcrumb overflow

### DIFF
--- a/packages/frontend/src/components/common/PageBreadcrumbs.tsx
+++ b/packages/frontend/src/components/common/PageBreadcrumbs.tsx
@@ -31,18 +31,28 @@ const PageBreadcrumbs: FC<PageBreadcrumbsProps> = ({
     ...rest
 }) => {
     return (
-        <Breadcrumbs {...rest}>
+        <Breadcrumbs
+            {...rest}
+            styles={{
+                root: {
+                    display: 'block',
+                    flexWrap: 'wrap',
+                },
+                separator: {
+                    display: 'inline-block',
+                },
+            }}
+        >
             {items.map((item, index) => {
                 const commonProps: AnchorProps &
                     HTMLAttributes<HTMLAnchorElement> & { key: Key } = {
                     key: index,
                     size: size,
-
-                    truncate: true,
                     fw: item.active ? 600 : 500,
                     color: item.active ? 'gray.7' : 'gray.6',
                     onClick: item.onClick,
                     sx: {
+                        whiteSpace: 'normal',
                         ...(item.onClick || item.to
                             ? {
                                   cursor: 'pointer',
@@ -65,7 +75,9 @@ const PageBreadcrumbs: FC<PageBreadcrumbsProps> = ({
                 );
 
                 return item.tooltipProps ? (
-                    <Tooltip {...item.tooltipProps}>{anchor}</Tooltip>
+                    <Tooltip withArrow {...item.tooltipProps}>
+                        {anchor}
+                    </Tooltip>
                 ) : (
                     anchor
                 );


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/5363

### Description:

<img width="254" alt="CleanShot 2023-05-05 at 13 43 45@2x" src="https://user-images.githubusercontent.com/962095/236426102-4f343ff1-f075-4714-9d2f-f3bc2f20ba71.png">
<img width="366" alt="CleanShot 2023-05-05 at 13 43 54@2x" src="https://user-images.githubusercontent.com/962095/236426104-7cd351ba-672a-486a-8d06-08d9f658e511.png">
<img width="791" alt="CleanShot 2023-05-05 at 13 44 05@2x" src="https://user-images.githubusercontent.com/962095/236426110-b8d6559e-3ce6-44b3-b15a-852616403ca5.png">
