### PR TITLE
feat: updated styling when comparison is n/a

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,3 +1,4 @@
+import { Colors } from '@blueprintjs/core';
 import { ComparisonDiffTypes } from '@lightdash/common';
 import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash-es/clamp';
@@ -102,6 +103,15 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
         };
     }, [observerElementSize]);
 
+    const comparisonValueColor = useMemo(() => {
+        switch (comparisonDiff) {
+            case ComparisonDiffTypes.NAN:
+                return Colors.GRAY3;
+            case ComparisonDiffTypes.UNDEFINED:
+                return Colors.GRAY3;
+        }
+    }, [comparisonDiff]);
+
     const validData = bigNumber && resultsData?.rows.length;
 
     if (isLoading) return <LoadingChart />;
@@ -151,6 +161,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             marginTop: 10,
                             display: 'flex',
                             alignItems: 'center',
+                            color: comparisonValueColor,
                         }}
                     >
                         {comparisonValue}

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -228,6 +228,7 @@ const useBigNumberConfig = (
               compact: bigNumberStyle,
           });
 
+    const NOT_APPLICABLE = 'n/a';
     const unformattedValue =
         isNumber(item, secondRowValueRaw) && isNumber(item, firstRowValueRaw)
             ? calculateComparisonValue(
@@ -235,7 +236,7 @@ const useBigNumberConfig = (
                   Number(secondRowValueRaw),
                   comparisonFormat,
               )
-            : 'N/A';
+            : NOT_APPLICABLE;
 
     const comparisonDiff = useMemo(() => {
         return unformattedValue > 0
@@ -250,8 +251,8 @@ const useBigNumberConfig = (
     }, [unformattedValue]);
 
     const comparisonValue =
-        unformattedValue === 'N/A'
-            ? 'N/A'
+        unformattedValue === NOT_APPLICABLE
+            ? NOT_APPLICABLE
             : formatComparisonValue(
                   comparisonFormat,
                   comparisonDiff,


### PR DESCRIPTION
Closes: #5454 

### Description:
Update the styling of the Big Number comparison when it shows `n/a` (in the case where there is no previous row to compare to or the table calculation is a string).

- [x] If result is `n/a`, change the colour to match that of the label 

<img width="873" alt="Screenshot 2023-05-12 at 10 40 02" src="https://github.com/lightdash/lightdash/assets/67699259/c67c202c-3b38-42d0-9128-d6b058347218">

