### PR TITLE
feat: add validation error indicator for resource items

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -366,6 +366,7 @@ export class DashboardModel {
                 firstViewedAt: first_viewed_at,
                 validationErrors: validation_errors?.map(
                     (error: DbValidationTable) => ({
+                        validationId: error.validation_id,
                         error: error.error,
                         createdAt: error.created_at,
                     }),

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -467,9 +467,10 @@ export class SpaceModel {
             pinnedListUuid: savedQuery.pinned_list_uuid,
             pinnedListOrder: savedQuery.order,
             validationErrors: savedQuery.validation_errors.map(
-                ({ error, created_at }) => ({
+                ({ error, created_at, validation_id }) => ({
                     error,
                     createdAt: created_at,
+                    validationId: validation_id,
                 }),
             ),
         }));

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -24,6 +24,7 @@ export type ResourceViewChartItem = {
         | 'description'
         | 'updatedAt'
         | 'updatedByUser'
+        | 'validationErrors'
     >;
 };
 
@@ -41,6 +42,7 @@ export type ResourceViewDashboardItem = {
         | 'pinnedListOrder'
         | 'updatedAt'
         | 'updatedByUser'
+        | 'validationErrors'
     >;
 };
 

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -21,4 +21,7 @@ export type ApiValidateResponse = {
     results: ValidationResponse[];
 };
 
-export type ValidationSummary = Pick<ValidationResponse, 'error' | 'createdAt'>;
+export type ValidationSummary = Pick<
+    ValidationResponse,
+    'error' | 'createdAt' | 'validationId'
+>;

--- a/packages/frontend/src/components/SettingsValidator/hooks/useScrollAndHighlight.ts
+++ b/packages/frontend/src/components/SettingsValidator/hooks/useScrollAndHighlight.ts
@@ -1,0 +1,29 @@
+import { MantineThemeColors } from '@mantine/core';
+import { RefObject, useEffect } from 'react';
+
+export const useScrollAndHighlight = (
+    refs: { [key: string]: RefObject<HTMLTableRowElement> },
+    validationId: string | null,
+    colors: MantineThemeColors,
+) => {
+    useEffect(() => {
+        if (validationId) {
+            refs[validationId]?.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+            });
+
+            refs[validationId]?.current?.animate(
+                [
+                    { backgroundColor: 'white' },
+                    { backgroundColor: colors.gray[3] },
+                    { backgroundColor: 'white' },
+                ],
+                {
+                    duration: 1000,
+                    iterations: 2,
+                },
+            );
+        }
+    }, [refs, validationId, colors]);
+};

--- a/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
@@ -4,9 +4,10 @@ import {
     ResourceViewItem,
     ResourceViewItemType,
 } from '@lightdash/common';
