### PR TITLE
feat: settings restructure - project switcher

### DIFF
--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../hooks/useActiveProject';
 import { useProjects } from '../../hooks/useProjects';
 
-const routesToReplace = (activeProjectUuid: string) => [
+const swappableProjectRoutes = (activeProjectUuid: string) => [
     `/projects/${activeProjectUuid}/home`,
     `/projects/${activeProjectUuid}/saved`,
     `/projects/${activeProjectUuid}/dashboards`,
@@ -37,15 +37,18 @@ const ProjectSwitcher = () => {
         useActiveProjectUuid();
     const { mutate: setLastProjectMutation } = useUpdateActiveProjectMutation();
 
-    const isHomePage = useRouteMatch({
+    const isHomePage = !!useRouteMatch({
         path: '/projects/:projectUuid/home',
         exact: true,
     });
-    const replaceRouteMatch = useRouteMatch(
+
+    const swappableRouteMatch = useRouteMatch(
         activeProjectUuid
-            ? { path: routesToReplace(activeProjectUuid), exact: true }
+            ? { path: swappableProjectRoutes(activeProjectUuid), exact: true }
             : [],
     );
+
+    const shouldSwapProjectRoute = !!swappableRouteMatch && activeProjectUuid;
 
     if (isLoadingProjects || isLoadingActiveProjectUuid) {
         return null;
@@ -65,20 +68,23 @@ const ProjectSwitcher = () => {
         showToastSuccess({
             icon: 'tick',
             title: `You are now viewing ${project.name}`,
-            action: isHomePage
-                ? undefined
-                : {
-                      text: 'Go to project home',
-                      icon: 'arrow-right',
-                      onClick: () => {
-                          history.push(`/projects/${project.projectUuid}/home`);
-                      },
-                  },
+            action:
+                !isHomePage && shouldSwapProjectRoute
+                    ? {
+                          text: 'Go to project home',
+                          icon: 'arrow-right',
+                          onClick: () => {
+                              history.push(
+                                  `/projects/${project.projectUuid}/home`,
+                              );
+                          },
+                      }
+                    : undefined,
         });
 
-        if (activeProjectUuid && replaceRouteMatch) {
+        if (shouldSwapProjectRoute) {
             history.push(
-                replaceRouteMatch.path.replace(
+                swappableRouteMatch.path.replace(
                     activeProjectUuid,
                     project.projectUuid,
                 ),

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -3,11 +3,11 @@ import { Select } from '@mantine/core';
 import { useQueryClient } from 'react-query';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import useToaster from '../../hooks/toaster/useToaster';
-import { useActiveProjectUuid } from '../../hooks/useProject';
 import {
-    useProjects,
+    useActiveProjectUuid,
     useUpdateActiveProjectMutation,
-} from '../../hooks/useProjects';
+} from '../../hooks/useActiveProject';
+import { useProjects } from '../../hooks/useProjects';
 
 const routesToReplace = (activeProjectUuid: string) => [
     `/projects/${activeProjectUuid}/home`,

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -1,6 +1,5 @@
 import { ProjectType } from '@lightdash/common';
 import { Select } from '@mantine/core';
-import { useQueryClient } from 'react-query';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import useToaster from '../../hooks/toaster/useToaster';
 import {
@@ -28,7 +27,6 @@ const swappableProjectRoutes = (activeProjectUuid: string) => [
 ];
 
 const ProjectSwitcher = () => {
-    const queryClient = useQueryClient();
     const { showToastSuccess } = useToaster();
     const history = useHistory();
 
@@ -59,9 +57,6 @@ const ProjectSwitcher = () => {
 
         const project = projects?.find((p) => p.projectUuid === newUuid);
         if (!project) return;
-
-        queryClient.removeQueries('project');
-        queryClient.removeQueries('projects');
 
         setLastProjectMutation(project.projectUuid);
 

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -6,7 +6,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 import { useActiveProjectUuid } from '../../hooks/useProject';
 import {
     useProjects,
-    useSetLastProjectMutation,
+    useUpdateActiveProjectMutation,
 } from '../../hooks/useProjects';
 
 const routesToReplace = (activeProjectUuid: string) => [
@@ -35,7 +35,7 @@ const ProjectSwitcher = () => {
     const { isLoading: isLoadingProjects, data: projects = [] } = useProjects();
     const { isLoading: isLoadingActiveProjectUuid, activeProjectUuid } =
         useActiveProjectUuid();
-    const { mutate: setLastProjectMutation } = useSetLastProjectMutation();
+    const { mutate: setLastProjectMutation } = useUpdateActiveProjectMutation();
 
     const isHomePage = useRouteMatch({
         path: '/projects/:projectUuid/home',

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -1,0 +1,113 @@
+import { ProjectType } from '@lightdash/common';
+import { Select } from '@mantine/core';
+import { useQueryClient } from 'react-query';
+import { useHistory, useRouteMatch } from 'react-router-dom';
+import useToaster from '../../hooks/toaster/useToaster';
+import { useActiveProjectUuid } from '../../hooks/useProject';
+import {
+    useProjects,
+    useSetLastProjectMutation,
+} from '../../hooks/useProjects';
+
+const routesToReplace = (activeProjectUuid: string) => [
+    `/projects/${activeProjectUuid}/home`,
+    `/projects/${activeProjectUuid}/saved`,
+    `/projects/${activeProjectUuid}/dashboards`,
+    `/projects/${activeProjectUuid}/spaces`,
+    `/projects/${activeProjectUuid}/sqlRunner`,
+    `/projects/${activeProjectUuid}/tables`,
+    `/projects/${activeProjectUuid}/user-activity`,
+    `/projects/${activeProjectUuid}`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/settings`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/tablesConfiguration`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/projectAccess`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/integrations/dbt-cloud`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/usageAnalytics`,
+    `/generalSettings/projectManagement/${activeProjectUuid}/scheduledDeliveries`,
+    `/generalSettings/projectManagement/${activeProjectUuid}`,
+];
+
+const ProjectSwitcher = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess } = useToaster();
+    const history = useHistory();
+
+    const { isLoading: isLoadingProjects, data: projects = [] } = useProjects();
+    const { isLoading: isLoadingActiveProjectUuid, activeProjectUuid } =
+        useActiveProjectUuid();
+    const { mutate: setLastProjectMutation } = useSetLastProjectMutation();
+
+    const isHomePage = useRouteMatch({
+        path: '/projects/:projectUuid/home',
+        exact: true,
+    });
+    const replaceRouteMatch = useRouteMatch(
+        activeProjectUuid
+            ? { path: routesToReplace(activeProjectUuid), exact: true }
+            : [],
+    );
+
+    if (isLoadingProjects || isLoadingActiveProjectUuid) {
+        return null;
+    }
+
+    const handleProjectChange = (newUuid: string) => {
+        if (!newUuid) return;
+
+        const project = projects?.find((p) => p.projectUuid === newUuid);
+
+        if (!project) return;
+
+        queryClient.removeQueries('project');
+        queryClient.removeQueries('projects');
+
+        setLastProjectMutation(project.projectUuid);
+
+        showToastSuccess({
+            icon: 'tick',
+            title: `You are now viewing ${project.name}`,
+            action: isHomePage
+                ? undefined
+                : {
+                      text: 'Go to project home',
+                      icon: 'arrow-right',
+                      onClick: () => {
+                          history.push(`/projects/${project.projectUuid}/home`);
+                      },
+                  },
+        });
+
+        if (activeProjectUuid && replaceRouteMatch) {
+            history.replace(
+                replaceRouteMatch.path.replace(
+                    activeProjectUuid,
+                    project.projectUuid,
+                ),
+            );
+        } else {
+            history.push(`/projects/${project.projectUuid}/home`);
+        }
+    };
+
+    return (
+        <Select
+            size="xs"
+            w={250}
+            disabled={
+                isLoadingProjects ||
+                isLoadingActiveProjectUuid ||
+                projects.length <= 0
+            }
+            data={projects.map((item) => ({
+                value: item.projectUuid,
+                label: `${
+                    item.type === ProjectType.PREVIEW ? '[Preview] ' : ''
+                }${item.name}`,
+            }))}
+            value={activeProjectUuid}
+            onChange={handleProjectChange}
+        />
+    );
+};
+
+export default ProjectSwitcher;

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -55,7 +55,6 @@ const ProjectSwitcher = () => {
         if (!newUuid) return;
 
         const project = projects?.find((p) => p.projectUuid === newUuid);
-
         if (!project) return;
 
         queryClient.removeQueries('project');
@@ -78,7 +77,7 @@ const ProjectSwitcher = () => {
         });
 
         if (activeProjectUuid && replaceRouteMatch) {
-            history.replace(
+            history.push(
                 replaceRouteMatch.path.replace(
                     activeProjectUuid,
                     project.projectUuid,

--- a/packages/frontend/src/components/NavBar/SettingsMenu.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu.tsx
@@ -16,9 +16,9 @@ const SettingsMenu: FC = () => {
     const {
         user: { data: user },
     } = useApp();
-    const activeProjectUuid = useActiveProjectUuid();
+    const { activeProjectUuid } = useActiveProjectUuid();
 
-    if (!user) return null;
+    if (!user || !activeProjectUuid) return null;
 
     const userCanViewOrganization = user.ability.can(
         'view',

--- a/packages/frontend/src/components/NavBar/SettingsMenu.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu.tsx
@@ -8,7 +8,7 @@ import { FC } from 'react';
 
 import { Button, Menu } from '@mantine/core';
 import { Link } from 'react-router-dom';
-import { useActiveProjectUuid } from '../../hooks/useProject';
+import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useApp } from '../../providers/AppProvider';
 import MantineIcon from '../common/MantineIcon';
 

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -13,7 +13,7 @@ import {
 import { IconTool } from '@tabler/icons-react';
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
-import { useActiveProjectUuid } from '../../hooks/useProject';
+import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProjects } from '../../hooks/useProjects';
 import { useErrorLogs } from '../../providers/ErrorLogsProvider';
 import { ReactComponent as Logo } from '../../svgs/logo-icon.svg';

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -8,15 +8,13 @@ import {
     Group,
     Header,
     MantineProvider,
-    Select,
     Text,
 } from '@mantine/core';
 import { IconTool } from '@tabler/icons-react';
 import { memo } from 'react';
-import { Link, useHistory } from 'react-router-dom';
-import useToaster from '../../hooks/toaster/useToaster';
+import { Link } from 'react-router-dom';
 import { useActiveProjectUuid } from '../../hooks/useProject';
-import { setLastProject, useProjects } from '../../hooks/useProjects';
+import { useProjects } from '../../hooks/useProjects';
 import { useErrorLogs } from '../../providers/ErrorLogsProvider';
 import { ReactComponent as Logo } from '../../svgs/logo-icon.svg';
 import MantineIcon from '../common/MantineIcon';
@@ -28,6 +26,7 @@ import GlobalSearch from './GlobalSearch';
 import HeadwayMenuItem from './HeadwayMenuItem';
 import HelpMenu from './HelpMenu';
 import { NotificationsMenu } from './NotificationsMenu';
+import ProjectSwitcher from './ProjectSwitcher';
 import SettingsMenu from './SettingsMenu';
 import UserMenu from './UserMenu';
 
@@ -46,11 +45,9 @@ const PreviewBanner = () => (
 
 const NavBar = memo(() => {
     const { errorLogs, setErrorLogsVisible } = useErrorLogs();
-    const { showToastSuccess } = useToaster();
-    const { isLoading, data: projects } = useProjects();
-    const activeProjectUuid = useActiveProjectUuid();
-
-    const history = useHistory();
+    const { data: projects } = useProjects();
+    const { activeProjectUuid, isLoading: isLoadingActiveProject } =
+        useActiveProjectUuid();
 
     const homeUrl = activeProjectUuid
         ? `/projects/${activeProjectUuid}/home`
@@ -96,7 +93,7 @@ const NavBar = memo(() => {
                         <Logo />
                     </ActionIcon>
 
-                    {!!activeProjectUuid && (
+                    {!isLoadingActiveProject && activeProjectUuid ? (
                         <>
                             <Button.Group>
                                 <ExploreMenu projectUuid={activeProjectUuid} />
@@ -111,7 +108,7 @@ const NavBar = memo(() => {
 
                             <GlobalSearch projectUuid={activeProjectUuid} />
                         </>
-                    )}
+                    ) : null}
                 </Group>
 
                 <Box sx={{ flexGrow: 1 }} />
@@ -125,49 +122,24 @@ const NavBar = memo(() => {
 
                     <Button.Group>
                         <SettingsMenu />
-                        {activeProjectUuid && (
+
+                        {!isLoadingActiveProject && activeProjectUuid ? (
                             <NotificationsMenu
                                 projectUuid={activeProjectUuid}
                             />
-                        )}
+                        ) : null}
+
                         <HelpMenu />
-                        <HeadwayMenuItem projectUuid={activeProjectUuid} />
+
+                        {!isLoadingActiveProject && activeProjectUuid ? (
+                            <HeadwayMenuItem projectUuid={activeProjectUuid} />
+                        ) : null}
                     </Button.Group>
 
                     <Divider orientation="vertical" my="xs" color="gray.8" />
 
-                    {activeProjectUuid && (
-                        <Select
-                            size="xs"
-                            w={250}
-                            disabled={isLoading || (projects || []).length <= 0}
-                            data={
-                                projects?.map((item) => ({
-                                    value: item.projectUuid,
-                                    label: `${
-                                        item.type === ProjectType.PREVIEW
-                                            ? '[Preview] '
-                                            : ''
-                                    }${item.name}`,
-                                })) ?? []
-                            }
-                            value={activeProjectUuid}
-                            onChange={(newUuid) => {
-                                if (!newUuid) return;
+                    <ProjectSwitcher />
 
-                                setLastProject(newUuid);
-                                showToastSuccess({
-                                    icon: 'tick',
-                                    title: `You are now viewing ${
-                                        projects?.find(
-                                            (p) => p.projectUuid === newUuid,
-                                        )?.name
-                                    }`,
-                                });
-                                history.push(`/projects/${newUuid}/home`);
-                            }}
-                        />
-                    )}
                     <UserMenu />
                 </Group>
             </Header>

--- a/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const CardContent = styled.div`
+    display: flex;
+    gap: 10px;
+    height: 24px;
+`;

--- a/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.styles.ts
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-export const CardContent = styled.div`
-    display: flex;
-    gap: 10px;
-    height: 24px;
-`;

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -13,6 +13,8 @@ import { Redirect, useHistory } from 'react-router-dom';
 import {
     useActiveProject,
     useDeleteActiveProjectMutation,
+} from '../../../hooks/useActiveProject';
+import {
     useDeleteProjectMutation,
     useProjects,
 } from '../../../hooks/useProjects';

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -11,9 +11,9 @@ import { Stack } from '@mantine/core';
 import { FC, useState } from 'react';
 import { Redirect, useHistory } from 'react-router-dom';
 import {
-    useDeleteLastProjectMutation,
+    useActiveProject,
+    useDeleteActiveProjectMutation,
     useDeleteProjectMutation,
-    useLastProject,
     useProjects,
 } from '../../../hooks/useProjects';
 import { useApp } from '../../../providers/AppProvider';
@@ -39,7 +39,7 @@ const ProjectListItem: FC<{
     const { mutate: deleteProjectMutation, isLoading: isDeleting } =
         useDeleteProjectMutation();
     const { mutate: deleteLastProjectMutation } =
-        useDeleteLastProjectMutation();
+        useDeleteActiveProjectMutation();
 
     return (
         <SettingsCard shadow="sm">
@@ -133,7 +133,7 @@ const ProjectManagementPanel: FC = () => {
     const history = useHistory();
     const { data: projects = [], isLoading: isLoadingProjects } = useProjects();
     const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
-        useLastProject();
+        useActiveProject();
 
     if (isLoadingProjects || isLoadingLastProject) return null;
 

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import {
+    QueryClient,
+    useMutation,
+    useQuery,
+    useQueryClient,
+} from 'react-query';
 import { useParams } from 'react-router-dom';
 import { useDefaultProject, useProjects } from './useProjects';
 
@@ -20,6 +25,12 @@ export const useActiveProject = () => {
     );
 };
 
+const clearProjectCache = (queryClient: QueryClient) => {
+    queryClient.removeQueries(['project']);
+    queryClient.removeQueries(['projects']);
+    queryClient.invalidateQueries();
+};
+
 export const useUpdateActiveProjectMutation = () => {
     const queryClient = useQueryClient();
 
@@ -28,7 +39,7 @@ export const useUpdateActiveProjectMutation = () => {
             Promise.resolve(
                 localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
             ),
-        onSuccess: () => queryClient.clear(),
+        onSuccess: () => clearProjectCache(queryClient),
     });
 };
 
@@ -38,7 +49,7 @@ export const useDeleteActiveProjectMutation = () => {
     return useMutation<void, Error>({
         mutationFn: () =>
             Promise.resolve(localStorage.removeItem(LAST_PROJECT_KEY)),
-        onSuccess: () => queryClient.clear(),
+        onSuccess: () => clearProjectCache(queryClient),
     });
 };
 

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useParams } from 'react-router-dom';
+import { useDefaultProject, useProjects } from './useProjects';
+
+const LAST_PROJECT_KEY = 'lastProject';
+
+export const useActiveProject = () => {
+    return useQuery<string | undefined>(
+        ['activeProject'],
+        () =>
+            Promise.resolve(
+                localStorage.getItem(LAST_PROJECT_KEY) || undefined,
+            ),
+        {
+            cacheTime: 0,
+            refetchOnWindowFocus: false,
+            refetchOnMount: false,
+            refetchOnReconnect: false,
+        },
+    );
+};
+
+export const useUpdateActiveProjectMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<void, Error, string>({
+        mutationFn: (projectUuid) =>
+            Promise.resolve(
+                localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
+            ),
+        onSuccess: () => queryClient.clear(),
+    });
+};
+
+export const useDeleteActiveProjectMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<void, Error>({
+        mutationFn: () =>
+            Promise.resolve(localStorage.removeItem(LAST_PROJECT_KEY)),
+        onSuccess: () => queryClient.clear(),
+    });
+};
+
+export const useActiveProjectUuid = () => {
+    const params = useParams<{ projectUuid?: string }>();
+    const { data: projects, isLoading: isLoadingProjects } = useProjects();
+    const { data: defaultProject, isLoading: isLoadingDefaultProject } =
+        useDefaultProject();
+    const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
+        useActiveProject();
+
+    if (isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject) {
+        return {
+            isLoading: true,
+            activeProjectUuid: undefined,
+        };
+    }
+
+    const lastProject = projects?.find(
+        (project) => project.projectUuid === lastProjectUuid,
+    );
+
+    return {
+        isLoading: false,
+        activeProjectUuid:
+            params.projectUuid ||
+            lastProject?.projectUuid ||
+            defaultProject?.projectUuid,
+    };
+};

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -10,7 +10,11 @@ import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useActiveJob } from '../providers/ActiveJobProvider';
 import useToaster from './toaster/useToaster';
-import { useDefaultProject, useLastProject, useProjects } from './useProjects';
+import {
+    useActiveProject,
+    useDefaultProject,
+    useProjects,
+} from './useProjects';
 import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
@@ -99,7 +103,7 @@ export const useActiveProjectUuid = () => {
     const { data: defaultProject, isLoading: isLoadingDefaultProject } =
         useDefaultProject();
     const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
-        useLastProject();
+        useActiveProject();
 
     if (isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject) {
         return {

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useActiveJob } from '../providers/ActiveJobProvider';
 import useToaster from './toaster/useToaster';
-import { getLastProject, useDefaultProject, useProjects } from './useProjects';
+import { useDefaultProject, useLastProject, useProjects } from './useProjects';
 import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
@@ -95,17 +95,28 @@ export const useCreateMutation = () => {
 
 export const useActiveProjectUuid = () => {
     const params = useParams<{ projectUuid?: string }>();
-    const { data: defaultProject } = useDefaultProject();
-    const { data: projects } = useProjects();
+    const { data: projects, isLoading: isLoadingProjects } = useProjects();
+    const { data: defaultProject, isLoading: isLoadingDefaultProject } =
+        useDefaultProject();
+    const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
+        useLastProject();
 
-    const lastProjectUuid = getLastProject();
+    if (isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject) {
+        return {
+            isLoading: true,
+            activeProjectUuid: undefined,
+        };
+    }
+
     const lastProject = projects?.find(
         (project) => project.projectUuid === lastProjectUuid,
     );
 
-    return (
-        params.projectUuid ||
-        lastProject?.projectUuid ||
-        defaultProject?.projectUuid
-    );
+    return {
+        isLoading: false,
+        activeProjectUuid:
+            params.projectUuid ||
+            lastProject?.projectUuid ||
+            defaultProject?.projectUuid,
+    };
 };

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -6,15 +6,9 @@ import {
     UpdateProject,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
 import { useActiveJob } from '../providers/ActiveJobProvider';
 import useToaster from './toaster/useToaster';
-import {
-    useActiveProject,
-    useDefaultProject,
-    useProjects,
-} from './useProjects';
 import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
@@ -95,32 +89,4 @@ export const useCreateMutation = () => {
             },
         },
     );
-};
-
-export const useActiveProjectUuid = () => {
-    const params = useParams<{ projectUuid?: string }>();
-    const { data: projects, isLoading: isLoadingProjects } = useProjects();
-    const { data: defaultProject, isLoading: isLoadingDefaultProject } =
-        useDefaultProject();
-    const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
-        useActiveProject();
-
-    if (isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject) {
-        return {
-            isLoading: true,
-            activeProjectUuid: undefined,
-        };
-    }
-
-    const lastProject = projects?.find(
-        (project) => project.projectUuid === lastProjectUuid,
-    );
-
-    return {
-        isLoading: false,
-        activeProjectUuid:
-            params.projectUuid ||
-            lastProject?.projectUuid ||
-            defaultProject?.projectUuid,
-    };
 };

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -25,46 +25,6 @@ export const useProjects = (
     });
 };
 
-const LAST_PROJECT_KEY = 'lastProject';
-
-export const useActiveProject = () => {
-    return useQuery<string | undefined>({
-        queryKey: ['activeProject'],
-        queryFn: () =>
-            Promise.resolve(
-                localStorage.getItem(LAST_PROJECT_KEY) || undefined,
-            ),
-    });
-};
-
-export const useUpdateActiveProjectMutation = () => {
-    const queryClient = useQueryClient();
-
-    return useMutation<void, Error, string>({
-        mutationFn: (projectUuid) => {
-            return Promise.resolve(
-                localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
-            );
-        },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries('activeProject');
-        },
-    });
-};
-
-export const useDeleteActiveProjectMutation = () => {
-    const queryClient = useQueryClient();
-
-    return useMutation<void, Error>({
-        mutationFn: () => {
-            return Promise.resolve(localStorage.removeItem(LAST_PROJECT_KEY));
-        },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries('activeProject');
-        },
-    });
-};
-
 export const useDefaultProject = () => {
     const query = useProjects();
 

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -27,16 +27,42 @@ export const useProjects = (
 
 const LAST_PROJECT_KEY = 'lastProject';
 
-export const getLastProject = (): string | undefined => {
-    return localStorage.getItem(LAST_PROJECT_KEY) || undefined;
+export const useLastProject = () => {
+    return useQuery<string | undefined>({
+        queryKey: ['lastProject'],
+        queryFn: () =>
+            Promise.resolve(
+                localStorage.getItem(LAST_PROJECT_KEY) || undefined,
+            ),
+    });
 };
 
-export const setLastProject = (projectUuid: string) => {
-    localStorage.setItem(LAST_PROJECT_KEY, projectUuid);
+export const useSetLastProjectMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<void, Error, string>({
+        mutationFn: (projectUuid) => {
+            return Promise.resolve(
+                localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
+            );
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries('lastProject');
+        },
+    });
 };
 
-export const deleteLastProject = () => {
-    localStorage.removeItem(LAST_PROJECT_KEY);
+export const useDeleteLastProjectMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<void, Error>({
+        mutationFn: () => {
+            return Promise.resolve(localStorage.removeItem(LAST_PROJECT_KEY));
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries('lastProject');
+        },
+    });
 };
 
 export const useDefaultProject = () => {

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -27,9 +27,9 @@ export const useProjects = (
 
 const LAST_PROJECT_KEY = 'lastProject';
 
-export const useLastProject = () => {
+export const useActiveProject = () => {
     return useQuery<string | undefined>({
-        queryKey: ['lastProject'],
+        queryKey: ['activeProject'],
         queryFn: () =>
             Promise.resolve(
                 localStorage.getItem(LAST_PROJECT_KEY) || undefined,
@@ -37,7 +37,7 @@ export const useLastProject = () => {
     });
 };
 
-export const useSetLastProjectMutation = () => {
+export const useUpdateActiveProjectMutation = () => {
     const queryClient = useQueryClient();
 
     return useMutation<void, Error, string>({
@@ -47,12 +47,12 @@ export const useSetLastProjectMutation = () => {
             );
         },
         onSuccess: async () => {
-            await queryClient.invalidateQueries('lastProject');
+            await queryClient.invalidateQueries('activeProject');
         },
     });
 };
 
-export const useDeleteLastProjectMutation = () => {
+export const useDeleteActiveProjectMutation = () => {
     const queryClient = useQueryClient();
 
     return useMutation<void, Error>({
@@ -60,7 +60,7 @@ export const useDeleteLastProjectMutation = () => {
             return Promise.resolve(localStorage.removeItem(LAST_PROJECT_KEY));
         },
         onSuccess: async () => {
-            await queryClient.invalidateQueries('lastProject');
+            await queryClient.invalidateQueries('activeProject');
         },
     });
 };

--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { Redirect } from 'react-router-dom';
 import ErrorState from '../components/common/ErrorState';
 import PageSpinner from '../components/PageSpinner';
-import { useActiveProjectUuid } from '../hooks/useProject';
+import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useProjects } from '../hooks/useProjects';
 
 const Projects: FC = () => {

--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -7,9 +7,10 @@ import { useProjects } from '../hooks/useProjects';
 
 const Projects: FC = () => {
     const { isLoading, data, error } = useProjects();
-    const activeProjectUuid = useActiveProjectUuid();
+    const { isLoading: isActiveProjectLoading, activeProjectUuid } =
+        useActiveProjectUuid();
 
-    if (isLoading) {
+    if (isLoading || isActiveProjectLoading || !activeProjectUuid) {
         return <PageSpinner />;
     }
     if (error && error.error) {


### PR DESCRIPTION
Closes: #5457 

I’m viewing Project X.
I am on the Usage Analytics page.
I use the project switcher to go to Project Y
I am redirected to the Usage Analytics page for Project Y.
I see the toast confirming this.

### Description:

- [x] unblocks https://github.com/lightdash/lightdash/issues/5420
- [x] affects all subpages under Settings.
- [x] works on most of the project pages like all-charts, all-dashboards, spaces, settings
- [x] bonus: toast shows to navigate to project home