### PR TITLE
fix: toggle tables results total

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -63,6 +63,7 @@ export type TableChart = {
     showRowCalculation?: boolean;
     showTableNames?: boolean;
     hideRowNumbers?: boolean;
+    showResultsTotal?: boolean;
     columns?: Record<string, ColumnProperties>;
     conditionalFormattings?: ConditionalFormattingConfig[];
     metricsAsRows?: boolean;

--- a/packages/e2e/cypress/e2e/sqlrunner.cy.ts
+++ b/packages/e2e/cypress/e2e/sqlrunner.cy.ts
@@ -23,7 +23,6 @@ describe('SQL Runner', () => {
             .type('{ctrl}{enter}');
 
         const find = [
-            '1 result',
             'First name',
             firstCustomer.created,
             firstCustomer.firstName,
@@ -70,8 +69,5 @@ describe('SQL Runner', () => {
         const sql = `select a from ( values ('foo'), ('bar')) s(a);`;
 
         cy.get('.ace_content').type(sql).type('{ctrl}{enter}');
-
-        const find = ['2 results'];
-        find.forEach((text) => cy.findAllByText(text));
     });
 });

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -106,7 +106,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 return <CellContextMenu {...props} />;
             }}
             pagination={{
-                showResultsTotal: showResultsTotal,
+                showResultsTotal,
             }}
             {...rest}
         />

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -39,6 +39,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
             pivotTableData,
             getFieldLabel,
             getField,
+            showResultsTotal,
         },
         isSqlRunner,
         explore,
@@ -103,6 +104,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         />
                     );
                 return <CellContextMenu {...props} />;
+            }}
+            pagination={{
+                showResultsTotal: showResultsTotal,
             }}
             {...rest}
         />

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -105,9 +105,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                     );
                 return <CellContextMenu {...props} />;
             }}
-            pagination={{
-                showResultsTotal,
-            }}
+            pagination={{ showResultsTotal }}
             {...rest}
         />
     );

--- a/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
@@ -239,7 +239,7 @@ const GeneralSettings: FC = () => {
                 />
             </FormGroup>
             <FormGroup label="Columns">
-                <ColumnConfiguration />
+                <ColumnConfiguration fieldId={''} />
             </FormGroup>
         </>
     );

--- a/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
@@ -29,6 +29,8 @@ const GeneralSettings: FC = () => {
             setShowColumnCalculation,
             showRowCalculation,
             setShowRowCalculation,
+            showResultsTotal,
+            setShowResultsTotal,
             metricsAsRows,
             setMetricsAsRows,
             canUsePivotTable,
@@ -228,6 +230,16 @@ const GeneralSettings: FC = () => {
                         setShowColumnCalculation(!showColumnCalculation);
                     }}
                 />
+                <Checkbox
+                    label="Show results total"
+                    checked={showResultsTotal}
+                    onChange={() => {
+                        setShowResultsTotal(!showResultsTotal);
+                    }}
+                />
+            </FormGroup>
+            <FormGroup label="Columns">
+                <ColumnConfiguration />
             </FormGroup>
         </>
     );

--- a/packages/frontend/src/components/common/Table/TablePagination/index.tsx
+++ b/packages/frontend/src/components/common/Table/TablePagination/index.tsx
@@ -61,9 +61,9 @@ const TablePagination = () => {
                         disabled={!table.getCanNextPage()}
                     />
                 </PaginationWrapper>
-            ) : (
+            ) : pagination?.showResultsTotal ? (
                 <ResultCount count={table.getRowModel().rows.length} />
-            )}
+            ) : null}
         </TableFooter>
     );
 };

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -38,6 +38,7 @@ type Props = {
     pagination?: {
         show?: boolean;
         defaultScroll?: boolean;
+        showResultsTotal?: boolean;
     };
     hideRowNumbers?: boolean;
     showColumnCalculation?: boolean;

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -43,8 +43,9 @@ const useTableConfig = (
             ? true
             : tableChartConfig.showTableNames,
     );
-
-   const [showResultsTotal, setShowResultsTotal] = useState<boolean>(tableChartConfig?.showResultsTotal ?? false);
+    const [showResultsTotal, setShowResultsTotal] = useState<boolean>(
+        tableChartConfig?.showResultsTotal ?? false,
+    );
     const [hideRowNumbers, setHideRowNumbers] = useState<boolean>(
         tableChartConfig?.hideRowNumbers === undefined
             ? false

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -44,12 +44,7 @@ const useTableConfig = (
             : tableChartConfig.showTableNames,
     );
 
-    const [showResultsTotal, setShowResultsTotal] = useState<boolean>(
-        tableChartConfig?.showResultsTotal === undefined
-            ? false
-            : tableChartConfig.showResultsTotal,
-    );
-
+   const [showResultsTotal, setShowResultsTotal] = useState<boolean>(tableChartConfig?.showResultsTotal ?? false);
     const [hideRowNumbers, setHideRowNumbers] = useState<boolean>(
         tableChartConfig?.hideRowNumbers === undefined
             ? false

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -44,6 +44,12 @@ const useTableConfig = (
             : tableChartConfig.showTableNames,
     );
 
+    const [showResultsTotal, setShowResultsTotal] = useState<boolean>(
+        tableChartConfig?.showResultsTotal === undefined
+            ? false
+            : tableChartConfig.showResultsTotal,
+    );
+
     const [hideRowNumbers, setHideRowNumbers] = useState<boolean>(
         tableChartConfig?.hideRowNumbers === undefined
             ? false
@@ -288,6 +294,7 @@ const useTableConfig = (
             showColumnCalculation,
             showRowCalculation,
             showTableNames,
+            showResultsTotal,
             columns: columnProperties,
             hideRowNumbers,
             conditionalFormattings,
@@ -298,6 +305,7 @@ const useTableConfig = (
             showRowCalculation,
             hideRowNumbers,
             showTableNames,
+            showResultsTotal,
             columnProperties,
             conditionalFormattings,
             metricsAsRows,
@@ -316,6 +324,8 @@ const useTableConfig = (
         setShowTableNames,
         hideRowNumbers,
         setHideRowNumbers,
+        showResultsTotal,
+        setShowResultsTotal,
         columnProperties,
         setColumnProperties,
         updateColumnProperty,


### PR DESCRIPTION
Closes: #5360 

### Description:

https://github.com/lightdash/lightdash/assets/67699259/e977cdce-06e0-42be-ba4f-c53c8ab4d64e

- [x] Add an option `Show total number of results` to the chart config panel when editing a table.
- [x] Disabled by default
