### PR TITLE
fix: use space summaries where possible in frontend

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -3,7 +3,7 @@ import { subject } from '@casl/ability';
 import { Dashboard } from '@lightdash/common';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSavedCharts } from '../../../hooks/useSpaces';
+import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import { useApp } from '../../../providers/AppProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -73,7 +73,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     isEditMode,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const savedChartsRequest = useSavedCharts(projectUuid);
+    const savedChartsRequest = useChartSummaries(projectUuid);
     const savedCharts = savedChartsRequest.data || [];
     const hasSavedCharts = savedCharts.length > 0;
 

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
@@ -14,12 +14,9 @@ import {
     useDashboards,
     useUpdateMultipleDashboard,
 } from '../../../hooks/dashboard/useDashboards';
+import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import { useUpdateMultipleMutation } from '../../../hooks/useSavedQuery';
-import {
-    useSavedCharts,
-    useSpace,
-    useSpaceSummaries,
-} from '../../../hooks/useSpaces';
+import { useSpace, useSpaceSummaries } from '../../../hooks/useSpaces';
 import Form from '../../ReactHookForm/Form';
 import MultiSelect from '../../ReactHookForm/MultiSelect';
 import { SpaceLabel } from './AddResourceToSpaceModal.style';
@@ -74,7 +71,7 @@ const AddResourceToSpaceModal: FC<Props> = ({
         mode: 'onSubmit',
     });
 
-    const { data: savedCharts, isLoading } = useSavedCharts(projectUuid);
+    const { data: savedCharts, isLoading } = useChartSummaries(projectUuid);
     const { data: dashboards } = useDashboards(projectUuid);
 
     const closeModal = useCallback(() => {

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -51,6 +51,8 @@ export const useSpaceSummaries = (
     );
 };
 
+// DEPRECATED: masks usage of `/spaces-and-content` endpoint
+// Use `useSpaceSummaries` where possible
 export const useSavedCharts = (projectUuid: string) => {
     const spaces = useSpaces(projectUuid);
     const allCharts = spaces.data?.flatMap((space) => space.queries);

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -29,10 +29,12 @@ const Home: FC = () => {
 
     const { data: pinnedItems = [], isLoading: pinnedItemsLoading } =
         usePinnedItems(selectedProjectUuid, project?.data?.pinnedListUuid);
+    // only used for recently updated panel - could be faster
     const { data: dashboards = [], isLoading: dashboardsLoading } =
         useDashboards(selectedProjectUuid);
     const { data: savedCharts = [], isLoading: chartsLoading } =
         useSavedCharts(selectedProjectUuid);
+    // -----
 
     const { user } = useApp();
 

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -42,7 +42,8 @@ import { SpaceBrowserMenu } from '../components/Explorer/SpaceBrowser/SpaceBrows
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
 import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
-import { useSavedCharts, useSpace } from '../hooks/useSpaces';
+import { useChartSummaries } from '../hooks/useChartSummaries';
+import { useSpace } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 
 const Space: FC = () => {
@@ -54,7 +55,7 @@ const Space: FC = () => {
     const { data: dashboards = [], isLoading: dashboardsLoading } =
         useDashboards(projectUuid);
     const { data: savedCharts = [], isLoading: chartsLoading } =
-        useSavedCharts(projectUuid);
+        useChartSummaries(projectUuid);
     const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
     const { user, health } = useApp();
 


### PR DESCRIPTION
Just noticed there are still `/spaces-and-content` queries happening on the dashboard page.

Went and cleared up more usages. 
