### PR TITLE
fix: project dropdown styling

### DIFF
--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -113,7 +113,7 @@ const NavBar = memo(() => {
                     {activeProjectUuid && (
                         <Select
                             size="xs"
-                            w={200}
+                            w={250}
                             disabled={isLoading || (projects || []).length <= 0}
                             data={
                                 projects?.map((item) => ({


### PR DESCRIPTION
Closes: #5366 

### Description:
Increased the width to match the global search width `200px` > `250px`
<img width="325" alt="Screenshot 2023-05-25 at 17 00 28" src="https://github.com/lightdash/lightdash/assets/67699259/57229c9f-5a15-4f82-acea-4d76e6b5d86f">