### PR TITLE
chore: end pg pool after query (stacked 1)

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -153,6 +153,10 @@ export type WarehouseCredentials =
     | DatabricksCredentials
     | TrinoCredentials;
 
+export type CreatePostgresLikeCredentials =
+    | CreateRedshiftCredentials
+    | CreatePostgresCredentials;
+
 export interface DbtProjectConfigBase {
     type: DbtProjectType;
 }

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -28,16 +28,17 @@ describe('PostgresWarehouseClient', () => {
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
     });
-    it('expect schema with postgres types mapped to dimension types', async () => {
-        const warehouse = new PostgresWarehouseClient(credentials);
-        (warehouse.pool.query as jest.Mock).mockImplementationOnce(() => ({
-            fields: queryColumnsMock,
-            rows: columns,
-        }));
-        expect(await warehouse.getCatalog(config)).toEqual(
-            expectedWarehouseSchema,
-        );
-    });
+    // How to mock?
+    // it('expect schema with postgres types mapped to dimension types', async () => {
+    //     const warehouse = new PostgresWarehouseClient(credentials);
+    //     (warehouse.pool.query as jest.Mock).mockImplementationOnce(() => ({
+    //         fields: queryColumnsMock,
+    //         rows: columns,
+    //     }));
+    //     expect(await warehouse.getCatalog(config)).toEqual(
+    //         expectedWarehouseSchema,
+    //     );
+    // });
     it('expect empty catalog when dbt project has no references', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         expect(await warehouse.getCatalog([])).toEqual({});

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -1,3 +1,4 @@
+import * as pg from 'pg';
 import { PostgresWarehouseClient } from './PostgresWarehouseClient';
 import {
     columns,
@@ -29,17 +30,19 @@ describe('PostgresWarehouseClient', () => {
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
     });
-    // How to mock?
-    // it('expect schema with postgres types mapped to dimension types', async () => {
-    //     const warehouse = new PostgresWarehouseClient(credentials);
-    //     (warehouse.pool.query as jest.Mock).mockImplementationOnce(() => ({
-    //         fields: queryColumnsMock,
-    //         rows: columns,
-    //     }));
-    //     expect(await warehouse.getCatalog(config)).toEqual(
-    //         expectedWarehouseSchema,
-    //     );
-    // });
+    it('expect schema with postgres types mapped to dimension types', async () => {
+        const warehouse = new PostgresWarehouseClient(credentials);
+        (pg.Pool as unknown as jest.Mock).mockImplementationOnce(() => ({
+            query: jest.fn(() => ({
+                fields: queryColumnsMock,
+                rows: columns,
+            })),
+            end: jest.fn(),
+        }));
+        expect(await warehouse.getCatalog(config)).toEqual(
+            expectedWarehouseSchema,
+        );
+    });
     it('expect empty catalog when dbt project has no references', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         expect(await warehouse.getCatalog([])).toEqual({});

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -18,6 +18,7 @@ jest.mock('pg', () => ({
             fields: queryColumnsMock,
             rows: [expectedRow],
         })),
+        end: jest.fn(),
     })),
 }));
 


### PR DESCRIPTION
Stacked PR1 for #2650 (original big PR: https://github.com/lightdash/lightdash/pull/5612)

Needed for SSH Tunnels because the pool must be killed before we close an SSH tunnel. 