### PR TITLE
fix: settings restructure collapsible navbar

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Box, NavLink, Stack, Title } from '@mantine/core';
+import { Box, Stack, Title } from '@mantine/core';
 import {
     IconBuildingSkyscraper,
     IconCalendarStats,
@@ -116,12 +116,12 @@ const Settings: FC = () => {
                         items={[{ title: 'Settings', active: true }]}
                     />
 
-                    <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
-                        <NavLink
-                            label="Your settings"
-                            opened
-                            childrenOffset={0}
-                        >
+                    <Stack spacing="lg" sx={{ flexGrow: 1, overflow: 'auto' }}>
+                        <Box>
+                            <Title order={6} fw={600} mb="xs">
+                                Your settings
+                            </Title>
+
                             <RouterNavLink
                                 exact
                                 to="/generalSettings"
@@ -148,7 +148,7 @@ const Settings: FC = () => {
                                 to="/generalSettings/personalAccessTokens"
                                 icon={<MantineIcon icon={IconKey} />}
                             />
-                        </NavLink>
+                        </Box>
 
                         <Can
                             I="create"
@@ -156,11 +156,11 @@ const Settings: FC = () => {
                                 organizationUuid: organization.organizationUuid,
                             })}
                         >
-                            <NavLink
-                                label="Organization settings"
-                                opened
-                                childrenOffset={0}
-                            >
+                            <Box>
+                                <Title order={6} fw={600} mb="xs">
+                                    Organization settings
+                                </Title>
+
                                 {user.ability.can('manage', 'Organization') && (
                                     <RouterNavLink
                                         label="General"
@@ -224,7 +224,7 @@ const Settings: FC = () => {
                                             }
                                         />
                                     )}
-                            </NavLink>
+                            </Box>
                         </Can>
 
                         {organization &&
@@ -237,11 +237,11 @@ const Settings: FC = () => {
                                 projectUuid: project.projectUuid,
                             }),
                         ) ? (
-                            <NavLink
-                                label={`Current project (${project?.name})`}
-                                opened
-                                childrenOffset={0}
-                            >
+                            <Box>
+                                <Title order={6} fw={600} mb="xs">
+                                    Current project ({project?.name})
+                                </Title>
+
                                 <RouterNavLink
                                     label="Project settings"
                                     exact
@@ -327,9 +327,9 @@ const Settings: FC = () => {
                                         }
                                     />
                                 ) : null}
-                            </NavLink>
+                            </Box>
                         ) : null}
-                    </Box>
+                    </Stack>
                 </Stack>
             }
         >


### PR DESCRIPTION
Closes: #5480 

### Description:

before
<img width="384" alt="CleanShot 2023-05-31 at 12 45 15@2x" src="https://github.com/lightdash/lightdash/assets/962095/1c808b72-170c-45da-9338-0b0f4f9e16c4">

after
<img width="379" alt="CleanShot 2023-05-31 at 12 44 21@2x" src="https://github.com/lightdash/lightdash/assets/962095/6f5e0132-b9e9-42cf-9aea-a0f8fe39fb40">
