### PR TITLE
feat: apply relevant dashboard filters to autocomplete search

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -261,33 +261,22 @@ projectRouter.get(
     },
 );
 
-projectRouter.get(
+projectRouter.post(
     '/field/:fieldId/search',
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const value: string =
-                typeof req.query.value === 'string'
-                    ? req.query.value.toString()
-                    : '';
-            const limit: number =
-                typeof req.query.limit === 'string'
-                    ? parseInt(req.query.limit.toString(), 10)
-                    : 100;
-
-            const table =
-                typeof req.query.table === 'string' ? req.query.table : '';
-
             const results = {
-                search: value,
+                search: req.body.search,
                 results: await projectService.searchFieldUniqueValues(
                     req.user!,
                     req.params.projectUuid,
-                    table,
+                    req.body.table,
                     req.params.fieldId,
-                    value,
-                    limit,
+                    req.body.search,
+                    req.body.limit,
+                    req.body.filters,
                 ),
             };
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -18,7 +18,6 @@ import {
     ExploreError,
     fieldId as getFieldId,
     FilterableField,
-    filterFilterGroupByTable,
     FilterGroup,
     FilterGroupItem,
     FilterOperator,
@@ -28,6 +27,7 @@ import {
     formatRows,
     getDimensions,
     getFields,
+    getFiltersFromTable,
     getItemId,
     getItemMap,
     getMetrics,
@@ -961,7 +961,7 @@ export class ProjectService {
         ];
         if (filters) {
             autocompleteDimensionFilters.push(
-                ...filterFilterGroupByTable(filters, explore.name).and,
+                ...getFiltersFromTable(filters, explore.name).and,
             );
         }
         const metricQuery: MetricQuery = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -27,7 +27,6 @@ import {
     formatRows,
     getDimensions,
     getFields,
-    getFiltersFromTable,
     getItemId,
     getItemMap,
     getMetrics,
@@ -960,9 +959,7 @@ export class ProjectService {
             },
         ];
         if (filters) {
-            autocompleteDimensionFilters.push(
-                ...getFiltersFromTable(filters, explore.name).and,
-            );
+            autocompleteDimensionFilters.push(filters);
         }
         const metricQuery: MetricQuery = {
             dimensions: [],

--- a/packages/common/src/types/conditionalRule.ts
+++ b/packages/common/src/types/conditionalRule.ts
@@ -17,6 +17,7 @@ export enum ConditionalOperator {
 }
 
 export type ConditionalRule<O = ConditionalOperator, V = unknown> = {
+    id: string;
     operator: O;
     values?: V[];
 };

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -153,31 +153,6 @@ export enum FilterGroupOperator {
     or = 'or',
 }
 
-export const getFiltersFromTable = <T extends FilterGroup>(
-    filterGroup: T,
-    tableName: string,
-): T => {
-    const groupProperty = isAndFilterGroup(filterGroup) ? 'and' : 'or';
-    const groupItems = isAndFilterGroup(filterGroup)
-        ? filterGroup.and
-        : filterGroup.or;
-    return {
-        ...filterGroup,
-        [groupProperty]: groupItems.reduce<FilterGroupItem[]>((acc, item) => {
-            if (isFilterGroup(item)) {
-                return [...acc, getFiltersFromTable(item, tableName)];
-            }
-            if (
-                isDashboardFilterRule(item) &&
-                item.target.tableName === tableName
-            ) {
-                return [...acc, item];
-            }
-            return acc;
-        }, []),
-    };
-};
-
 export const convertDashboardFiltersToFilters = (
     dashboardFilters: DashboardFilters,
 ): Filters => {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -58,17 +58,13 @@ export type DashboardFieldTarget = {
 
 export type DashboardFilterRule<
     O = FilterOperator,
-    T = DashboardFieldTarget,
+    T extends DashboardFieldTarget = DashboardFieldTarget,
     V = any,
     S = any,
 > = FilterRule<O, T, V, S> & {
     tileTargets?: Record<string, DashboardFieldTarget>;
     label: undefined | string;
 };
-
-export const isDashboardFilterRule = (
-    value: ConditionalRule,
-): value is DashboardFilterRule => 'tileTargets' in value;
 
 export type DateFilterRule = FilterRule<
     FilterOperator,
@@ -146,6 +142,11 @@ export const getFilterRules = (filters: Filters): FilterRule[] => {
     }
     return rules;
 };
+
+export const isDashboardFilterRule = (
+    value: ConditionalRule,
+): value is DashboardFilterRule =>
+    isFilterRule(value) && 'tableName' in value.target;
 
 export enum FilterGroupOperator {
     and = 'and',

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -153,7 +153,7 @@ export enum FilterGroupOperator {
     or = 'or',
 }
 
-export const filterFilterGroupByTable = <T extends FilterGroup>(
+export const getFiltersFromTable = <T extends FilterGroup>(
     filterGroup: T,
     tableName: string,
 ): T => {
@@ -165,7 +165,7 @@ export const filterFilterGroupByTable = <T extends FilterGroup>(
         ...filterGroup,
         [groupProperty]: groupItems.reduce<FilterGroupItem[]>((acc, item) => {
             if (isFilterGroup(item)) {
-                return [...acc, filterFilterGroupByTable(item, tableName)];
+                return [...acc, getFiltersFromTable(item, tableName)];
             }
             if (
                 isDashboardFilterRule(item) &&

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -152,6 +152,31 @@ export enum FilterGroupOperator {
     or = 'or',
 }
 
+export const filterFilterGroupByTable = <T extends FilterGroup>(
+    filterGroup: T,
+    tableName: string,
+): T => {
+    const groupProperty = isAndFilterGroup(filterGroup) ? 'and' : 'or';
+    const groupItems = isAndFilterGroup(filterGroup)
+        ? filterGroup.and
+        : filterGroup.or;
+    return {
+        ...filterGroup,
+        [groupProperty]: groupItems.reduce<FilterGroupItem[]>((acc, item) => {
+            if (isFilterGroup(item)) {
+                return [...acc, filterFilterGroupByTable(item, tableName)];
+            }
+            if (
+                isDashboardFilterRule(item) &&
+                item.target.tableName === tableName
+            ) {
+                return [...acc, item];
+            }
+            return acc;
+        }, []),
+    };
+};
+
 export const convertDashboardFiltersToFilters = (
     dashboardFilters: DashboardFilters,
 ): Filters => {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import {
     ConditionalFormattingConfig,
     ConditionalFormattingRule,
@@ -18,6 +19,7 @@ import { getItemId, isNumericItem } from './item';
 
 export const createConditionalFormatingRule =
     (): ConditionalFormattingRule => ({
+        id: uuidv4(),
         operator: ConditionalOperator.EQUALS,
         values: [],
     });

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -23,7 +23,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
 
     const project = useProject(projectUuid);
     const {
-        dashboardFilters,
+        allFilters,
         fieldsWithSuggestions,
         dashboardTiles,
         allFilterableFields,
@@ -44,6 +44,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
             projectUuid={projectUuid}
             fieldsMap={fieldsWithSuggestions}
             startOfWeek={project.data?.warehouseConnection?.startOfWeek}
+            dashboardFilters={allFilters}
         >
             <DashboardFilterWrapper>
                 <Popover2
@@ -90,7 +91,7 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                     </Tooltip2>
                 </Popover2>
 
-                {dashboardFilters && <ActiveFilters isEditMode={isEditMode} />}
+                <ActiveFilters isEditMode={isEditMode} />
             </DashboardFilterWrapper>
         </FiltersProvider>
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
@@ -19,6 +19,7 @@ import {
 } from './autoCompleteUtils';
 
 type Props = {
+    filterId: string;
     field: FilterableItem;
     values: string[];
     suggestions: string[];
@@ -34,6 +35,7 @@ const PaddedMenuItem = styled(MenuItem2)`
 `;
 
 const MultiAutoComplete: FC<Props> = ({
+    filterId,
     values,
     field,
     suggestions: initialSuggestionData,
@@ -41,18 +43,24 @@ const MultiAutoComplete: FC<Props> = ({
     disabled,
     onChange,
 }) => {
-    const { projectUuid } = useFiltersContext();
+    const { projectUuid, getRelatedFilterGroup } = useFiltersContext();
     if (!projectUuid) {
         throw new Error('projectUuid is required in FiltersProvider');
     }
 
     const [search, setSearch] = useState('');
 
+    const relatedFilterGroup = useMemo(
+        () => getRelatedFilterGroup(filterId),
+        [filterId, getRelatedFilterGroup],
+    );
+
     const { isLoading, results: resultsSet } = useFieldValues(
         search,
         initialSuggestionData,
         projectUuid,
         field,
+        relatedFilterGroup,
         true,
         { refetchOnMount: 'always' },
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
@@ -43,16 +43,16 @@ const MultiAutoComplete: FC<Props> = ({
     disabled,
     onChange,
 }) => {
-    const { projectUuid, getRelatedFilterGroup } = useFiltersContext();
+    const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
     if (!projectUuid) {
         throw new Error('projectUuid is required in FiltersProvider');
     }
 
     const [search, setSearch] = useState('');
 
-    const relatedFilterGroup = useMemo(
-        () => getRelatedFilterGroup(filterId),
-        [filterId, getRelatedFilterGroup],
+    const autocompleteFilterGroup = useMemo(
+        () => getAutocompleteFilterGroup(filterId, field),
+        [field, filterId, getAutocompleteFilterGroup],
     );
 
     const { isLoading, results: resultsSet } = useFieldValues(
@@ -60,7 +60,7 @@ const MultiAutoComplete: FC<Props> = ({
         initialSuggestionData,
         projectUuid,
         field,
-        relatedFilterGroup,
+        autocompleteFilterGroup,
         true,
         { refetchOnMount: 'always' },
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -48,6 +48,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
             if (filterType === FilterType.STRING) {
                 return (
                     <MultiAutoComplete
+                        filterId={rule.id}
                         disabled={disabled}
                         field={field}
                         values={(rule.values || []).filter(isString)}

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -19,7 +19,7 @@ const getFieldValues = async (
     table: string | undefined,
     fieldId: string,
     search: string,
-    filters: AndFilterGroup,
+    filters: AndFilterGroup | undefined,
     limit: number = MAX_AUTOCOMPLETE_RESULTS,
 ) => {
     if (!table) {
@@ -43,7 +43,7 @@ export const useFieldValues = (
     initialData: string[],
     projectId: string,
     field: FilterableItem,
-    filters: AndFilterGroup,
+    filters: AndFilterGroup | undefined,
     debounce: boolean = true,
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
 ) => {

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -42,6 +42,7 @@ type DashboardContext = {
     setHaveTilesChanged: Dispatch<SetStateAction<boolean>>;
     dashboardFilters: DashboardFilters;
     dashboardTemporaryFilters: DashboardFilters;
+    allFilters: DashboardFilters;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     setDashboardTemporaryFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (
@@ -264,6 +265,19 @@ export const DashboardProvider: React.FC = ({ children }) => {
         });
     }, [dashboardTemporaryFilters, history, pathname, search]);
 
+    const allFilters = useMemo(() => {
+        return {
+            dimensions: [
+                ...dashboardFilters.dimensions,
+                ...dashboardTemporaryFilters?.dimensions,
+            ],
+            metrics: [
+                ...dashboardFilters.metrics,
+                ...dashboardTemporaryFilters?.metrics,
+            ],
+        };
+    }, [dashboardFilters, dashboardTemporaryFilters]);
+
     const value = {
         dashboard,
         dashboardError,
@@ -286,6 +300,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         allFilterableFields,
         filterableFieldsBySavedQueryUuid,
         filterableFieldsByTileUuid,
+        allFilters,
     };
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3651 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- FE sends dashboard filters to "auto complete" endpoint
- BE adds the relevant filters to the search SQL. relevant filters = the filter table is the same


Example: ( on the right you can see the SQL query with the relevant filters )

 

https://github.com/lightdash/lightdash/assets/9117144/ac0c39e7-fb6d-4dae-920e-8f938cd64958

