### PR TITLE
fix: settings page layout issue

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnection.styles.tsx
@@ -10,6 +10,7 @@ export const FormContainer = styled(Form)`
     display: flex;
     flex-direction: column;
     gap: ${CARD_GAP}px;
+    width: 100%;
 `;
 
 export const CompileProjectButton = styled(Button)`


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/5364

### Description:

not sure why but this is not present locally (fixes prod if we add 100% width to it)

<img width="1466" alt="CleanShot 2023-05-09 at 17 19 27@2x" src="https://github.com/lightdash/lightdash/assets/962095/7f98ad47-f7e5-47da-9388-45c37e3daad6">
<img width="1285" alt="CleanShot 2023-05-09 at 17 19 22@2x" src="https://github.com/lightdash/lightdash/assets/962095/ccc4a07a-7b3c-4590-969b-b9dfe9ea39f9">
