### PR TITLE
fix: duplicated tile uuids

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -27,7 +27,6 @@ import {
 } from '@lightdash/warehouses';
 import { Knex } from 'knex';
 import { DatabaseError } from 'pg';
-import { v4 as uuid4 } from 'uuid';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DbDashboard } from '../../database/entities/dashboards';
 import { OrganizationTableName } from '../../database/entities/organizations';
@@ -1023,7 +1022,7 @@ export class ProjectModel {
 
             const dashboardTiles = await trx('dashboard_tiles').whereIn(
                 'dashboard_version_id',
-                lastDashboardVersionsIds.map((d) => d.max),
+                dashboardVersionIds,
             );
 
             Logger.debug(
@@ -1040,7 +1039,7 @@ export class ProjectModel {
                           .insert(
                               dashboardTiles.map((d) => ({
                                   ...d,
-                                  dashboard_tile_uuid: uuid4(),
+                                  // we keep the same dashboard_tile_uuid
                                   dashboard_version_id:
                                       dashboardVersionsMapping.find(
                                           (m) =>

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -945,7 +945,7 @@ export class ProjectModel {
             );
             await copyChartVersionContent(
                 'saved_queries_version_additional_metrics',
-                'saved_queries_additional_metric_id',
+                'saved_queries_version_additional_metric_id',
             );
 
             const dashboards = await trx('dashboards')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

The tile_uuids behave a bit different to other uuids, i tis important we keep the same uuid between dashboard versions, as they need to match version + tile uuid 

![image](https://github.com/lightdash/lightdash/assets/1983672/78dfec59-4139-4900-b7eb-efc365cbd3c4)

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
