### PR TITLE
fix: get correct link for a space in all spaces grid

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -50,7 +50,9 @@ export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
         case ResourceViewItemType.CHART:
             return `/projects/${projectUuid}/saved/${item.data.uuid}`;
         case ResourceViewItemType.SPACE:
-            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+            return `/projects/${projectUuid || item.data.projectUuid}/spaces/${
+                item.data.uuid
+            }`;
         default:
             return assertUnreachable(item, `Can't get URL for ${itemType}`);
     }

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -50,9 +50,7 @@ export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
         case ResourceViewItemType.CHART:
             return `/projects/${projectUuid}/saved/${item.data.uuid}`;
         case ResourceViewItemType.SPACE:
-            return `/projects/${projectUuid || item.data.projectUuid}/spaces/${
-                item.data.uuid
-            }`;
+            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
         default:
             return assertUnreachable(item, `Can't get URL for ${itemType}`);
     }

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -98,6 +98,7 @@ const Spaces: FC = () => {
                                 </Button>
                             ) : undefined,
                     }}
+                    pinnedItemsProps={{ projectUuid, pinnedListUuid: '' }}
                 />
             </Stack>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5401 

### Description:
When viewing All Spaces, each Link has an empty string for `projectUuid`. 
This only happens on spaces. 


Before
(see issue)

After
![image](https://github.com/lightdash/lightdash/assets/7611706/f7917858-4ef8-481b-963b-4989bb88fe11)


