### PR TITLE
chore: track what charts have metric as rows and rows/columns calcula…

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -200,6 +200,9 @@ export type CreateSavedChartOrVersionEvent = BaseTrack & {
         };
         table?: {
             conditionalFormattingRulesCount: number;
+            hasMetricsAsRows: boolean;
+            hasRowCalculation: boolean;
+            hasColumnCalculations: boolean;
         };
         duplicated?: boolean;
     };

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -122,6 +122,10 @@ export class SavedChartService {
                     ? {
                           conditionalFormattingRulesCount:
                               tableConfig?.conditionalFormattings?.length || 0,
+                          hasMetricsAsRows: !!tableConfig?.metricsAsRows,
+                          hasRowCalculation: !!tableConfig?.showRowCalculation,
+                          hasColumnCalculations:
+                              !!tableConfig?.showColumnCalculation,
                       }
                     : undefined,
             cartesian:


### PR DESCRIPTION
…tions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5304 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add `hasMetricsAsRows`, `hasRowCalculation` and `hasColumnCalculations` to events `saved_chart.created` and `saved_chart_version.created`.

The ticket requested this info to be in the `query.executed` event but that information is not available there since it doesn't impact the SQL, only the table viz. 
