### PR TITLE
fix: get fieldId for dashboard error filter

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -312,7 +312,7 @@ export class ValidationService {
                         acc,
                         existingFieldIds,
                         filter.target.fieldId,
-                        `Filter error: the field '${filter}' no longer exists`,
+                        `Filter error: the field '${filter.target.fieldId}' no longer exists`,
                     ),
                 [],
             );


### PR DESCRIPTION

### Description:

Similar to the way we get the `fieldId` for error filters in charts, we should do the same for dashboards