### PR TITLE
chore: remove unecessary uses of `spaces-and-content`

### DIFF
--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
@@ -15,7 +15,11 @@ import {
     useUpdateMultipleDashboard,
 } from '../../../hooks/dashboard/useDashboards';
 import { useUpdateMultipleMutation } from '../../../hooks/useSavedQuery';
-import { useSavedCharts, useSpace, useSpaces } from '../../../hooks/useSpaces';
+import {
+    useSavedCharts,
+    useSpace,
+    useSpaceSummaries,
+} from '../../../hooks/useSpaces';
 import Form from '../../ReactHookForm/Form';
 import MultiSelect from '../../ReactHookForm/MultiSelect';
 import { SpaceLabel } from './AddResourceToSpaceModal.style';
@@ -60,7 +64,7 @@ const AddResourceToSpaceModal: FC<Props> = ({
     }>();
 
     const { data: space } = useSpace(projectUuid, spaceUuid);
-    const { data: spaces } = useSpaces(projectUuid);
+    const { data: spaces } = useSpaceSummaries(projectUuid);
 
     const { mutate: chartMutation } = useUpdateMultipleMutation(projectUuid);
     const { mutate: dashboardMutation } =

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 import { Button, Classes, Divider, Intent, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
-import { Dashboard, Space, UpdatedByUser } from '@lightdash/common';
+import { Dashboard, SpaceSummary, UpdatedByUser } from '@lightdash/common';
 import { IconDots, IconPencil } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
@@ -28,7 +28,7 @@ import ViewInfo from '../PageHeader/ViewInfo';
 import SpaceActionModal, { ActionType } from '../SpaceActionModal';
 
 type DashboardHeaderProps = {
-    spaces?: Space[];
+    spaces?: SpaceSummary[];
     dashboardDescription?: string;
     dashboardName: string;
     dashboardSpaceName?: string;

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -20,7 +20,7 @@ import {
 } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { useSpaces } from '../../../hooks/useSpaces';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import MantineIcon from '../MantineIcon';
 import {
@@ -51,7 +51,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const location = useLocation();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const organizationUuid = user.data?.organizationUuid;
-    const { data: spaces = [] } = useSpaces(projectUuid);
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid);
     const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -19,7 +19,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
 import { useTableStyles } from '../../../../hooks/styles/useTableStyles';
-import { useSpaces } from '../../../../hooks/useSpaces';
+import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { ResourceIcon } from '../ResourceIcon';
 import {
     getResourceTypeName,
@@ -85,7 +85,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
 
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: spaces = [] } = useSpaces(projectUuid);
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid);
 
     const [columnSorts, setColumnSorts] = useState<SortingStateMap>(
         defaultSort ? new Map(Object.entries(defaultSort)) : new Map(),

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router-dom';
 import { useCreateMutation } from '../../../hooks/useSavedQuery';
 import {
     useCreateMutation as useSpaceCreateMutation,
-    useSpaces,
+    useSpaceSummaries,
 } from '../../../hooks/useSpaces';
 import {
     CreateNewText,
@@ -32,8 +32,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     ...modalProps
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-
-    const { data: spaces } = useSpaces(projectUuid);
+    const { data: spaces } = useSpaceSummaries(projectUuid);
     const { mutateAsync, isLoading: isCreating } = useCreateMutation();
     const { mutateAsync: createSpaceAsync, isLoading: isCreatingSpace } =
         useSpaceCreateMutation(projectUuid);

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -14,7 +14,7 @@ import { FC, useCallback, useState } from 'react';
 import { useCreateMutation } from '../../../hooks/dashboard/useDashboard';
 import {
     useCreateMutation as useSpaceCreateMutation,
-    useSpaces,
+    useSpaceSummaries,
 } from '../../../hooks/useSpaces';
 import { useApp } from '../../../providers/AppProvider';
 import {} from '../ShareSpaceModal/ShareSpaceModal.style';
@@ -47,7 +47,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
         useState<boolean>(false);
     const [newSpaceName, setNewSpaceName] = useState('');
 
-    const { data: spaces, isLoading: isLoadingSpaces } = useSpaces(
+    const { data: spaces, isLoading: isLoadingSpaces } = useSpaceSummaries(
         projectUuid,
         {
             onSuccess: (data) => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -37,7 +37,7 @@ import {
     useUpdateDashboard,
 } from '../hooks/dashboard/useDashboard';
 import { useSavedQuery } from '../hooks/useSavedQuery';
-import { useSpaces } from '../hooks/useSpaces';
+import { useSpaceSummaries } from '../hooks/useSpaces';
 import {
     DashboardProvider,
     useDashboardContext,
@@ -134,7 +134,7 @@ const Dashboard: FC = () => {
         dashboardUuid: string;
         mode?: string;
     }>();
-    const { data: spaces } = useSpaces(projectUuid);
+    const { data: spaces } = useSpaceSummaries(projectUuid);
 
     const {
         dashboard,

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -16,7 +16,7 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
-import { useSpaces } from '../hooks/useSpaces';
+import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
 export const DEFAULT_DASHBOARD_NAME = 'Untitled dashboard';
@@ -30,7 +30,8 @@ const SavedDashboards = () => {
 
     const { user, health } = useApp();
     const isDemo = health.data?.mode === LightdashMode.DEMO;
-    const { data: spaces, isLoading: isLoadingSpaces } = useSpaces(projectUuid);
+    const { data: spaces, isLoading: isLoadingSpaces } =
+        useSpaceSummaries(projectUuid);
     const hasNoSpaces = spaces && spaces.length === 0;
 
     const userCanManageDashboards = user.data?.ability?.can(


### PR DESCRIPTION
Closes: #5439 

### Description:

before
<img width="1238" alt="Screenshot 2023-05-11 at 15 55 01" src="https://github.com/lightdash/lightdash/assets/67699259/134ef5db-2933-4973-a878-a57a90eb8607">
after
<img width="916" alt="Screenshot 2023-05-11 at 15 54 34" src="https://github.com/lightdash/lightdash/assets/67699259/945d3d16-097e-44f5-9be7-500af05a9990">