### PR TITLE
fix: return if no entries on resizeObserver

### DIFF
--- a/packages/frontend/src/hooks/useResizeObserver/index.ts
+++ b/packages/frontend/src/hooks/useResizeObserver/index.ts
@@ -27,17 +27,19 @@ export const useResizeObserver = <T extends HTMLElement = any>() => {
         () =>
             typeof window !== 'undefined'
                 ? new ResizeObserver((entries: any) => {
+                      if (!Array.isArray(entries) || !entries.length) {
+                          return;
+                      }
+
                       const entry = entries[0];
 
-                      if (entry) {
-                          cancelAnimationFrame(frameID.current);
+                      cancelAnimationFrame(frameID.current);
 
-                          frameID.current = requestAnimationFrame(() => {
-                              if (ref) {
-                                  setRect(entry.contentRect);
-                              }
-                          });
-                      }
+                      frameID.current = requestAnimationFrame(() => {
+                          if (ref) {
+                              setRect(entry.contentRect);
+                          }
+                      });
                   })
                 : null,
         [ref],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5433 

### Description:

Return if no `entries` to fix `resizeObserver` loop error.

Unfortunately, I can't replicate this locally :/

Reference: https://github.com/adazzle/react-data-grid/pull/2933/files
