### PR TITLE
fix: add correct rendering logic for empty pats list

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -12,37 +12,36 @@ const AccessTokensPanel: FC = () => {
     const [isCreatingToken, setIsCreatingToken] = useState(false);
     const hasAvailableTokens = data && data.length > 0;
 
-    if (!hasAvailableTokens) {
-        return (
-            <EmptyState
-                icon={
-                    <MantineIcon
-                        icon={IconKey}
-                        color="gray.6"
-                        stroke={1}
-                        size="5xl"
-                    />
-                }
-                title="No tokens"
-                description="You haven't generated any tokens yet!, generate your first token"
-            >
-                <Button onClick={() => setIsCreatingToken(true)}>
-                    Generate token
-                </Button>
-            </EmptyState>
-        );
-    }
-
     return (
         <Stack mb="lg">
-            <Group position="apart">
-                <Title order={5}>Personal access tokens</Title>
-                <Button onClick={() => setIsCreatingToken(true)}>
-                    Generate new token
-                </Button>
-            </Group>
-
-            <TokensTable />
+            {hasAvailableTokens ? (
+                <>
+                    <Group position="apart">
+                        <Title order={5}>Personal access tokens</Title>
+                        <Button onClick={() => setIsCreatingToken(true)}>
+                            Generate new token
+                        </Button>
+                    </Group>
+                    <TokensTable />
+                </>
+            ) : (
+                <EmptyState
+                    icon={
+                        <MantineIcon
+                            icon={IconKey}
+                            color="gray.6"
+                            stroke={1}
+                            size="5xl"
+                        />
+                    }
+                    title="No tokens"
+                    description="You haven't generated any tokens yet!, generate your first token"
+                >
+                    <Button onClick={() => setIsCreatingToken(true)}>
+                        Generate token
+                    </Button>
+                </EmptyState>
+            )}
 
             {isCreatingToken && (
                 <CreateTokenModal


### PR DESCRIPTION
### Description:

Rendering logic wasn't correct for empty PATs list. 


Before

https://github.com/lightdash/lightdash/assets/7611706/02636e59-3c5c-49f3-8625-29aa6af15acf


After


https://github.com/lightdash/lightdash/assets/7611706/4345c1de-761f-4f8d-8a6a-c4732a2a3cdf



