### PR TITLE
fix: get chart view stats in a separate endpoint

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -52,8 +52,6 @@ export class AnalyticsModel {
                 .min({
                     first_viewed_at: 'timestamp',
                 })
-                .select('chart_uuid')
-                .groupBy('chart_uuid')
                 .where('chart_uuid', chartUuid)
                 .first();
 

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -34,8 +34,8 @@ savedChartRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        analyticsService
-            .getChartViews(req.params.savedQueryUuid)
+        savedChartsService
+            .getViewStats(req.user!, req.params.savedQueryUuid)
             .then((results) => {
                 res.json({
                     status: 'ok',

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -13,10 +13,6 @@ export class AnalyticsService {
         this.analyticsModel = dependencies.analyticsModel;
     }
 
-    async getChartViews(chartUuid: string): Promise<number> {
-        return this.analyticsModel.countChartViews(chartUuid);
-    }
-
     async getDashboardViews(dashboardUuid: string): Promise<number> {
         return this.analyticsModel.countDashboardViews(dashboardUuid);
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-import { UserActivity } from './types/analytics';
+import { UserActivity, ViewStatistics } from './types/analytics';
 import {
     Dashboard,
     DashboardAvailableFilters,
@@ -477,6 +477,7 @@ type ApiResults =
     | EmailStatusExpiring
     | ApiScheduledDownloadCsv
     | PinnedItems
+    | ViewStatistics
     | SchedulerWithLogs;
 
 export type ApiResponse = {

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -26,3 +26,8 @@ export type UserActivity = {
         average_number_of_weekly_queries_per_user: string;
     }[];
 };
+
+export type ViewStatistics = {
+    views: number;
+    firstViewedAt: Date | string | null;
+};

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1,4 +1,5 @@
 import assertUnreachable from '../utils/assertUnreachable';
+import { ViewStatistics } from './analytics';
 import { ConditionalFormattingConfig } from './conditionalFormatting';
 import { CompactOrAlias } from './field';
 import { MetricQuery } from './metricQuery';
@@ -231,8 +232,6 @@ export type SavedChart = {
     organizationUuid: string;
     spaceUuid: string;
     spaceName: string;
-    views: number;
-    firstViewedAt: Date | string | null;
     pinnedListUuid: string | null;
     pinnedListOrder: number | null;
 };
@@ -283,11 +282,12 @@ export type SpaceQuery = Pick<
     | 'updatedByUser'
     | 'description'
     | 'spaceUuid'
-    | 'views'
-    | 'firstViewedAt'
     | 'pinnedListUuid'
     | 'pinnedListOrder'
-> & { chartType: ChartKind | undefined };
+> &
+    ViewStatistics & {
+        chartType: ChartKind | undefined;
+    };
 
 export const isCompleteLayout = (
     value: CartesianChartLayout | undefined,

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -13,6 +13,7 @@ import { FC, useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
 
+import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
 import {
     useDuplicateChartMutation,
     useMoveChartMutation,
@@ -82,6 +83,7 @@ const SavedChartsHeader: FC = () => {
         dashboardUuid ? dashboardUuid : undefined,
         savedChart?.uuid,
     );
+    const chartViewStats = useChartViewStats(savedChart?.uuid);
 
     const { mutate: duplicateChart } = useDuplicateChartMutation();
     const chartId = savedChart?.uuid || '';
@@ -217,8 +219,10 @@ const SavedChartsHeader: FC = () => {
                                 <SeparatorDot icon="dot" size={6} />
 
                                 <ViewInfo
-                                    views={savedChart.views}
-                                    firstViewedAt={savedChart.firstViewedAt}
+                                    views={chartViewStats.data?.views}
+                                    firstViewedAt={
+                                        chartViewStats.data?.firstViewedAt
+                                    }
                                 />
 
                                 <SeparatorDot icon="dot" size={6} />

--- a/packages/frontend/src/components/common/PageHeader/ViewInfo.tsx
+++ b/packages/frontend/src/components/common/PageHeader/ViewInfo.tsx
@@ -6,7 +6,7 @@ import { InfoContainer } from '.';
 
 interface ViewInfoProps {
     views?: number;
-    firstViewedAt: Date | string | null;
+    firstViewedAt?: Date | string | null;
 }
 
 const ViewInfo: FC<ViewInfoProps> = ({ views, firstViewedAt }) => {

--- a/packages/frontend/src/hooks/chart/useChartViewStats.ts
+++ b/packages/frontend/src/hooks/chart/useChartViewStats.ts
@@ -1,0 +1,25 @@
+import { ApiError, ViewStatistics } from '@lightdash/common';
+import { useQuery, UseQueryOptions } from 'react-query';
+import { lightdashApi } from '../../api';
+
+const getChartViewStats = async (chartUuid: string) => {
+    return lightdashApi<ViewStatistics>({
+        url: `/saved/${chartUuid}/views`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useChartViewStats = (
+    chartUuid: string | undefined,
+    queryOptions?: UseQueryOptions<ViewStatistics, ApiError>,
+) => {
+    return useQuery<ViewStatistics, ApiError>(
+        ['chart-views', chartUuid],
+        () => getChartViewStats(chartUuid || ''),
+        {
+            enabled: !!chartUuid,
+            ...queryOptions,
+        },
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5367 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- remove view stats from the chart type
- in the chart page, get the chart view stats from a separate endpoint

![Captura de ecrã 2023-05-12, às 14 43 55](https://github.com/lightdash/lightdash/assets/9117144/811696c8-da70-42a5-8b28-6019b460d6d2)
