### PR TITLE
fix: get space summary sql to exclude null values from access array

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -103,7 +103,7 @@ export class SpaceModel {
                     name: this.database.raw('max(spaces.name)'),
                     isPrivate: this.database.raw('bool_or(spaces.is_private)'),
                     access: this.database.raw(
-                        'jsonb_agg(shared_with.user_uuid)',
+                        "COALESCE(json_agg(shared_with.user_uuid) FILTER (WHERE shared_with.user_uuid IS NOT NULL), '[]')",
                     ),
                 });
             if (filters.projectUuid) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes: 
- exclude null values from access array

Before: `[null]`

![Captura de ecrã 2023-05-23, às 09 31 02](https://github.com/lightdash/lightdash/assets/9117144/b65cb82e-3c49-4efa-8320-38a86fb7ca72)

After: `[]` 
![Captura de ecrã 2023-05-23, às 09 45 49](https://github.com/lightdash/lightdash/assets/9117144/ccb22371-a254-4298-8e6f-2503a6cad6d8)
