### PR TITLE
fix: add break-all to validation erros

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -156,7 +156,13 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                                                       color="red"
                                                       fw={500}
                                                   >
-                                                      <Text fz="xs">
+                                                      <Text
+                                                          fz="xs"
+                                                          sx={{
+                                                              wordBreak:
+                                                                  'break-all',
+                                                          }}
+                                                      >
                                                           {
                                                               validationError.error
                                                           }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Add `word-break: break-all` to validation errors 

before

![image](https://github.com/lightdash/lightdash/assets/7611706/d1536f2e-3f56-45d5-b184-7db778b4d6d8)

after

![image](https://github.com/lightdash/lightdash/assets/7611706/0a752677-d423-413f-a0ca-c10236ca9bae)

