### PR TITLE
feat: change and move headway icon

### DIFF
--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,12 +1,11 @@
 import { Box, Button } from '@mantine/core';
-import { IconBell } from '@tabler/icons-react';
-import MantineIcon from '../common/MantineIcon';
-
+import { IconAccessPoint } from '@tabler/icons-react';
 import { FC, useEffect } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
 
 type Props = {
     projectUuid?: string;
@@ -66,7 +65,7 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
 
     return (
         <Button variant="default" size="xs" pos="relative" id="headway-trigger">
-            <MantineIcon icon={IconBell} />
+            <MantineIcon icon={IconAccessPoint} size="lg" />
             <Box
                 id="headway-badge"
                 pos="absolute"

--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Button } from '@mantine/core';
-import { IconAccessPoint } from '@tabler/icons-react';
+import { IconSparkles } from '@tabler/icons-react';
 import { FC, useEffect } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
 import { useApp } from '../../providers/AppProvider';
@@ -65,7 +65,7 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
 
     return (
         <Button variant="default" size="xs" pos="relative" id="headway-trigger">
-            <MantineIcon icon={IconAccessPoint} size="lg" />
+            <MantineIcon icon={IconSparkles} size="lg" />
             <Box
                 id="headway-badge"
                 pos="absolute"

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -98,8 +98,8 @@ const NavBar = memo(() => {
 
                     <Button.Group>
                         <SettingsMenu />
-                        <HeadwayMenuItem projectUuid={activeProjectUuid} />
                         <HelpMenu />
+                        <HeadwayMenuItem projectUuid={activeProjectUuid} />
                     </Button.Group>
 
                     <Divider orientation="vertical" my="xs" color="gray.8" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #5324 

### Description:

Ahead of new notifications (for validation errors) tab:
* change bell icon to sparkles
* move that icon to the end



Before
![Screenshot 2023-05-17 at 10 19 57](https://github.com/lightdash/lightdash/assets/7611706/f5bc71a3-e35c-4d23-9c9e-b0127efb6693)

After
![image](https://github.com/lightdash/lightdash/assets/7611706/8d897330-90c0-4b3a-bba9-3c7e111a433a)