### PR TITLE
feat: big number comp color switch

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -41,6 +41,7 @@ export type BigNumber = {
     showLabel?: boolean;
     showComparison?: boolean;
     comparisonFormat?: ComparisonFormatTypes;
+    flipColors?: boolean;
 };
 
 export type BigNumberConfig = {

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -47,6 +47,8 @@ const BigNumberConfigPanel: React.FC = () => {
             setShowComparison,
             comparisonFormat,
             setComparisonFormat,
+            flipColors,
+            setFlipColors,
         },
     } = useVisualizationContext();
     const [isOpen, setIsOpen] = useState(false);
@@ -135,26 +137,47 @@ const BigNumberConfigPanel: React.FC = () => {
                             }}
                         />
                     </FormGroup>
+
                     {showComparison && (
-                        <RadioGroup
-                            onChange={(e) => {
-                                setComparisonFormat(
-                                    e.currentTarget.value === 'raw'
-                                        ? ComparisonFormatTypes.RAW
-                                        : ComparisonFormatTypes.PERCENTAGE,
-                                );
-                            }}
-                            selectedValue={comparisonFormat}
-                        >
-                            <Radio
-                                label="By raw value"
-                                value={ComparisonFormatTypes.RAW}
-                            />
-                            <Radio
-                                label="By percentage"
-                                value={ComparisonFormatTypes.PERCENTAGE}
-                            />
-                        </RadioGroup>
+                        <>
+                            <RadioGroup
+                                onChange={(e) => {
+                                    setComparisonFormat(
+                                        e.currentTarget.value === 'raw'
+                                            ? ComparisonFormatTypes.RAW
+                                            : ComparisonFormatTypes.PERCENTAGE,
+                                    );
+                                }}
+                                selectedValue={comparisonFormat}
+                            >
+                                <Radio
+                                    label="By raw value"
+                                    value={ComparisonFormatTypes.RAW}
+                                />
+                                <Radio
+                                    label="By percentage"
+                                    value={ComparisonFormatTypes.PERCENTAGE}
+                                />
+                            </RadioGroup>
+                            <FormGroup
+                                labelFor="bignumber-comparison-color"
+                                label="Flip colors"
+                                inline
+                                style={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    marginBottom: 'none',
+                                }}
+                            >
+                                <Switch
+                                    alignIndicator="right"
+                                    checked={flipColors}
+                                    onChange={() => {
+                                        setFlipColors(!flipColors);
+                                    }}
+                                />
+                            </FormGroup>
+                        </>
                     )}
                 </InputWrapper>
             }

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -161,7 +161,7 @@ const BigNumberConfigPanel: React.FC = () => {
                             </RadioGroup>
                             <FormGroup
                                 labelFor="bignumber-comparison-color"
-                                label="Flip colors"
+                                label="Flip positive color"
                                 inline
                                 style={{
                                     display: 'flex',

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -65,6 +65,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             showComparison,
             showLabel,
             comparisonDiff,
+            flipColors,
         },
         isSqlRunner,
     } = useVisualizationContext();
@@ -109,6 +110,12 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                 return Colors.GRAY3;
             case ComparisonDiffTypes.UNDEFINED:
                 return Colors.GRAY3;
+            case ComparisonDiffTypes.POSITIVE:
+                return Colors.GREEN3;
+            case ComparisonDiffTypes.NEGATIVE:
+                return Colors.RED3;
+            case ComparisonDiffTypes.NONE:
+                return 'inherit';
         }
     }, [comparisonDiff]);
 
@@ -161,7 +168,9 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             marginTop: 10,
                             display: 'flex',
                             alignItems: 'center',
-                            color: comparisonValueColor,
+                            color: `${
+                                flipColors ? comparisonValueColor : 'inherit'
+                            }`,
                         }}
                     >
                         {comparisonValue}

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -107,17 +107,16 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     const comparisonValueColor = useMemo(() => {
         switch (comparisonDiff) {
             case ComparisonDiffTypes.NAN:
-                return Colors.GRAY3;
             case ComparisonDiffTypes.UNDEFINED:
                 return Colors.GRAY3;
             case ComparisonDiffTypes.POSITIVE:
-                return Colors.GREEN3;
+                return flipColors ? Colors.RED3 : Colors.GREEN3;
             case ComparisonDiffTypes.NEGATIVE:
-                return Colors.RED3;
+                return flipColors ? Colors.GREEN3 : Colors.RED3;
             case ComparisonDiffTypes.NONE:
                 return 'inherit';
         }
-    }, [comparisonDiff]);
+    }, [comparisonDiff, flipColors]);
 
     const validData = bigNumber && resultsData?.rows.length;
 
@@ -168,9 +167,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             marginTop: 10,
                             display: 'flex',
                             alignItems: 'center',
-                            color: `${
-                                flipColors ? comparisonValueColor : 'inherit'
-                            }`,
+                            color: comparisonValueColor,
                         }}
                     >
                         {comparisonValue}

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -206,7 +206,7 @@ const useBigNumberConfig = (
         setComparisonFormat(
             bigNumberConfigData?.comparisonFormat ?? ComparisonFormatTypes.RAW,
         );
-        setFlipColors(bigNumberConfigData?.flipColors ?? true);
+        setFlipColors(bigNumberConfigData?.flipColors ?? false);
     }, [bigNumberConfigData]);
 
     // big number value (first row)

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -189,6 +189,9 @@ const useBigNumberConfig = (
     const [comparisonFormat, setComparisonFormat] = useState<
         BigNumber['comparisonFormat'] | undefined
     >(bigNumberConfigData?.comparisonFormat);
+    const [flipColors, setFlipColors] = useState<BigNumber['flipColors']>(
+        bigNumberConfigData?.flipColors,
+    );
 
     useEffect(() => {
         if (bigNumberConfigData?.selectedField !== undefined)
@@ -203,6 +206,7 @@ const useBigNumberConfig = (
         setComparisonFormat(
             bigNumberConfigData?.comparisonFormat ?? ComparisonFormatTypes.RAW,
         );
+        setFlipColors(bigNumberConfigData?.flipColors ?? true);
     }, [bigNumberConfigData]);
 
     // big number value (first row)
@@ -273,6 +277,7 @@ const useBigNumberConfig = (
             showLabel,
             showComparison,
             comparisonFormat,
+            flipColors,
         };
     }, [
         bigNumberLabel,
@@ -281,6 +286,7 @@ const useBigNumberConfig = (
         showLabel,
         showComparison,
         comparisonFormat,
+        flipColors,
     ]);
     return {
         bigNumber,
@@ -303,6 +309,8 @@ const useBigNumberConfig = (
         comparisonFormat,
         setComparisonFormat,
         comparisonDiff,
+        flipColors,
+        setFlipColors,
     };
 };
 


### PR DESCRIPTION
Closes: #4884 

### Description:

For cases where an increase in a KPI metric is not a good thing, the user should be able to switch what 'green' represents. By default, red = bad and green = good. 
- [x] Add colour to the comparison number and arrow.  By default, `arrow-down = red6`  and `arrow-up = green6`
- [x] Add a toggle in the config panel: `Flip colors`
- [x] If the user turns the toggle on, `arrow-down = green6`  and `arrow-up = red6`
- [x] If there is no change, the label colour remains unaffected.



https://github.com/lightdash/lightdash/assets/67699259/e9991323-ceac-4fd0-a939-33accb74e899



