### PR TITLE
fix: overflow with mantine tooltips in explore panel

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -83,7 +83,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         multiline
                         sx={{ whiteSpace: 'normal' }}
                         disabled={!item.description}
-                        label={item.description?.repeat(10)}
+                        label={item.description}
                         position="top-start"
                         withinPortal
                         maw={700}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -80,12 +80,13 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                 <Group noWrap>
                     <Tooltip
                         withArrow
-                        inline
-                        openDelay={500}
+                        multiline
+                        sx={{ whiteSpace: 'normal' }}
                         disabled={!item.description}
-                        label={<Text truncate>{item.description}</Text>}
+                        label={item.description?.repeat(10)}
                         position="top-start"
-                        maw={350}
+                        withinPortal
+                        maw={700}
                     >
                         <Highlight
                             component={Text}
@@ -98,7 +99,11 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     </Tooltip>
 
                     {isFiltered ? (
-                        <Tooltip withArrow label="This field is filtered">
+                        <Tooltip
+                            withArrow
+                            withinPortal
+                            label="This field is filtered"
+                        >
                             <MantineIcon
                                 icon={IconFilter}
                                 color="gray.7"
@@ -110,6 +115,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     {item.hidden ? (
                         <Tooltip
                             withArrow
+                            withinPortal
                             label="This field has been hidden in the dbt project. It's recommend to remove it from the query"
                         >
                             <MantineIcon


### PR DESCRIPTION
Closes: #5411 

### Description:

<img width="825" alt="CleanShot 2023-05-09 at 16 58 50@2x" src="https://github.com/lightdash/lightdash/assets/962095/8b26de28-63d7-4054-9eb3-e7867a1cc5ee">
