### PR TITLE
feat: row totals

### DIFF
--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -6,7 +6,7 @@ export type PivotConfig = {
     metricsAsRows: boolean;
     columnOrder?: string[];
     hiddenMetricFieldIds?: string[];
-
+    summableMetricFieldIds?: string[];
     columnTotals?: boolean;
     rowTotals?: boolean;
 };

--- a/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
@@ -11,35 +11,49 @@ const ShowTotalsToggle: FC = () => {
             showRowCalculation,
             setShowRowCalculation,
             canUsePivotTable,
-            metricsAsRows,
         },
     } = useVisualizationContext();
 
-    const options =
-        canUsePivotTable && metricsAsRows
-            ? {
-                  label: 'Show row total',
-                  value: showRowCalculation,
-                  onChange: () => setShowRowCalculation(!showRowCalculation),
-              }
-            : {
-                  label: 'Show column total',
-                  value: showColumnCalculation,
-                  onChange: () =>
-                      setShowColumnCalculation(!showColumnCalculation),
-              };
+    const rowTotalOption = canUsePivotTable
+        ? {
+              label: 'Show row total',
+              value: showRowCalculation,
+              onChange: () => setShowRowCalculation(!showRowCalculation),
+          }
+        : undefined;
+
+    const columnTotalOption = {
+        label: 'Show column total',
+        value: showColumnCalculation,
+        onChange: () => setShowColumnCalculation(!showColumnCalculation),
+    };
 
     return (
-        <StyledSwitch
-            large
-            id="showTotals"
-            innerLabelChecked="Yes"
-            innerLabel="No"
-            alignIndicator="right"
-            label={options.label}
-            checked={options.value}
-            onChange={options.onChange}
-        />
+        <>
+            {rowTotalOption ? (
+                <StyledSwitch
+                    large
+                    id="showTotals"
+                    innerLabelChecked="Yes"
+                    innerLabel="No"
+                    alignIndicator="right"
+                    label={rowTotalOption.label}
+                    checked={rowTotalOption.value}
+                    onChange={rowTotalOption.onChange}
+                />
+            ) : null}
+
+            <StyledSwitch
+                large
+                id="showTotals"
+                innerLabelChecked="Yes"
+                innerLabel="No"
+                alignIndicator="right"
+                label={columnTotalOption.label}
+                checked={columnTotalOption.value}
+                onChange={columnTotalOption.onChange}
+            />
+        </>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/ShowTotalsToggle.tsx
@@ -14,32 +14,18 @@ const ShowTotalsToggle: FC = () => {
         },
     } = useVisualizationContext();
 
-    const rowTotalOption = canUsePivotTable
-        ? {
-              label: 'Show row total',
-              value: showRowCalculation,
-              onChange: () => setShowRowCalculation(!showRowCalculation),
-          }
-        : undefined;
-
-    const columnTotalOption = {
-        label: 'Show column total',
-        value: showColumnCalculation,
-        onChange: () => setShowColumnCalculation(!showColumnCalculation),
-    };
-
     return (
         <>
-            {rowTotalOption ? (
+            {canUsePivotTable ? (
                 <StyledSwitch
                     large
                     id="showTotals"
                     innerLabelChecked="Yes"
                     innerLabel="No"
                     alignIndicator="right"
-                    label={rowTotalOption.label}
-                    checked={rowTotalOption.value}
-                    onChange={rowTotalOption.onChange}
+                    label="Show row total"
+                    checked={showRowCalculation}
+                    onChange={() => setShowRowCalculation(!showRowCalculation)}
                 />
             ) : null}
 
@@ -49,9 +35,11 @@ const ShowTotalsToggle: FC = () => {
                 innerLabelChecked="Yes"
                 innerLabel="No"
                 alignIndicator="right"
-                label={columnTotalOption.label}
-                checked={columnTotalOption.value}
-                onChange={columnTotalOption.onChange}
+                label="Show column total"
+                checked={showColumnCalculation}
+                onChange={() =>
+                    setShowColumnCalculation(!showColumnCalculation)
+                }
             />
         </>
     );

--- a/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
@@ -207,7 +207,7 @@ const GeneralSettings: FC = () => {
                     />
                 ) : null}
 
-                {canUsePivotTable && metricsAsRows ? (
+                {canUsePivotTable ? (
                     <Checkbox
                         label="Show row total"
                         checked={showRowCalculation}
@@ -215,15 +215,14 @@ const GeneralSettings: FC = () => {
                             setShowRowCalculation(!showRowCalculation);
                         }}
                     />
-                ) : (
-                    <Checkbox
-                        label="Show column total"
-                        checked={showColumnCalculation}
-                        onChange={() => {
-                            setShowColumnCalculation(!showColumnCalculation);
-                        }}
-                    />
-                )}
+                ) : null}
+                <Checkbox
+                    label="Show column total"
+                    checked={showColumnCalculation}
+                    onChange={() => {
+                        setShowColumnCalculation(!showColumnCalculation);
+                    }}
+                />
             </FormGroup>
 
             <SectionTitle>Columns</SectionTitle>

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -489,6 +489,18 @@ const PivotTable: FC<PivotTableProps> = ({
                                     />
                                 );
                             })}
