### PR TITLE
fix: undefined item on chart click

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
+++ b/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
@@ -69,11 +69,15 @@ export const getDataFromChartClick = (
         (item) => !isDimension(item),
     );
 
-    const selectedField =
-        selectedMetricsAndTableCalculations.length > 0
-            ? selectedMetricsAndTableCalculations[0]
-            : selectedFields[0];
-    const selectedValue = e.data[getItemId(selectedField)];
+    let selectedField: Field | TableCalculation | undefined = undefined;
+    if (selectedMetricsAndTableCalculations.length > 0) {
+        selectedField = selectedMetricsAndTableCalculations[0];
+    } else if (selectedFields.length > 0) {
+        selectedField = selectedFields[0];
+    }
+    const selectedValue = selectedField
+        ? e.data[getItemId(selectedField)]
+        : undefined;
     const fieldValues: Record<string, ResultValue> = Object.entries(
         e.data as Record<string, any>,
     ).reduce((acc, entry) => {

--- a/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
+++ b/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
@@ -2,6 +2,7 @@ import {
     DashboardFilters,
     Explore,
     Field,
+    formatItemValue,
     getItemId,
     hashFieldReference,
     isDimension,
@@ -79,7 +80,7 @@ export const getDataFromChartClick = (
         ? e.data[getItemId(selectedField)]
         : undefined;
     const fieldValues: Record<string, ResultValue> = Object.entries(
-        e.data as Record<string, any>,
+        e.data,
     ).reduce((acc, entry) => {
         const [key, val] = entry;
         return { ...acc, [key]: { raw: val, formatted: val } };
@@ -87,7 +88,10 @@ export const getDataFromChartClick = (
 
     return {
         item: selectedField,
-        value: { raw: selectedValue, formatted: selectedValue },
+        value: {
+            raw: selectedValue,
+            formatted: formatItemValue(selectedField, selectedValue),
+        },
         fieldValues,
         pivotReference,
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5356 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Haven't been able to reproduce ( it might be an edge case where a column was removed from the query or yml ) but the error report points to this line of code. The code assumes the `selectedFields` is not empty and selectedField can't be undefined, which is not true.
