### PR TITLE
fix: replace truncate function for Bigquery timestamps

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -85,7 +85,7 @@ const bigqueryConfig: WarehouseConfig = {
                 ? `${timeFrame}(${bigqueryStartOfWeekMap[startOfWeek]})`
                 : timeFrame;
         if (type === DimensionType.TIMESTAMP) {
-            return `DATETIME_TRUNC(${originalSql}, ${datePart})`;
+            return `TIMESTAMP_TRUNC(${originalSql}, ${datePart})`;
         }
         return `DATE_TRUNC(${originalSql}, ${datePart})`;
     },


### PR DESCRIPTION
Closes: #5559

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