+
+                            {hasRowTotals
+                                ? data.rowTotalFields?.[0].map((_, index) => (
+                                      <td
+                                          key={`footer-empty-${totalRowIndex}-${index}`}
+                                          className={cellCx(
+                                              cellStyles.root,
+                                              cellStyles.rowNumber,
+                                          )}
+                                      />
+                                  ))
+                                : null}
                         </tr>
                     ))}
                 </tfoot>

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -60,7 +60,7 @@ const PivotTable: FC<PivotTableProps> = ({
     );
 
     const getRowTotalValueFromAxis = useCallback(
-        (total: unknown, colIndex: number): ResultValue | null => {
+        (total: unknown, colIndex: number): ResultValue => {
             const value = last(data.rowTotalFields)?.[colIndex];
 
             if (!value || !value.fieldId) throw new Error('Invalid pivot data');
@@ -115,11 +115,8 @@ const PivotTable: FC<PivotTableProps> = ({
     );
 
     const getMetricAsRowColumnTotalValueFromAxis = useCallback(
-        (total: unknown, rowIndex: number): ResultValue | null => {
-            if (!data.columnTotalFields) {
-                return null;
-            }
-            const value = last(data.columnTotalFields[rowIndex]);
+        (total: unknown, rowIndex: number): ResultValue => {
+            const value = last(data.columnTotalFields?.[rowIndex]);
             if (!value || !value.fieldId) throw new Error('Invalid pivot data');
 
             const item = getField(value.fieldId);

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -335,7 +335,7 @@ export const pivotQueryResults = ({
 
             summableMetricFieldIds.forEach((fieldId, metricIndex) => {
                 rowTotalFields![N_TOTAL_ROWS - 1][metricIndex] = {
-                    fieldId: fieldId,
+                    fieldId,
                 };
             });
 
@@ -375,7 +375,7 @@ export const pivotQueryResults = ({
 
             summableMetricFieldIds.forEach((fieldId, metricIndex) => {
                 columnTotalFields![metricIndex][N_TOTAL_COLS - 1] = {
-                    fieldId: fieldId,
+                    fieldId,
                 };
             });
 

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -333,7 +333,6 @@ export const pivotQueryResults = ({
             rowTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
             rowTotals = create2DArray(N_DATA_ROWS, N_TOTAL_COLS);
 
-            // set the last header cells as the "Total"
             summableMetricFieldIds.forEach((fieldId, metricIndex) => {
                 rowTotalFields![N_TOTAL_ROWS - 1][metricIndex] = {
                     fieldId: fieldId,

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -340,24 +340,25 @@ export const pivotQueryResults = ({
             });
 
             rowTotals = rowTotals.map((row, rowIndex) =>
-                row.map((_, colIndex) =>
-                    dataValues[rowIndex]
+                row.map((_, totalColIndex) => {
+                    const totalColFieldId =
+                        rowTotalFields![N_TOTAL_ROWS - 1][totalColIndex]
+                            ?.fieldId;
+                    const valueColIndices = totalColFieldId
+                        ? getAllIndicesForFieldId(
+                              columnIndices,
+                              totalColFieldId,
+                          )
+                        : [];
+                    return dataValues[rowIndex]
                         .filter((__, dataValueColIndex) => {
-                            const fieldId =
-                                rowTotalFields![N_TOTAL_ROWS - 1][colIndex]
-                                    ?.fieldId;
-                            if (!fieldId) return false;
-                            const indices = getAllIndicesForFieldId(
-                                columnIndices,
-                                fieldId,
-                            );
-                            return indices.includes(dataValueColIndex);
+                            return valueColIndices.includes(dataValueColIndex);
                         })
                         .reduce(
                             (acc, value) => acc + parseNumericValue(value),
                             0,
-                        ),
-                ),
+                        );
+                }),
             );
         }
     }

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -338,25 +338,20 @@ export const pivotQueryResults = ({
                     fieldId: metric.fieldId,
                 };
             });
-            console.log('dataValues', columnIndices);
-            console.log('dataValues', dataValues);
-            // TODO: not working yet for multiple metrics
+
             rowTotals = rowTotals.map((row, rowIndex) =>
                 row.map((_, colIndex) =>
                     dataValues[rowIndex]
-                        .filter(() => {
-                            console.log('colIndex', {
-                                colIndex,
-                                columnIndices,
-                                rowTotalFields,
-                            });
+                        .filter((__, dataValueColIndex) => {
+                            const fieldId =
+                                rowTotalFields![N_TOTAL_ROWS - 1][colIndex]
+                                    ?.fieldId;
+                            if (!fieldId) return false;
                             const indices = getAllIndicesForFieldId(
                                 columnIndices,
-                                rowTotalFields![N_TOTAL_ROWS - 1][colIndex]!
-                                    .fieldId!,
+                                fieldId,
                             );
-                            console.log('getAllIndicesForFieldId', indices);
-                            return indices.includes(colIndex);
+                            return indices.includes(dataValueColIndex);
                         })
                         .reduce(
                             (acc, value) => acc + parseNumericValue(value),
@@ -364,7 +359,6 @@ export const pivotQueryResults = ({
                         ),
                 ),
             );
-            console.log('rowTotalFields, rowTotals', rowTotalFields, rowTotals);
         }
     }
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -16,6 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TableColumn, TableHeader } from '../../components/common/Table/types';
 import { pivotQueryResults } from '../pivotTable/pivotQueryResults';
+import { isSummable } from '../useColumnTotals';
 import getDataAndColumns from './getDataAndColumns';
 
 const useTableConfig = (
@@ -207,6 +208,15 @@ const useTableConfig = (
             );
         });
 
+        const summableMetricFieldIds = selectedItemIds?.filter((fieldId) => {
+            const field = getField(fieldId);
+
+            return (
+                isSummable(field) &&
+                !(hiddenMetricFieldIds || []).includes(fieldId)
+            );
+        });
+
         try {
             const data = pivotQueryResults({
                 pivotConfig: {
@@ -214,6 +224,7 @@ const useTableConfig = (
                     metricsAsRows,
                     columnOrder,
                     hiddenMetricFieldIds,
+                    summableMetricFieldIds,
                     columnTotals: tableChartConfig?.showColumnCalculation,
                     rowTotals: tableChartConfig?.showRowCalculation,
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3245 <!-- reference the related issue e.g. #150 -->

### Description:

Changes:
- add row totals option ( column totals when metrics as rows )
- take into account hidden metrics and metrics that can't have a total ( eg: average )


Row totals
![Captura de ecrã 2023-05-18, às 12 24 43](https://github.com/lightdash/lightdash/assets/9117144/9c1f4373-c59c-40dc-ab35-ea7b9c113b1b)

Column totals ( metric as rows )
![Captura de ecrã 2023-05-18, às 12 25 02](https://github.com/lightdash/lightdash/assets/9117144/6c7983b2-ef2a-40da-89f1-ddbbd8894de8)

The option is available when there is a group ( the same way we have for "metric as rows" ):
![Captura de ecrã 2023-05-18, às 12 28 26](https://github.com/lightdash/lightdash/assets/9117144/c4f87c9e-f6e0-4589-b2b5-b8c78777c7e1)
![Captura de ecrã 2023-05-18, às 12 28 39](https://github.com/lightdash/lightdash/assets/9117144/272d40f2-c1df-4d8a-a1d6-ca01a05c4972)


