### PR TITLE
feat: big number comparisons tooltips

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -30,7 +30,7 @@ export enum ComparisonDiffTypes {
     POSITIVE = 'positive',
     NEGATIVE = 'negative',
     NONE = 'none',
-    NAN = 'nan',
+    NAN = 'NaN',
     UNDEFINED = 'undefined',
 }
 

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -1,5 +1,6 @@
 import { Colors } from '@blueprintjs/core';
 import { ComparisonDiffTypes } from '@lightdash/common';
+import { Tooltip } from '@mantine/core';
 import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash-es/clamp';
 import { FC, HTMLAttributes, useMemo } from 'react';
@@ -66,6 +67,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             showLabel,
             comparisonDiff,
             flipColors,
+            comparisonTooltip,
         },
         isSqlRunner,
     } = useVisualizationContext();
@@ -161,30 +163,33 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
 
             {showComparison ? (
                 <BigNumberHalf>
-                    <BigNumber
-                        $fontSize={comparisonFontSize}
-                        style={{
-                            marginTop: 10,
-                            display: 'flex',
-                            alignItems: 'center',
-                            color: comparisonValueColor,
-                        }}
-                    >
-                        {comparisonValue}
-                        {comparisonDiff === ComparisonDiffTypes.POSITIVE ? (
-                            <MantineIcon
-                                icon={IconArrowUpRight}
-                                size={18}
-                                style={{ display: 'inline', marginLeft: 5 }}
-                            />
-                        ) : comparisonDiff === ComparisonDiffTypes.NEGATIVE ? (
-                            <MantineIcon
-                                icon={IconArrowDownRight}
-                                size={18}
-                                style={{ display: 'inline', marginLeft: 5 }}
-                            />
-                        ) : null}
-                    </BigNumber>
+                    <Tooltip label={comparisonTooltip}>
+                        <BigNumber
+                            $fontSize={comparisonFontSize}
+                            style={{
+                                marginTop: 10,
+                                display: 'flex',
+                                alignItems: 'center',
+                                color: comparisonValueColor,
+                            }}
+                        >
+                            {comparisonValue}
+                            {comparisonDiff === ComparisonDiffTypes.POSITIVE ? (
+                                <MantineIcon
+                                    icon={IconArrowUpRight}
+                                    size={18}
+                                    style={{ display: 'inline', marginLeft: 5 }}
+                                />
+                            ) : comparisonDiff ===
+                              ComparisonDiffTypes.NEGATIVE ? (
+                                <MantineIcon
+                                    icon={IconArrowDownRight}
+                                    size={18}
+                                    style={{ display: 'inline', marginLeft: 5 }}
+                                />
+                            ) : null}
+                        </BigNumber>
+                    </Tooltip>
                 </BigNumberHalf>
             ) : null}
         </BigNumberContainer>


### PR DESCRIPTION
Closes: #5447 

### Description:
- [ ] Add Mantine tooltips on hover to the comparison section on Big Number charts. 
- [ ] The change should affect both chart view and dashboard view
- [ ] The content: 

  | Increase | Decrease | No change | No previous row | Table calculation is a string
-- | -- | -- | -- | -- | --
**%** | +5% | -5% | +0% | n/a | n/a
**Raw** | +5 | -5 | +0 | n/a | n/a
**Message on hover** | +5 compared to previous row | -5 compared to previous row | No change compared to previous row | There is no previous row to compare to | Table calculation is as string