-import { Center, Paper } from '@mantine/core';
+import { Center, Indicator, Paper, Tooltip } from '@mantine/core';
 import {
     Icon as TablerIconType,
+    IconAlertTriangle,
     IconChartArea,
     IconChartAreaLine,
     IconChartBar,
@@ -17,7 +18,7 @@ import {
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
-import { FC } from 'react';
+import { FC, ReactNode, useRef, useState } from 'react';
 import MantineIcon, { MantineIconProps } from '../MantineIcon';
 
 interface ResourceIconProps {
@@ -56,7 +57,7 @@ export const IconBox: FC<IconBoxProps> = ({
     </Paper>
 );
 
-const ResourceIcon: FC<ResourceIconProps> = ({ item }) => {
+export const ResourceIcon: FC<ResourceIconProps> = ({ item }) => {
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
             return <IconBox icon={IconLayoutDashboard} color="green.8" />;
@@ -107,7 +108,7 @@ const COMMON_ICON_PROPS = {
     fillOpacity: 0.1,
 };
 
-const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
+export const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
     switch (type) {
         case ResourceViewItemType.DASHBOARD:
             return (
@@ -141,4 +142,74 @@ const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
     }
 };
 
-export { ResourceIcon, ResourceTypeIcon };
+export const ResourceIconWithIndicator: FC<{
+    children: ReactNode;
+    disabled: boolean;
+    tooltipLabel: ReactNode;
+}> = ({ disabled, tooltipLabel, children }) => {
+    // NOTE: Control the Tooltip visibility manually to allow hovering on Label.
+    const [opened, setOpened] = useState(false);
+    const [isHovering, setIsHovering] = useState(false);
+    const closeTimeoutId = useRef<number | undefined>(undefined);
+
+    const handleMouseEnter = () => {
+        clearTimeout(closeTimeoutId.current);
+        setOpened(true);
+    };
+
+    const handleMouseLeave = () => {
+        // NOTE: Provide similar delay as Tooltip component
+        closeTimeoutId.current = window.setTimeout(() => {
+            setOpened(false);
+        }, 100);
+    };
+
+    const handleLabelMouseEnter = () => {
+        setIsHovering(true);
+        clearTimeout(closeTimeoutId.current);
+    };
+
+    const handleLabelMouseLeave = () => {
+        setIsHovering(false);
+        // NOTE: Provide similar delay as Tooltip component
+        closeTimeoutId.current = window.setTimeout(() => {
+            setOpened(false);
+        }, 100);
+    };
+
+    return (
+        <Indicator
+            disabled={disabled}
+            position="bottom-end"
+            color="transparent"
+            label={
+                <Tooltip
+                    w={300}
+                    withinPortal
+                    multiline
+                    offset={-2}
+                    position="bottom"
+                    sx={{ pointerEvents: 'auto' }}
+                    label={
+                        <div
+                            onMouseEnter={handleLabelMouseEnter}
+                            onMouseLeave={handleLabelMouseLeave}
+                        >
+                            {tooltipLabel}
+                        </div>
+                    }
+                    opened={opened || isHovering}
+                >
+                    <MantineIcon
+                        fill="red"
+                        icon={IconAlertTriangle}
+                        onMouseEnter={handleMouseEnter}
+                        onMouseLeave={handleMouseLeave}
+                    />
+                </Tooltip>
+            }
+        >
+            {children}
+        </Indicator>
+    );
+};

--- a/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
@@ -148,7 +148,7 @@ export const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
     }
 };
 
-export const ResourceIconWithIndicator: FC<
+export const ResourceIndicator: FC<
     {
         children: ReactNode;
         tooltipLabel: ReactNode;

--- a/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceIcon.tsx
@@ -4,10 +4,16 @@ import {
     ResourceViewItem,
     ResourceViewItemType,
 } from '@lightdash/common';
-import { Center, Indicator, Paper, Tooltip } from '@mantine/core';
+import {
+    Center,
+    Indicator,
+    IndicatorProps,
+    Paper,
+    Tooltip,
+    TooltipProps,
+} from '@mantine/core';
 import {
     Icon as TablerIconType,
-    IconAlertTriangle,
     IconChartArea,
     IconChartAreaLine,
     IconChartBar,
@@ -142,11 +148,14 @@ export const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
     }
 };
 
-export const ResourceIconWithIndicator: FC<{
-    children: ReactNode;
-    disabled: boolean;
-    tooltipLabel: ReactNode;
-}> = ({ disabled, tooltipLabel, children }) => {
+export const ResourceIconWithIndicator: FC<
+    {
+        children: ReactNode;
+        tooltipLabel: ReactNode;
+        iconProps: MantineIconProps;
+        tooltipProps: Partial<TooltipProps>;
+    } & Pick<IndicatorProps, 'disabled'>
+> = ({ disabled, tooltipLabel, iconProps, tooltipProps, children }) => {
     // NOTE: Control the Tooltip visibility manually to allow hovering on Label.
     const [opened, setOpened] = useState(false);
     const [isHovering, setIsHovering] = useState(false);
@@ -184,11 +193,7 @@ export const ResourceIconWithIndicator: FC<{
             color="transparent"
             label={
                 <Tooltip
-                    w={300}
-                    withinPortal
-                    multiline
-                    offset={-2}
-                    position="bottom"
+                    {...tooltipProps}
                     sx={{ pointerEvents: 'auto' }}
                     label={
                         <div
@@ -201,8 +206,7 @@ export const ResourceIconWithIndicator: FC<{
                     opened={opened || isHovering}
                 >
                     <MantineIcon
-                        fill="red"
-                        icon={IconAlertTriangle}
+                        {...iconProps}
                         onMouseEnter={handleMouseEnter}
                         onMouseLeave={handleMouseLeave}
                     />

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -179,7 +179,12 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                             ? 'teal'
                                                             : 'blue.4'
                                                     }
-                                                    onClickCapture={(e) => {
+                                                    onClickCapture={(
+                                                        e: React.MouseEvent<
+                                                            HTMLSpanElement,
+                                                            MouseEvent
+                                                        >,
+                                                    ) => {
                                                         e.stopPropagation();
 
                                                         clipboard.copy(

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -25,7 +25,7 @@ import { ResourceViewCommonProps } from '..';
 import { useTableStyles } from '../../../../hooks/styles/useTableStyles';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../../hooks/validation/useValidation';
-import { ResourceIcon, ResourceIconWithIndicator } from '../ResourceIcon';
+import { ResourceIcon, ResourceIndicator } from '../ResourceIcon';
 import {
     getResourceTypeName,
     getResourceUrl,
@@ -141,7 +141,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                             <Group noWrap>
                                 {canBelongToSpace &&
                                 item.data.validationErrors?.length ? (
-                                    <ResourceIconWithIndicator
+                                    <ResourceIndicator
                                         iconProps={{
                                             fill: 'red',
                                             icon: IconAlertTriangle,
@@ -153,9 +153,6 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                             offset: -2,
                                             position: 'bottom',
                                         }}
-                                        disabled={
-                                            !item.data.validationErrors.length
-                                        }
                                         tooltipLabel={
                                             canUserManageValidation ? (
                                                 <>
@@ -189,7 +186,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                         }
                                     >
                                         <ResourceIcon item={item} />
-                                    </ResourceIconWithIndicator>
+                                    </ResourceIndicator>
                                 ) : (
                                     <ResourceIcon item={item} />
                                 )}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -150,7 +150,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                 <ResourceIconWithIndicator
                                     disabled={!validationError}
                                     tooltipLabel={
-                                        !canUserManageValidation ? (
+                                        canUserManageValidation ? (
                                             <>
                                                 This content is broken. Learn
                                                 more about the validation

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -15,7 +15,11 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
-import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import {
+    IconAlertTriangle,
+    IconChevronDown,
+    IconChevronUp,
+} from '@tabler/icons-react';
 import React, { FC, useMemo, useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
@@ -148,6 +152,17 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                         >
                             <Group noWrap>
                                 <ResourceIconWithIndicator
+                                    iconProps={{
+                                        fill: 'red',
+                                        icon: IconAlertTriangle,
+                                    }}
+                                    tooltipProps={{
+                                        w: 300,
+                                        withinPortal: true,
+                                        multiline: true,
+                                        offset: -2,
+                                        position: 'bottom',
+                                    }}
                                     disabled={!validationError}
                                     tooltipLabel={
                                         canUserManageValidation ? (

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -121,8 +121,6 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                 id: 'name',
                 label: 'Name',
                 cell: (item: ResourceViewItem) => {
-                    console.log(item);
-
                     const canBelongToSpace =
                         isResourceViewItemChart(item) ||
                         isResourceViewItemDashboard(item);
@@ -169,12 +167,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                         fw={600}
                                                         to={{
                                                             pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
-                                                            state: {
-                                                                validationId:
-                                                                    item.data
-                                                                        .validationErrors[0]
-                                                                        .validationId,
-                                                            },
+                                                            search: `?validationId=${item.data.validationErrors[0].validationId}`,
                                                         }}
                                                         color="blue.4"
                                                     >

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -14,7 +14,6 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { useClipboard } from '@mantine/hooks';
 import {
     IconAlertTriangle,
     IconChevronDown,
@@ -93,7 +92,6 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: spaces = [] } = useSpaceSummaries(projectUuid);
     const canUserManageValidation = useValidationUserAbility(projectUuid);
-    const clipboard = useClipboard({ timeout: 500 });
 
     const [columnSorts, setColumnSorts] = useState<SortingStateMap>(
         defaultSort ? new Map(Object.entries(defaultSort)) : new Map(),
@@ -124,6 +122,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                 label: 'Name',
                 cell: (item: ResourceViewItem) => {
                     console.log(item);
+
                     const canBelongToSpace =
                         isResourceViewItemChart(item) ||
                         isResourceViewItemDashboard(item);
@@ -142,21 +141,22 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                             onClick={(e) => e.stopPropagation()}
                         >
                             <Group noWrap>
-                                {canBelongToSpace ? (
+                                {canBelongToSpace &&
+                                item.data.validationErrors?.length ? (
                                     <ResourceIconWithIndicator
                                         iconProps={{
                                             fill: 'red',
                                             icon: IconAlertTriangle,
                                         }}
                                         tooltipProps={{
-                                            w: 300,
+                                            maw: 300,
                                             withinPortal: true,
                                             multiline: true,
                                             offset: -2,
                                             position: 'bottom',
                                         }}
                                         disabled={
-                                            !item.data.validationErrors?.length
+                                            !item.data.validationErrors.length
                                         }
                                         tooltipLabel={
                                             canUserManageValidation ? (
@@ -167,7 +167,15 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                     <Anchor
                                                         component={Link}
                                                         fw={600}
-                                                        to={`/generalSettings/projectManagement/${projectUuid}/validator`}
+                                                        to={{
+                                                            pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
+                                                            state: {
+                                                                validationId:
+                                                                    item.data
+                                                                        .validationErrors[0]
+                                                                        .validationId,
+                                                            },
+                                                        }}
                                                         color="blue.4"
                                                     >
                                                         here
@@ -176,38 +184,13 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                 </>
                                             ) : (
                                                 <>
-                                                    This content is broken.
-                                                    Click{' '}
-                                                    <Text
-                                                        span
-                                                        sx={{
-                                                            cursor: 'pointer',
-                                                        }}
-                                                        fw={600}
-                                                        color={
-                                                            clipboard.copied
-                                                                ? 'teal'
-                                                                : 'blue.4'
-                                                        }
-                                                        onClickCapture={(
-                                                            e: React.MouseEvent<
-                                                                HTMLSpanElement,
-                                                                MouseEvent
-                                                            >,
-                                                        ) => {
-                                                            e.stopPropagation();
-                                                            // TODO: improve message / or change
-
-                                                            // clipboard.copy(
-                                                            //     validationError?.error,
-                                                            // );
-                                                        }}
-                                                    >
-                                                        here to copy the error
-                                                    </Text>{' '}
-                                                    then share it with a
-                                                    developer or admin in your
-                                                    project to get more details.
+                                                    There's an error with this{' '}
+                                                    {isResourceViewItemChart(
+                                                        item,
+                                                    )
+                                                        ? 'chart'
+                                                        : 'dashboard'}
+                                                    .
                                                 </>
                                             )
                                         }
@@ -379,7 +362,6 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
             columnVisibility,
             projectUuid,
             canUserManageValidation,
-            clipboard,
             spaces,
             onAction,
         ],

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -157,7 +157,9 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                 error(s){' '}
                                                 <Anchor
                                                     component={Link}
+                                                    fw={600}
                                                     to={`/generalSettings/projectManagement/${projectUuid}/validator`}
+                                                    color="blue.4"
                                                 >
                                                     here
                                                 </Anchor>

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -3,7 +3,6 @@ import {
     ChartKind,
     ResourceViewItem,
     ResourceViewItemType,
-    ValidationResponse,
 } from '@lightdash/common';
 import moment from 'moment';
 
@@ -85,23 +84,4 @@ export const getResourceViewsSinceWhenDescription = (
               item.data.firstViewedAt,
           ).format('MMM D, YYYY h:mm A')}`
         : undefined;
-};
-
-export const getResourceValidationError = (
-    item: ResourceViewItem,
-    validationErrors: ValidationResponse[] | undefined,
-) => {
-    switch (item.type) {
-        case ResourceViewItemType.CHART:
-            return validationErrors?.find(
-                (error) => error.chartUuid === item.data.uuid,
-            );
-        case ResourceViewItemType.DASHBOARD:
-            return validationErrors?.find(
-                (error) => error.dashboardUuid === item.data.uuid,
-            );
-        case ResourceViewItemType.SPACE:
-        default:
-            return undefined;
-    }
 };

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -3,6 +3,7 @@ import {
     ChartKind,
     ResourceViewItem,
     ResourceViewItemType,
+    ValidationResponse,
 } from '@lightdash/common';
 import moment from 'moment';
 
@@ -84,4 +85,23 @@ export const getResourceViewsSinceWhenDescription = (
               item.data.firstViewedAt,
           ).format('MMM D, YYYY h:mm A')}`
         : undefined;
+};
+
+export const hasResourceValidationError = (
+    item: ResourceViewItem,
+    validationErrors: ValidationResponse[] | undefined,
+) => {
+    switch (item.type) {
+        case ResourceViewItemType.CHART:
+            return !!validationErrors?.find(
+                (error) => error.chartUuid === item.data.uuid,
+            );
+        case ResourceViewItemType.DASHBOARD:
+            return !!validationErrors?.find(
+                (error) => error.dashboardUuid === item.data.uuid,
+            );
+        case ResourceViewItemType.SPACE:
+        default:
+            return false;
+    }
 };

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -87,21 +87,21 @@ export const getResourceViewsSinceWhenDescription = (
         : undefined;
 };
 
-export const hasResourceValidationError = (
+export const getResourceValidationError = (
     item: ResourceViewItem,
     validationErrors: ValidationResponse[] | undefined,
 ) => {
     switch (item.type) {
         case ResourceViewItemType.CHART:
-            return !!validationErrors?.find(
+            return validationErrors?.find(
                 (error) => error.chartUuid === item.data.uuid,
             );
         case ResourceViewItemType.DASHBOARD:
-            return !!validationErrors?.find(
+            return validationErrors?.find(
                 (error) => error.dashboardUuid === item.data.uuid,
             );
         case ResourceViewItemType.SPACE:
         default:
-            return false;
+            return undefined;
     }
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5325

### Description:

Add warning icon to `ResourceIcon`s in case there are validation errors for that chart/dashboard

The tooltip is different between admins/developers and the rest of the org. 

For Admins/Developers:

https://github.com/lightdash/lightdash/assets/7611706/b558d907-117b-43f7-8528-f231c5a59eef

on click of link in tooltip, the user gets redirected to the validator page and scrolled to the first error and it gets highlighted. 


For Non-admins/developers:

https://github.com/lightdash/lightdash/assets/7611706/76f3a96e-dc3e-4a21-bf6b-fd88450e0cda


More scenarios:


https://github.com/lightdash/lightdash/assets/7611706/5e8c351c-4ed2-4431-a328-c4d95b390271





NB: Had to control the `Tooltip` component so we can interact with its content on hover. Hopefully, the comments make sense. 
