### PR TITLE
feat: allow admins view/edit private spaces

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -11,6 +11,7 @@ import {
     isDashboardVersionedFields,
     isSlackTarget,
     isUserWithOrg,
+    OrganizationMemberRole,
     SchedulerAndTargets,
     SessionUser,
     Space,
@@ -164,6 +165,7 @@ export class DashboardService {
             throw new ForbiddenError();
         }
         if (
+            user.role !== OrganizationMemberRole.ADMIN &&
             !(await this.hasDashboardSpaceAccess(
                 dashboard.spaceUuid,
                 user.userUuid,
@@ -311,6 +313,7 @@ export class DashboardService {
         }
 
         if (
+            user.role !== OrganizationMemberRole.ADMIN &&
             !(await this.hasDashboardSpaceAccess(
                 existingDashboard.spaceUuid,
                 user.userUuid,
@@ -470,7 +473,10 @@ export class DashboardService {
             throw new ForbiddenError();
         }
 
-        if (!(await this.hasDashboardSpaceAccess(spaceUuid, user.userUuid))) {
+        if (
+            user.role !== OrganizationMemberRole.ADMIN &&
+            !(await this.hasDashboardSpaceAccess(spaceUuid, user.userUuid))
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -10,6 +10,7 @@ import {
     isChartScheduler,
     isSlackTarget,
     isUserWithOrg,
+    OrganizationMemberRole,
     SavedChart,
     SchedulerAndTargets,
     SessionUser,
@@ -178,7 +179,10 @@ export class SavedChartService {
         ) {
             throw new ForbiddenError();
         }
-        if (!(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))) {
+        if (
+            user.role !== OrganizationMemberRole.ADMIN &&
+            !(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this chart belongs to",
             );
@@ -213,7 +217,10 @@ export class SavedChartService {
         ) {
             throw new ForbiddenError();
         }
-        if (!(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))) {
+        if (
+            user.role !== OrganizationMemberRole.ADMIN &&
+            !(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this chart belongs to",
             );
@@ -321,7 +328,10 @@ export class SavedChartService {
         ) {
             throw new ForbiddenError();
         }
-        if (!(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))) {
+        if (
+            user.role !== OrganizationMemberRole.ADMIN &&
+            !(await this.hasChartSpaceAccess(spaceUuid, user.userUuid))
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this chart belongs to",
             );
@@ -367,6 +377,7 @@ export class SavedChartService {
             throw new ForbiddenError();
         }
         if (
+            user.role !== OrganizationMemberRole.ADMIN &&
             !(await this.hasChartSpaceAccess(
                 savedChart.spaceUuid,
                 user.userUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5042

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


- [ ] admins have two types of content available to them:
    - `shared with me`  - this is content/spaces where they have been explicitly invited or they have created it themselves - this is the content they have access to today
   - `private` - this is content where they have not been explicitly invited - they do not have access to this today. 
- [ ] updated documentation
- [ ] admins can't browse content that's `private` - they can only view the content by direct access to the URL (either saved chart, dashboard, or space)
- [ ] update the modal on creating a private space to say `only you and admins can access this`

<img width="516" alt="image" src="https://user-images.githubusercontent.com/31848148/236245055-a4536346-c5e9-49a1-9f58-6f395bcb4a34.png">

- [ ] update the modal on creating a `restricted access` space to say `only invited members and admins can access`
- [ ] Also update the list of users in the modal to default include all admins
<img width="508" alt="image" src="https://user-images.githubusercontent.com/31848148/236245380-4fcff18b-70a5-4b64-beee-e55b3c58ad45.png">
