### PR TITLE
fix: check permission on explores update

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -100,7 +100,7 @@ projectRouter.put(
     unauthorisedInDemo,
     async (req, res, next) => {
         projectService
-            .setExplores(req.params.projectUuid, req.body)
+            .setExplores(req.user!, req.params.projectUuid, req.body)
             .then(() => {
                 res.json({
                     status: 'ok',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -323,9 +323,19 @@ export class ProjectService {
     }
 
     async setExplores(
+        user: SessionUser,
         projectUuid: string,
         explores: (Explore | ExploreError)[],
     ): Promise<void> {
+        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        if (
+            user.ability.cannot(
+                'update',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         await this.projectModel.saveExploresToCache(projectUuid, explores);
 
         await schedulerClient.generateValidation({ projectUuid });
@@ -411,6 +421,10 @@ export class ProjectService {
         const updatedProject = await this.projectModel.getWithSensitiveFields(
             projectUuid,
         );
+
+        if (user.ability.cannot('update', subject('Project', updatedProject))) {
+            throw new ForbiddenError();
+        }
 
         if (updatedProject.warehouseConnection === undefined) {
             throw new Error(
@@ -763,7 +777,7 @@ export class ProjectService {
         );
     }
 
-    async runQueryAndFormatRows(
+    private async runQueryAndFormatRows(
         user: SessionUser,
         metricQuery: MetricQuery,
         projectUuid: string,
@@ -828,6 +842,18 @@ export class ProjectService {
     ): Promise<Record<string, any>[]> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const { organizationUuid } =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
         }
 
         const metricQueryWithLimit = ProjectService.metricQueryWithLimit(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5545 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- check user permission when updating explores
- check user permission on methods that are triggered via scheduler jobs
- add e2e tests 
