### PR TITLE
feat: move headway badge to top right

### DIFF
--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Tooltip } from '@mantine/core';
+import { Box, Button, Indicator, Tooltip } from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { FC, useEffect } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
@@ -65,25 +65,33 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
 
     return (
         <Tooltip color="dark" label="What's new?">
-            <Button
-                variant="default"
-                size="xs"
-                pos="relative"
-                id="headway-trigger"
+            <Indicator
+                color="transparent"
+                offset={8}
+                label={
+                    <Box
+                        id="headway-badge"
+                        sx={{
+                            pointerEvents: 'none',
+                            '.HW_badge.HW_softHidden': {
+                                background: 'transparent !important',
+                            },
+                            '.HW_badge.HW_bounce': {
+                                animation: 'none !important',
+                            },
+                        }}
+                    />
+                }
             >
-                <MantineIcon icon={IconSparkles} size="lg" />
-                <Box
-                    id="headway-badge"
-                    pos="absolute"
-                    sx={{
-                        pointerEvents: 'none',
-                        top: 8,
-                        '.HW_badge.HW_softHidden': {
-                            background: 'transparent',
-                        },
-                    }}
-                />
-            </Button>
+                <Button
+                    variant="default"
+                    size="xs"
+                    pos="relative"
+                    id="headway-trigger"
+                >
+                    <MantineIcon icon={IconSparkles} size="lg" />
+                </Button>
+            </Indicator>
         </Tooltip>
     );
 };

--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,4 +1,10 @@
-import { Box, Button, Indicator, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Indicator,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { FC, useEffect } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
@@ -12,6 +18,7 @@ type Props = {
 };
 
 const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
+    const theme = useMantineTheme();
     const { track } = useTracking();
     const { user } = useApp();
     const isHeadwayloaded = useHeadway();
@@ -67,16 +74,34 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
         <Tooltip color="dark" label="What's new?">
             <Indicator
                 color="transparent"
-                offset={8}
+                offset={10}
+                size={4}
                 label={
                     <Box
                         id="headway-badge"
                         sx={{
                             pointerEvents: 'none',
+                            '.HW_badge': {
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                top: '8px',
+                                left: '1px',
+                                width: '12px',
+                                height: '12px',
+                                fontSize: theme.fontSizes.xs,
+                                background: theme.colors.red[8],
+                            },
                             '.HW_badge.HW_softHidden': {
                                 background: 'transparent !important',
                             },
                             '.HW_badge.HW_bounce': {
+                                animation: 'none !important',
+                            },
+                            '.HW_badge.HW_shake': {
+                                animation: 'none !important',
+                            },
+                            '.HW_badge.HW_wobble': {
                                 animation: 'none !important',
                             },
                         }}

--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,10 +1,4 @@
-import {
-    Box,
-    Button,
-    Indicator,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine/core';
+import { Box, Button, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { FC, useEffect } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
@@ -71,52 +65,45 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
     if (!isHeadwayloaded || !projectUuid) return null;
 
     return (
-        <Tooltip color="dark" label="What's new?">
-            <Indicator
-                color="transparent"
-                offset={10}
-                size={4}
-                label={
-                    <Box
-                        id="headway-badge"
-                        sx={{
-                            pointerEvents: 'none',
-                            '.HW_badge': {
-                                display: 'flex',
-                                justifyContent: 'center',
-                                alignItems: 'center',
-                                top: '8px',
-                                left: '1px',
-                                width: '12px',
-                                height: '12px',
-                                fontSize: theme.fontSizes.xs,
-                                background: theme.colors.red[8],
-                            },
-                            '.HW_badge.HW_softHidden': {
-                                background: 'transparent !important',
-                            },
-                            '.HW_badge.HW_bounce': {
-                                animation: 'none !important',
-                            },
-                            '.HW_badge.HW_shake': {
-                                animation: 'none !important',
-                            },
-                            '.HW_badge.HW_wobble': {
-                                animation: 'none !important',
-                            },
-                        }}
-                    />
-                }
+        <Tooltip color="dark" label="What's new?" withinPortal>
+            <Button
+                variant="default"
+                size="xs"
+                pos="relative"
+                id="headway-trigger"
             >
-                <Button
-                    variant="default"
-                    size="xs"
-                    pos="relative"
-                    id="headway-trigger"
-                >
-                    <MantineIcon icon={IconSparkles} size="lg" />
-                </Button>
-            </Indicator>
+                <MantineIcon icon={IconSparkles} size="lg" />
+                <Box
+                    id="headway-badge"
+                    pos="absolute"
+                    sx={{
+                        pointerEvents: 'none',
+                        '.HW_badge': {
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                            top: '4px',
+                            left: '12px',
+                            width: '12px',
+                            height: '12px',
+                            fontSize: theme.fontSizes.xs,
+                            background: theme.colors.red[8],
+                        },
+                        '.HW_badge.HW_softHidden': {
+                            background: 'transparent !important',
+                        },
+                        '.HW_badge.HW_bounce': {
+                            animation: 'none !important',
+                        },
+                        '.HW_badge.HW_shake': {
+                            animation: 'none !important',
+                        },
+                        '.HW_badge.HW_wobble': {
+                            animation: 'none !important',
+                        },
+                    }}
+                />
+            </Button>
         </Tooltip>
     );
 };

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -44,7 +44,12 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                         },
                     }}
                 >
-                    <Indicator color="red" offset={2} disabled={disableBadge}>
+                    <Indicator
+                        size={12}
+                        color="red"
+                        offset={1}
+                        disabled={disableBadge}
+                    >
                         <MantineIcon icon={IconBell} />
                     </Indicator>
                 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #5324 

### Description:

- Move Headway icon to top right
- Make sure both indicators/badges are matching in size and color (notifications vs headway )
- Remove some broken animations from Headway's widget badge: `bounce`, `shake`, and `wobble`


Recording: 

https://github.com/lightdash/lightdash/assets/7611706/15f6e85c-20a7-4ea0-aebc-eaca7ae6cab4



