### PR TITLE
fix: big number comp arrow margin

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -184,7 +184,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                                     size={18}
                                     style={{
                                         display: 'inline',
-                                        margin: '0 7px 0 3px',
+                                        margin: '0 7px 0 0px',
                                     }}
                                 />
                             ) : comparisonDiff ===


### PR DESCRIPTION
Closes: #5591 

### Description:
<img width="1055" alt="Screenshot 2023-05-25 at 11 27 20" src="https://github.com/lightdash/lightdash/assets/67699259/cc0acd82-7d4d-473e-9113-f8b56e22ca51">
