### PR TITLE
fix: refetch job data for status STARTED

### DIFF
--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -103,7 +103,13 @@ export const useJob = (
         queryKey: ['job', jobId],
         queryFn: () => getJob(jobId || ''),
         enabled: !!jobId,
-        refetchInterval: (data) => data?.jobStatus === 'RUNNING' && 500,
+        refetchInterval: (data) =>
+            [
+                JobStatusType.DONE.valueOf(),
+                JobStatusType.ERROR.valueOf(),
+            ].includes(data?.jobStatus || '')
+                ? false
+                : 500,
         onSuccess: (job) => {
             queryClient.invalidateQueries('tables');
             onSuccess(job);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5475 

After change: first api response can show `STARTED` and still polls

<img width="931" alt="CleanShot 2023-05-12 at 14 34 02@2x" src="https://github.com/lightdash/lightdash/assets/11660098/b3a51e32-7d54-4289-8b90-a2303b6a7c64">


### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
