### PR TITLE
fix: change key to be index

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -133,8 +133,8 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                             </thead>
                             <tbody>
                                 {data && data.length
-                                    ? data.map((validationError) => (
-                                          <tr key={validationError.name}>
+                                    ? data.map((validationError, index) => (
+                                          <tr key={index}>
                                               <td>
                                                   <Flex gap="sm" align="center">
                                                       <Icon


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #5324 

### Description:

Change `key` to be index instead of `name` so that we avoid `Table` errors to have the same key in table.
