### PR TITLE
feat: big number comparison

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -38,16 +38,9 @@ export type BigNumber = {
     label?: string;
     style?: CompactOrAlias;
     selectedField?: string;
-    comparisonValue: string;
-    showLabel: boolean;
-    setShowLabel: React.Dispatch<React.SetStateAction<boolean>>;
-    showComparison: boolean;
-    setShowComparison: React.Dispatch<React.SetStateAction<boolean>>;
-    comparisonFormat: ComparisonFormatTypes;
-    setComparisonFormat: React.Dispatch<
-        React.SetStateAction<ComparisonFormatTypes>
-    >;
-    comparisonDiff: ComparisonDiffTypes;
+    showLabel?: boolean;
+    showComparison?: boolean;
+    comparisonFormat?: ComparisonFormatTypes;
 };
 
 export type BigNumberConfig = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -21,10 +21,33 @@ export enum ChartType {
     BIG_NUMBER = 'big_number',
 }
 
+export enum ComparisonFormatTypes {
+    RAW = 'raw',
+    PERCENTAGE = 'percentage',
+}
+
+export enum ComparisonDiffTypes {
+    POSITIVE = 'positive',
+    NEGATIVE = 'negative',
+    NONE = 'none',
+    NAN = 'nan',
+    UNDEFINED = 'undefined',
+}
+
 export type BigNumber = {
     label?: string;
     style?: CompactOrAlias;
     selectedField?: string;
+    comparisonValue: string;
+    showLabel: boolean;
+    setShowLabel: React.Dispatch<React.SetStateAction<boolean>>;
+    showComparison: boolean;
+    setShowComparison: React.Dispatch<React.SetStateAction<boolean>>;
+    comparisonFormat: ComparisonFormatTypes;
+    setComparisonFormat: React.Dispatch<
+        React.SetStateAction<ComparisonFormatTypes>
+    >;
+    comparisonDiff: ComparisonDiffTypes;
 };
 
 export type BigNumberConfig = {

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -42,7 +42,7 @@ const BigNumberConfigPanel: React.FC = () => {
             setShowComparison,
             comparisonFormat,
             setComparisonFormat,
-            formatValues,
+            comparisonFormatTypes,
         },
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
@@ -134,17 +134,18 @@ const BigNumberConfigPanel: React.FC = () => {
                     {showComparison && (
                         <RadioGroup
                             onChange={(e) => {
+                                // @ts-ignore
                                 setComparisonFormat(e.currentTarget.value);
                             }}
                             selectedValue={comparisonFormat}
                         >
                             <Radio
                                 label="By raw value"
-                                value={formatValues.RAW}
+                                value={comparisonFormatTypes.RAW}
                             />
                             <Radio
                                 label="By percentage"
-                                value={formatValues.PERCENTAGE}
+                                value={comparisonFormatTypes.PERCENTAGE}
                             />
                         </RadioGroup>
                     )}

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -134,8 +134,11 @@ const BigNumberConfigPanel: React.FC = () => {
                     {showComparison && (
                         <RadioGroup
                             onChange={(e) => {
-                                // @ts-ignore
-                                setComparisonFormat(e.currentTarget.value);
+                                setComparisonFormat(
+                                    e.currentTarget.value === 'raw'
+                                        ? comparisonFormatTypes.RAW
+                                        : comparisonFormatTypes.PERCENTAGE,
+                                );
                             }}
                             selectedValue={comparisonFormat}
                         >

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -8,7 +8,12 @@ import {
     Switch,
 } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { CompactConfigMap, CompactOrAlias, getItemId } from '@lightdash/common';
+import {
+    CompactConfigMap,
+    CompactOrAlias,
+    ComparisonFormatTypes,
+    getItemId,
+} from '@lightdash/common';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import React, { useState } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
@@ -42,7 +47,6 @@ const BigNumberConfigPanel: React.FC = () => {
             setShowComparison,
             comparisonFormat,
             setComparisonFormat,
-            comparisonFormatTypes,
         },
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
@@ -136,19 +140,19 @@ const BigNumberConfigPanel: React.FC = () => {
                             onChange={(e) => {
                                 setComparisonFormat(
                                     e.currentTarget.value === 'raw'
-                                        ? comparisonFormatTypes.RAW
-                                        : comparisonFormatTypes.PERCENTAGE,
+                                        ? ComparisonFormatTypes.RAW
+                                        : ComparisonFormatTypes.PERCENTAGE,
                                 );
                             }}
                             selectedValue={comparisonFormat}
                         >
                             <Radio
                                 label="By raw value"
-                                value={comparisonFormatTypes.RAW}
+                                value={ComparisonFormatTypes.RAW}
                             />
                             <Radio
                                 label="By percentage"
-                                value={comparisonFormatTypes.PERCENTAGE}
+                                value={ComparisonFormatTypes.PERCENTAGE}
                             />
                         </RadioGroup>
                     )}

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -1,6 +1,15 @@
-import { Button, FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
+import {
+    Button,
+    FormGroup,
+    HTMLSelect,
+    InputGroup,
+    Radio,
+    RadioGroup,
+    Switch,
+} from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
 import { CompactConfigMap, CompactOrAlias, getItemId } from '@lightdash/common';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import React, { useState } from 'react';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
@@ -27,6 +36,13 @@ const BigNumberConfigPanel: React.FC = () => {
             selectedField,
             setSelectedField,
             getField,
+            showLabel,
+            setShowLabel,
+            showComparison,
+            setShowComparison,
+            comparisonFormat,
+            setComparisonFormat,
+            formatValues,
         },
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
@@ -37,7 +53,7 @@ const BigNumberConfigPanel: React.FC = () => {
             disabled={disabled}
             content={
                 <InputWrapper>
-                    <FormGroup labelFor="bignumber-field" label="Select field">
+                    <FormGroup labelFor="bignumber-field" label="Field">
                         <FieldAutoComplete
                             id="bignumber-field"
                             fields={availableFields}
@@ -60,11 +76,26 @@ const BigNumberConfigPanel: React.FC = () => {
                             onBlur={(e) =>
                                 setBigNumberLabel(e.currentTarget.value)
                             }
+                            rightElement={
+                                <Button
+                                    active={showLabel}
+                                    icon={
+                                        showLabel ? (
+                                            <IconEye size={18} />
+                                        ) : (
+                                            <IconEyeOff size={18} />
+                                        )
+                                    }
+                                    onClick={() => {
+                                        setShowLabel(!showLabel);
+                                    }}
+                                />
+                            }
                         />
                     </FormGroup>
 
                     {showStyle && (
-                        <FormGroup labelFor="bignumber-style" label="Style">
+                        <FormGroup labelFor="bignumber-style" label="Format">
                             <HTMLSelect
                                 id="bignumber-style"
                                 fill
@@ -81,6 +112,41 @@ const BigNumberConfigPanel: React.FC = () => {
                                 }}
                             />
                         </FormGroup>
+                    )}
+                    <FormGroup
+                        labelFor="bignumber-comparison"
+                        label="Compare to previous row"
+                        inline
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            marginBottom: 'none',
+                        }}
+                    >
+                        <Switch
+                            alignIndicator="right"
+                            checked={showComparison}
+                            onChange={() => {
+                                setShowComparison(!showComparison);
+                            }}
+                        />
+                    </FormGroup>
+                    {showComparison && (
+                        <RadioGroup
+                            onChange={(e) => {
+                                setComparisonFormat(e.currentTarget.value);
+                            }}
+                            selectedValue={comparisonFormat}
+                        >
+                            <Radio
+                                label="By raw value"
+                                value={formatValues.RAW}
+                            />
+                            <Radio
+                                label="By percentage"
+                                value={formatValues.PERCENTAGE}
+                            />
+                        </RadioGroup>
                     )}
                 </InputWrapper>
             }

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -2,6 +2,7 @@ import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash-es/clamp';
 import { FC, HTMLAttributes, useMemo } from 'react';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
+import MantineIcon from '../common/MantineIcon';
 import {
     TILE_HEADER_HEIGHT,
     TILE_HEADER_MARGIN_BOTTOM,
@@ -31,8 +32,8 @@ const VALUE_SIZE_MAX = 64;
 const LABEL_SIZE_MIN = 14;
 const LABEL_SIZE_MAX = 32;
 
-const COMPARISON_VALUE_SIZE_MIN = 14;
-const COMPARISON_VALUE_SIZE_MAX = 32;
+const COMPARISON_VALUE_SIZE_MIN = 12;
+const COMPARISON_VALUE_SIZE_MAX = 22;
 
 const calculateFontSize = (
     fontSizeMin: number,
@@ -61,8 +62,8 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             comparisonValue,
             showComparison,
             showLabel,
-            comparisonFormat,
-            formatValues,
+            comparisonDiff,
+            comparisonDiffTypes,
         },
         isSqlRunner,
     } = useVisualizationContext();
@@ -150,16 +151,19 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             marginTop: 10,
                         }}
                     >
-                        {typeof comparisonValue === 'number' &&
-                        comparisonFormat === formatValues.PERCENTAGE
-                            ? `${comparisonValue}%`
-                            : comparisonValue}
-                        {typeof comparisonValue === 'number' &&
-                        comparisonValue > 0 ? (
-                            <IconArrowUpRight style={{ marginLeft: 5 }} />
-                        ) : typeof comparisonValue === 'number' &&
-                          comparisonValue < 0 ? (
-                            <IconArrowDownRight style={{ marginLeft: 5 }} />
+                        {comparisonValue}
+                        {comparisonDiff === comparisonDiffTypes.POSITIVE ? (
+                            <MantineIcon
+                                icon={IconArrowUpRight}
+                                size={18}
+                                style={{ display: 'inline', marginLeft: 5 }}
+                            />
+                        ) : comparisonDiff === comparisonDiffTypes.NEGATIVE ? (
+                            <MantineIcon
+                                icon={IconArrowDownRight}
+                                size={18}
+                                style={{ display: 'inline', marginLeft: 5 }}
+                            />
                         ) : null}
                     </BigNumber>
                 </BigNumberHalf>

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -149,6 +149,8 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                         $fontSize={comparisonFontSize}
                         style={{
                             marginTop: 10,
+                            display: 'flex',
+                            alignItems: 'center',
                         }}
                     >
                         {comparisonValue}

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,3 +1,4 @@
+import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash-es/clamp';
 import { FC, HTMLAttributes, useMemo } from 'react';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
@@ -30,6 +31,9 @@ const VALUE_SIZE_MAX = 64;
 const LABEL_SIZE_MIN = 14;
 const LABEL_SIZE_MAX = 32;
 
+const COMPARISON_VALUE_SIZE_MIN = 14;
+const COMPARISON_VALUE_SIZE_MAX = 32;
+
 const calculateFontSize = (
     fontSizeMin: number,
     fontSizeMax: number,
@@ -50,13 +54,22 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     const {
         resultsData,
         isLoading,
-        bigNumberConfig: { bigNumber, bigNumberLabel, defaultLabel },
+        bigNumberConfig: {
+            bigNumber,
+            bigNumberLabel,
+            defaultLabel,
+            comparisonValue,
+            showComparison,
+            showLabel,
+            comparisonFormat,
+            formatValues,
+        },
         isSqlRunner,
     } = useVisualizationContext();
 
     const [setRef, observerElementSize] = useResizeObserver();
 
-    const { valueFontSize, labelFontSize } = useMemo(() => {
+    const { valueFontSize, labelFontSize, comparisonFontSize } = useMemo(() => {
         const boundWidth = clamp(
             observerElementSize?.width || 0,
             BOX_MIN_WIDTH,
@@ -75,9 +88,16 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             boundWidth,
         );
 
+        const comparisonValueSize = calculateFontSize(
+            COMPARISON_VALUE_SIZE_MIN,
+            COMPARISON_VALUE_SIZE_MAX,
+            boundWidth,
+        );
+
         return {
             valueFontSize: valueSize,
             labelFontSize: labelSize,
+            comparisonFontSize: comparisonValueSize,
         };
     }, [observerElementSize]);
 
@@ -114,11 +134,36 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                 )}
             </BigNumberHalf>
 
-            <BigNumberHalf>
-                <BigNumberLabel $fontSize={labelFontSize}>
-                    {bigNumberLabel || defaultLabel}
-                </BigNumberLabel>
-            </BigNumberHalf>
+            {showLabel ? (
+                <BigNumberHalf>
+                    <BigNumberLabel $fontSize={labelFontSize}>
+                        {bigNumberLabel || defaultLabel}
+                    </BigNumberLabel>
+                </BigNumberHalf>
+            ) : null}
+
+            {showComparison ? (
+                <BigNumberHalf>
+                    <BigNumber
+                        $fontSize={comparisonFontSize}
+                        style={{
+                            marginTop: 10,
+                        }}
+                    >
+                        {typeof comparisonValue === 'number' &&
+                        comparisonFormat === formatValues.PERCENTAGE
+                            ? `${comparisonValue}%`
+                            : comparisonValue}
+                        {typeof comparisonValue === 'number' &&
+                        comparisonValue > 0 ? (
+                            <IconArrowUpRight style={{ marginLeft: 5 }} />
+                        ) : typeof comparisonValue === 'number' &&
+                          comparisonValue < 0 ? (
+                            <IconArrowDownRight style={{ marginLeft: 5 }} />
+                        ) : null}
+                    </BigNumber>
+                </BigNumberHalf>
+            ) : null}
         </BigNumberContainer>
     ) : (
         <EmptyChart />

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,3 +1,4 @@
+import { ComparisonDiffTypes } from '@lightdash/common';
 import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash-es/clamp';
 import { FC, HTMLAttributes, useMemo } from 'react';
@@ -63,7 +64,6 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             showComparison,
             showLabel,
             comparisonDiff,
-            comparisonDiffTypes,
         },
         isSqlRunner,
     } = useVisualizationContext();
@@ -154,13 +154,13 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                         }}
                     >
                         {comparisonValue}
-                        {comparisonDiff === comparisonDiffTypes.POSITIVE ? (
+                        {comparisonDiff === ComparisonDiffTypes.POSITIVE ? (
                             <MantineIcon
                                 icon={IconArrowUpRight}
                                 size={18}
                                 style={{ display: 'inline', marginLeft: 5 }}
                             />
-                        ) : comparisonDiff === comparisonDiffTypes.NEGATIVE ? (
+                        ) : comparisonDiff === ComparisonDiffTypes.NEGATIVE ? (
                             <MantineIcon
                                 icon={IconArrowDownRight}
                                 size={18}

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -45,11 +45,8 @@ const formatComparisonValue = (
     value: number | string,
 ) => {
     const prefix =
-        comparisonDiff === ComparisonDiffTypes.NAN ||
-        ComparisonDiffTypes.NEGATIVE
-            ? ''
-            : comparisonDiff === ComparisonDiffTypes.POSITIVE ||
-              ComparisonDiffTypes.NONE
+        comparisonDiff ===
+        (ComparisonDiffTypes.POSITIVE || ComparisonDiffTypes.NONE)
             ? '+'
             : '';
     switch (format) {

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -1,6 +1,8 @@
 import {
     ApiQueryResults,
     BigNumber,
+    ComparisonDiffTypes,
+    ComparisonFormatTypes,
     convertAdditionalMetric,
     Explore,
     Field,
@@ -20,28 +22,16 @@ import {
 } from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-enum comparisonFormatTypes {
-    RAW = 'raw',
-    PERCENTAGE = 'percentage',
-}
-
-enum comparisonDiffTypes {
-    POSITIVE = 'positive',
-    NEGATIVE = 'negative',
-    NONE = 'none',
-    NAN = 'nan',
-}
-
 const calculateComparisonValue = (
     a: number,
     b: number,
-    format: comparisonFormatTypes,
+    format: ComparisonFormatTypes,
 ) => {
     const rawValue = a - b;
     switch (format) {
-        case comparisonFormatTypes.PERCENTAGE:
+        case ComparisonFormatTypes.PERCENTAGE:
             return rawValue / b;
-        case comparisonFormatTypes.RAW:
+        case ComparisonFormatTypes.RAW:
             return rawValue;
         default:
             return rawValue;
@@ -49,26 +39,26 @@ const calculateComparisonValue = (
 };
 
 const formatComparisonValue = (
-    format: comparisonFormatTypes,
-    comparisonDiff: comparisonDiffTypes | undefined,
+    format: ComparisonFormatTypes,
+    comparisonDiff: ComparisonDiffTypes | undefined,
     item: Field | TableCalculation | undefined,
     value: number | string,
 ) => {
     const prefix =
-        comparisonDiff === comparisonDiffTypes.NAN ||
-        comparisonDiffTypes.NEGATIVE
+        comparisonDiff === ComparisonDiffTypes.NAN ||
+        ComparisonDiffTypes.NEGATIVE
             ? ''
-            : comparisonDiff === comparisonDiffTypes.POSITIVE ||
-              comparisonDiffTypes.NONE
+            : comparisonDiff === ComparisonDiffTypes.POSITIVE ||
+              ComparisonDiffTypes.NONE
             ? '+'
             : '';
     switch (format) {
-        case comparisonFormatTypes.PERCENTAGE:
+        case ComparisonFormatTypes.PERCENTAGE:
             return `${prefix}${formatValue(value, {
                 format: 'percent',
                 round: 0,
             })}`;
-        case comparisonFormatTypes.RAW:
+        case ComparisonFormatTypes.RAW:
             return `${prefix}${formatItemValue(item, value)}`;
         default:
             return formatItemValue(item, value);
@@ -211,10 +201,10 @@ const useBigNumberConfig = (
 
     const [showComparison, setShowComparison] = useState<boolean>(false);
     const [comparisonFormat, setComparisonFormat] =
-        useState<comparisonFormatTypes>(comparisonFormatTypes.RAW);
-    const [comparisonDiff, setComparisonDiff] = useState<
-        comparisonDiffTypes | undefined
-    >(undefined);
+        useState<ComparisonFormatTypes>(ComparisonFormatTypes.RAW);
+    const [comparisonDiff, setComparisonDiff] = useState<ComparisonDiffTypes>(
+        ComparisonDiffTypes.UNDEFINED,
+    );
 
     const unformattedValue =
         isNumber(item, secondRowValueRaw) && isNumber(item, firstRowValueRaw)
@@ -228,14 +218,14 @@ const useBigNumberConfig = (
     useEffect(() => {
         setComparisonDiff(
             unformattedValue > 0
-                ? comparisonDiffTypes.POSITIVE
+                ? ComparisonDiffTypes.POSITIVE
                 : unformattedValue < 0
-                ? comparisonDiffTypes.NEGATIVE
+                ? ComparisonDiffTypes.NEGATIVE
                 : unformattedValue === 0
-                ? comparisonDiffTypes.NONE
+                ? ComparisonDiffTypes.NONE
                 : valueIsNaN(unformattedValue)
-                ? comparisonDiffTypes.NAN
-                : undefined,
+                ? ComparisonDiffTypes.NAN
+                : ComparisonDiffTypes.UNDEFINED,
         );
     }, [unformattedValue]);
 
@@ -255,8 +245,28 @@ const useBigNumberConfig = (
             label: bigNumberLabel,
             style: bigNumberStyle,
             selectedField: selectedField,
+            comparisonValue,
+            showLabel,
+            setShowLabel,
+            showComparison,
+            setShowComparison,
+            comparisonFormat,
+            setComparisonFormat,
+            comparisonDiff,
         }),
-        [bigNumberLabel, bigNumberStyle, selectedField],
+        [
+            bigNumberLabel,
+            bigNumberStyle,
+            selectedField,
+            comparisonValue,
+            showLabel,
+            setShowLabel,
+            showComparison,
+            setShowComparison,
+            comparisonFormat,
+            setComparisonFormat,
+            comparisonDiff,
+        ],
     );
     return {
         bigNumber,
@@ -276,11 +286,11 @@ const useBigNumberConfig = (
         setShowLabel,
         showComparison,
         setShowComparison,
-        comparisonFormatTypes,
+        comparisonFormatTypes: ComparisonFormatTypes,
         comparisonFormat,
         setComparisonFormat,
         comparisonDiff,
-        comparisonDiffTypes,
+        comparisonDiffTypes: ComparisonDiffTypes,
     };
 };
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -281,11 +281,9 @@ const useBigNumberConfig = (
         setShowLabel,
         showComparison,
         setShowComparison,
-        comparisonFormatTypes: ComparisonFormatTypes,
         comparisonFormat,
         setComparisonFormat,
         comparisonDiff,
-        comparisonDiffTypes: ComparisonDiffTypes,
     };
 };
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -182,8 +182,10 @@ const useBigNumberConfig = (
 
         setBigNumberStyle(bigNumberConfigData?.style);
 
-        setShowComparison(bigNumberConfigData?.showComparison);
-        setComparisonFormat(bigNumberConfigData?.comparisonFormat);
+        setShowComparison(bigNumberConfigData?.showComparison ?? false);
+        setComparisonFormat(
+            bigNumberConfigData?.comparisonFormat ?? ComparisonFormatTypes.RAW,
+        );
     }, [bigNumberConfigData]);
 
     // big number value (first row)

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -230,12 +230,15 @@ const useBigNumberConfig = (
             : ComparisonDiffTypes.UNDEFINED;
     }, [unformattedValue]);
 
-    const comparisonValue = formatComparisonValue(
-        comparisonFormat,
-        comparisonDiff,
-        item,
-        unformattedValue,
-    );
+    const comparisonValue =
+        unformattedValue === 'N/A'
+            ? 'N/A'
+            : formatComparisonValue(
+                  comparisonFormat,
+                  comparisonDiff,
+                  item,
+                  unformattedValue,
+              );
 
     const showStyle =
         isNumber(item, firstRowValueRaw) &&

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -168,14 +168,15 @@ const useBigNumberConfig = (
     );
 
     const calculateComparisonValue = (a: number, b: number, format: string) => {
+        const rawValue = Math.round(b - a);
         switch (format) {
             case formatValues.PERCENTAGE:
-                return ((b - a) / a) * 100;
+                return Math.round(((b - a) / a) * 100);
 
             case formatValues.RAW:
-                return b - a;
+                return rawValue === 0 ? 'No change' : rawValue;
             default:
-                return b - a;
+                return rawValue;
         }
     };
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -25,7 +25,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 const calculateComparisonValue = (
     a: number,
     b: number,
-    format: ComparisonFormatTypes,
+    format: ComparisonFormatTypes | undefined,
 ) => {
     const rawValue = a - b;
     switch (format) {
@@ -39,7 +39,7 @@ const calculateComparisonValue = (
 };
 
 const formatComparisonValue = (
-    format: ComparisonFormatTypes,
+    format: ComparisonFormatTypes | undefined,
     comparisonDiff: ComparisonDiffTypes | undefined,
     item: Field | TableCalculation | undefined,
     value: number | string,
@@ -162,19 +162,32 @@ const useBigNumberConfig = (
     const [bigNumberLabel, setBigNumberLabel] = useState<
         BigNumber['label'] | undefined
     >(bigNumberConfigData?.label);
-    const [showLabel, setShowLabel] = useState<boolean>(true);
-
+    const [showLabel, setShowLabel] = useState<
+        BigNumber['showLabel'] | undefined
+    >(true);
     const [bigNumberStyle, setBigNumberStyle] = useState<
         BigNumber['style'] | undefined
     >(bigNumberConfigData?.style);
+
+    const [showComparison, setShowComparison] = useState<
+        BigNumber['showComparison'] | undefined
+    >(false);
+    const [comparisonFormat, setComparisonFormat] = useState<
+        BigNumber['comparisonFormat'] | undefined
+    >(ComparisonFormatTypes.RAW);
 
     useEffect(() => {
         if (bigNumberConfigData?.selectedField !== undefined)
             setSelectedField(bigNumberConfigData.selectedField);
 
         setBigNumberLabel(bigNumberConfigData?.label);
+        // setShowLabel(bigNumberConfigData?.showLabel);
+
         setBigNumberStyle(bigNumberConfigData?.style);
-    }, [bigNumberConfigData, showLabel]);
+
+        // setShowComparison(bigNumberConfigData?.showComparison);
+        // setComparisonFormat(bigNumberConfigData?.comparisonFormat);
+    }, [bigNumberConfigData]);
 
     // big number value (first row)
     const firstRowValueRaw =
@@ -199,13 +212,6 @@ const useBigNumberConfig = (
               compact: bigNumberStyle,
           });
 
-    const [showComparison, setShowComparison] = useState<boolean>(false);
-    const [comparisonFormat, setComparisonFormat] =
-        useState<ComparisonFormatTypes>(ComparisonFormatTypes.RAW);
-    const [comparisonDiff, setComparisonDiff] = useState<ComparisonDiffTypes>(
-        ComparisonDiffTypes.UNDEFINED,
-    );
-
     const unformattedValue =
         isNumber(item, secondRowValueRaw) && isNumber(item, firstRowValueRaw)
             ? calculateComparisonValue(
@@ -215,18 +221,16 @@ const useBigNumberConfig = (
               )
             : 'N/A';
 
-    useEffect(() => {
-        setComparisonDiff(
-            unformattedValue > 0
-                ? ComparisonDiffTypes.POSITIVE
-                : unformattedValue < 0
-                ? ComparisonDiffTypes.NEGATIVE
-                : unformattedValue === 0
-                ? ComparisonDiffTypes.NONE
-                : valueIsNaN(unformattedValue)
-                ? ComparisonDiffTypes.NAN
-                : ComparisonDiffTypes.UNDEFINED,
-        );
+    const comparisonDiff = useMemo(() => {
+        return unformattedValue > 0
+            ? ComparisonDiffTypes.POSITIVE
+            : unformattedValue < 0
+            ? ComparisonDiffTypes.NEGATIVE
+            : unformattedValue === 0
+            ? ComparisonDiffTypes.NONE
+            : valueIsNaN(unformattedValue)
+            ? ComparisonDiffTypes.NAN
+            : ComparisonDiffTypes.UNDEFINED;
     }, [unformattedValue]);
 
     const comparisonValue = formatComparisonValue(
@@ -240,34 +244,23 @@ const useBigNumberConfig = (
         isNumber(item, firstRowValueRaw) &&
         (!isField(item) || item.format !== 'percent');
 
-    const validBigNumberConfig: BigNumber = useMemo(
-        () => ({
+    const validBigNumberConfig: BigNumber = useMemo(() => {
+        return {
             label: bigNumberLabel,
             style: bigNumberStyle,
             selectedField: selectedField,
-            comparisonValue,
             showLabel,
-            setShowLabel,
             showComparison,
-            setShowComparison,
             comparisonFormat,
-            setComparisonFormat,
-            comparisonDiff,
-        }),
-        [
-            bigNumberLabel,
-            bigNumberStyle,
-            selectedField,
-            comparisonValue,
-            showLabel,
-            setShowLabel,
-            showComparison,
-            setShowComparison,
-            comparisonFormat,
-            setComparisonFormat,
-            comparisonDiff,
-        ],
-    );
+        };
+    }, [
+        bigNumberLabel,
+        bigNumberStyle,
+        selectedField,
+        showLabel,
+        showComparison,
+        comparisonFormat,
+    ]);
     return {
         bigNumber,
         bigNumberLabel,

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -223,7 +223,7 @@ const useBigNumberConfig = (
                   Number(secondRowValueRaw),
                   comparisonFormat,
               )
-            : 'Comparison not applicable';
+            : 'N/A';
 
     useEffect(() => {
         setComparisonDiff(

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -178,7 +178,7 @@ const useBigNumberConfig = (
             setSelectedField(bigNumberConfigData.selectedField);
 
         setBigNumberLabel(bigNumberConfigData?.label);
-        setShowLabel(bigNumberConfigData?.showLabel);
+        setShowLabel(bigNumberConfigData?.showLabel ?? true);
 
         setBigNumberStyle(bigNumberConfigData?.style);
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -164,29 +164,29 @@ const useBigNumberConfig = (
     >(bigNumberConfigData?.label);
     const [showLabel, setShowLabel] = useState<
         BigNumber['showLabel'] | undefined
-    >(true);
+    >(bigNumberConfigData?.showLabel);
     const [bigNumberStyle, setBigNumberStyle] = useState<
         BigNumber['style'] | undefined
     >(bigNumberConfigData?.style);
 
     const [showComparison, setShowComparison] = useState<
         BigNumber['showComparison'] | undefined
-    >(false);
+    >(bigNumberConfigData?.showComparison);
     const [comparisonFormat, setComparisonFormat] = useState<
         BigNumber['comparisonFormat'] | undefined
-    >(ComparisonFormatTypes.RAW);
+    >(bigNumberConfigData?.comparisonFormat);
 
     useEffect(() => {
         if (bigNumberConfigData?.selectedField !== undefined)
             setSelectedField(bigNumberConfigData.selectedField);
 
         setBigNumberLabel(bigNumberConfigData?.label);
-        // setShowLabel(bigNumberConfigData?.showLabel);
+        setShowLabel(bigNumberConfigData?.showLabel);
 
         setBigNumberStyle(bigNumberConfigData?.style);
 
-        // setShowComparison(bigNumberConfigData?.showComparison);
-        // setComparisonFormat(bigNumberConfigData?.comparisonFormat);
+        setShowComparison(bigNumberConfigData?.showComparison);
+        setComparisonFormat(bigNumberConfigData?.comparisonFormat);
     }, [bigNumberConfigData]);
 
     // big number value (first row)

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -45,8 +45,8 @@ const formatComparisonValue = (
     value: number | string,
 ) => {
     const prefix =
-        comparisonDiff ===
-        (ComparisonDiffTypes.POSITIVE || ComparisonDiffTypes.NONE)
+        comparisonDiff === ComparisonDiffTypes.POSITIVE ||
+        comparisonDiff === ComparisonDiffTypes.NONE
             ? '+'
             : '';
     switch (format) {

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -168,10 +168,10 @@ const useBigNumberConfig = (
     );
 
     const calculateComparisonValue = (a: number, b: number, format: string) => {
-        const rawValue = Math.round(b - a);
+        const rawValue = Math.round(a - b);
         switch (format) {
             case formatValues.PERCENTAGE:
-                return Math.round(((b - a) / a) * 100);
+                return Math.round(((a - b) / b) * 100);
 
             case formatValues.RAW:
                 return rawValue === 0 ? 'No change' : rawValue;

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -1,13 +1,13 @@
 import {
     ApiQueryResults,
     BigNumber,
+    CompactOrAlias,
     ComparisonDiffTypes,
     ComparisonFormatTypes,
     convertAdditionalMetric,
     Explore,
     Field,
     fieldId,
-    formatItemValue,
     formatValue,
     friendlyName,
     getDimensions,
@@ -43,6 +43,7 @@ const formatComparisonValue = (
     comparisonDiff: ComparisonDiffTypes | undefined,
     item: Field | TableCalculation | undefined,
     value: number | string,
+    bigNumberStyle: CompactOrAlias | undefined,
 ) => {
     const prefix =
         comparisonDiff === ComparisonDiffTypes.POSITIVE ||
@@ -56,9 +57,25 @@ const formatComparisonValue = (
                 round: 0,
             })}`;
         case ComparisonFormatTypes.RAW:
-            return `${prefix}${formatItemValue(item, value)}`;
+            return `${prefix}${formatValue(value, {
+                format: isField(item) ? item.format : undefined,
+                round: bigNumberStyle
+                    ? 2
+                    : isField(item)
+                    ? item.round
+                    : undefined,
+                compact: bigNumberStyle,
+            })}`;
         default:
-            return formatItemValue(item, value);
+            return formatValue(value, {
+                format: isField(item) ? item.format : undefined,
+                round: bigNumberStyle
+                    ? 2
+                    : isField(item)
+                    ? item.round
+                    : undefined,
+                compact: bigNumberStyle,
+            });
     }
 };
 
@@ -240,6 +257,7 @@ const useBigNumberConfig = (
                   comparisonDiff,
                   item,
                   unformattedValue,
+                  bigNumberStyle,
               );
 
     const showStyle =


### PR DESCRIPTION
### Description:
Closes: #2045 

### Description:

### MVP requirements
**Big Number Chart config panel**:
- [x] The user can hide the label
- [x] If the user has chosen a numerical field (metric, dimension, table calculation), show an additional option in the chart config panel : `Compare to previous row`. This can be toggled on and off. 
- [x] The user should be able to choose between `raw value` and `percentage`.

**Big Number tile**:
- [x] Show the comparison below the label. We can play around with sizing, placement, responsiveness etc.
- [x] Icons : [arrow-up-right](https://tabler-icons.io/i/arrow-up-right) and [arrow-down-right](https://tabler-icons.io/i/arrow-down-right)
- [x] If there is no previous row to compare to, the comparison should show `n/a`
- [x] If the user has selected a table calculation that is a string, the comparison should show `n/a`
