### PR TITLE
feat: truncate large text in table cell

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -42,7 +42,7 @@ const CellContextMenu: FC<
     const fieldValues = mapValues(cell.row.original, (v) => v?.value) || {};
 
     return (
-        <Menu>
+        <Menu style={{ maxWidth: 500 }}>
             {!!value.raw && isField(item) && (
                 <UrlMenuItems
                     urls={item.urls}

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -20,6 +20,7 @@ interface CommonBodyCellProps {
     fontColor?: string;
     copying?: boolean;
     selected?: boolean;
+    isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
     onSelect: () => void;
@@ -39,6 +40,7 @@ const BodyCell: FC<CommonBodyCellProps> = ({
     isNumericItem,
     index,
     selected = false,
+    isLargeText = false,
     style,
     tooltipContent,
     minimal = false,
@@ -91,6 +93,7 @@ const BodyCell: FC<CommonBodyCellProps> = ({
                             style={style}
                             $rowIndex={index}
                             $isSelected={selected}
+                            $isLargeText={isLargeText}
                             $isInteractive={hasContextMenu}
                             $isCopying={copying}
                             $backgroundColor={backgroundColor}

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -94,6 +94,7 @@ const BodyCell: FC<CommonBodyCellProps> = ({
                             $rowIndex={index}
                             $isSelected={selected}
                             $isLargeText={isLargeText}
+                            $isMinimal={minimal}
                             $isInteractive={hasContextMenu}
                             $isCopying={copying}
                             $backgroundColor={backgroundColor}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -44,6 +44,9 @@ interface TableRowProps {
     minimal?: boolean;
 }
 
+// arbitrary number that is usually smaller than the 300px max width of the cell
+const SMALL_TEXT_LENGTH = 35;
+
 const TableRow: FC<TableRowProps> = ({
     row,
     index,
@@ -96,6 +99,10 @@ const TableRow: FC<TableRowProps> = ({
                         cellContextMenu={cellContextMenu}
                         copying={cell.id === copyingCellId}
                         selected={cell.id === selectedCell?.id}
+                        isLargeText={
+                            (cellValue?.value.formatted || '').length >
+                            SMALL_TEXT_LENGTH
+                        }
                         tooltipContent={tooltipContent}
                         onSelect={() => onSelectCell?.(cell)}
                         onDeselect={() => onSelectCell?.(undefined)}

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -144,17 +144,18 @@ export const Td = styled.td<{
     $fontColor?: string;
     $hasData: boolean;
     $isLargeText: boolean;
+    $isMinimal: boolean;
 }>`
     max-width: 300px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 
-    ${({ $isLargeText, $isSelected }) =>
+    ${({ $isLargeText, $isSelected, $isMinimal }) =>
         $isLargeText
             ? `
                 min-width: 300px;
-                white-space: ${$isSelected ? 'normal' : 'nowrap'};
+                white-space: ${$isSelected || $isMinimal ? 'normal' : 'nowrap'};
                 :hover {
                     white-space: normal;
                 }

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -143,7 +143,24 @@ export const Td = styled.td<{
     $backgroundColor?: string;
     $fontColor?: string;
     $hasData: boolean;
+    $isLargeText: boolean;
 }>`
+    max-width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    ${({ $isLargeText, $isSelected }) =>
+        $isLargeText
+            ? `
+                min-width: 300px;
+                white-space: ${$isSelected ? 'normal' : 'nowrap'};
+                :hover {
+                    white-space: normal;
+                }
+            `
+            : ''}
+
     ${CellStyles}
 
     ${({ $isInteractive, $hasData }) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5121 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

To avoid issues with virtualization, where the rows have different heights, we now truncate large texts.
We consider large text if there are more than 35 chars. ( an arbitrary number that is usually close to 300px )
We set those cells to have 300px width and expand them on hover or when the cell is selected.

Preview:

![May-05-2023 16-49-17](https://user-images.githubusercontent.com/9117144/236506955-1e2b7d80-e19d-41df-ae02-5faa3dbf43b2.gif)

Preview in PR: 
https://lightdash-pr-5388.onrender.com/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/1db7e2c3-8f73-489d-a145-d30ff0043b1c/view
Note that our demo data doesn't have large text so I had to use a table calculation (table calculation values are always aligned to the right).


### Cons:

- Words longer that 300px won't be fully visible.

![Captura de ecrã 2023-05-05, às 15 40 22](https://user-images.githubusercontent.com/9117144/236504328-7a9a87c5-9964-43e7-a654-372c99fb5593.png)

- We force the cell to be 300px when the text is longer than 35 chars, even if the text isn't truncated. This problem exists because [we don't use a monospaces font in the tables](https://github.com/lightdash/lightdash/issues/2396).

![Captura de ecrã 2023-05-05, às 15 58 03](https://user-images.githubusercontent.com/9117144/236504331-967d618e-5be2-478b-823a-a1613aaaeed4.png)

- Didn't add support for such cases in pivot tables with metrics as rows. Should we support it ?

![Captura de ecrã 2023-05-05, às 16 19 59](https://user-images.githubusercontent.com/9117144/236504339-4b9ac671-ff1a-4755-b691-12b22ef09359.png)

