### PR TITLE
fix: suppress aws sdk warning in cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,9 @@ import {
 import { setProjectInteractivelyHandler } from './handlers/setProject';
 import * as styles from './styles';
 
+// Suppress AWS SDK V2 warning, imported by snowflake SDK
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
+
 const nodeVersion = require('parse-node-version')(process.version);
 
 const OPTIMIZED_NODE_VERSION = 16;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Attempting to suppress this warning but I can't reproduce the warning message with any local build. So let's try publishing with this flag and see if it takes effect

```
(node:22848) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
```
