### PR TITLE
feat: limit scheduler logs and include chart and dashboard names

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1,16 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import {
-    Controller,
-    fetchMiddlewares,
-    FieldErrors,
-    HttpStatusCodeLiteral,
-    TsoaResponse,
-    TsoaRoute,
-    ValidateError,
-    ValidationService,
-} from '@tsoa/runtime';
+import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute, HttpStatusCodeLiteral, TsoaResponse, fetchMiddlewares } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CsvController } from './../controllers/csvController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -38,1883 +29,599 @@ import { SshController } from './../controllers/sshController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ValidationController } from './../controllers/validationController';
 import type { RequestHandler } from 'express';
 import * as express from 'express';
-import { ValidationController } from './../controllers/validationController';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
-    ApiErrorPayload: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                error: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        data: { dataType: 'any' },
-                        message: { dataType: 'string' },
-                        name: { dataType: 'string', required: true },
-                        statusCode: { dataType: 'double', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['error'], required: true },
-            },
-            validators: {},
-        },
+    "ApiErrorPayload": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"any"},"message":{"dataType":"string"},"name":{"dataType":"string","required":true},"statusCode":{"dataType":"double","required":true}},"required":true},"status":{"dataType":"enum","enums":["error"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiCsvUrlResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: { dataType: 'string', required: true },
-                        url: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiCsvUrlResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true},"url":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateDbtCloudIntegration.metricsJobId_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metricsJobId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Pick_CreateDbtCloudIntegration.metricsJobId_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metricsJobId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudIntegration: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateDbtCloudIntegration.metricsJobId_',
-            validators: {},
-        },
+    "DbtCloudIntegration": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateDbtCloudIntegration.metricsJobId_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudIntegrationSettings: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DbtCloudIntegration' },
-                        { dataType: 'undefined' },
-                    ],
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudIntegrationSettings": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"union","subSchemas":[{"ref":"DbtCloudIntegration"},{"dataType":"undefined"}],"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudSettingsDeleteSuccess: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { dataType: 'undefined', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudSettingsDeleteSuccess": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudMetric: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                label: { dataType: 'string', required: true },
-                timeGrains: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                description: { dataType: 'string', required: true },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                name: { dataType: 'string', required: true },
-                uniqueId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "DbtCloudMetric": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"label":{"dataType":"string","required":true},"timeGrains":{"dataType":"array","array":{"dataType":"string"},"required":true},"description":{"dataType":"string","required":true},"dimensions":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true},"uniqueId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudMetadataResponseMetrics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'DbtCloudMetric' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "DbtCloudMetadataResponseMetrics": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"DbtCloudMetric"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudMetrics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    ref: 'DbtCloudMetadataResponseMetrics',
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudMetrics": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"DbtCloudMetadataResponseMetrics","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Group: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                organizationUuid: { dataType: 'string', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                name: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Group": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organizationUuid":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Group', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiGroupResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Group","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSuccessEmpty: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { dataType: 'undefined', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiSuccessEmpty": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    GroupMember: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "GroupMember": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupMembersResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'GroupMember' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiGroupMembersResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"GroupMember"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Group.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "Pick_Group.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateGroup: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_Group.name_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Organization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                needsProject: { dataType: 'boolean' },
-                chartColors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
-                name: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "UpdateGroup": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_Group.name_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Organization', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Organization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"needsProject":{"dataType":"boolean"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Organization.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "ApiOrganization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Organization","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateOrganization: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_Organization.name_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Omit_Organization.organizationUuid-or-needsProject__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string' },
-                chartColors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
-            },
-            validators: {},
-        },
+    "Pick_Organization.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateOrganization: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Partial_Omit_Organization.organizationUuid-or-needsProject__',
-            validators: {},
-        },
+    "CreateOrganization": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_Organization.name_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberRole: {
-        dataType: 'refEnum',
-        enums: [
-            'member',
-            'viewer',
-            'interactive_viewer',
-            'editor',
-            'developer',
-            'admin',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberProfile: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                isInviteExpired: { dataType: 'boolean' },
-                isActive: { dataType: 'boolean', required: true },
-                role: { ref: 'OrganizationMemberRole', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string"},"chartColors":{"dataType":"array","array":{"dataType":"string"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationMemberProfiles: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'OrganizationMemberProfile',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "UpdateOrganization": {
+        "dataType": "refAlias",
+        "type": {"ref":"Partial_Omit_Organization.organizationUuid-or-needsProject__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationMemberProfile: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'OrganizationMemberProfile', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "OrganizationMemberRole": {
+        "dataType": "refEnum",
+        "enums": ["member","viewer","interactive_viewer","editor","developer","admin"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_OrganizationMemberProfile.role__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { role: { ref: 'OrganizationMemberRole' } },
-            validators: {},
-        },
+    "OrganizationMemberProfile": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isInviteExpired":{"dataType":"boolean"},"isActive":{"dataType":"boolean","required":true},"role":{"ref":"OrganizationMemberRole","required":true},"organizationUuid":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberProfileUpdate: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Partial_Pick_OrganizationMemberProfile.role__',
-            validators: {},
-        },
+    "ApiOrganizationMemberProfiles": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                projectUuids: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                role: { ref: 'OrganizationMemberRole', required: true },
-                emailDomains: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ApiOrganizationMemberProfile": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"OrganizationMemberProfile","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationAllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'AllowedEmailDomains', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Partial_Pick_OrganizationMemberProfile.role__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    role: { ref: 'OrganizationMemberRole', required: true },
-                    emailDomains: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                    projectUuids: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
+    "OrganizationMemberProfileUpdate": {
+        "dataType": "refAlias",
+        "type": {"ref":"Partial_Pick_OrganizationMemberProfile.role__","validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_AllowedEmailDomains.organizationUuid_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__',
-            validators: {},
-        },
+    "AllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"OrganizationMemberRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateAllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_AllowedEmailDomains.organizationUuid_',
-            validators: {},
-        },
+    "ApiOrganizationAllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"AllowedEmailDomains","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateGroup.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'Group' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Omit_AllowedEmailDomains.organizationUuid_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.DASHBOARD': {
-        dataType: 'refEnum',
-        enums: ['dashboard'],
+    "UpdateAllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_AllowedEmailDomains.organizationUuid_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdatedByUser: {
-        dataType: 'refObject',
-        properties: {
-            userUuid: { dataType: 'string', required: true },
-            firstName: { dataType: 'string', required: true },
-            lastName: { dataType: 'string', required: true },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ValidationResponse.error-or-createdAt-or-validationId_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                error: { dataType: 'string', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
+    "Pick_CreateGroup.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationSummary: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationId_',
-            validators: {},
-        },
+    "ApiGroupListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"Group"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    views: { dataType: 'double', required: true },
-                    firstViewedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    validationErrors: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'refAlias',
-                            ref: 'ValidationSummary',
-                        },
-                    },
-                },
-                validators: {},
-            },
-        },
+    "ResourceViewItemType.DASHBOARD": {
+        "dataType": "refEnum",
+        "enums": ["dashboard"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewDashboardItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.DASHBOARD', required: true },
-            },
-            validators: {},
+    "UpdatedByUser": {
+        "dataType": "refObject",
+        "properties": {
+            "userUuid": {"dataType":"string","required":true},
+            "firstName": {"dataType":"string","required":true},
+            "lastName": {"dataType":"string","required":true},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.CHART': {
-        dataType: 'refEnum',
-        enums: ['chart'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartKind: {
-        dataType: 'refEnum',
-        enums: [
-            'line',
-            'horizontal_bar',
-            'vertical_bar',
-            'scatter',
-            'area',
-            'mixed',
-            'table',
-            'big_number',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    views: { dataType: 'double', required: true },
-                    firstViewedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    validationErrors: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'refAlias',
-                            ref: 'ValidationSummary',
-                        },
-                    },
-                    chartType: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'ChartKind' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
+    "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewChartItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.CHART', required: true },
-            },
-            validators: {},
-        },
+    "ValidationSummary": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_ValidationResponse.error-or-createdAt-or-validationId_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.SPACE': {
-        dataType: 'refEnum',
-        enums: ['space'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    projectUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    isPrivate: { dataType: 'boolean', required: true },
-                },
-                validators: {},
-            },
-        },
+    "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewSpaceItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    dataType: 'intersection',
-                    subSchemas: [
-                        {
-                            ref: 'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_',
-                        },
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                chartCount: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                dashboardCount: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                accessListLength: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                access: {
-                                    dataType: 'array',
-                                    array: { dataType: 'string' },
-                                    required: true,
-                                },
-                            },
-                        },
-                    ],
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.SPACE', required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewDashboardItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.DASHBOARD","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    PinnedItems: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'array',
-            array: {
-                dataType: 'union',
-                subSchemas: [
-                    { ref: 'ResourceViewDashboardItem' },
-                    { ref: 'ResourceViewChartItem' },
-                    { ref: 'ResourceViewSpaceItem' },
-                ],
-            },
-            validators: {},
-        },
+    "ResourceViewItemType.CHART": {
+        "dataType": "refEnum",
+        "enums": ["chart"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiPinnedItems: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'PinnedItems', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ChartKind": {
+        "dataType": "refEnum",
+        "enums": ["line","horizontal_bar","vertical_bar","scatter","area","mixed","table","big_number"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewItemType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'space'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                uuid: { dataType: 'string', required: true },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdatePinnedItemOrder: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType', required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewChartItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.CHART","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    projectUuid: { dataType: 'string', required: true },
-                    spaceUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    spaceName: { dataType: 'string', required: true },
-                },
-                validators: {},
-            },
-        },
+    "ResourceViewItemType.SPACE": {
+        "dataType": "refEnum",
+        "enums": ["space"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartSummary: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
-            validators: {},
-        },
+    "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiChartSummaryListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewSpaceItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartCount":{"dataType":"double","required":true},"dashboardCount":{"dataType":"double","required":true},"accessListLength":{"dataType":"double","required":true},"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"required":true},"type":{"ref":"ResourceViewItemType.SPACE","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    projectUuid: { dataType: 'string', required: true },
-                    isPrivate: { dataType: 'boolean', required: true },
-                },
-                validators: {},
-            },
-        },
+    "PinnedItems": {
+        "dataType": "refAlias",
+        "type": {"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"ResourceViewDashboardItem"},{"ref":"ResourceViewChartItem"},{"ref":"ResourceViewSpaceItem"}]},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceSummary: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        access: {
-                            dataType: 'array',
-                            array: { dataType: 'string' },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "ApiPinnedItems": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"PinnedItems","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSpaceSummaryListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceSummary' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewItemType": {
+        "dataType": "refEnum",
+        "enums": ["chart","dashboard","space"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    FieldId: {
-        dataType: 'refAlias',
-        type: { dataType: 'string', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    FilterGroupResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        or: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        id: { dataType: 'string', required: true },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        and: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        id: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"uuid":{"dataType":"string","required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Filters: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metrics: { ref: 'FilterGroupResponse' },
-                dimensions: { ref: 'FilterGroupResponse' },
-            },
-            validators: {},
-        },
+    "UpdatePinnedItemOrder": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_","required":true},"type":{"ref":"ResourceViewItemType","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SortField: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                descending: { dataType: 'boolean', required: true },
-                fieldId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"spaceName":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    TableCalculation: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                sql: { dataType: 'string', required: true },
-                displayName: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-                index: { dataType: 'double' },
-            },
-            validators: {},
-        },
+    "ChartSummary": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MetricType: {
-        dataType: 'refEnum',
-        enums: [
-            'percentile',
-            'average',
-            'count',
-            'count_distinct',
-            'sum',
-            'min',
-            'max',
-            'number',
-            'median',
-            'string',
-            'date',
-            'boolean',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Compact: {
-        dataType: 'refEnum',
-        enums: ['thousands', 'millions', 'billions', 'trillions'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CompactOrAlias: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'Compact' },
-                {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['K'] },
-                        { dataType: 'enum', enums: ['thousand'] },
-                        { dataType: 'enum', enums: ['M'] },
-                        { dataType: 'enum', enums: ['million'] },
-                        { dataType: 'enum', enums: ['B'] },
-                        { dataType: 'enum', enums: ['billion'] },
-                        { dataType: 'enum', enums: ['T'] },
-                        { dataType: 'enum', enums: ['trillion'] },
-                    ],
-                },
-            ],
-            validators: {},
-        },
+    "ApiChartSummaryListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ChartSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AdditionalMetric: {
-        dataType: 'refObject',
-        properties: {
-            label: { dataType: 'string' },
-            type: { ref: 'MetricType', required: true },
-            description: { dataType: 'string' },
-            sql: { dataType: 'string', required: true },
-            hidden: { dataType: 'boolean' },
-            round: { dataType: 'double' },
-            compact: { ref: 'CompactOrAlias' },
-            format: { dataType: 'string' },
-            table: { dataType: 'string', required: true },
-            name: { dataType: 'string', required: true },
-            index: { dataType: 'double' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MetricQueryResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                additionalMetrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
-                },
-                tableCalculations: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
-                    required: true,
-                },
-                limit: { dataType: 'double', required: true },
-                sorts: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SortField' },
-                    required: true,
-                },
-                filters: { ref: 'Filters', required: true },
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiRunQueryResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        rows: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        metricQuery: {
-                            ref: 'MetricQueryResponse',
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SpaceSummary": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    RunQueryRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                csvLimit: { dataType: 'double' },
-                additionalMetrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
-                },
-                tableCalculations: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
-                    required: true,
-                },
-                limit: { dataType: 'double', required: true },
-                sorts: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SortField' },
-                    required: true,
-                },
-                filters: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        metrics: { dataType: 'any' },
-                        dimensions: { dataType: 'any' },
-                    },
-                    required: true,
-                },
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "ApiSpaceSummaryListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerFormat: {
-        dataType: 'refEnum',
-        enums: ['csv', 'image'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerCsvOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                limit: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['table'] },
-                        { dataType: 'enum', enums: ['all'] },
-                        { dataType: 'double' },
-                    ],
-                    required: true,
-                },
-                formatted: { dataType: 'boolean', required: true },
-            },
-            validators: {},
-        },
+    "FieldId": {
+        "dataType": "refAlias",
+        "type": {"dataType":"string","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerImageOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            validators: {},
-        },
+    "FilterGroupResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"or":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}},{"dataType":"nestedObjectLiteral","nestedProperties":{"and":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'SchedulerCsvOptions' },
-                { ref: 'SchedulerImageOptions' },
-            ],
-            validators: {},
-        },
+    "Filters": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"ref":"FilterGroupResponse"},"dimensions":{"ref":"FilterGroupResponse"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerBase: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                options: { ref: 'SchedulerOptions', required: true },
-                dashboardUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedChartUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                cron: { dataType: 'string', required: true },
-                format: { ref: 'SchedulerFormat', required: true },
-                createdBy: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                name: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SortField": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"descending":{"dataType":"boolean","required":true},"fieldId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dashboardUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedChartUuid: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "TableCalculation": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"sql":{"dataType":"string","required":true},"displayName":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"index":{"dataType":"double"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DashboardScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dashboardUuid: { dataType: 'string', required: true },
-                        savedChartUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "MetricType": {
+        "dataType": "refEnum",
+        "enums": ["percentile","average","count","count_distinct","sum","min","max","number","median","string","date","boolean"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Scheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ChartScheduler' },
-                { ref: 'DashboardScheduler' },
-            ],
-            validators: {},
-        },
+    "Compact": {
+        "dataType": "refEnum",
+        "enums": ["thousands","millions","billions","trillions"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerSlackTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                channel: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerSlackTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "CompactOrAlias": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"Compact"},{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["K"]},{"dataType":"enum","enums":["thousand"]},{"dataType":"enum","enums":["M"]},{"dataType":"enum","enums":["million"]},{"dataType":"enum","enums":["B"]},{"dataType":"enum","enums":["billion"]},{"dataType":"enum","enums":["T"]},{"dataType":"enum","enums":["trillion"]}]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerEmailTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                recipient: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerEmailTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
+    "AdditionalMetric": {
+        "dataType": "refObject",
+        "properties": {
+            "label": {"dataType":"string"},
+            "type": {"ref":"MetricType","required":true},
+            "description": {"dataType":"string"},
+            "sql": {"dataType":"string","required":true},
+            "hidden": {"dataType":"boolean"},
+            "round": {"dataType":"double"},
+            "compact": {"ref":"CompactOrAlias"},
+            "format": {"dataType":"string"},
+            "table": {"dataType":"string","required":true},
+            "name": {"dataType":"string","required":true},
+            "index": {"dataType":"double"},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerAndTargets: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'Scheduler' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        targets: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { ref: 'SchedulerSlackTarget' },
-                                    { ref: 'SchedulerEmailTarget' },
-                                ],
-                            },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "MetricQueryResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"ref":"Filters","required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerJobStatus: {
-        dataType: 'refEnum',
-        enums: ['scheduled', 'started', 'completed', 'error'],
+    "ApiRunQueryResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"rows":{"dataType":"array","array":{"dataType":"any"},"required":true},"metricQuery":{"ref":"MetricQueryResponse","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.any_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            validators: {},
-        },
+    "RunQueryRequest": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"csvLimit":{"dataType":"double"},"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"any"},"dimensions":{"dataType":"any"}},"required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerLog: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                details: { ref: 'Record_string.any_' },
-                targetType: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['email'] },
-                        { dataType: 'enum', enums: ['slack'] },
-                    ],
-                },
-                target: { dataType: 'string' },
-                status: { ref: 'SchedulerJobStatus', required: true },
-                scheduledTime: { dataType: 'datetime', required: true },
-                jobGroup: { dataType: 'string' },
-                jobId: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string' },
-                task: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'enum',
-                            enums: ['handleScheduledDelivery'],
-                        },
-                        { dataType: 'enum', enums: ['sendEmailNotification'] },
-                        { dataType: 'enum', enums: ['sendSlackNotification'] },
-                        { dataType: 'enum', enums: ['downloadCsv'] },
-                        { dataType: 'enum', enums: ['compileProject'] },
-                        { dataType: 'enum', enums: ['testAndCompileProject'] },
-                        { dataType: 'enum', enums: ['validateProject'] },
-                    ],
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "SchedulerFormat": {
+        "dataType": "refEnum",
+        "enums": ["csv","image"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerWithLogs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                logs: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerLog' },
-                    required: true,
-                },
-                users: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            userUuid: { dataType: 'string', required: true },
-                            lastName: { dataType: 'string', required: true },
-                            firstName: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                schedulers: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "SchedulerCsvOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"limit":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["table"]},{"dataType":"enum","enums":["all"]},{"dataType":"double"}],"required":true},"formatted":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSchedulerLogsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'SchedulerWithLogs', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerImageOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSchedulerAndTargetsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'SchedulerAndTargets', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"SchedulerCsvOptions"},{"ref":"SchedulerImageOptions"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ScheduledJobs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                id: { dataType: 'string', required: true },
-                date: { dataType: 'datetime', required: true },
-            },
-            validators: {},
-        },
+    "SchedulerBase": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"options":{"ref":"SchedulerOptions","required":true},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"savedChartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"cron":{"dataType":"string","required":true},"format":{"ref":"SchedulerFormat","required":true},"createdBy":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiScheduledJobsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ScheduledJobs' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ChartScheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"enum","enums":[null],"required":true},"savedChartUuid":{"dataType":"string","required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiJobStatusResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "DashboardScheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"savedChartUuid":{"dataType":"enum","enums":[null],"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ShareUrl: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                host: { dataType: 'string' },
-                url: { dataType: 'string' },
-                shareUrl: { dataType: 'string' },
-                organizationUuid: { dataType: 'string' },
-                createdByUserUuid: { dataType: 'string' },
-                params: { dataType: 'string', required: true },
-                path: { dataType: 'string', required: true },
-                nanoid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Scheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ChartScheduler"},{"ref":"DashboardScheduler"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiShareResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'ShareUrl', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerSlackTarget": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"channel":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerSlackTargetUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ShareUrl.path-or-params_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                path: { dataType: 'string', required: true },
-                params: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SchedulerEmailTarget": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"recipient":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerEmailTargetUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateShareUrl: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_ShareUrl.path-or-params_', validators: {} },
+    "SchedulerAndTargets": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Scheduler"},{"dataType":"nestedObjectLiteral","nestedProperties":{"targets":{"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"SchedulerSlackTarget"},{"ref":"SchedulerEmailTarget"}]},"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SlackChannel: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string', required: true },
-                id: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SchedulerJobStatus": {
+        "dataType": "refEnum",
+        "enums": ["scheduled","started","completed","error"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSlackChannelsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SlackChannel' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Record_string.any_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SshKeyPair.publicKey_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                publicKey: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SchedulerLog": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"details":{"ref":"Record_string.any_"},"targetType":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["email"]},{"dataType":"enum","enums":["slack"]}]},"target":{"dataType":"string"},"status":{"ref":"SchedulerJobStatus","required":true},"createdAt":{"dataType":"datetime","required":true},"scheduledTime":{"dataType":"datetime","required":true},"jobGroup":{"dataType":"string"},"jobId":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string"},"task":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["handleScheduledDelivery"]},{"dataType":"enum","enums":["sendEmailNotification"]},{"dataType":"enum","enums":["sendSlackNotification"]},{"dataType":"enum","enums":["downloadCsv"]},{"dataType":"enum","enums":["compileProject"]},{"dataType":"enum","enums":["testAndCompileProject"]},{"dataType":"enum","enums":["validateProject"]}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSshKeyPairResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Pick_SshKeyPair.publicKey_', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerWithLogs": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"logs":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerLog"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"charts":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"savedChartUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"users":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true}}},"required":true},"schedulers":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerAndTargets"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailOneTimePassword: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                numberOfAttempts: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-            },
-            validators: {},
-        },
+    "ApiSchedulerLogsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerWithLogs","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailStatus: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                otp: { ref: 'EmailOneTimePassword' },
-                isVerified: { dataType: 'boolean', required: true },
-                email: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ApiSchedulerAndTargetsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerAndTargets","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailOneTimePasswordExpiring: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'EmailOneTimePassword' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        isMaxAttempts: { dataType: 'boolean', required: true },
-                        isExpired: { dataType: 'boolean', required: true },
-                        expiresAt: { dataType: 'datetime', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "ScheduledJobs": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"dataType":"string","required":true},"date":{"dataType":"datetime","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailStatusExpiring: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'EmailStatus' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        otp: { ref: 'EmailOneTimePasswordExpiring' },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "ApiScheduledJobsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ScheduledJobs"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiEmailStatusResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'EmailStatusExpiring', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiJobStatusResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAllowedOrganization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                membersCount: { dataType: 'double', required: true },
-                name: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ShareUrl": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"host":{"dataType":"string"},"url":{"dataType":"string"},"shareUrl":{"dataType":"string"},"organizationUuid":{"dataType":"string"},"createdByUserUuid":{"dataType":"string"},"params":{"dataType":"string","required":true},"path":{"dataType":"string","required":true},"nanoid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUserAllowedOrganizationsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'UserAllowedOrganization',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiShareResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"ShareUrl","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiJobScheduledResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        jobId: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Pick_ShareUrl.path-or-params_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"path":{"dataType":"string","required":true},"params":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'sorting', 'filter', 'metric', 'model', 'dimension'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationResponseBase: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                spaceUuid: { dataType: 'string' },
-                projectUuid: { dataType: 'string', required: true },
-                errorType: { ref: 'ValidationErrorType' },
-                error: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
+    "CreateShareUrl": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_ShareUrl.path-or-params_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorChartResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ValidationResponseBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        lastUpdatedAt: { dataType: 'datetime' },
-                        lastUpdatedBy: { dataType: 'string' },
-                        fieldName: { dataType: 'string' },
-                        chartType: { ref: 'ChartKind' },
-                        chartUuid: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "SlackChannel": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorDashboardResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ValidationResponseBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        lastUpdatedAt: { dataType: 'datetime' },
-                        lastUpdatedBy: { dataType: 'string' },
-                        fieldName: { dataType: 'string' },
-                        chartName: { dataType: 'string' },
-                        dashboardUuid: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "ApiSlackChannelsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SlackChannel"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorTableResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ValidationResponseBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dimensionName: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        modelName: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Pick_SshKeyPair.publicKey_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"publicKey":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ValidationErrorChartResponse' },
-                { ref: 'ValidationErrorDashboardResponse' },
-                { ref: 'ValidationErrorTableResponse' },
-            ],
-            validators: {},
-        },
+    "ApiSshKeyPairResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Pick_SshKeyPair.publicKey_","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiValidateResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ValidationResponse' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "EmailOneTimePassword": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"numberOfAttempts":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailStatus": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePassword"},"isVerified":{"dataType":"boolean","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailOneTimePasswordExpiring": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailOneTimePassword"},{"dataType":"nestedObjectLiteral","nestedProperties":{"isMaxAttempts":{"dataType":"boolean","required":true},"isExpired":{"dataType":"boolean","required":true},"expiresAt":{"dataType":"datetime","required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailStatusExpiring": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailStatus"},{"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePasswordExpiring"}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiEmailStatusResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"EmailStatusExpiring","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserAllowedOrganization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"membersCount":{"dataType":"double","required":true},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiUserAllowedOrganizationsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"UserAllowedOrganization"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiJobScheduledResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"jobId":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorType": {
+        "dataType": "refEnum",
+        "enums": ["chart","sorting","filter","metric","model","dimension"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationResponseBase": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"spaceUuid":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType"},"error":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorChartResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartType":{"ref":"ChartKind"},"chartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorDashboardResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartName":{"dataType":"string"},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorTableResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dimensionName":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true},"modelName":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ValidationErrorChartResponse"},{"ref":"ValidationErrorDashboardResponse"},{"ref":"ValidationErrorTableResponse"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiValidateResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationResponse"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -1927,25 +634,14 @@ export function RegisterRoutes(app: express.Router) {
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
-    app.get(
-        '/api/v1/csv/:jobId',
-        ...fetchMiddlewares<RequestHandler>(CsvController),
-        ...fetchMiddlewares<RequestHandler>(CsvController.prototype.get),
+        app.get('/api/v1/csv/:jobId',
+            ...(fetchMiddlewares<RequestHandler>(CsvController)),
+            ...(fetchMiddlewares<RequestHandler>(CsvController.prototype.get)),
 
-        function CsvController_get(request: any, response: any, next: any) {
+            function CsvController_get(request: any, response: any, next: any) {
             const args = {
-                jobId: {
-                    in: 'path',
-                    name: 'jobId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1956,42 +652,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new CsvController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.getSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getSettings)),
 
-        function DbtCloudIntegrationController_getSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_getSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2002,42 +678,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.getSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.updateSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.updateSettings)),
 
-        function DbtCloudIntegrationController_updateSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_updateSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2048,42 +704,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.updateSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.deleteSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.deleteSettings)),
 
-        function DbtCloudIntegrationController_deleteSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_deleteSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2094,42 +730,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.deleteSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.getMetrics,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getMetrics)),
 
-        function DbtCloudIntegrationController_getMetrics(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_getMetrics(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2140,42 +756,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.getMetrics.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getMetrics.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.getGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroup)),
 
-        function GroupsController_getGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_getGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2186,42 +782,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.getGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.deleteGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.deleteGroup)),
 
-        function GroupsController_deleteGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_deleteGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2232,48 +808,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.deleteGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/groups/:groupUuid/members/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.addUserToGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/groups/:groupUuid/members/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.addUserToGroup)),
 
-        function GroupsController_addUserToGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_addUserToGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2284,48 +835,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.addUserToGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.addUserToGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/groups/:groupUuid/members/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.removeUserFromGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/groups/:groupUuid/members/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.removeUserFromGroup)),
 
-        function GroupsController_removeUserFromGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_removeUserFromGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2336,42 +862,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.removeUserFromGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.removeUserFromGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/groups/:groupUuid/members',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.getGroupMembers,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/groups/:groupUuid/members',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroupMembers)),
 
-        function GroupsController_getGroupMembers(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_getGroupMembers(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2382,48 +888,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.getGroupMembers.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getGroupMembers.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.updateGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.updateGroup)),
 
-        function GroupsController_updateGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_updateGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateGroup',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateGroup"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2434,36 +915,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.updateGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganization)),
 
-        function OrganizationController_getOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2474,42 +940,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.createOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createOrganization)),
 
-        function OrganizationController_createOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_createOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateOrganization',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateOrganization"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2520,42 +966,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.createOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.updateOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganization)),
 
-        function OrganizationController_updateOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateOrganization',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateOrganization"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2566,42 +992,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.updateOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/org/:organizationUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.deleteOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/org/:organizationUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteOrganization)),
 
-        function OrganizationController_deleteOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_deleteOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                organizationUuid: {
-                    in: 'path',
-                    name: 'organizationUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2612,36 +1018,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.deleteOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/users',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganizationMembers,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/users',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationMembers)),
 
-        function OrganizationController_getOrganizationMembers(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganizationMembers(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2652,48 +1043,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getOrganizationMembers.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationMembers.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org/users/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.updateOrganizationMember,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org/users/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationMember)),
 
-        function OrganizationController_updateOrganizationMember(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganizationMember(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'OrganizationMemberProfileUpdate',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"OrganizationMemberProfileUpdate"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2704,42 +1070,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.updateOrganizationMember.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganizationMember.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/org/user/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.deleteUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/org/user/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteUser)),
 
-        function OrganizationController_deleteUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_deleteUser(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2750,36 +1096,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.deleteUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/allowedEmailDomains',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganizationAllowedEmailDomains,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/allowedEmailDomains',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationAllowedEmailDomains)),
 
-        function OrganizationController_getOrganizationAllowedEmailDomains(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2790,44 +1121,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise =
-                    controller.getOrganizationAllowedEmailDomains.apply(
-                        controller,
-                        validatedArgs as any,
-                    );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org/allowedEmailDomains',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype
-                .updateOrganizationAllowedEmailDomains,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org/allowedEmailDomains',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationAllowedEmailDomains)),
 
-        function OrganizationController_updateOrganizationAllowedEmailDomains(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateAllowedEmailDomains',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateAllowedEmailDomains"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2838,43 +1147,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise =
-                    controller.updateOrganizationAllowedEmailDomains.apply(
-                        controller,
-                        validatedArgs as any,
-                    );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/org/groups',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.createGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/org/groups',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createGroup)),
 
-        function OrganizationController_createGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_createGroup(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'Pick_CreateGroup.name_',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"Pick_CreateGroup.name_"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2885,36 +1173,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.createGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/groups',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.listGroupsInOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/groups',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.listGroupsInOrganization)),
 
-        function OrganizationController_listGroupsInOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_listGroupsInOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2925,42 +1198,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.listGroupsInOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.listGroupsInOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
-        ...fetchMiddlewares<RequestHandler>(PinningController),
-        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
+            ...(fetchMiddlewares<RequestHandler>(PinningController)),
+            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.get)),
 
-        function PinningController_get(request: any, response: any, next: any) {
+            function PinningController_get(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                pinnedListUuid: {
-                    in: 'path',
-                    name: 'pinnedListUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2971,56 +1225,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
-        ...fetchMiddlewares<RequestHandler>(PinningController),
-        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.post),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
+            ...(fetchMiddlewares<RequestHandler>(PinningController)),
+            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.post)),
 
-        function PinningController_post(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function PinningController_post(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                pinnedListUuid: {
-                    in: 'path',
-                    name: 'pinnedListUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'UpdatePinnedItemOrder',
-                    },
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"dataType":"array","array":{"dataType":"refAlias","ref":"UpdatePinnedItemOrder"}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3031,42 +1253,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-                const promise = controller.post.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.post.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/charts',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getChartsInProject,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/charts',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getChartsInProject)),
 
-        function ProjectController_getChartsInProject(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getChartsInProject(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3077,42 +1279,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getChartsInProject.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getChartsInProject.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/spaces',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getSpacesInProject,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/spaces',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getSpacesInProject)),
 
-        function ProjectController_getSpacesInProject(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getSpacesInProject(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3123,54 +1305,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getSpacesInProject.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getSpacesInProject.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
-        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
-        ...fetchMiddlewares<RequestHandler>(
-            RunViewChartQueryController.prototype.postUnderlyingData,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postUnderlyingData)),
 
-        function RunViewChartQueryController_postUnderlyingData(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function RunViewChartQueryController_postUnderlyingData(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'RunQueryRequest',
-                },
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                exploreId: {
-                    in: 'path',
-                    name: 'exploreId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3181,54 +1333,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-                const promise = controller.postUnderlyingData.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postUnderlyingData.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
-        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
-        ...fetchMiddlewares<RequestHandler>(
-            RunViewChartQueryController.prototype.postRunQuery,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postRunQuery)),
 
-        function RunViewChartQueryController_postRunQuery(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function RunViewChartQueryController_postRunQuery(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'RunQueryRequest',
-                },
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                exploreId: {
-                    in: 'path',
-                    name: 'exploreId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3239,49 +1361,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-                const promise = controller.postRunQuery.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postRunQuery.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/saved/:chartUuid/results',
-        ...fetchMiddlewares<RequestHandler>(SavedChartController),
-        ...fetchMiddlewares<RequestHandler>(
-            SavedChartController.prototype.postDashboardTile,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/saved/:chartUuid/results',
+            ...(fetchMiddlewares<RequestHandler>(SavedChartController)),
+            ...(fetchMiddlewares<RequestHandler>(SavedChartController.prototype.postDashboardTile)),
 
-        function SavedChartController_postDashboardTile(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SavedChartController_postDashboardTile(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: { filters: { ref: 'Filters' } },
-                },
-                chartUuid: {
-                    in: 'path',
-                    name: 'chartUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"filters":{"ref":"Filters"}}},
+                    chartUuid: {"in":"path","name":"chartUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3292,42 +1388,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SavedChartController();
 
-                const promise = controller.postDashboardTile.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postDashboardTile.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:projectUuid/logs',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getLogs,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:projectUuid/logs',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getLogs)),
 
-        function SchedulerController_getLogs(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getLogs(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3338,40 +1414,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getLogs.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getLogs.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get)),
 
-        function SchedulerController_get(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_get(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3382,48 +1440,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.patch,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.patch)),
 
-        function SchedulerController_patch(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_patch(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'any',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"dataType":"any"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3434,42 +1467,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.patch.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.patch.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.delete,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.delete)),
 
-        function SchedulerController_delete(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_delete(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3480,42 +1493,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.delete.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.delete.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:schedulerUuid/jobs',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getJobs,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:schedulerUuid/jobs',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getJobs)),
 
-        function SchedulerController_getJobs(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getJobs(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3526,42 +1519,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getJobs.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getJobs.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/job/:jobId/status',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getSchedulerStatus,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/job/:jobId/status',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getSchedulerStatus)),
 
-        function SchedulerController_getSchedulerStatus(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getSchedulerStatus(request: any, response: any, next: any) {
             const args = {
-                jobId: {
-                    in: 'path',
-                    name: 'jobId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3572,36 +1545,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getSchedulerStatus.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getSchedulerStatus.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/share/:nanoId',
-        ...fetchMiddlewares<RequestHandler>(ShareController),
-        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/share/:nanoId',
+            ...(fetchMiddlewares<RequestHandler>(ShareController)),
+            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.get)),
 
-        function ShareController_get(request: any, response: any, next: any) {
+            function ShareController_get(request: any, response: any, next: any) {
             const args = {
-                nanoId: {
-                    in: 'path',
-                    name: 'nanoId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    nanoId: {"in":"path","name":"nanoId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3612,40 +1571,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/share',
-        ...fetchMiddlewares<RequestHandler>(ShareController),
-        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.create),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/share',
+            ...(fetchMiddlewares<RequestHandler>(ShareController)),
+            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.create)),
 
-        function ShareController_create(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ShareController_create(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateShareUrl',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateShareUrl"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3656,30 +1597,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-                const promise = controller.create.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.create.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/slack/channels',
-        ...fetchMiddlewares<RequestHandler>(SlackController),
-        ...fetchMiddlewares<RequestHandler>(SlackController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/slack/channels',
+            ...(fetchMiddlewares<RequestHandler>(SlackController)),
+            ...(fetchMiddlewares<RequestHandler>(SlackController.prototype.get)),
 
-        function SlackController_get(request: any, response: any, next: any) {
+            function SlackController_get(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3690,36 +1622,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SlackController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/ssh/key-pairs',
-        ...fetchMiddlewares<RequestHandler>(SshController),
-        ...fetchMiddlewares<RequestHandler>(
-            SshController.prototype.createSshKeyPair,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/ssh/key-pairs',
+            ...(fetchMiddlewares<RequestHandler>(SshController)),
+            ...(fetchMiddlewares<RequestHandler>(SshController.prototype.createSshKeyPair)),
 
-        function SshController_createSshKeyPair(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SshController_createSshKeyPair(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3730,36 +1647,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SshController();
 
-                const promise = controller.createSshKeyPair.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.createSshKeyPair.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/user/me/email/otp',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.createEmailOneTimePasscode,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/user/me/email/otp',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.createEmailOneTimePasscode)),
 
-        function UserController_createEmailOneTimePasscode(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_createEmailOneTimePasscode(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3770,37 +1672,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.createEmailOneTimePasscode.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createEmailOneTimePasscode.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/user/me/email/status',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.getEmailVerificationStatus,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/user/me/email/status',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getEmailVerificationStatus)),
 
-        function UserController_getEmailVerificationStatus(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_getEmailVerificationStatus(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                passcode: { in: 'query', name: 'passcode', dataType: 'string' },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    passcode: {"in":"query","name":"passcode","dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3811,36 +1698,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.getEmailVerificationStatus.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getEmailVerificationStatus.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/user/me/allowedOrganizations',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.getOrganizationsUserCanJoin,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/user/me/allowedOrganizations',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getOrganizationsUserCanJoin)),
 
-        function UserController_getOrganizationsUserCanJoin(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_getOrganizationsUserCanJoin(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3851,42 +1723,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.getOrganizationsUserCanJoin.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationsUserCanJoin.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/user/me/joinOrganization/:organizationUuid',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.joinOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/user/me/joinOrganization/:organizationUuid',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.joinOrganization)),
 
-        function UserController_joinOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_joinOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                organizationUuid: {
-                    in: 'path',
-                    name: 'organizationUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3897,36 +1749,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.joinOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.joinOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/user/me',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.deleteUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/user/me',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.deleteUser)),
 
-        function UserController_deleteUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_deleteUser(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3937,42 +1774,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.deleteUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/validate',
-        ...fetchMiddlewares<RequestHandler>(ValidationController),
-        ...fetchMiddlewares<RequestHandler>(
-            ValidationController.prototype.post,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/validate',
+            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
+            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.post)),
 
-        function ValidationController_post(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ValidationController_post(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3983,45 +1800,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-                const promise = controller.post.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.post.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/validate',
-        ...fetchMiddlewares<RequestHandler>(ValidationController),
-        ...fetchMiddlewares<RequestHandler>(ValidationController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/validate',
+            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
+            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.get)),
 
-        function ValidationController_get(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ValidationController_get(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                fromSettings: {
-                    in: 'query',
-                    name: 'fromSettings',
-                    dataType: 'boolean',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    fromSettings: {"in":"query","name":"fromSettings","dataType":"boolean"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4032,37 +1827,25 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function isController(object: any): object is Controller {
-        return (
-            'getHeaders' in object &&
-            'getStatus' in object &&
-            'setStatus' in object
-        );
+        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
     }
 
-    function promiseHandler(
-        controllerObj: any,
-        promise: any,
-        response: any,
-        successStatus: any,
-        next: any,
-    ) {
+    function promiseHandler(controllerObj: any, promise: any, response: any, successStatus: any, next: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 let statusCode = successStatus;
@@ -4074,31 +1857,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-                returnHandler(response, statusCode, data, headers);
+                returnHandler(response, statusCode, data, headers)
             })
             .catch((error: any) => next(error));
     }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function returnHandler(
-        response: any,
-        statusCode?: number,
-        data?: any,
-        headers: any = {},
-    ) {
+    function returnHandler(response: any, statusCode?: number, data?: any, headers: any = {}) {
         if (response.headersSent) {
             return;
         }
         Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
         });
-        if (
-            data &&
-            typeof data.pipe === 'function' &&
-            data.readable &&
-            typeof data._read === 'function'
-        ) {
+        if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
             data.pipe(response);
         } else if (data !== null && data !== undefined) {
             response.status(statusCode || 200).json(data);
@@ -4109,108 +1882,38 @@ export function RegisterRoutes(app: express.Router) {
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function responder(
-        response: any,
-    ): TsoaResponse<HttpStatusCodeLiteral, unknown> {
-        return function (status, data, headers) {
+    function responder(response: any): TsoaResponse<HttpStatusCodeLiteral, unknown>  {
+        return function(status, data, headers) {
             returnHandler(response, status, data, headers);
         };
-    }
+    };
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function getValidatedArgs(args: any, request: any, response: any): any[] {
-        const fieldErrors: FieldErrors = {};
+        const fieldErrors: FieldErrors  = {};
         const values = Object.keys(args).map((key) => {
             const name = args[key].name;
             switch (args[key].in) {
                 case 'request':
                     return request;
                 case 'query':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.query[name],
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'path':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.params[name],
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'header':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.header(name),
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'body':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.body,
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'body-prop':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.body[name],
-                        name,
-                        fieldErrors,
-                        'body.',
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'formData':
                     if (args[key].dataType === 'file') {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.file,
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
-                    } else if (
-                        args[key].dataType === 'array' &&
-                        args[key].array.dataType === 'file'
-                    ) {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.files,
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
+                        return validationService.ValidateParam(args[key], request.file, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    } else if (args[key].dataType === 'array' && args[key].array.dataType === 'file') {
+                        return validationService.ValidateParam(args[key], request.files, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                     } else {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.body[name],
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
+                        return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                     }
                 case 'res':
                     return responder(response);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1,7 +1,16 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute, HttpStatusCodeLiteral, TsoaResponse, fetchMiddlewares } from '@tsoa/runtime';
+import {
+    Controller,
+    fetchMiddlewares,
+    FieldErrors,
+    HttpStatusCodeLiteral,
+    TsoaResponse,
+    TsoaRoute,
+    ValidateError,
+    ValidationService,
+} from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CsvController } from './../controllers/csvController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -29,599 +38,1912 @@ import { SshController } from './../controllers/sshController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { ValidationController } from './../controllers/validationController';
 import type { RequestHandler } from 'express';
 import * as express from 'express';
+import { ValidationController } from './../controllers/validationController';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
-    "ApiErrorPayload": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"any"},"message":{"dataType":"string"},"name":{"dataType":"string","required":true},"statusCode":{"dataType":"double","required":true}},"required":true},"status":{"dataType":"enum","enums":["error"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiCsvUrlResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true},"url":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateDbtCloudIntegration.metricsJobId_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metricsJobId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudIntegration": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateDbtCloudIntegration.metricsJobId_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudIntegrationSettings": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"union","subSchemas":[{"ref":"DbtCloudIntegration"},{"dataType":"undefined"}],"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudSettingsDeleteSuccess": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudMetric": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"label":{"dataType":"string","required":true},"timeGrains":{"dataType":"array","array":{"dataType":"string"},"required":true},"description":{"dataType":"string","required":true},"dimensions":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true},"uniqueId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudMetadataResponseMetrics": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"DbtCloudMetric"},"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudMetrics": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"DbtCloudMetadataResponseMetrics","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Group": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organizationUuid":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Group","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSuccessEmpty": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "GroupMember": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupMembersResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"GroupMember"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Group.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateGroup": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_Group.name_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Organization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"needsProject":{"dataType":"boolean"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Organization","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Organization.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateOrganization": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_Organization.name_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string"},"chartColors":{"dataType":"array","array":{"dataType":"string"}}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateOrganization": {
-        "dataType": "refAlias",
-        "type": {"ref":"Partial_Omit_Organization.organizationUuid-or-needsProject__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole": {
-        "dataType": "refEnum",
-        "enums": ["member","viewer","interactive_viewer","editor","developer","admin"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberProfile": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isInviteExpired":{"dataType":"boolean"},"isActive":{"dataType":"boolean","required":true},"role":{"ref":"OrganizationMemberRole","required":true},"organizationUuid":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationMemberProfiles": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationMemberProfile": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"OrganizationMemberProfile","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_Pick_OrganizationMemberProfile.role__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberProfileUpdate": {
-        "dataType": "refAlias",
-        "type": {"ref":"Partial_Pick_OrganizationMemberProfile.role__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"OrganizationMemberRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationAllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"AllowedEmailDomains","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_AllowedEmailDomains.organizationUuid_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateAllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_AllowedEmailDomains.organizationUuid_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateGroup.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"Group"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.DASHBOARD": {
-        "dataType": "refEnum",
-        "enums": ["dashboard"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdatedByUser": {
-        "dataType": "refObject",
-        "properties": {
-            "userUuid": {"dataType":"string","required":true},
-            "firstName": {"dataType":"string","required":true},
-            "lastName": {"dataType":"string","required":true},
+    ApiErrorPayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                error: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        data: { dataType: 'any' },
+                        message: { dataType: 'string' },
+                        name: { dataType: 'string', required: true },
+                        statusCode: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['error'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationSummary": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_ValidationResponse.error-or-createdAt-or-validationId_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewDashboardItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.DASHBOARD","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.CHART": {
-        "dataType": "refEnum",
-        "enums": ["chart"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartKind": {
-        "dataType": "refEnum",
-        "enums": ["line","horizontal_bar","vertical_bar","scatter","area","mixed","table","big_number"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewChartItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.CHART","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.SPACE": {
-        "dataType": "refEnum",
-        "enums": ["space"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewSpaceItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartCount":{"dataType":"double","required":true},"dashboardCount":{"dataType":"double","required":true},"accessListLength":{"dataType":"double","required":true},"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"required":true},"type":{"ref":"ResourceViewItemType.SPACE","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "PinnedItems": {
-        "dataType": "refAlias",
-        "type": {"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"ResourceViewDashboardItem"},{"ref":"ResourceViewChartItem"},{"ref":"ResourceViewSpaceItem"}]},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiPinnedItems": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"PinnedItems","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType": {
-        "dataType": "refEnum",
-        "enums": ["chart","dashboard","space"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"uuid":{"dataType":"string","required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdatePinnedItemOrder": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_","required":true},"type":{"ref":"ResourceViewItemType","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"spaceName":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartSummary": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiChartSummaryListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ChartSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SpaceSummary": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSpaceSummaryListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FieldId": {
-        "dataType": "refAlias",
-        "type": {"dataType":"string","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterGroupResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"or":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}},{"dataType":"nestedObjectLiteral","nestedProperties":{"and":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Filters": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"ref":"FilterGroupResponse"},"dimensions":{"ref":"FilterGroupResponse"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SortField": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"descending":{"dataType":"boolean","required":true},"fieldId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TableCalculation": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"sql":{"dataType":"string","required":true},"displayName":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"index":{"dataType":"double"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MetricType": {
-        "dataType": "refEnum",
-        "enums": ["percentile","average","count","count_distinct","sum","min","max","number","median","string","date","boolean"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Compact": {
-        "dataType": "refEnum",
-        "enums": ["thousands","millions","billions","trillions"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CompactOrAlias": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"Compact"},{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["K"]},{"dataType":"enum","enums":["thousand"]},{"dataType":"enum","enums":["M"]},{"dataType":"enum","enums":["million"]},{"dataType":"enum","enums":["B"]},{"dataType":"enum","enums":["billion"]},{"dataType":"enum","enums":["T"]},{"dataType":"enum","enums":["trillion"]}]}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AdditionalMetric": {
-        "dataType": "refObject",
-        "properties": {
-            "label": {"dataType":"string"},
-            "type": {"ref":"MetricType","required":true},
-            "description": {"dataType":"string"},
-            "sql": {"dataType":"string","required":true},
-            "hidden": {"dataType":"boolean"},
-            "round": {"dataType":"double"},
-            "compact": {"ref":"CompactOrAlias"},
-            "format": {"dataType":"string"},
-            "table": {"dataType":"string","required":true},
-            "name": {"dataType":"string","required":true},
-            "index": {"dataType":"double"},
+    ApiCsvUrlResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        status: { dataType: 'string', required: true },
+                        url: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MetricQueryResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"ref":"Filters","required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
+    'Pick_CreateDbtCloudIntegration.metricsJobId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metricsJobId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiRunQueryResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"rows":{"dataType":"array","array":{"dataType":"any"},"required":true},"metricQuery":{"ref":"MetricQueryResponse","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    DbtCloudIntegration: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateDbtCloudIntegration.metricsJobId_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "RunQueryRequest": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"csvLimit":{"dataType":"double"},"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"any"},"dimensions":{"dataType":"any"}},"required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
+    ApiDbtCloudIntegrationSettings: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DbtCloudIntegration' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerFormat": {
-        "dataType": "refEnum",
-        "enums": ["csv","image"],
+    ApiDbtCloudSettingsDeleteSuccess: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { dataType: 'undefined', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerCsvOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"limit":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["table"]},{"dataType":"enum","enums":["all"]},{"dataType":"double"}],"required":true},"formatted":{"dataType":"boolean","required":true}},"validators":{}},
+    DbtCloudMetric: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string', required: true },
+                timeGrains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                description: { dataType: 'string', required: true },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uniqueId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerImageOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    DbtCloudMetadataResponseMetrics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DbtCloudMetric' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"SchedulerCsvOptions"},{"ref":"SchedulerImageOptions"}],"validators":{}},
+    ApiDbtCloudMetrics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'DbtCloudMetadataResponseMetrics',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerBase": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"options":{"ref":"SchedulerOptions","required":true},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"savedChartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"cron":{"dataType":"string","required":true},"format":{"ref":"SchedulerFormat","required":true},"createdBy":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true}},"validators":{}},
+    Group: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartScheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"enum","enums":[null],"required":true},"savedChartUuid":{"dataType":"string","required":true}}}],"validators":{}},
+    ApiGroupResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Group', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DashboardScheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"savedChartUuid":{"dataType":"enum","enums":[null],"required":true}}}],"validators":{}},
+    ApiSuccessEmpty: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { dataType: 'undefined', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Scheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ChartScheduler"},{"ref":"DashboardScheduler"}],"validators":{}},
+    GroupMember: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                email: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerSlackTarget": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"channel":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerSlackTargetUuid":{"dataType":"string","required":true}},"validators":{}},
+    ApiGroupMembersResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GroupMember' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerEmailTarget": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"recipient":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerEmailTargetUuid":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_Group.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerAndTargets": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Scheduler"},{"dataType":"nestedObjectLiteral","nestedProperties":{"targets":{"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"SchedulerSlackTarget"},{"ref":"SchedulerEmailTarget"}]},"required":true}}}],"validators":{}},
+    UpdateGroup: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_Group.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerJobStatus": {
-        "dataType": "refEnum",
-        "enums": ["scheduled","started","completed","error"],
+    Organization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                needsProject: { dataType: 'boolean' },
+                chartColors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                name: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Record_string.any_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    ApiOrganization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Organization', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerLog": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"details":{"ref":"Record_string.any_"},"targetType":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["email"]},{"dataType":"enum","enums":["slack"]}]},"target":{"dataType":"string"},"status":{"ref":"SchedulerJobStatus","required":true},"createdAt":{"dataType":"datetime","required":true},"scheduledTime":{"dataType":"datetime","required":true},"jobGroup":{"dataType":"string"},"jobId":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string"},"task":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["handleScheduledDelivery"]},{"dataType":"enum","enums":["sendEmailNotification"]},{"dataType":"enum","enums":["sendSlackNotification"]},{"dataType":"enum","enums":["downloadCsv"]},{"dataType":"enum","enums":["compileProject"]},{"dataType":"enum","enums":["testAndCompileProject"]},{"dataType":"enum","enums":["validateProject"]}],"required":true}},"validators":{}},
+    'Pick_Organization.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerWithLogs": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"logs":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerLog"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"charts":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"savedChartUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"users":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true}}},"required":true},"schedulers":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerAndTargets"},"required":true}},"validators":{}},
+    CreateOrganization: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_Organization.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSchedulerLogsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerWithLogs","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'Partial_Omit_Organization.organizationUuid-or-needsProject__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string' },
+                chartColors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSchedulerAndTargetsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerAndTargets","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    UpdateOrganization: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Partial_Omit_Organization.organizationUuid-or-needsProject__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ScheduledJobs": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"dataType":"string","required":true},"date":{"dataType":"datetime","required":true}},"validators":{}},
+    OrganizationMemberRole: {
+        dataType: 'refEnum',
+        enums: [
+            'member',
+            'viewer',
+            'interactive_viewer',
+            'editor',
+            'developer',
+            'admin',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiScheduledJobsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ScheduledJobs"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    OrganizationMemberProfile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                isInviteExpired: { dataType: 'boolean' },
+                isActive: { dataType: 'boolean', required: true },
+                role: { ref: 'OrganizationMemberRole', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                email: { dataType: 'string', required: true },
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiJobStatusResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ApiOrganizationMemberProfiles: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'OrganizationMemberProfile',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ShareUrl": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"host":{"dataType":"string"},"url":{"dataType":"string"},"shareUrl":{"dataType":"string"},"organizationUuid":{"dataType":"string"},"createdByUserUuid":{"dataType":"string"},"params":{"dataType":"string","required":true},"path":{"dataType":"string","required":true},"nanoid":{"dataType":"string","required":true}},"validators":{}},
+    ApiOrganizationMemberProfile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'OrganizationMemberProfile', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiShareResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"ShareUrl","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'Partial_Pick_OrganizationMemberProfile.role__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { role: { ref: 'OrganizationMemberRole' } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ShareUrl.path-or-params_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"path":{"dataType":"string","required":true},"params":{"dataType":"string","required":true}},"validators":{}},
+    OrganizationMemberProfileUpdate: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Partial_Pick_OrganizationMemberProfile.role__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateShareUrl": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_ShareUrl.path-or-params_","validators":{}},
+    AllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                role: { ref: 'OrganizationMemberRole', required: true },
+                emailDomains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SlackChannel": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"validators":{}},
+    ApiOrganizationAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AllowedEmailDomains', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSlackChannelsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SlackChannel"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    role: { ref: 'OrganizationMemberRole', required: true },
+                    emailDomains: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                    projectUuids: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AllowedEmailDomains.organizationUuid_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SshKeyPair.publicKey_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"publicKey":{"dataType":"string","required":true}},"validators":{}},
+    UpdateAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_AllowedEmailDomains.organizationUuid_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSshKeyPairResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Pick_SshKeyPair.publicKey_","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'Pick_CreateGroup.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailOneTimePassword": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"numberOfAttempts":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true}},"validators":{}},
+    ApiGroupListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'Group' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailStatus": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePassword"},"isVerified":{"dataType":"boolean","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
+    'ResourceViewItemType.DASHBOARD': {
+        dataType: 'refEnum',
+        enums: ['dashboard'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailOneTimePasswordExpiring": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailOneTimePassword"},{"dataType":"nestedObjectLiteral","nestedProperties":{"isMaxAttempts":{"dataType":"boolean","required":true},"isExpired":{"dataType":"boolean","required":true},"expiresAt":{"dataType":"datetime","required":true}}}],"validators":{}},
+    UpdatedByUser: {
+        dataType: 'refObject',
+        properties: {
+            userUuid: { dataType: 'string', required: true },
+            firstName: { dataType: 'string', required: true },
+            lastName: { dataType: 'string', required: true },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailStatusExpiring": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailStatus"},{"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePasswordExpiring"}}}],"validators":{}},
+    'Pick_ValidationResponse.error-or-createdAt-or-validationId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                error: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                validationId: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiEmailStatusResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"EmailStatusExpiring","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ValidationSummary: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationId_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UserAllowedOrganization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"membersCount":{"dataType":"double","required":true},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    validationErrors: {
+                        dataType: 'array',
+                        array: {
+                            dataType: 'refAlias',
+                            ref: 'ValidationSummary',
+                        },
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewDashboardItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.DASHBOARD', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiUserAllowedOrganizationsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"UserAllowedOrganization"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'ResourceViewItemType.CHART': {
+        dataType: 'refEnum',
+        enums: ['chart'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiJobScheduledResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"jobId":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ChartKind: {
+        dataType: 'refEnum',
+        enums: [
+            'line',
+            'horizontal_bar',
+            'vertical_bar',
+            'scatter',
+            'area',
+            'mixed',
+            'table',
+            'big_number',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorType": {
-        "dataType": "refEnum",
-        "enums": ["chart","sorting","filter","metric","model","dimension"],
+    'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    validationErrors: {
+                        dataType: 'array',
+                        array: {
+                            dataType: 'refAlias',
+                            ref: 'ValidationSummary',
+                        },
+                    },
+                    chartType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ChartKind' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewChartItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.CHART', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationResponseBase": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"spaceUuid":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType"},"error":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
+    'ResourceViewItemType.SPACE': {
+        dataType: 'refEnum',
+        enums: ['space'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorChartResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartType":{"ref":"ChartKind"},"chartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    isPrivate: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewSpaceItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        {
+                            ref: 'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_',
+                        },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                chartCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                dashboardCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                accessListLength: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                access: {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.SPACE', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorDashboardResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartName":{"dataType":"string"},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    PinnedItems: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'array',
+            array: {
+                dataType: 'union',
+                subSchemas: [
+                    { ref: 'ResourceViewDashboardItem' },
+                    { ref: 'ResourceViewChartItem' },
+                    { ref: 'ResourceViewSpaceItem' },
+                ],
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorTableResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dimensionName":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true},"modelName":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    ApiPinnedItems: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'PinnedItems', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ValidationErrorChartResponse"},{"ref":"ValidationErrorDashboardResponse"},{"ref":"ValidationErrorTableResponse"}],"validators":{}},
+    ResourceViewItemType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'dashboard', 'space'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiValidateResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationResponse"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                uuid: { dataType: 'string', required: true },
+                pinnedListOrder: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdatePinnedItemOrder: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    projectUuid: { dataType: 'string', required: true },
+                    spaceUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    spaceName: { dataType: 'string', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartSummary: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiChartSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    isPrivate: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        access: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSpaceSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceSummary' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FieldId: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterGroupResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        or: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        id: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        and: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        id: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Filters: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: { ref: 'FilterGroupResponse' },
+                dimensions: { ref: 'FilterGroupResponse' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SortField: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                descending: { dataType: 'boolean', required: true },
+                fieldId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableCalculation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sql: { dataType: 'string', required: true },
+                displayName: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                index: { dataType: 'double' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricType: {
+        dataType: 'refEnum',
+        enums: [
+            'percentile',
+            'average',
+            'count',
+            'count_distinct',
+            'sum',
+            'min',
+            'max',
+            'number',
+            'median',
+            'string',
+            'date',
+            'boolean',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Compact: {
+        dataType: 'refEnum',
+        enums: ['thousands', 'millions', 'billions', 'trillions'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CompactOrAlias: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'Compact' },
+                {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['K'] },
+                        { dataType: 'enum', enums: ['thousand'] },
+                        { dataType: 'enum', enums: ['M'] },
+                        { dataType: 'enum', enums: ['million'] },
+                        { dataType: 'enum', enums: ['B'] },
+                        { dataType: 'enum', enums: ['billion'] },
+                        { dataType: 'enum', enums: ['T'] },
+                        { dataType: 'enum', enums: ['trillion'] },
+                    ],
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AdditionalMetric: {
+        dataType: 'refObject',
+        properties: {
+            label: { dataType: 'string' },
+            type: { ref: 'MetricType', required: true },
+            description: { dataType: 'string' },
+            sql: { dataType: 'string', required: true },
+            hidden: { dataType: 'boolean' },
+            round: { dataType: 'double' },
+            compact: { ref: 'CompactOrAlias' },
+            format: { dataType: 'string' },
+            table: { dataType: 'string', required: true },
+            name: { dataType: 'string', required: true },
+            index: { dataType: 'double' },
+        },
+        additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricQueryResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                additionalMetrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
+                },
+                tableCalculations: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
+                    required: true,
+                },
+                limit: { dataType: 'double', required: true },
+                sorts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SortField' },
+                    required: true,
+                },
+                filters: { ref: 'Filters', required: true },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRunQueryResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        rows: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        metricQuery: {
+                            ref: 'MetricQueryResponse',
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RunQueryRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                csvLimit: { dataType: 'double' },
+                additionalMetrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
+                },
+                tableCalculations: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
+                    required: true,
+                },
+                limit: { dataType: 'double', required: true },
+                sorts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SortField' },
+                    required: true,
+                },
+                filters: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        metrics: { dataType: 'any' },
+                        dimensions: { dataType: 'any' },
+                    },
+                    required: true,
+                },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerFormat: {
+        dataType: 'refEnum',
+        enums: ['csv', 'image'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerCsvOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                limit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['table'] },
+                        { dataType: 'enum', enums: ['all'] },
+                        { dataType: 'double' },
+                    ],
+                    required: true,
+                },
+                formatted: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerImageOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'SchedulerCsvOptions' },
+                { ref: 'SchedulerImageOptions' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                options: { ref: 'SchedulerOptions', required: true },
+                dashboardUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedChartUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                cron: { dataType: 'string', required: true },
+                format: { ref: 'SchedulerFormat', required: true },
+                createdBy: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                name: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedChartUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: { dataType: 'string', required: true },
+                        savedChartUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Scheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ChartScheduler' },
+                { ref: 'DashboardScheduler' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerSlackTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                channel: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerSlackTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerEmailTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                recipient: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerEmailTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerAndTargets: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Scheduler' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        targets: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'SchedulerSlackTarget' },
+                                    { ref: 'SchedulerEmailTarget' },
+                                ],
+                            },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerJobStatus: {
+        dataType: 'refEnum',
+        enums: ['scheduled', 'started', 'completed', 'error'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.any_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerLog: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                details: { ref: 'Record_string.any_' },
+                targetType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['email'] },
+                        { dataType: 'enum', enums: ['slack'] },
+                    ],
+                },
+                target: { dataType: 'string' },
+                status: { ref: 'SchedulerJobStatus', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                scheduledTime: { dataType: 'datetime', required: true },
+                jobGroup: { dataType: 'string' },
+                jobId: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string' },
+                task: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'enum',
+                            enums: ['handleScheduledDelivery'],
+                        },
+                        { dataType: 'enum', enums: ['sendEmailNotification'] },
+                        { dataType: 'enum', enums: ['sendSlackNotification'] },
+                        { dataType: 'enum', enums: ['downloadCsv'] },
+                        { dataType: 'enum', enums: ['compileProject'] },
+                        { dataType: 'enum', enums: ['testAndCompileProject'] },
+                        { dataType: 'enum', enums: ['validateProject'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerWithLogs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                logs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SchedulerLog' },
+                    required: true,
+                },
+                dashboards: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            dashboardUuid: {
+                                dataType: 'string',
+                                required: true,
+                            },
+                            name: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                charts: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            savedChartUuid: {
+                                dataType: 'string',
+                                required: true,
+                            },
+                            name: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                users: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            userUuid: { dataType: 'string', required: true },
+                            lastName: { dataType: 'string', required: true },
+                            firstName: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                schedulers: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSchedulerLogsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SchedulerWithLogs', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSchedulerAndTargetsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SchedulerAndTargets', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScheduledJobs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                id: { dataType: 'string', required: true },
+                date: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiScheduledJobsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ScheduledJobs' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiJobStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        status: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ShareUrl: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                host: { dataType: 'string' },
+                url: { dataType: 'string' },
+                shareUrl: { dataType: 'string' },
+                organizationUuid: { dataType: 'string' },
+                createdByUserUuid: { dataType: 'string' },
+                params: { dataType: 'string', required: true },
+                path: { dataType: 'string', required: true },
+                nanoid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiShareResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ShareUrl', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_ShareUrl.path-or-params_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                path: { dataType: 'string', required: true },
+                params: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateShareUrl: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_ShareUrl.path-or-params_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SlackChannel: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSlackChannelsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SlackChannel' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SshKeyPair.publicKey_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                publicKey: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSshKeyPairResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Pick_SshKeyPair.publicKey_', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePassword: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                numberOfAttempts: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                otp: { ref: 'EmailOneTimePassword' },
+                isVerified: { dataType: 'boolean', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePasswordExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailOneTimePassword' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        isMaxAttempts: { dataType: 'boolean', required: true },
+                        isExpired: { dataType: 'boolean', required: true },
+                        expiresAt: { dataType: 'datetime', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatusExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailStatus' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        otp: { ref: 'EmailOneTimePasswordExpiring' },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiEmailStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'EmailStatusExpiring', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAllowedOrganization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                membersCount: { dataType: 'double', required: true },
+                name: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserAllowedOrganizationsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'UserAllowedOrganization',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiJobScheduledResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        jobId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'sorting', 'filter', 'metric', 'model', 'dimension'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationResponseBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                spaceUuid: { dataType: 'string' },
+                projectUuid: { dataType: 'string', required: true },
+                errorType: { ref: 'ValidationErrorType' },
+                error: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                validationId: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorChartResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ValidationResponseBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        lastUpdatedAt: { dataType: 'datetime' },
+                        lastUpdatedBy: { dataType: 'string' },
+                        fieldName: { dataType: 'string' },
+                        chartType: { ref: 'ChartKind' },
+                        chartUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorDashboardResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ValidationResponseBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        lastUpdatedAt: { dataType: 'datetime' },
+                        lastUpdatedBy: { dataType: 'string' },
+                        fieldName: { dataType: 'string' },
+                        chartName: { dataType: 'string' },
+                        dashboardUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorTableResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ValidationResponseBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dimensionName: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        modelName: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ValidationErrorChartResponse' },
+                { ref: 'ValidationErrorDashboardResponse' },
+                { ref: 'ValidationErrorTableResponse' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiValidateResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ValidationResponse' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -634,14 +1956,25 @@ export function RegisterRoutes(app: express.Router) {
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
-        app.get('/api/v1/csv/:jobId',
-            ...(fetchMiddlewares<RequestHandler>(CsvController)),
-            ...(fetchMiddlewares<RequestHandler>(CsvController.prototype.get)),
+    app.get(
+        '/api/v1/csv/:jobId',
+        ...fetchMiddlewares<RequestHandler>(CsvController),
+        ...fetchMiddlewares<RequestHandler>(CsvController.prototype.get),
 
-            function CsvController_get(request: any, response: any, next: any) {
+        function CsvController_get(request: any, response: any, next: any) {
             const args = {
-                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                jobId: {
+                    in: 'path',
+                    name: 'jobId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -652,22 +1985,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new CsvController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.getSettings,
+        ),
 
-            function DbtCloudIntegrationController_getSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_getSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -678,22 +2031,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.getSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.updateSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.updateSettings,
+        ),
 
-            function DbtCloudIntegrationController_updateSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_updateSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -704,22 +2077,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.updateSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.deleteSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.deleteSettings,
+        ),
 
-            function DbtCloudIntegrationController_deleteSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_deleteSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -730,22 +2123,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.deleteSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getMetrics)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.getMetrics,
+        ),
 
-            function DbtCloudIntegrationController_getMetrics(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_getMetrics(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -756,22 +2169,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.getMetrics.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getMetrics.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.getGroup,
+        ),
 
-            function GroupsController_getGroup(request: any, response: any, next: any) {
+        function GroupsController_getGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -782,22 +2215,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.getGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.deleteGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.deleteGroup,
+        ),
 
-            function GroupsController_deleteGroup(request: any, response: any, next: any) {
+        function GroupsController_deleteGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -808,23 +2261,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.deleteGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/groups/:groupUuid/members/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.addUserToGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/groups/:groupUuid/members/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.addUserToGroup,
+        ),
 
-            function GroupsController_addUserToGroup(request: any, response: any, next: any) {
+        function GroupsController_addUserToGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -835,23 +2313,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.addUserToGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.addUserToGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/groups/:groupUuid/members/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.removeUserFromGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/groups/:groupUuid/members/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.removeUserFromGroup,
+        ),
 
-            function GroupsController_removeUserFromGroup(request: any, response: any, next: any) {
+        function GroupsController_removeUserFromGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -862,22 +2365,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.removeUserFromGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.removeUserFromGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/groups/:groupUuid/members',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroupMembers)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/groups/:groupUuid/members',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.getGroupMembers,
+        ),
 
-            function GroupsController_getGroupMembers(request: any, response: any, next: any) {
+        function GroupsController_getGroupMembers(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -888,23 +2411,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.getGroupMembers.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getGroupMembers.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.updateGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.updateGroup,
+        ),
 
-            function GroupsController_updateGroup(request: any, response: any, next: any) {
+        function GroupsController_updateGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateGroup"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateGroup',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -915,21 +2463,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.updateGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganization,
+        ),
 
-            function OrganizationController_getOrganization(request: any, response: any, next: any) {
+        function OrganizationController_getOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -940,22 +2503,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.createOrganization,
+        ),
 
-            function OrganizationController_createOrganization(request: any, response: any, next: any) {
+        function OrganizationController_createOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateOrganization"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateOrganization',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -966,22 +2549,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.createOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.updateOrganization,
+        ),
 
-            function OrganizationController_updateOrganization(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateOrganization"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateOrganization',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -992,22 +2595,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/org/:organizationUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/org/:organizationUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.deleteOrganization,
+        ),
 
-            function OrganizationController_deleteOrganization(request: any, response: any, next: any) {
+        function OrganizationController_deleteOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                organizationUuid: {
+                    in: 'path',
+                    name: 'organizationUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1018,21 +2641,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.deleteOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/users',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationMembers)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/users',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationMembers,
+        ),
 
-            function OrganizationController_getOrganizationMembers(request: any, response: any, next: any) {
+        function OrganizationController_getOrganizationMembers(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1043,23 +2681,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganizationMembers.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganizationMembers.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org/users/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationMember)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org/users/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.updateOrganizationMember,
+        ),
 
-            function OrganizationController_updateOrganizationMember(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganizationMember(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"OrganizationMemberProfileUpdate"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'OrganizationMemberProfileUpdate',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1070,22 +2733,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganizationMember.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateOrganizationMember.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/org/user/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/org/user/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.deleteUser,
+        ),
 
-            function OrganizationController_deleteUser(request: any, response: any, next: any) {
+        function OrganizationController_deleteUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1096,21 +2779,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/allowedEmailDomains',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationAllowedEmailDomains)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationAllowedEmailDomains,
+        ),
 
-            function OrganizationController_getOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
+        function OrganizationController_getOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1121,22 +2819,44 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise =
+                    controller.getOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org/allowedEmailDomains',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationAllowedEmailDomains)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype
+                .updateOrganizationAllowedEmailDomains,
+        ),
 
-            function OrganizationController_updateOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateAllowedEmailDomains"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateAllowedEmailDomains',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1147,22 +2867,43 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise =
+                    controller.updateOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/org/groups',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/org/groups',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.createGroup,
+        ),
 
-            function OrganizationController_createGroup(request: any, response: any, next: any) {
+        function OrganizationController_createGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"Pick_CreateGroup.name_"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'Pick_CreateGroup.name_',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1173,21 +2914,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.createGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/groups',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.listGroupsInOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/groups',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.listGroupsInOrganization,
+        ),
 
-            function OrganizationController_listGroupsInOrganization(request: any, response: any, next: any) {
+        function OrganizationController_listGroupsInOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1198,23 +2954,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.listGroupsInOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.listGroupsInOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
-            ...(fetchMiddlewares<RequestHandler>(PinningController)),
-            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
+        ...fetchMiddlewares<RequestHandler>(PinningController),
+        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.get),
 
-            function PinningController_get(request: any, response: any, next: any) {
+        function PinningController_get(request: any, response: any, next: any) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                pinnedListUuid: {
+                    in: 'path',
+                    name: 'pinnedListUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1225,24 +3000,56 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
-            ...(fetchMiddlewares<RequestHandler>(PinningController)),
-            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.post)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
+        ...fetchMiddlewares<RequestHandler>(PinningController),
+        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.post),
 
-            function PinningController_post(request: any, response: any, next: any) {
+        function PinningController_post(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"dataType":"array","array":{"dataType":"refAlias","ref":"UpdatePinnedItemOrder"}},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                pinnedListUuid: {
+                    in: 'path',
+                    name: 'pinnedListUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'UpdatePinnedItemOrder',
+                    },
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1253,22 +3060,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-
-              const promise = controller.post.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.post.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/charts',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getChartsInProject)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/charts',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getChartsInProject,
+        ),
 
-            function ProjectController_getChartsInProject(request: any, response: any, next: any) {
+        function ProjectController_getChartsInProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1279,22 +3106,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getChartsInProject.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getChartsInProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/spaces',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getSpacesInProject)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/spaces',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getSpacesInProject,
+        ),
 
-            function ProjectController_getSpacesInProject(request: any, response: any, next: any) {
+        function ProjectController_getSpacesInProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1305,24 +3152,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getSpacesInProject.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getSpacesInProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postUnderlyingData)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
+        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
+        ...fetchMiddlewares<RequestHandler>(
+            RunViewChartQueryController.prototype.postUnderlyingData,
+        ),
 
-            function RunViewChartQueryController_postUnderlyingData(request: any, response: any, next: any) {
+        function RunViewChartQueryController_postUnderlyingData(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'RunQueryRequest',
+                },
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                exploreId: {
+                    in: 'path',
+                    name: 'exploreId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1333,24 +3210,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-
-              const promise = controller.postUnderlyingData.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postUnderlyingData.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postRunQuery)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
+        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
+        ...fetchMiddlewares<RequestHandler>(
+            RunViewChartQueryController.prototype.postRunQuery,
+        ),
 
-            function RunViewChartQueryController_postRunQuery(request: any, response: any, next: any) {
+        function RunViewChartQueryController_postRunQuery(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'RunQueryRequest',
+                },
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                exploreId: {
+                    in: 'path',
+                    name: 'exploreId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1361,23 +3268,49 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-
-              const promise = controller.postRunQuery.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postRunQuery.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/saved/:chartUuid/results',
-            ...(fetchMiddlewares<RequestHandler>(SavedChartController)),
-            ...(fetchMiddlewares<RequestHandler>(SavedChartController.prototype.postDashboardTile)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/saved/:chartUuid/results',
+        ...fetchMiddlewares<RequestHandler>(SavedChartController),
+        ...fetchMiddlewares<RequestHandler>(
+            SavedChartController.prototype.postDashboardTile,
+        ),
 
-            function SavedChartController_postDashboardTile(request: any, response: any, next: any) {
+        function SavedChartController_postDashboardTile(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"filters":{"ref":"Filters"}}},
-                    chartUuid: {"in":"path","name":"chartUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: { filters: { ref: 'Filters' } },
+                },
+                chartUuid: {
+                    in: 'path',
+                    name: 'chartUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1388,22 +3321,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SavedChartController();
 
-
-              const promise = controller.postDashboardTile.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postDashboardTile.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:projectUuid/logs',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getLogs)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:projectUuid/logs',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getLogs,
+        ),
 
-            function SchedulerController_getLogs(request: any, response: any, next: any) {
+        function SchedulerController_getLogs(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1414,22 +3367,40 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getLogs.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getLogs.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get),
 
-            function SchedulerController_get(request: any, response: any, next: any) {
+        function SchedulerController_get(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1440,23 +3411,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.patch)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.patch,
+        ),
 
-            function SchedulerController_patch(request: any, response: any, next: any) {
+        function SchedulerController_patch(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"dataType":"any"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'any',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1467,22 +3463,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.patch.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.patch.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.delete)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.delete,
+        ),
 
-            function SchedulerController_delete(request: any, response: any, next: any) {
+        function SchedulerController_delete(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1493,22 +3509,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.delete.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.delete.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:schedulerUuid/jobs',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getJobs)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:schedulerUuid/jobs',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getJobs,
+        ),
 
-            function SchedulerController_getJobs(request: any, response: any, next: any) {
+        function SchedulerController_getJobs(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1519,22 +3555,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getJobs.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getJobs.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/job/:jobId/status',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getSchedulerStatus)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/job/:jobId/status',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getSchedulerStatus,
+        ),
 
-            function SchedulerController_getSchedulerStatus(request: any, response: any, next: any) {
+        function SchedulerController_getSchedulerStatus(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                jobId: {
+                    in: 'path',
+                    name: 'jobId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1545,22 +3601,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getSchedulerStatus.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getSchedulerStatus.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/share/:nanoId',
-            ...(fetchMiddlewares<RequestHandler>(ShareController)),
-            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/share/:nanoId',
+        ...fetchMiddlewares<RequestHandler>(ShareController),
+        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.get),
 
-            function ShareController_get(request: any, response: any, next: any) {
+        function ShareController_get(request: any, response: any, next: any) {
             const args = {
-                    nanoId: {"in":"path","name":"nanoId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                nanoId: {
+                    in: 'path',
+                    name: 'nanoId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1571,22 +3641,40 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/share',
-            ...(fetchMiddlewares<RequestHandler>(ShareController)),
-            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.create)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/share',
+        ...fetchMiddlewares<RequestHandler>(ShareController),
+        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.create),
 
-            function ShareController_create(request: any, response: any, next: any) {
+        function ShareController_create(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateShareUrl"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateShareUrl',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1597,21 +3685,30 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-
-              const promise = controller.create.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.create.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/slack/channels',
-            ...(fetchMiddlewares<RequestHandler>(SlackController)),
-            ...(fetchMiddlewares<RequestHandler>(SlackController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/slack/channels',
+        ...fetchMiddlewares<RequestHandler>(SlackController),
+        ...fetchMiddlewares<RequestHandler>(SlackController.prototype.get),
 
-            function SlackController_get(request: any, response: any, next: any) {
+        function SlackController_get(request: any, response: any, next: any) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1622,21 +3719,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SlackController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/ssh/key-pairs',
-            ...(fetchMiddlewares<RequestHandler>(SshController)),
-            ...(fetchMiddlewares<RequestHandler>(SshController.prototype.createSshKeyPair)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/ssh/key-pairs',
+        ...fetchMiddlewares<RequestHandler>(SshController),
+        ...fetchMiddlewares<RequestHandler>(
+            SshController.prototype.createSshKeyPair,
+        ),
 
-            function SshController_createSshKeyPair(request: any, response: any, next: any) {
+        function SshController_createSshKeyPair(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1647,21 +3759,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SshController();
 
-
-              const promise = controller.createSshKeyPair.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.createSshKeyPair.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/user/me/email/otp',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.createEmailOneTimePasscode)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/user/me/email/otp',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.createEmailOneTimePasscode,
+        ),
 
-            function UserController_createEmailOneTimePasscode(request: any, response: any, next: any) {
+        function UserController_createEmailOneTimePasscode(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1672,22 +3799,37 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.createEmailOneTimePasscode.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createEmailOneTimePasscode.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/user/me/email/status',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getEmailVerificationStatus)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/user/me/email/status',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getEmailVerificationStatus,
+        ),
 
-            function UserController_getEmailVerificationStatus(request: any, response: any, next: any) {
+        function UserController_getEmailVerificationStatus(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    passcode: {"in":"query","name":"passcode","dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                passcode: { in: 'query', name: 'passcode', dataType: 'string' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1698,21 +3840,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.getEmailVerificationStatus.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getEmailVerificationStatus.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/user/me/allowedOrganizations',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getOrganizationsUserCanJoin)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/user/me/allowedOrganizations',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getOrganizationsUserCanJoin,
+        ),
 
-            function UserController_getOrganizationsUserCanJoin(request: any, response: any, next: any) {
+        function UserController_getOrganizationsUserCanJoin(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1723,22 +3880,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.getOrganizationsUserCanJoin.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganizationsUserCanJoin.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/user/me/joinOrganization/:organizationUuid',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.joinOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/user/me/joinOrganization/:organizationUuid',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.joinOrganization,
+        ),
 
-            function UserController_joinOrganization(request: any, response: any, next: any) {
+        function UserController_joinOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                organizationUuid: {
+                    in: 'path',
+                    name: 'organizationUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1749,21 +3926,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.joinOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.joinOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/user/me',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.deleteUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/user/me',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.deleteUser,
+        ),
 
-            function UserController_deleteUser(request: any, response: any, next: any) {
+        function UserController_deleteUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1774,22 +3966,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/validate',
-            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
-            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.post)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/validate',
+        ...fetchMiddlewares<RequestHandler>(ValidationController),
+        ...fetchMiddlewares<RequestHandler>(
+            ValidationController.prototype.post,
+        ),
 
-            function ValidationController_post(request: any, response: any, next: any) {
+        function ValidationController_post(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1800,23 +4012,45 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-
-              const promise = controller.post.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.post.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/validate',
-            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
-            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/validate',
+        ...fetchMiddlewares<RequestHandler>(ValidationController),
+        ...fetchMiddlewares<RequestHandler>(ValidationController.prototype.get),
 
-            function ValidationController_get(request: any, response: any, next: any) {
+        function ValidationController_get(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    fromSettings: {"in":"query","name":"fromSettings","dataType":"boolean"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                fromSettings: {
+                    in: 'query',
+                    name: 'fromSettings',
+                    dataType: 'boolean',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1827,25 +4061,37 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
+        },
+    );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function isController(object: any): object is Controller {
-        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
+        return (
+            'getHeaders' in object &&
+            'getStatus' in object &&
+            'setStatus' in object
+        );
     }
 
-    function promiseHandler(controllerObj: any, promise: any, response: any, successStatus: any, next: any) {
+    function promiseHandler(
+        controllerObj: any,
+        promise: any,
+        response: any,
+        successStatus: any,
+        next: any,
+    ) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 let statusCode = successStatus;
@@ -1857,21 +4103,31 @@ export function RegisterRoutes(app: express.Router) {
 
                 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-                returnHandler(response, statusCode, data, headers)
+                returnHandler(response, statusCode, data, headers);
             })
             .catch((error: any) => next(error));
     }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function returnHandler(response: any, statusCode?: number, data?: any, headers: any = {}) {
+    function returnHandler(
+        response: any,
+        statusCode?: number,
+        data?: any,
+        headers: any = {},
+    ) {
         if (response.headersSent) {
             return;
         }
         Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
         });
-        if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
+        if (
+            data &&
+            typeof data.pipe === 'function' &&
+            data.readable &&
+            typeof data._read === 'function'
+        ) {
             data.pipe(response);
         } else if (data !== null && data !== undefined) {
             response.status(statusCode || 200).json(data);
@@ -1882,38 +4138,108 @@ export function RegisterRoutes(app: express.Router) {
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function responder(response: any): TsoaResponse<HttpStatusCodeLiteral, unknown>  {
-        return function(status, data, headers) {
+    function responder(
+        response: any,
+    ): TsoaResponse<HttpStatusCodeLiteral, unknown> {
+        return function (status, data, headers) {
             returnHandler(response, status, data, headers);
         };
-    };
+    }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function getValidatedArgs(args: any, request: any, response: any): any[] {
-        const fieldErrors: FieldErrors  = {};
+        const fieldErrors: FieldErrors = {};
         const values = Object.keys(args).map((key) => {
             const name = args[key].name;
             switch (args[key].in) {
                 case 'request':
                     return request;
                 case 'query':
-                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.query[name],
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'path':
-                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.params[name],
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'header':
-                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.header(name),
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'body':
-                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.body,
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'body-prop':
-                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.body[name],
+                        name,
+                        fieldErrors,
+                        'body.',
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'formData':
                     if (args[key].dataType === 'file') {
-                        return validationService.ValidateParam(args[key], request.file, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
-                    } else if (args[key].dataType === 'array' && args[key].array.dataType === 'file') {
-                        return validationService.ValidateParam(args[key], request.files, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.file,
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
+                    } else if (
+                        args[key].dataType === 'array' &&
+                        args[key].array.dataType === 'file'
+                    ) {
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.files,
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
                     } else {
-                        return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.body[name],
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
                     }
                 case 'res':
                     return responder(response);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1,4114 +1,4559 @@
 {
-    "components": {
-        "examples": {},
-        "headers": {},
-        "parameters": {},
-        "requestBodies": {},
-        "responses": {},
-        "schemas": {
-            "ApiErrorPayload": {
-                "properties": {
-                    "error": {
-                        "properties": {
-                            "data": {
-                                "description": "Optional data containing details of the error"
-                            },
-                            "message": {
-                                "type": "string",
-                                "description": "A friendly message summarising the error"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Unique name for the type of error"
-                            },
-                            "statusCode": {
-                                "type": "number",
-                                "format": "integer",
-                                "description": "HTTP status code"
-                            }
-                        },
-                        "required": ["name", "statusCode"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["error"],
-                        "nullable": false
-                    }
-                },
-                "required": ["error", "status"],
-                "type": "object",
-                "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
-            },
-            "ApiCsvUrlResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "status": {
-                                "type": "string"
-                            },
-                            "url": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["status", "url"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_CreateDbtCloudIntegration.metricsJobId_": {
-                "properties": {
-                    "metricsJobId": {
-                        "type": "string",
-                        "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
-                    }
-                },
-                "required": ["metricsJobId"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "DbtCloudIntegration": {
-                "$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
-                "description": "Configuration for a Lightdash integration with dbt Cloud"
-            },
-            "ApiDbtCloudIntegrationSettings": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/DbtCloudIntegration"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "ApiDbtCloudSettingsDeleteSuccess": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "DbtCloudMetric": {
-                "properties": {
-                    "label": {
-                        "type": "string"
-                    },
-                    "timeGrains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "uniqueId": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "label",
-                    "timeGrains",
-                    "description",
-                    "dimensions",
-                    "name",
-                    "uniqueId"
-                ],
-                "type": "object"
-            },
-            "DbtCloudMetadataResponseMetrics": {
-                "properties": {
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtCloudMetric"
-                        },
-                        "type": "array",
-                        "description": "A list of dbt metric definitions from the dbt cloud metadata api"
-                    }
-                },
-                "required": ["metrics"],
-                "type": "object",
-                "description": "Response from dbt cloud metadata api containing a list of metric definitions"
-            },
-            "ApiDbtCloudMetrics": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Group": {
-                "properties": {
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "The UUID of the organization that the group belongs to"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The time that the group was created"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    },
-                    "uuid": {
-                        "type": "string",
-                        "description": "The group's UUID"
-                    }
-                },
-                "required": ["organizationUuid", "createdAt", "name", "uuid"],
-                "type": "object"
-            },
-            "ApiGroupResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Group"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiSuccessEmpty": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "GroupMember": {
-                "properties": {
-                    "lastName": {
-                        "type": "string",
-                        "description": "The user's last name"
-                    },
-                    "firstName": {
-                        "type": "string",
-                        "description": "The user's first name"
-                    },
-                    "email": {
-                        "type": "string",
-                        "description": "Primary email address for the user"
-                    },
-                    "userUuid": {
-                        "type": "string",
-                        "description": "Unique id for the user",
-                        "format": "uuid"
-                    }
-                },
-                "required": ["lastName", "firstName", "email", "userUuid"],
-                "type": "object",
-                "description": "A summary for a Lightdash user within a group"
-            },
-            "ApiGroupMembersResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/GroupMember"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Group.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "UpdateGroup": {
-                "$ref": "#/components/schemas/Pick_Group.name_"
-            },
-            "Organization": {
-                "properties": {
-                    "needsProject": {
-                        "type": "boolean",
-                        "description": "The organization needs a project if it doesn't have at least one project."
-                    },
-                    "chartColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "description": "The default color palette for all projects in the organization"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "The unique identifier of the organization",
-                        "format": "uuid"
-                    }
-                },
-                "required": ["name", "organizationUuid"],
-                "type": "object",
-                "description": "Details of a user's Organization"
-            },
-            "ApiOrganization": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Organization"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Organization.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "CreateOrganization": {
-                "$ref": "#/components/schemas/Pick_Organization.name_"
-            },
-            "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    },
-                    "chartColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "description": "The default color palette for all projects in the organization"
-                    }
-                },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "UpdateOrganization": {
-                "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
-            },
-            "OrganizationMemberRole": {
-                "enum": [
-                    "member",
-                    "viewer",
-                    "interactive_viewer",
-                    "editor",
-                    "developer",
-                    "admin"
-                ],
-                "type": "string"
-            },
-            "OrganizationMemberProfile": {
-                "properties": {
-                    "isInviteExpired": {
-                        "type": "boolean",
-                        "description": "Whether the user's invite to the organization has expired"
-                    },
-                    "isActive": {
-                        "type": "boolean",
-                        "description": "Whether the user has accepted their invite to the organization"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole",
-                        "description": "The role of the user in the organization"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "Unique identifier for the organization the user is a member of"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string",
-                        "description": "Unique identifier for the user",
-                        "format": "uuid"
-                    }
-                },
-                "required": [
-                    "isActive",
-                    "role",
-                    "organizationUuid",
-                    "email",
-                    "lastName",
-                    "firstName",
-                    "userUuid"
-                ],
-                "type": "object",
-                "description": "Profile for a user's membership in an organization"
-            },
-            "ApiOrganizationMemberProfiles": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/OrganizationMemberProfile"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiOrganizationMemberProfile": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/OrganizationMemberProfile"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Partial_Pick_OrganizationMemberProfile.role__": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole",
-                        "description": "The role of the user in the organization"
-                    }
-                },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "OrganizationMemberProfileUpdate": {
-                "$ref": "#/components/schemas/Partial_Pick_OrganizationMemberProfile.role__"
-            },
-            "AllowedEmailDomains": {
-                "properties": {
-                    "projectUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole"
-                    },
-                    "emailDomains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "projectUuids",
-                    "role",
-                    "emailDomains",
-                    "organizationUuid"
-                ],
-                "type": "object"
-            },
-            "ApiOrganizationAllowedEmailDomains": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/AllowedEmailDomains"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole"
-                    },
-                    "emailDomains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "projectUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": ["role", "emailDomains", "projectUuids"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_AllowedEmailDomains.organizationUuid_": {
-                "$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "UpdateAllowedEmailDomains": {
-                "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
-            },
-            "Pick_CreateGroup.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ApiGroupListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/Group"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ResourceViewItemType.DASHBOARD": {
-                "enum": ["dashboard"],
-                "type": "string"
-            },
-            "UpdatedByUser": {
-                "properties": {
-                    "userUuid": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    }
-                },
-                "required": ["userUuid", "firstName", "lastName"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-                "properties": {
-                    "error": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "validationId": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["error", "createdAt", "validationId"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ValidationSummary": {
-                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
-            },
-            "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "validationErrors": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationSummary"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "views",
-                    "firstViewedAt",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewDashboardItem": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "ResourceViewItemType.CHART": {
-                "enum": ["chart"],
-                "type": "string"
-            },
-            "ChartKind": {
-                "enum": [
-                    "line",
-                    "horizontal_bar",
-                    "vertical_bar",
-                    "scatter",
-                    "area",
-                    "mixed",
-                    "table",
-                    "big_number"
-                ],
-                "type": "string"
-            },
-            "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "validationErrors": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationSummary"
-                        },
-                        "type": "array"
-                    },
-                    "chartType": {
-                        "$ref": "#/components/schemas/ChartKind"
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "views",
-                    "firstViewedAt",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewChartItem": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.CHART"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "ResourceViewItemType.SPACE": {
-                "enum": ["space"],
-                "type": "string"
-            },
-            "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder",
-                    "isPrivate"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewSpaceItem": {
-                "properties": {
-                    "data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
-                            },
-                            {
-                                "properties": {
-                                    "chartCount": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "dashboardCount": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "accessListLength": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "access": {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    }
-                                },
-                                "required": [
-                                    "chartCount",
-                                    "dashboardCount",
-                                    "accessListLength",
-                                    "access"
-                                ],
-                                "type": "object"
-                            }
-                        ]
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "PinnedItems": {
-                "items": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/components/schemas/ResourceViewDashboardItem"
-                        },
-                        {
-                            "$ref": "#/components/schemas/ResourceViewChartItem"
-                        },
-                        {
-                            "$ref": "#/components/schemas/ResourceViewSpaceItem"
-                        }
-                    ]
-                },
-                "type": "array"
-            },
-            "ApiPinnedItems": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/PinnedItems"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ResourceViewItemType": {
-                "enum": ["chart", "dashboard", "space"],
-                "type": "string"
-            },
-            "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-                "properties": {
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "required": ["uuid", "pinnedListOrder"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "UpdatePinnedItemOrder": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "spaceName": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "spaceUuid",
-                    "pinnedListUuid",
-                    "spaceName"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ChartSummary": {
-                "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
-            },
-            "ApiChartSummaryListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ChartSummary"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "isPrivate"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "SpaceSummary": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
-                    },
-                    {
-                        "properties": {
-                            "access": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["access"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "ApiSpaceSummaryListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceSummary"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "FieldId": {
-                "type": "string"
-            },
-            "FilterGroupResponse": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "or": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "id": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["or", "id"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "and": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "id": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["and", "id"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Filters": {
-                "properties": {
-                    "metrics": {
-                        "$ref": "#/components/schemas/FilterGroupResponse"
-                    },
-                    "dimensions": {
-                        "$ref": "#/components/schemas/FilterGroupResponse"
-                    }
-                },
-                "type": "object"
-            },
-            "SortField": {
-                "properties": {
-                    "descending": {
-                        "type": "boolean"
-                    },
-                    "fieldId": {
-                        "type": "string"
-                    }
-                },
-                "required": ["descending", "fieldId"],
-                "type": "object"
-            },
-            "TableCalculation": {
-                "properties": {
-                    "sql": {
-                        "type": "string"
-                    },
-                    "displayName": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "index": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["sql", "displayName", "name"],
-                "type": "object"
-            },
-            "MetricType": {
-                "enum": [
-                    "percentile",
-                    "average",
-                    "count",
-                    "count_distinct",
-                    "sum",
-                    "min",
-                    "max",
-                    "number",
-                    "median",
-                    "string",
-                    "date",
-                    "boolean"
-                ],
-                "type": "string"
-            },
-            "Compact": {
-                "enum": ["thousands", "millions", "billions", "trillions"],
-                "type": "string"
-            },
-            "CompactOrAlias": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/Compact"
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "K",
-                            "thousand",
-                            "M",
-                            "million",
-                            "B",
-                            "billion",
-                            "T",
-                            "trillion"
-                        ]
-                    }
-                ]
-            },
-            "AdditionalMetric": {
-                "properties": {
-                    "label": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/MetricType"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "sql": {
-                        "type": "string"
-                    },
-                    "hidden": {
-                        "type": "boolean"
-                    },
-                    "round": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "compact": {
-                        "$ref": "#/components/schemas/CompactOrAlias"
-                    },
-                    "format": {
-                        "type": "string"
-                    },
-                    "table": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "index": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["type", "sql", "table", "name"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "MetricQueryResponse": {
-                "properties": {
-                    "additionalMetrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/AdditionalMetric"
-                        },
-                        "type": "array"
-                    },
-                    "tableCalculations": {
-                        "items": {
-                            "$ref": "#/components/schemas/TableCalculation"
-                        },
-                        "type": "array"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sorts": {
-                        "items": {
-                            "$ref": "#/components/schemas/SortField"
-                        },
-                        "type": "array"
-                    },
-                    "filters": {
-                        "$ref": "#/components/schemas/Filters"
-                    },
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "tableCalculations",
-                    "limit",
-                    "sorts",
-                    "filters",
-                    "metrics",
-                    "dimensions"
-                ],
-                "type": "object"
-            },
-            "ApiRunQueryResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "rows": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "metricQuery": {
-                                "$ref": "#/components/schemas/MetricQueryResponse"
-                            }
-                        },
-                        "required": ["rows", "metricQuery"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "RunQueryRequest": {
-                "properties": {
-                    "csvLimit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "additionalMetrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/AdditionalMetric"
-                        },
-                        "type": "array"
-                    },
-                    "tableCalculations": {
-                        "items": {
-                            "$ref": "#/components/schemas/TableCalculation"
-                        },
-                        "type": "array"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sorts": {
-                        "items": {
-                            "$ref": "#/components/schemas/SortField"
-                        },
-                        "type": "array"
-                    },
-                    "filters": {
-                        "properties": {
-                            "metrics": {},
-                            "dimensions": {}
-                        },
-                        "type": "object"
-                    },
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "tableCalculations",
-                    "limit",
-                    "sorts",
-                    "filters",
-                    "metrics",
-                    "dimensions"
-                ],
-                "type": "object"
-            },
-            "SchedulerFormat": {
-                "enum": ["csv", "image"],
-                "type": "string"
-            },
-            "SchedulerCsvOptions": {
-                "properties": {
-                    "limit": {
-                        "anyOf": [
-                            {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            {
-                                "type": "string",
-                                "enum": ["table", "all"]
-                            }
-                        ]
-                    },
-                    "formatted": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["limit", "formatted"],
-                "type": "object"
-            },
-            "SchedulerImageOptions": {
-                "properties": {},
-                "type": "object"
-            },
-            "SchedulerOptions": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerCsvOptions"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SchedulerImageOptions"
-                    }
-                ]
-            },
-            "SchedulerBase": {
-                "properties": {
-                    "options": {
-                        "$ref": "#/components/schemas/SchedulerOptions"
-                    },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedChartUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cron": {
-                        "type": "string"
-                    },
-                    "format": {
-                        "$ref": "#/components/schemas/SchedulerFormat"
-                    },
-                    "createdBy": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "options",
-                    "dashboardUuid",
-                    "savedChartUuid",
-                    "cron",
-                    "format",
-                    "createdBy",
-                    "updatedAt",
-                    "createdAt",
-                    "name",
-                    "schedulerUuid"
-                ],
-                "type": "object"
-            },
-            "ChartScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "dashboardUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedChartUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["dashboardUuid", "savedChartUuid"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "DashboardScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "dashboardUuid": {
-                                "type": "string"
-                            },
-                            "savedChartUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            }
-                        },
-                        "required": ["dashboardUuid", "savedChartUuid"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Scheduler": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ChartScheduler"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DashboardScheduler"
-                    }
-                ]
-            },
-            "SchedulerSlackTarget": {
-                "properties": {
-                    "channel": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerSlackTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "channel",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerSlackTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerEmailTarget": {
-                "properties": {
-                    "recipient": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerEmailTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "recipient",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerEmailTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerAndTargets": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Scheduler"
-                    },
-                    {
-                        "properties": {
-                            "targets": {
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
-                                        }
-                                    ]
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["targets"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "SchedulerJobStatus": {
-                "enum": ["scheduled", "started", "completed", "error"],
-                "type": "string"
-            },
-            "Record_string.any_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
-            "SchedulerLog": {
-                "properties": {
-                    "details": {
-                        "$ref": "#/components/schemas/Record_string.any_"
-                    },
-                    "targetType": {
-                        "type": "string",
-                        "enum": ["email", "slack"]
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/SchedulerJobStatus"
-                    },
-                    "scheduledTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "jobGroup": {
-                        "type": "string"
-                    },
-                    "jobId": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "task": {
-                        "type": "string",
-                        "enum": [
-                            "handleScheduledDelivery",
-                            "sendEmailNotification",
-                            "sendSlackNotification",
-                            "downloadCsv",
-                            "compileProject",
-                            "testAndCompileProject",
-                            "validateProject"
-                        ]
-                    }
-                },
-                "required": ["status", "scheduledTime", "jobId", "task"],
-                "type": "object"
-            },
-            "SchedulerWithLogs": {
-                "properties": {
-                    "logs": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerLog"
-                        },
-                        "type": "array"
-                    },
-                    "users": {
-                        "items": {
-                            "properties": {
-                                "userUuid": {
-                                    "type": "string"
-                                },
-                                "lastName": {
-                                    "type": "string"
-                                },
-                                "firstName": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["userUuid", "lastName", "firstName"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "schedulers": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerAndTargets"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": ["logs", "users", "schedulers"],
-                "type": "object"
-            },
-            "ApiSchedulerLogsResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/SchedulerWithLogs"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiSchedulerAndTargetsResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/SchedulerAndTargets"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ScheduledJobs": {
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
-                "required": ["id", "date"],
-                "type": "object"
-            },
-            "ApiScheduledJobsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ScheduledJobs"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiJobStatusResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "status": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["status"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ShareUrl": {
-                "properties": {
-                    "host": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "shareUrl": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "createdByUserUuid": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "params": {
-                        "type": "string"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "The URL path of the full URL"
-                    },
-                    "nanoid": {
-                        "type": "string",
-                        "description": "Unique shareable id"
-                    }
-                },
-                "required": ["params", "path", "nanoid"],
-                "type": "object",
-                "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
-            },
-            "ApiShareResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/ShareUrl"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_ShareUrl.path-or-params_": {
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "The URL path of the full URL"
-                    },
-                    "params": {
-                        "type": "string"
-                    }
-                },
-                "required": ["path", "params"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "CreateShareUrl": {
-                "$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
-                "description": "Contains the detail of a full URL to generate a short URL id"
-            },
-            "SlackChannel": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name", "id"],
-                "type": "object"
-            },
-            "ApiSlackChannelsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SlackChannel"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_SshKeyPair.publicKey_": {
-                "properties": {
-                    "publicKey": {
-                        "type": "string"
-                    }
-                },
-                "required": ["publicKey"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ApiSshKeyPairResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "EmailOneTimePassword": {
-                "properties": {
-                    "numberOfAttempts": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Number of times the passcode has been attempted"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Time that the passcode was created"
-                    }
-                },
-                "required": ["numberOfAttempts", "createdAt"],
-                "type": "object"
-            },
-            "EmailStatus": {
-                "properties": {
-                    "otp": {
-                        "$ref": "#/components/schemas/EmailOneTimePassword"
-                    },
-                    "isVerified": {
-                        "type": "boolean"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "required": ["isVerified", "email"],
-                "type": "object"
-            },
-            "EmailOneTimePasswordExpiring": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/EmailOneTimePassword"
-                    },
-                    {
-                        "properties": {
-                            "isMaxAttempts": {
-                                "type": "boolean"
-                            },
-                            "isExpired": {
-                                "type": "boolean"
-                            },
-                            "expiresAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            }
-                        },
-                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "EmailStatusExpiring": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/EmailStatus"
-                    },
-                    {
-                        "properties": {
-                            "otp": {
-                                "$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
-                                "description": "One time passcode information\nIf there is no active passcode, this will be undefined"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ],
-                "description": "Verification status of an email address"
-            },
-            "ApiEmailStatusResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/EmailStatusExpiring"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object",
-                "description": "Shows the current verification status of an email address"
-            },
-            "UserAllowedOrganization": {
-                "properties": {
-                    "membersCount": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["membersCount", "name", "organizationUuid"],
-                "type": "object"
-            },
-            "ApiUserAllowedOrganizationsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/UserAllowedOrganization"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiJobScheduledResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "jobId": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["jobId"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ValidationErrorType": {
-                "enum": [
-                    "chart",
-                    "sorting",
-                    "filter",
-                    "metric",
-                    "model",
-                    "dimension"
-                ],
-                "type": "string"
-            },
-            "ValidationResponseBase": {
-                "properties": {
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "errorType": {
-                        "$ref": "#/components/schemas/ValidationErrorType"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "validationId": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": [
-                    "projectUuid",
-                    "error",
-                    "name",
-                    "createdAt",
-                    "validationId"
-                ],
-                "type": "object"
-            },
-            "ValidationErrorChartResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationResponseBase"
-                    },
-                    {
-                        "properties": {
-                            "lastUpdatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "lastUpdatedBy": {
-                                "type": "string"
-                            },
-                            "fieldName": {
-                                "type": "string"
-                            },
-                            "chartType": {
-                                "$ref": "#/components/schemas/ChartKind"
-                            },
-                            "chartUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "ValidationErrorDashboardResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationResponseBase"
-                    },
-                    {
-                        "properties": {
-                            "lastUpdatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "lastUpdatedBy": {
-                                "type": "string"
-                            },
-                            "fieldName": {
-                                "type": "string"
-                            },
-                            "chartName": {
-                                "type": "string"
-                            },
-                            "dashboardUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "ValidationErrorTableResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationResponseBase"
-                    },
-                    {
-                        "properties": {
-                            "dimensionName": {
-                                "type": "string"
-                            },
-                            "modelName": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "ValidationResponse": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorChartResponse"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorDashboardResponse"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorTableResponse"
-                    }
-                ]
-            },
-            "ApiValidateResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationResponse"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            }
-        },
-        "securitySchemes": {
-            "session_cookie": {
-                "type": "apiKey",
-                "in": "cookie",
-                "name": "connect.sid"
-            },
-            "api_key": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "Authorization",
-                "description": "Value should be 'ApiKey <your key>'"
-            }
-        }
-    },
-    "info": {
-        "title": "Lightdash API",
-        "version": "0.586.1",
-        "description": "Open API documentation for all public Lightdash API endpoints",
-        "license": {
-            "name": "MIT"
-        },
-        "contact": {
-            "name": "Lightdash Support",
-            "email": "support@lightdash.com",
-            "url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
-        }
-    },
-    "openapi": "3.0.0",
-    "paths": {
-        "/api/v1/csv/{jobId}": {
-            "get": {
-                "operationId": "getCsvUrl",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiCsvUrlResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a Csv",
-                "tags": ["Exports"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the jobId for the CSV",
-                        "in": "path",
-                        "name": "jobId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
-            "get": {
-                "operationId": "getDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the current dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "updateDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "deleteDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
-            "get": {
-                "operationId": "getDbtCloudMetrics",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudMetrics"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/groups/{groupUuid}": {
-            "get": {
-                "operationId": "getGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get group details",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "unique id of the group",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "deleteGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "patch": {
-                "operationId": "updateGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateGroup"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/groups/{groupUuid}/members/{userUuid}": {
-            "put": {
-                "operationId": "addUserToGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Add a Lightdash user to a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to add the user to",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the UUID for the user to add to the group",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "removeUserFromGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove a user from a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to remove the user from",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the UUID for the user to remove from the group",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/groups/{groupUuid}/members": {
-            "get": {
-                "operationId": "getGroupMembers",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupMembersResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "View members of a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to view the members of",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org": {
-            "get": {
-                "operationId": "GetMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganization"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            },
-            "put": {
-                "operationId": "CreateOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new organization settings",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateOrganization",
-                                "description": "the new organization settings"
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "UpdateMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new organization settings",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateOrganization",
-                                "description": "the new organization settings"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/{organizationUuid}": {
-            "delete": {
-                "operationId": "DeleteMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deletes an organization and all users inside that organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the organization to delete",
-                        "in": "path",
-                        "name": "organizationUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org/users": {
-            "get": {
-                "operationId": "ListOrganizationMembers",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets all the members of the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/org/users/{userUuid}": {
-            "patch": {
-                "operationId": "UpdateOrganizationMember",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Updates the membership profile for a user in the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the user to update",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new membership profile",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
-                                "description": "the new membership profile"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/user/{userUuid}": {
-            "delete": {
-                "operationId": "DeleteOrganizationMember",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deletes a user from the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the user to delete",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org/allowedEmailDomains": {
-            "get": {
-                "operationId": "ListOrganizationEmailDomains",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            },
-            "patch": {
-                "operationId": "UpdateOrganizationEmailDomains",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateAllowedEmailDomains"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/groups": {
-            "post": {
-                "operationId": "CreateGroupInOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Creates a new group in the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Pick_CreateGroup.name_"
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "operationId": "ListGroupsInOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets all the groups in the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
-            "get": {
-                "operationId": "getPinnedItems",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiPinnedItems"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get pinned items",
-                "tags": ["Content"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "project uuid",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the list uuid for the pinned items",
-                        "in": "path",
-                        "name": "pinnedListUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
-            "patch": {
-                "operationId": "updatePinnedItemsOrder",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiPinnedItems"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update pinned items order",
-                "tags": ["Content"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "project uuid",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the list uuid for the pinned items",
-                        "in": "path",
-                        "name": "pinnedListUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new order of the pinned items",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "items": {
-                                    "$ref": "#/components/schemas/UpdatePinnedItemOrder"
-                                },
-                                "type": "array",
-                                "description": "the new order of the pinned items"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/charts": {
-            "get": {
-                "operationId": "ListChartsInProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List all charts in a project",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project to get charts for",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/spaces": {
-            "get": {
-                "operationId": "ListSpacesInProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List all spaces in a project",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project to get spaces for",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
-            "post": {
-                "operationId": "postRunUnderlyingDataQuery",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for underlying data results",
-                "tags": ["Exploring"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "table name",
-                        "in": "path",
-                        "name": "exploreId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "metricQuery for the chart to run",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunQueryRequest",
-                                "description": "metricQuery for the chart to run"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
-            "post": {
-                "operationId": "postRunQuery",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for explore",
-                "tags": ["Exploring"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "table name",
-                        "in": "path",
-                        "name": "exploreId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "metricQuery for the chart to run",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunQueryRequest",
-                                "description": "metricQuery for the chart to run"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/saved/{chartUuid}/results": {
-            "post": {
-                "operationId": "postChartResults",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for a chart",
-                "tags": ["Charts"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "chartUuid for the chart to run",
-                        "in": "path",
-                        "name": "chartUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "filters": {
-                                        "$ref": "#/components/schemas/Filters"
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/schedulers/{projectUuid}/logs": {
-            "get": {
-                "operationId": "getSchedulerLogs",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerLogsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get scheduled logs",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/{schedulerUuid}": {
-            "get": {
-                "operationId": "getScheduler",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "patch": {
-                "operationId": "updateScheduler",
-                "responses": {
-                    "201": {
-                        "description": "Updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new scheduler data",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "description": "the new scheduler data"
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "deleteScheduler",
-                "responses": {
-                    "201": {
-                        "description": "Deleted",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "results": {},
-                                        "status": {
-                                            "type": "string",
-                                            "enum": ["ok"],
-                                            "nullable": false
-                                        }
-                                    },
-                                    "required": ["status"],
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to delete",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/{schedulerUuid}/jobs": {
-            "get": {
-                "operationId": "getScheduledJobs",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiScheduledJobsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get scheduled jobs",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/job/{jobId}/status": {
-            "get": {
-                "operationId": "getSchedulerJobStatus",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiJobStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a generic job status\nThis method can be used when polling from the frontend",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the jobId for the status to check",
-                        "in": "path",
-                        "name": "jobId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/share/{nanoId}": {
-            "get": {
-                "operationId": "getShareUrl",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiShareResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a share url from a short url id",
-                "tags": ["Share links"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the short id for the share url",
-                        "in": "path",
-                        "name": "nanoId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/share": {
-            "post": {
-                "operationId": "CreateShareUrl",
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiShareResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Given a full URL generates a short url id that can be used for sharing",
-                "tags": ["Share links"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "a full URL used to generate a short url id",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateShareUrl",
-                                "description": "a full URL used to generate a short url id"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/slack/channels": {
-            "get": {
-                "operationId": "getSlackChannels",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSlackChannelsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get slack channels",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/ssh/key-pairs": {
-            "post": {
-                "operationId": "createSshKeyPair",
-                "responses": {
-                    "201": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSshKeyPairResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["SSH Keypairs"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/email/otp": {
-            "put": {
-                "operationId": "CreateEmailOneTimePasscode",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/email/status": {
-            "get": {
-                "operationId": "GetEmailVerificationStatus",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the verification status for the current user's primary email",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the one-time passcode sent to the user's primary email",
-                        "in": "query",
-                        "name": "passcode",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/user/me/allowedOrganizations": {
-            "get": {
-                "operationId": "ListMyAvailableOrganizations",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/joinOrganization/{organizationUuid}": {
-            "post": {
-                "operationId": "JoinOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the organization to join",
-                        "in": "path",
-                        "name": "organizationUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/user/me": {
-            "delete": {
-                "operationId": "DeleteMe",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete user",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/projects/{projectUuid}/validate": {
-            "post": {
-                "operationId": "ValidateProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the projectId for the validation",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "get": {
-                "operationId": "GetLatestValidationResults",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiValidateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get validation results for a project. This will return the results of the latest validation job.",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the projectId for the validation",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "boolean to know if this request is made from the settings page, for analytics",
-                        "in": "query",
-                        "name": "fromSettings",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    "servers": [
-        {
-            "url": "/"
-        }
-    ],
-    "tags": [
-        {
-            "name": "My Account",
-            "description": "These routes allow users to manage their own user account."
-        },
-        {
-            "name": "Organizations",
-            "description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
-        },
-        {
-            "name": "Projects",
-            "description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
-        }
-    ]
+	"components": {
+		"examples": {},
+		"headers": {},
+		"parameters": {},
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"ApiErrorPayload": {
+				"properties": {
+					"error": {
+						"properties": {
+							"data": {
+								"description": "Optional data containing details of the error"
+							},
+							"message": {
+								"type": "string",
+								"description": "A friendly message summarising the error"
+							},
+							"name": {
+								"type": "string",
+								"description": "Unique name for the type of error"
+							},
+							"statusCode": {
+								"type": "number",
+								"format": "integer",
+								"description": "HTTP status code"
+							}
+						},
+						"required": [
+							"name",
+							"statusCode"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"error"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"error",
+					"status"
+				],
+				"type": "object",
+				"description": "The Error object is returned from the api any time there is an error.\nThe message contains"
+			},
+			"ApiCsvUrlResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"status": {
+								"type": "string"
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"status",
+							"url"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_CreateDbtCloudIntegration.metricsJobId_": {
+				"properties": {
+					"metricsJobId": {
+						"type": "string",
+						"description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
+					}
+				},
+				"required": [
+					"metricsJobId"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"DbtCloudIntegration": {
+				"$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
+				"description": "Configuration for a Lightdash integration with dbt Cloud"
+			},
+			"ApiDbtCloudIntegrationSettings": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/DbtCloudIntegration"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiDbtCloudSettingsDeleteSuccess": {
+				"properties": {
+					"results": {},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"DbtCloudMetric": {
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"timeGrains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"description": {
+						"type": "string"
+					},
+					"dimensions": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"name": {
+						"type": "string"
+					},
+					"uniqueId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"label",
+					"timeGrains",
+					"description",
+					"dimensions",
+					"name",
+					"uniqueId"
+				],
+				"type": "object"
+			},
+			"DbtCloudMetadataResponseMetrics": {
+				"properties": {
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/DbtCloudMetric"
+						},
+						"type": "array",
+						"description": "A list of dbt metric definitions from the dbt cloud metadata api"
+					}
+				},
+				"required": [
+					"metrics"
+				],
+				"type": "object",
+				"description": "Response from dbt cloud metadata api containing a list of metric definitions"
+			},
+			"ApiDbtCloudMetrics": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Group": {
+				"properties": {
+					"organizationUuid": {
+						"type": "string",
+						"description": "The UUID of the organization that the group belongs to"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"description": "The time that the group was created"
+					},
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					},
+					"uuid": {
+						"type": "string",
+						"description": "The group's UUID"
+					}
+				},
+				"required": [
+					"organizationUuid",
+					"createdAt",
+					"name",
+					"uuid"
+				],
+				"type": "object"
+			},
+			"ApiGroupResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Group"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiSuccessEmpty": {
+				"properties": {
+					"results": {},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"GroupMember": {
+				"properties": {
+					"lastName": {
+						"type": "string",
+						"description": "The user's last name"
+					},
+					"firstName": {
+						"type": "string",
+						"description": "The user's first name"
+					},
+					"email": {
+						"type": "string",
+						"description": "Primary email address for the user"
+					},
+					"userUuid": {
+						"type": "string",
+						"description": "Unique id for the user",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"lastName",
+					"firstName",
+					"email",
+					"userUuid"
+				],
+				"type": "object",
+				"description": "A summary for a Lightdash user within a group"
+			},
+			"ApiGroupMembersResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/GroupMember"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Group.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"UpdateGroup": {
+				"$ref": "#/components/schemas/Pick_Group.name_"
+			},
+			"Organization": {
+				"properties": {
+					"needsProject": {
+						"type": "boolean",
+						"description": "The organization needs a project if it doesn't have at least one project."
+					},
+					"chartColors": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array",
+						"description": "The default color palette for all projects in the organization"
+					},
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"description": "The unique identifier of the organization",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid"
+				],
+				"type": "object",
+				"description": "Details of a user's Organization"
+			},
+			"ApiOrganization": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Organization"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Organization.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateOrganization": {
+				"$ref": "#/components/schemas/Pick_Organization.name_"
+			},
+			"Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					},
+					"chartColors": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array",
+						"description": "The default color palette for all projects in the organization"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"UpdateOrganization": {
+				"$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
+			},
+			"OrganizationMemberRole": {
+				"enum": [
+					"member",
+					"viewer",
+					"interactive_viewer",
+					"editor",
+					"developer",
+					"admin"
+				],
+				"type": "string"
+			},
+			"OrganizationMemberProfile": {
+				"properties": {
+					"isInviteExpired": {
+						"type": "boolean",
+						"description": "Whether the user's invite to the organization has expired"
+					},
+					"isActive": {
+						"type": "boolean",
+						"description": "Whether the user has accepted their invite to the organization"
+					},
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole",
+						"description": "The role of the user in the organization"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"description": "Unique identifier for the organization the user is a member of"
+					},
+					"email": {
+						"type": "string"
+					},
+					"lastName": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"userUuid": {
+						"type": "string",
+						"description": "Unique identifier for the user",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"isActive",
+					"role",
+					"organizationUuid",
+					"email",
+					"lastName",
+					"firstName",
+					"userUuid"
+				],
+				"type": "object",
+				"description": "Profile for a user's membership in an organization"
+			},
+			"ApiOrganizationMemberProfiles": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/OrganizationMemberProfile"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiOrganizationMemberProfile": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/OrganizationMemberProfile"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Partial_Pick_OrganizationMemberProfile.role__": {
+				"properties": {
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole",
+						"description": "The role of the user in the organization"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"OrganizationMemberProfileUpdate": {
+				"$ref": "#/components/schemas/Partial_Pick_OrganizationMemberProfile.role__"
+			},
+			"AllowedEmailDomains": {
+				"properties": {
+					"projectUuids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole"
+					},
+					"emailDomains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"projectUuids",
+					"role",
+					"emailDomains",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiOrganizationAllowedEmailDomains": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/AllowedEmailDomains"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+				"properties": {
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole"
+					},
+					"emailDomains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"projectUuids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"role",
+					"emailDomains",
+					"projectUuids"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_AllowedEmailDomains.organizationUuid_": {
+				"$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"UpdateAllowedEmailDomains": {
+				"$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
+			},
+			"Pick_CreateGroup.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ApiGroupListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/Group"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.DASHBOARD": {
+				"enum": [
+					"dashboard"
+				],
+				"type": "string"
+			},
+			"UpdatedByUser": {
+				"properties": {
+					"userUuid": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"lastName": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"userUuid",
+					"firstName",
+					"lastName"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+				"properties": {
+					"error": {
+						"type": "string"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"validationId": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"error",
+					"createdAt",
+					"validationId"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ValidationSummary": {
+				"$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
+			},
+			"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					},
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"validationErrors": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationSummary"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"name",
+					"uuid",
+					"updatedAt",
+					"spaceUuid",
+					"views",
+					"firstViewedAt",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewDashboardItem": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.CHART": {
+				"enum": [
+					"chart"
+				],
+				"type": "string"
+			},
+			"ChartKind": {
+				"enum": [
+					"line",
+					"horizontal_bar",
+					"vertical_bar",
+					"scatter",
+					"area",
+					"mixed",
+					"table",
+					"big_number"
+				],
+				"type": "string"
+			},
+			"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					},
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"validationErrors": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationSummary"
+						},
+						"type": "array"
+					},
+					"chartType": {
+						"$ref": "#/components/schemas/ChartKind"
+					}
+				},
+				"required": [
+					"name",
+					"uuid",
+					"updatedAt",
+					"spaceUuid",
+					"views",
+					"firstViewedAt",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewChartItem": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.CHART"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.SPACE": {
+				"enum": [
+					"space"
+				],
+				"type": "string"
+			},
+			"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"isPrivate": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"pinnedListUuid",
+					"pinnedListOrder",
+					"isPrivate"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewSpaceItem": {
+				"properties": {
+					"data": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
+							},
+							{
+								"properties": {
+									"chartCount": {
+										"type": "number",
+										"format": "double"
+									},
+									"dashboardCount": {
+										"type": "number",
+										"format": "double"
+									},
+									"accessListLength": {
+										"type": "number",
+										"format": "double"
+									},
+									"access": {
+										"items": {
+											"type": "string"
+										},
+										"type": "array"
+									}
+								},
+								"required": [
+									"chartCount",
+									"dashboardCount",
+									"accessListLength",
+									"access"
+								],
+								"type": "object"
+							}
+						]
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.SPACE"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"PinnedItems": {
+				"items": {
+					"anyOf": [
+						{
+							"$ref": "#/components/schemas/ResourceViewDashboardItem"
+						},
+						{
+							"$ref": "#/components/schemas/ResourceViewChartItem"
+						},
+						{
+							"$ref": "#/components/schemas/ResourceViewSpaceItem"
+						}
+					]
+				},
+				"type": "array"
+			},
+			"ApiPinnedItems": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/PinnedItems"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType": {
+				"enum": [
+					"chart",
+					"dashboard",
+					"space"
+				],
+				"type": "string"
+			},
+			"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+				"properties": {
+					"uuid": {
+						"type": "string"
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					}
+				},
+				"required": [
+					"uuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"UpdatePinnedItemOrder": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"spaceName": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"spaceUuid",
+					"pinnedListUuid",
+					"spaceName"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ChartSummary": {
+				"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+			},
+			"ApiChartSummaryListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ChartSummary"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"isPrivate": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"isPrivate"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"SpaceSummary": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+					},
+					{
+						"properties": {
+							"access": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"access"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"ApiSpaceSummaryListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceSummary"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"FieldId": {
+				"type": "string"
+			},
+			"FilterGroupResponse": {
+				"anyOf": [
+					{
+						"properties": {
+							"or": {
+								"items": {},
+								"type": "array"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"or",
+							"id"
+						],
+						"type": "object"
+					},
+					{
+						"properties": {
+							"and": {
+								"items": {},
+								"type": "array"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"and",
+							"id"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"Filters": {
+				"properties": {
+					"metrics": {
+						"$ref": "#/components/schemas/FilterGroupResponse"
+					},
+					"dimensions": {
+						"$ref": "#/components/schemas/FilterGroupResponse"
+					}
+				},
+				"type": "object"
+			},
+			"SortField": {
+				"properties": {
+					"descending": {
+						"type": "boolean"
+					},
+					"fieldId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"descending",
+					"fieldId"
+				],
+				"type": "object"
+			},
+			"TableCalculation": {
+				"properties": {
+					"sql": {
+						"type": "string"
+					},
+					"displayName": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"index": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"sql",
+					"displayName",
+					"name"
+				],
+				"type": "object"
+			},
+			"MetricType": {
+				"enum": [
+					"percentile",
+					"average",
+					"count",
+					"count_distinct",
+					"sum",
+					"min",
+					"max",
+					"number",
+					"median",
+					"string",
+					"date",
+					"boolean"
+				],
+				"type": "string"
+			},
+			"Compact": {
+				"enum": [
+					"thousands",
+					"millions",
+					"billions",
+					"trillions"
+				],
+				"type": "string"
+			},
+			"CompactOrAlias": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/Compact"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"K",
+							"thousand",
+							"M",
+							"million",
+							"B",
+							"billion",
+							"T",
+							"trillion"
+						]
+					}
+				]
+			},
+			"AdditionalMetric": {
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/MetricType"
+					},
+					"description": {
+						"type": "string"
+					},
+					"sql": {
+						"type": "string"
+					},
+					"hidden": {
+						"type": "boolean"
+					},
+					"round": {
+						"type": "number",
+						"format": "double"
+					},
+					"compact": {
+						"$ref": "#/components/schemas/CompactOrAlias"
+					},
+					"format": {
+						"type": "string"
+					},
+					"table": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"index": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"type",
+					"sql",
+					"table",
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MetricQueryResponse": {
+				"properties": {
+					"additionalMetrics": {
+						"items": {
+							"$ref": "#/components/schemas/AdditionalMetric"
+						},
+						"type": "array"
+					},
+					"tableCalculations": {
+						"items": {
+							"$ref": "#/components/schemas/TableCalculation"
+						},
+						"type": "array"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sorts": {
+						"items": {
+							"$ref": "#/components/schemas/SortField"
+						},
+						"type": "array"
+					},
+					"filters": {
+						"$ref": "#/components/schemas/Filters"
+					},
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					},
+					"dimensions": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"tableCalculations",
+					"limit",
+					"sorts",
+					"filters",
+					"metrics",
+					"dimensions"
+				],
+				"type": "object"
+			},
+			"ApiRunQueryResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"rows": {
+								"items": {},
+								"type": "array"
+							},
+							"metricQuery": {
+								"$ref": "#/components/schemas/MetricQueryResponse"
+							}
+						},
+						"required": [
+							"rows",
+							"metricQuery"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"RunQueryRequest": {
+				"properties": {
+					"csvLimit": {
+						"type": "number",
+						"format": "double"
+					},
+					"additionalMetrics": {
+						"items": {
+							"$ref": "#/components/schemas/AdditionalMetric"
+						},
+						"type": "array"
+					},
+					"tableCalculations": {
+						"items": {
+							"$ref": "#/components/schemas/TableCalculation"
+						},
+						"type": "array"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sorts": {
+						"items": {
+							"$ref": "#/components/schemas/SortField"
+						},
+						"type": "array"
+					},
+					"filters": {
+						"properties": {
+							"metrics": {},
+							"dimensions": {}
+						},
+						"type": "object"
+					},
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					},
+					"dimensions": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"tableCalculations",
+					"limit",
+					"sorts",
+					"filters",
+					"metrics",
+					"dimensions"
+				],
+				"type": "object"
+			},
+			"SchedulerFormat": {
+				"enum": [
+					"csv",
+					"image"
+				],
+				"type": "string"
+			},
+			"SchedulerCsvOptions": {
+				"properties": {
+					"limit": {
+						"anyOf": [
+							{
+								"type": "number",
+								"format": "double"
+							},
+							{
+								"type": "string",
+								"enum": [
+									"table",
+									"all"
+								]
+							}
+						]
+					},
+					"formatted": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"limit",
+					"formatted"
+				],
+				"type": "object"
+			},
+			"SchedulerImageOptions": {
+				"properties": {},
+				"type": "object"
+			},
+			"SchedulerOptions": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerCsvOptions"
+					},
+					{
+						"$ref": "#/components/schemas/SchedulerImageOptions"
+					}
+				]
+			},
+			"SchedulerBase": {
+				"properties": {
+					"options": {
+						"$ref": "#/components/schemas/SchedulerOptions"
+					},
+					"dashboardUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"savedChartUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"cron": {
+						"type": "string"
+					},
+					"format": {
+						"$ref": "#/components/schemas/SchedulerFormat"
+					},
+					"createdBy": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"name": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"options",
+					"dashboardUuid",
+					"savedChartUuid",
+					"cron",
+					"format",
+					"createdBy",
+					"updatedAt",
+					"createdAt",
+					"name",
+					"schedulerUuid"
+				],
+				"type": "object"
+			},
+			"ChartScheduler": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerBase"
+					},
+					{
+						"properties": {
+							"dashboardUuid": {
+								"type": "number",
+								"enum": [
+									null
+								],
+								"nullable": true
+							},
+							"savedChartUuid": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"dashboardUuid",
+							"savedChartUuid"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"DashboardScheduler": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerBase"
+					},
+					{
+						"properties": {
+							"dashboardUuid": {
+								"type": "string"
+							},
+							"savedChartUuid": {
+								"type": "number",
+								"enum": [
+									null
+								],
+								"nullable": true
+							}
+						},
+						"required": [
+							"dashboardUuid",
+							"savedChartUuid"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"Scheduler": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ChartScheduler"
+					},
+					{
+						"$ref": "#/components/schemas/DashboardScheduler"
+					}
+				]
+			},
+			"SchedulerSlackTarget": {
+				"properties": {
+					"channel": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"schedulerSlackTargetUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"channel",
+					"schedulerUuid",
+					"updatedAt",
+					"createdAt",
+					"schedulerSlackTargetUuid"
+				],
+				"type": "object"
+			},
+			"SchedulerEmailTarget": {
+				"properties": {
+					"recipient": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"schedulerEmailTargetUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"recipient",
+					"schedulerUuid",
+					"updatedAt",
+					"createdAt",
+					"schedulerEmailTargetUuid"
+				],
+				"type": "object"
+			},
+			"SchedulerAndTargets": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Scheduler"
+					},
+					{
+						"properties": {
+							"targets": {
+								"items": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/SchedulerSlackTarget"
+										},
+										{
+											"$ref": "#/components/schemas/SchedulerEmailTarget"
+										}
+									]
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"targets"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"SchedulerJobStatus": {
+				"enum": [
+					"scheduled",
+					"started",
+					"completed",
+					"error"
+				],
+				"type": "string"
+			},
+			"Record_string.any_": {
+				"properties": {},
+				"type": "object",
+				"description": "Construct a type with a set of properties K of type T"
+			},
+			"SchedulerLog": {
+				"properties": {
+					"details": {
+						"$ref": "#/components/schemas/Record_string.any_"
+					},
+					"targetType": {
+						"type": "string",
+						"enum": [
+							"email",
+							"slack"
+						]
+					},
+					"target": {
+						"type": "string"
+					},
+					"status": {
+						"$ref": "#/components/schemas/SchedulerJobStatus"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"scheduledTime": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"jobGroup": {
+						"type": "string"
+					},
+					"jobId": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"task": {
+						"type": "string",
+						"enum": [
+							"handleScheduledDelivery",
+							"sendEmailNotification",
+							"sendSlackNotification",
+							"downloadCsv",
+							"compileProject",
+							"testAndCompileProject",
+							"validateProject"
+						]
+					}
+				},
+				"required": [
+					"status",
+					"createdAt",
+					"scheduledTime",
+					"jobId",
+					"task"
+				],
+				"type": "object"
+			},
+			"SchedulerWithLogs": {
+				"properties": {
+					"logs": {
+						"items": {
+							"$ref": "#/components/schemas/SchedulerLog"
+						},
+						"type": "array"
+					},
+					"dashboards": {
+						"items": {
+							"properties": {
+								"dashboardUuid": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"dashboardUuid",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"charts": {
+						"items": {
+							"properties": {
+								"savedChartUuid": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"savedChartUuid",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"users": {
+						"items": {
+							"properties": {
+								"userUuid": {
+									"type": "string"
+								},
+								"lastName": {
+									"type": "string"
+								},
+								"firstName": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"userUuid",
+								"lastName",
+								"firstName"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"schedulers": {
+						"items": {
+							"$ref": "#/components/schemas/SchedulerAndTargets"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"logs",
+					"dashboards",
+					"charts",
+					"users",
+					"schedulers"
+				],
+				"type": "object"
+			},
+			"ApiSchedulerLogsResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/SchedulerWithLogs"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiSchedulerAndTargetsResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/SchedulerAndTargets"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ScheduledJobs": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"date": {
+						"type": "string",
+						"format": "date-time"
+					}
+				},
+				"required": [
+					"id",
+					"date"
+				],
+				"type": "object"
+			},
+			"ApiScheduledJobsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ScheduledJobs"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiJobStatusResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"status": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"status"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ShareUrl": {
+				"properties": {
+					"host": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					},
+					"shareUrl": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"createdByUserUuid": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"params": {
+						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "The URL path of the full URL"
+					},
+					"nanoid": {
+						"type": "string",
+						"description": "Unique shareable id"
+					}
+				},
+				"required": [
+					"params",
+					"path",
+					"nanoid"
+				],
+				"type": "object",
+				"description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
+			},
+			"ApiShareResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/ShareUrl"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_ShareUrl.path-or-params_": {
+				"properties": {
+					"path": {
+						"type": "string",
+						"description": "The URL path of the full URL"
+					},
+					"params": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"path",
+					"params"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateShareUrl": {
+				"$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
+				"description": "Contains the detail of a full URL to generate a short URL id"
+			},
+			"SlackChannel": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"id"
+				],
+				"type": "object"
+			},
+			"ApiSlackChannelsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/SlackChannel"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_SshKeyPair.publicKey_": {
+				"properties": {
+					"publicKey": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"publicKey"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ApiSshKeyPairResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"EmailOneTimePassword": {
+				"properties": {
+					"numberOfAttempts": {
+						"type": "number",
+						"format": "double",
+						"description": "Number of times the passcode has been attempted"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"description": "Time that the passcode was created"
+					}
+				},
+				"required": [
+					"numberOfAttempts",
+					"createdAt"
+				],
+				"type": "object"
+			},
+			"EmailStatus": {
+				"properties": {
+					"otp": {
+						"$ref": "#/components/schemas/EmailOneTimePassword"
+					},
+					"isVerified": {
+						"type": "boolean"
+					},
+					"email": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"isVerified",
+					"email"
+				],
+				"type": "object"
+			},
+			"EmailOneTimePasswordExpiring": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/EmailOneTimePassword"
+					},
+					{
+						"properties": {
+							"isMaxAttempts": {
+								"type": "boolean"
+							},
+							"isExpired": {
+								"type": "boolean"
+							},
+							"expiresAt": {
+								"type": "string",
+								"format": "date-time"
+							}
+						},
+						"required": [
+							"isMaxAttempts",
+							"isExpired",
+							"expiresAt"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"EmailStatusExpiring": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/EmailStatus"
+					},
+					{
+						"properties": {
+							"otp": {
+								"$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
+								"description": "One time passcode information\nIf there is no active passcode, this will be undefined"
+							}
+						},
+						"type": "object"
+					}
+				],
+				"description": "Verification status of an email address"
+			},
+			"ApiEmailStatusResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/EmailStatusExpiring"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object",
+				"description": "Shows the current verification status of an email address"
+			},
+			"UserAllowedOrganization": {
+				"properties": {
+					"membersCount": {
+						"type": "number",
+						"format": "double"
+					},
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"membersCount",
+					"name",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiUserAllowedOrganizationsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/UserAllowedOrganization"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiJobScheduledResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"jobId": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"jobId"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ValidationErrorType": {
+				"enum": [
+					"chart",
+					"sorting",
+					"filter",
+					"metric",
+					"model",
+					"dimension"
+				],
+				"type": "string"
+			},
+			"ValidationResponseBase": {
+				"properties": {
+					"spaceUuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"errorType": {
+						"$ref": "#/components/schemas/ValidationErrorType"
+					},
+					"error": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"validationId": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"projectUuid",
+					"error",
+					"name",
+					"createdAt",
+					"validationId"
+				],
+				"type": "object"
+			},
+			"ValidationErrorChartResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/ValidationResponseBase"
+					},
+					{
+						"properties": {
+							"lastUpdatedAt": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"lastUpdatedBy": {
+								"type": "string"
+							},
+							"fieldName": {
+								"type": "string"
+							},
+							"chartType": {
+								"$ref": "#/components/schemas/ChartKind"
+							},
+							"chartUuid": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"ValidationErrorDashboardResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/ValidationResponseBase"
+					},
+					{
+						"properties": {
+							"lastUpdatedAt": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"lastUpdatedBy": {
+								"type": "string"
+							},
+							"fieldName": {
+								"type": "string"
+							},
+							"chartName": {
+								"type": "string"
+							},
+							"dashboardUuid": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"ValidationErrorTableResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/ValidationResponseBase"
+					},
+					{
+						"properties": {
+							"dimensionName": {
+								"type": "string"
+							},
+							"modelName": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"ValidationResponse": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ValidationErrorChartResponse"
+					},
+					{
+						"$ref": "#/components/schemas/ValidationErrorDashboardResponse"
+					},
+					{
+						"$ref": "#/components/schemas/ValidationErrorTableResponse"
+					}
+				]
+			},
+			"ApiValidateResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationResponse"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			}
+		},
+		"securitySchemes": {
+			"session_cookie": {
+				"type": "apiKey",
+				"in": "cookie",
+				"name": "connect.sid"
+			},
+			"api_key": {
+				"type": "apiKey",
+				"in": "header",
+				"name": "Authorization",
+				"description": "Value should be 'ApiKey <your key>'"
+			}
+		}
+	},
+	"info": {
+		"title": "Lightdash API",
+		"version": "0.587.0",
+		"description": "Open API documentation for all public Lightdash API endpoints",
+		"license": {
+			"name": "MIT"
+		},
+		"contact": {
+			"name": "Lightdash Support",
+			"email": "support@lightdash.com",
+			"url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
+		}
+	},
+	"openapi": "3.0.0",
+	"paths": {
+		"/api/v1/csv/{jobId}": {
+			"get": {
+				"operationId": "getCsvUrl",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiCsvUrlResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a Csv",
+				"tags": [
+					"Exports"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the jobId for the CSV",
+						"in": "path",
+						"name": "jobId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
+			"get": {
+				"operationId": "getDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the current dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"post": {
+				"operationId": "updateDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update the dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "deleteDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove the dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
+			"get": {
+				"operationId": "getDbtCloudMetrics",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudMetrics"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/groups/{groupUuid}": {
+			"get": {
+				"operationId": "getGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get group details",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "unique id of the group",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "deleteGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"patch": {
+				"operationId": "updateGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateGroup"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/groups/{groupUuid}/members/{userUuid}": {
+			"put": {
+				"operationId": "addUserToGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Add a Lightdash user to a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to add the user to",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the UUID for the user to add to the group",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "removeUserFromGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove a user from a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to remove the user from",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the UUID for the user to remove from the group",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/groups/{groupUuid}/members": {
+			"get": {
+				"operationId": "getGroupMembers",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupMembersResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "View members of a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to view the members of",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org": {
+			"get": {
+				"operationId": "GetMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganization"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			},
+			"put": {
+				"operationId": "CreateOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new organization settings",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateOrganization",
+								"description": "the new organization settings"
+							}
+						}
+					}
+				}
+			},
+			"patch": {
+				"operationId": "UpdateMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new organization settings",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateOrganization",
+								"description": "the new organization settings"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/{organizationUuid}": {
+			"delete": {
+				"operationId": "DeleteMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Deletes an organization and all users inside that organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the organization to delete",
+						"in": "path",
+						"name": "organizationUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org/users": {
+			"get": {
+				"operationId": "ListOrganizationMembers",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets all the members of the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/org/users/{userUuid}": {
+			"patch": {
+				"operationId": "UpdateOrganizationMember",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Updates the membership profile for a user in the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the user to update",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new membership profile",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
+								"description": "the new membership profile"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/user/{userUuid}": {
+			"delete": {
+				"operationId": "DeleteOrganizationMember",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Deletes a user from the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the user to delete",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org/allowedEmailDomains": {
+			"get": {
+				"operationId": "ListOrganizationEmailDomains",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets the allowed email domains for the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			},
+			"patch": {
+				"operationId": "UpdateOrganizationEmailDomains",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets the allowed email domains for the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAllowedEmailDomains"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/groups": {
+			"post": {
+				"operationId": "CreateGroupInOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a new group in the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_CreateGroup.name_"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "ListGroupsInOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets all the groups in the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
+			"get": {
+				"operationId": "getPinnedItems",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiPinnedItems"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get pinned items",
+				"tags": [
+					"Content"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "project uuid",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the list uuid for the pinned items",
+						"in": "path",
+						"name": "pinnedListUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
+			"patch": {
+				"operationId": "updatePinnedItemsOrder",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiPinnedItems"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update pinned items order",
+				"tags": [
+					"Content"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "project uuid",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the list uuid for the pinned items",
+						"in": "path",
+						"name": "pinnedListUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new order of the pinned items",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"items": {
+									"$ref": "#/components/schemas/UpdatePinnedItemOrder"
+								},
+								"type": "array",
+								"description": "the new order of the pinned items"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/charts": {
+			"get": {
+				"operationId": "ListChartsInProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiChartSummaryListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List all charts in a project",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project to get charts for",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/spaces": {
+			"get": {
+				"operationId": "ListSpacesInProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List all spaces in a project",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project to get spaces for",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
+			"post": {
+				"operationId": "postRunUnderlyingDataQuery",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for underlying data results",
+				"tags": [
+					"Exploring"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "table name",
+						"in": "path",
+						"name": "exploreId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "metricQuery for the chart to run",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RunQueryRequest",
+								"description": "metricQuery for the chart to run"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
+			"post": {
+				"operationId": "postRunQuery",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for explore",
+				"tags": [
+					"Exploring"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "table name",
+						"in": "path",
+						"name": "exploreId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "metricQuery for the chart to run",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RunQueryRequest",
+								"description": "metricQuery for the chart to run"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/saved/{chartUuid}/results": {
+			"post": {
+				"operationId": "postChartResults",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for a chart",
+				"tags": [
+					"Charts"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "chartUuid for the chart to run",
+						"in": "path",
+						"name": "chartUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"filters": {
+										"$ref": "#/components/schemas/Filters"
+									}
+								},
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/schedulers/{projectUuid}/logs": {
+			"get": {
+				"operationId": "getSchedulerLogs",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerLogsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get scheduled logs",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/{schedulerUuid}": {
+			"get": {
+				"operationId": "getScheduler",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"patch": {
+				"operationId": "updateScheduler",
+				"responses": {
+					"201": {
+						"description": "Updated",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new scheduler data",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"description": "the new scheduler data"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "deleteScheduler",
+				"responses": {
+					"201": {
+						"description": "Deleted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"results": {},
+										"status": {
+											"type": "string",
+											"enum": [
+												"ok"
+											],
+											"nullable": false
+										}
+									},
+									"required": [
+										"status"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to delete",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/{schedulerUuid}/jobs": {
+			"get": {
+				"operationId": "getScheduledJobs",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiScheduledJobsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get scheduled jobs",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/job/{jobId}/status": {
+			"get": {
+				"operationId": "getSchedulerJobStatus",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiJobStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a generic job status\nThis method can be used when polling from the frontend",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the jobId for the status to check",
+						"in": "path",
+						"name": "jobId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/share/{nanoId}": {
+			"get": {
+				"operationId": "getShareUrl",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiShareResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a share url from a short url id",
+				"tags": [
+					"Share links"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the short id for the share url",
+						"in": "path",
+						"name": "nanoId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/share": {
+			"post": {
+				"operationId": "CreateShareUrl",
+				"responses": {
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiShareResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Given a full URL generates a short url id that can be used for sharing",
+				"tags": [
+					"Share links"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "a full URL used to generate a short url id",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateShareUrl",
+								"description": "a full URL used to generate a short url id"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/slack/channels": {
+			"get": {
+				"operationId": "getSlackChannels",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSlackChannelsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get slack channels",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/ssh/key-pairs": {
+			"post": {
+				"operationId": "createSshKeyPair",
+				"responses": {
+					"201": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSshKeyPairResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"SSH Keypairs"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/email/otp": {
+			"put": {
+				"operationId": "CreateEmailOneTimePasscode",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiEmailStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/email/status": {
+			"get": {
+				"operationId": "GetEmailVerificationStatus",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiEmailStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the verification status for the current user's primary email",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the one-time passcode sent to the user's primary email",
+						"in": "query",
+						"name": "passcode",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/user/me/allowedOrganizations": {
+			"get": {
+				"operationId": "ListMyAvailableOrganizations",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/joinOrganization/{organizationUuid}": {
+			"post": {
+				"operationId": "JoinOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the organization to join",
+						"in": "path",
+						"name": "organizationUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/user/me": {
+			"delete": {
+				"operationId": "DeleteMe",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete user",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/projects/{projectUuid}/validate": {
+			"post": {
+				"operationId": "ValidateProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiJobScheduledResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the projectId for the validation",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"get": {
+				"operationId": "GetLatestValidationResults",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiValidateResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get validation results for a project. This will return the results of the latest validation job.",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the projectId for the validation",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "boolean to know if this request is made from the settings page, for analytics",
+						"in": "query",
+						"name": "fromSettings",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				]
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "/"
+		}
+	],
+	"tags": [
+		{
+			"name": "My Account",
+			"description": "These routes allow users to manage their own user account."
+		},
+		{
+			"name": "Organizations",
+			"description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
+		},
+		{
+			"name": "Projects",
+			"description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
+		}
+	]
 }

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1,4559 +1,4160 @@
 {
-	"components": {
-		"examples": {},
-		"headers": {},
-		"parameters": {},
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"ApiErrorPayload": {
-				"properties": {
-					"error": {
-						"properties": {
-							"data": {
-								"description": "Optional data containing details of the error"
-							},
-							"message": {
-								"type": "string",
-								"description": "A friendly message summarising the error"
-							},
-							"name": {
-								"type": "string",
-								"description": "Unique name for the type of error"
-							},
-							"statusCode": {
-								"type": "number",
-								"format": "integer",
-								"description": "HTTP status code"
-							}
-						},
-						"required": [
-							"name",
-							"statusCode"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"error"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"error",
-					"status"
-				],
-				"type": "object",
-				"description": "The Error object is returned from the api any time there is an error.\nThe message contains"
-			},
-			"ApiCsvUrlResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"status": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"status",
-							"url"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_CreateDbtCloudIntegration.metricsJobId_": {
-				"properties": {
-					"metricsJobId": {
-						"type": "string",
-						"description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
-					}
-				},
-				"required": [
-					"metricsJobId"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DbtCloudIntegration": {
-				"$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
-				"description": "Configuration for a Lightdash integration with dbt Cloud"
-			},
-			"ApiDbtCloudIntegrationSettings": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/DbtCloudIntegration"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiDbtCloudSettingsDeleteSuccess": {
-				"properties": {
-					"results": {},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"DbtCloudMetric": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"timeGrains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"description": {
-						"type": "string"
-					},
-					"dimensions": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"name": {
-						"type": "string"
-					},
-					"uniqueId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"label",
-					"timeGrains",
-					"description",
-					"dimensions",
-					"name",
-					"uniqueId"
-				],
-				"type": "object"
-			},
-			"DbtCloudMetadataResponseMetrics": {
-				"properties": {
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/DbtCloudMetric"
-						},
-						"type": "array",
-						"description": "A list of dbt metric definitions from the dbt cloud metadata api"
-					}
-				},
-				"required": [
-					"metrics"
-				],
-				"type": "object",
-				"description": "Response from dbt cloud metadata api containing a list of metric definitions"
-			},
-			"ApiDbtCloudMetrics": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Group": {
-				"properties": {
-					"organizationUuid": {
-						"type": "string",
-						"description": "The UUID of the organization that the group belongs to"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time",
-						"description": "The time that the group was created"
-					},
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					},
-					"uuid": {
-						"type": "string",
-						"description": "The group's UUID"
-					}
-				},
-				"required": [
-					"organizationUuid",
-					"createdAt",
-					"name",
-					"uuid"
-				],
-				"type": "object"
-			},
-			"ApiGroupResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Group"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiSuccessEmpty": {
-				"properties": {
-					"results": {},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"GroupMember": {
-				"properties": {
-					"lastName": {
-						"type": "string",
-						"description": "The user's last name"
-					},
-					"firstName": {
-						"type": "string",
-						"description": "The user's first name"
-					},
-					"email": {
-						"type": "string",
-						"description": "Primary email address for the user"
-					},
-					"userUuid": {
-						"type": "string",
-						"description": "Unique id for the user",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"lastName",
-					"firstName",
-					"email",
-					"userUuid"
-				],
-				"type": "object",
-				"description": "A summary for a Lightdash user within a group"
-			},
-			"ApiGroupMembersResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/GroupMember"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Group.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"UpdateGroup": {
-				"$ref": "#/components/schemas/Pick_Group.name_"
-			},
-			"Organization": {
-				"properties": {
-					"needsProject": {
-						"type": "boolean",
-						"description": "The organization needs a project if it doesn't have at least one project."
-					},
-					"chartColors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The default color palette for all projects in the organization"
-					},
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"description": "The unique identifier of the organization",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid"
-				],
-				"type": "object",
-				"description": "Details of a user's Organization"
-			},
-			"ApiOrganization": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Organization"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Organization.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"CreateOrganization": {
-				"$ref": "#/components/schemas/Pick_Organization.name_"
-			},
-			"Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					},
-					"chartColors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The default color palette for all projects in the organization"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"UpdateOrganization": {
-				"$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
-			},
-			"OrganizationMemberRole": {
-				"enum": [
-					"member",
-					"viewer",
-					"interactive_viewer",
-					"editor",
-					"developer",
-					"admin"
-				],
-				"type": "string"
-			},
-			"OrganizationMemberProfile": {
-				"properties": {
-					"isInviteExpired": {
-						"type": "boolean",
-						"description": "Whether the user's invite to the organization has expired"
-					},
-					"isActive": {
-						"type": "boolean",
-						"description": "Whether the user has accepted their invite to the organization"
-					},
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole",
-						"description": "The role of the user in the organization"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"description": "Unique identifier for the organization the user is a member of"
-					},
-					"email": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"userUuid": {
-						"type": "string",
-						"description": "Unique identifier for the user",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"isActive",
-					"role",
-					"organizationUuid",
-					"email",
-					"lastName",
-					"firstName",
-					"userUuid"
-				],
-				"type": "object",
-				"description": "Profile for a user's membership in an organization"
-			},
-			"ApiOrganizationMemberProfiles": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/OrganizationMemberProfile"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiOrganizationMemberProfile": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/OrganizationMemberProfile"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Partial_Pick_OrganizationMemberProfile.role__": {
-				"properties": {
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole",
-						"description": "The role of the user in the organization"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"OrganizationMemberProfileUpdate": {
-				"$ref": "#/components/schemas/Partial_Pick_OrganizationMemberProfile.role__"
-			},
-			"AllowedEmailDomains": {
-				"properties": {
-					"projectUuids": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole"
-					},
-					"emailDomains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"projectUuids",
-					"role",
-					"emailDomains",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiOrganizationAllowedEmailDomains": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/AllowedEmailDomains"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-				"properties": {
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole"
-					},
-					"emailDomains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"projectUuids": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"role",
-					"emailDomains",
-					"projectUuids"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_AllowedEmailDomains.organizationUuid_": {
-				"$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"UpdateAllowedEmailDomains": {
-				"$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
-			},
-			"Pick_CreateGroup.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ApiGroupListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/Group"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.DASHBOARD": {
-				"enum": [
-					"dashboard"
-				],
-				"type": "string"
-			},
-			"UpdatedByUser": {
-				"properties": {
-					"userUuid": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"userUuid",
-					"firstName",
-					"lastName"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-				"properties": {
-					"error": {
-						"type": "string"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"validationId": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"error",
-					"createdAt",
-					"validationId"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ValidationSummary": {
-				"$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
-			},
-			"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					},
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"validationErrors": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationSummary"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"name",
-					"uuid",
-					"updatedAt",
-					"spaceUuid",
-					"views",
-					"firstViewedAt",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewDashboardItem": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.CHART": {
-				"enum": [
-					"chart"
-				],
-				"type": "string"
-			},
-			"ChartKind": {
-				"enum": [
-					"line",
-					"horizontal_bar",
-					"vertical_bar",
-					"scatter",
-					"area",
-					"mixed",
-					"table",
-					"big_number"
-				],
-				"type": "string"
-			},
-			"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					},
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"validationErrors": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationSummary"
-						},
-						"type": "array"
-					},
-					"chartType": {
-						"$ref": "#/components/schemas/ChartKind"
-					}
-				},
-				"required": [
-					"name",
-					"uuid",
-					"updatedAt",
-					"spaceUuid",
-					"views",
-					"firstViewedAt",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewChartItem": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.CHART"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.SPACE": {
-				"enum": [
-					"space"
-				],
-				"type": "string"
-			},
-			"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"isPrivate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"pinnedListUuid",
-					"pinnedListOrder",
-					"isPrivate"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewSpaceItem": {
-				"properties": {
-					"data": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
-							},
-							{
-								"properties": {
-									"chartCount": {
-										"type": "number",
-										"format": "double"
-									},
-									"dashboardCount": {
-										"type": "number",
-										"format": "double"
-									},
-									"accessListLength": {
-										"type": "number",
-										"format": "double"
-									},
-									"access": {
-										"items": {
-											"type": "string"
-										},
-										"type": "array"
-									}
-								},
-								"required": [
-									"chartCount",
-									"dashboardCount",
-									"accessListLength",
-									"access"
-								],
-								"type": "object"
-							}
-						]
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.SPACE"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"PinnedItems": {
-				"items": {
-					"anyOf": [
-						{
-							"$ref": "#/components/schemas/ResourceViewDashboardItem"
-						},
-						{
-							"$ref": "#/components/schemas/ResourceViewChartItem"
-						},
-						{
-							"$ref": "#/components/schemas/ResourceViewSpaceItem"
-						}
-					]
-				},
-				"type": "array"
-			},
-			"ApiPinnedItems": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/PinnedItems"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType": {
-				"enum": [
-					"chart",
-					"dashboard",
-					"space"
-				],
-				"type": "string"
-			},
-			"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-				"properties": {
-					"uuid": {
-						"type": "string"
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					}
-				},
-				"required": [
-					"uuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"UpdatePinnedItemOrder": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"spaceName": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"spaceUuid",
-					"pinnedListUuid",
-					"spaceName"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ChartSummary": {
-				"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
-			},
-			"ApiChartSummaryListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ChartSummary"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"isPrivate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"isPrivate"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"SpaceSummary": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
-					},
-					{
-						"properties": {
-							"access": {
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						},
-						"required": [
-							"access"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"ApiSpaceSummaryListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceSummary"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"FieldId": {
-				"type": "string"
-			},
-			"FilterGroupResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"or": {
-								"items": {},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"or",
-							"id"
-						],
-						"type": "object"
-					},
-					{
-						"properties": {
-							"and": {
-								"items": {},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"and",
-							"id"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Filters": {
-				"properties": {
-					"metrics": {
-						"$ref": "#/components/schemas/FilterGroupResponse"
-					},
-					"dimensions": {
-						"$ref": "#/components/schemas/FilterGroupResponse"
-					}
-				},
-				"type": "object"
-			},
-			"SortField": {
-				"properties": {
-					"descending": {
-						"type": "boolean"
-					},
-					"fieldId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"descending",
-					"fieldId"
-				],
-				"type": "object"
-			},
-			"TableCalculation": {
-				"properties": {
-					"sql": {
-						"type": "string"
-					},
-					"displayName": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"index": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"sql",
-					"displayName",
-					"name"
-				],
-				"type": "object"
-			},
-			"MetricType": {
-				"enum": [
-					"percentile",
-					"average",
-					"count",
-					"count_distinct",
-					"sum",
-					"min",
-					"max",
-					"number",
-					"median",
-					"string",
-					"date",
-					"boolean"
-				],
-				"type": "string"
-			},
-			"Compact": {
-				"enum": [
-					"thousands",
-					"millions",
-					"billions",
-					"trillions"
-				],
-				"type": "string"
-			},
-			"CompactOrAlias": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/Compact"
-					},
-					{
-						"type": "string",
-						"enum": [
-							"K",
-							"thousand",
-							"M",
-							"million",
-							"B",
-							"billion",
-							"T",
-							"trillion"
-						]
-					}
-				]
-			},
-			"AdditionalMetric": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"type": {
-						"$ref": "#/components/schemas/MetricType"
-					},
-					"description": {
-						"type": "string"
-					},
-					"sql": {
-						"type": "string"
-					},
-					"hidden": {
-						"type": "boolean"
-					},
-					"round": {
-						"type": "number",
-						"format": "double"
-					},
-					"compact": {
-						"$ref": "#/components/schemas/CompactOrAlias"
-					},
-					"format": {
-						"type": "string"
-					},
-					"table": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"index": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"type",
-					"sql",
-					"table",
-					"name"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"MetricQueryResponse": {
-				"properties": {
-					"additionalMetrics": {
-						"items": {
-							"$ref": "#/components/schemas/AdditionalMetric"
-						},
-						"type": "array"
-					},
-					"tableCalculations": {
-						"items": {
-							"$ref": "#/components/schemas/TableCalculation"
-						},
-						"type": "array"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sorts": {
-						"items": {
-							"$ref": "#/components/schemas/SortField"
-						},
-						"type": "array"
-					},
-					"filters": {
-						"$ref": "#/components/schemas/Filters"
-					},
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					},
-					"dimensions": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"tableCalculations",
-					"limit",
-					"sorts",
-					"filters",
-					"metrics",
-					"dimensions"
-				],
-				"type": "object"
-			},
-			"ApiRunQueryResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"rows": {
-								"items": {},
-								"type": "array"
-							},
-							"metricQuery": {
-								"$ref": "#/components/schemas/MetricQueryResponse"
-							}
-						},
-						"required": [
-							"rows",
-							"metricQuery"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"RunQueryRequest": {
-				"properties": {
-					"csvLimit": {
-						"type": "number",
-						"format": "double"
-					},
-					"additionalMetrics": {
-						"items": {
-							"$ref": "#/components/schemas/AdditionalMetric"
-						},
-						"type": "array"
-					},
-					"tableCalculations": {
-						"items": {
-							"$ref": "#/components/schemas/TableCalculation"
-						},
-						"type": "array"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sorts": {
-						"items": {
-							"$ref": "#/components/schemas/SortField"
-						},
-						"type": "array"
-					},
-					"filters": {
-						"properties": {
-							"metrics": {},
-							"dimensions": {}
-						},
-						"type": "object"
-					},
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					},
-					"dimensions": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"tableCalculations",
-					"limit",
-					"sorts",
-					"filters",
-					"metrics",
-					"dimensions"
-				],
-				"type": "object"
-			},
-			"SchedulerFormat": {
-				"enum": [
-					"csv",
-					"image"
-				],
-				"type": "string"
-			},
-			"SchedulerCsvOptions": {
-				"properties": {
-					"limit": {
-						"anyOf": [
-							{
-								"type": "number",
-								"format": "double"
-							},
-							{
-								"type": "string",
-								"enum": [
-									"table",
-									"all"
-								]
-							}
-						]
-					},
-					"formatted": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"limit",
-					"formatted"
-				],
-				"type": "object"
-			},
-			"SchedulerImageOptions": {
-				"properties": {},
-				"type": "object"
-			},
-			"SchedulerOptions": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerCsvOptions"
-					},
-					{
-						"$ref": "#/components/schemas/SchedulerImageOptions"
-					}
-				]
-			},
-			"SchedulerBase": {
-				"properties": {
-					"options": {
-						"$ref": "#/components/schemas/SchedulerOptions"
-					},
-					"dashboardUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"savedChartUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"cron": {
-						"type": "string"
-					},
-					"format": {
-						"$ref": "#/components/schemas/SchedulerFormat"
-					},
-					"createdBy": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"name": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"options",
-					"dashboardUuid",
-					"savedChartUuid",
-					"cron",
-					"format",
-					"createdBy",
-					"updatedAt",
-					"createdAt",
-					"name",
-					"schedulerUuid"
-				],
-				"type": "object"
-			},
-			"ChartScheduler": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerBase"
-					},
-					{
-						"properties": {
-							"dashboardUuid": {
-								"type": "number",
-								"enum": [
-									null
-								],
-								"nullable": true
-							},
-							"savedChartUuid": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"dashboardUuid",
-							"savedChartUuid"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"DashboardScheduler": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerBase"
-					},
-					{
-						"properties": {
-							"dashboardUuid": {
-								"type": "string"
-							},
-							"savedChartUuid": {
-								"type": "number",
-								"enum": [
-									null
-								],
-								"nullable": true
-							}
-						},
-						"required": [
-							"dashboardUuid",
-							"savedChartUuid"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Scheduler": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ChartScheduler"
-					},
-					{
-						"$ref": "#/components/schemas/DashboardScheduler"
-					}
-				]
-			},
-			"SchedulerSlackTarget": {
-				"properties": {
-					"channel": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"schedulerSlackTargetUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"channel",
-					"schedulerUuid",
-					"updatedAt",
-					"createdAt",
-					"schedulerSlackTargetUuid"
-				],
-				"type": "object"
-			},
-			"SchedulerEmailTarget": {
-				"properties": {
-					"recipient": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"schedulerEmailTargetUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"recipient",
-					"schedulerUuid",
-					"updatedAt",
-					"createdAt",
-					"schedulerEmailTargetUuid"
-				],
-				"type": "object"
-			},
-			"SchedulerAndTargets": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Scheduler"
-					},
-					{
-						"properties": {
-							"targets": {
-								"items": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/SchedulerSlackTarget"
-										},
-										{
-											"$ref": "#/components/schemas/SchedulerEmailTarget"
-										}
-									]
-								},
-								"type": "array"
-							}
-						},
-						"required": [
-							"targets"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"SchedulerJobStatus": {
-				"enum": [
-					"scheduled",
-					"started",
-					"completed",
-					"error"
-				],
-				"type": "string"
-			},
-			"Record_string.any_": {
-				"properties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"SchedulerLog": {
-				"properties": {
-					"details": {
-						"$ref": "#/components/schemas/Record_string.any_"
-					},
-					"targetType": {
-						"type": "string",
-						"enum": [
-							"email",
-							"slack"
-						]
-					},
-					"target": {
-						"type": "string"
-					},
-					"status": {
-						"$ref": "#/components/schemas/SchedulerJobStatus"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"scheduledTime": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"jobGroup": {
-						"type": "string"
-					},
-					"jobId": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"task": {
-						"type": "string",
-						"enum": [
-							"handleScheduledDelivery",
-							"sendEmailNotification",
-							"sendSlackNotification",
-							"downloadCsv",
-							"compileProject",
-							"testAndCompileProject",
-							"validateProject"
-						]
-					}
-				},
-				"required": [
-					"status",
-					"createdAt",
-					"scheduledTime",
-					"jobId",
-					"task"
-				],
-				"type": "object"
-			},
-			"SchedulerWithLogs": {
-				"properties": {
-					"logs": {
-						"items": {
-							"$ref": "#/components/schemas/SchedulerLog"
-						},
-						"type": "array"
-					},
-					"dashboards": {
-						"items": {
-							"properties": {
-								"dashboardUuid": {
-									"type": "string"
-								},
-								"name": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"dashboardUuid",
-								"name"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"charts": {
-						"items": {
-							"properties": {
-								"savedChartUuid": {
-									"type": "string"
-								},
-								"name": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"savedChartUuid",
-								"name"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"users": {
-						"items": {
-							"properties": {
-								"userUuid": {
-									"type": "string"
-								},
-								"lastName": {
-									"type": "string"
-								},
-								"firstName": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"userUuid",
-								"lastName",
-								"firstName"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"schedulers": {
-						"items": {
-							"$ref": "#/components/schemas/SchedulerAndTargets"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"logs",
-					"dashboards",
-					"charts",
-					"users",
-					"schedulers"
-				],
-				"type": "object"
-			},
-			"ApiSchedulerLogsResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/SchedulerWithLogs"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiSchedulerAndTargetsResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/SchedulerAndTargets"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ScheduledJobs": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"date": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"required": [
-					"id",
-					"date"
-				],
-				"type": "object"
-			},
-			"ApiScheduledJobsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ScheduledJobs"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiJobStatusResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"status": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"status"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ShareUrl": {
-				"properties": {
-					"host": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"shareUrl": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"format": "uuid"
-					},
-					"createdByUserUuid": {
-						"type": "string",
-						"format": "uuid"
-					},
-					"params": {
-						"type": "string"
-					},
-					"path": {
-						"type": "string",
-						"description": "The URL path of the full URL"
-					},
-					"nanoid": {
-						"type": "string",
-						"description": "Unique shareable id"
-					}
-				},
-				"required": [
-					"params",
-					"path",
-					"nanoid"
-				],
-				"type": "object",
-				"description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
-			},
-			"ApiShareResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/ShareUrl"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_ShareUrl.path-or-params_": {
-				"properties": {
-					"path": {
-						"type": "string",
-						"description": "The URL path of the full URL"
-					},
-					"params": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"path",
-					"params"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"CreateShareUrl": {
-				"$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
-				"description": "Contains the detail of a full URL to generate a short URL id"
-			},
-			"SlackChannel": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"id"
-				],
-				"type": "object"
-			},
-			"ApiSlackChannelsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/SlackChannel"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_SshKeyPair.publicKey_": {
-				"properties": {
-					"publicKey": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"publicKey"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ApiSshKeyPairResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"EmailOneTimePassword": {
-				"properties": {
-					"numberOfAttempts": {
-						"type": "number",
-						"format": "double",
-						"description": "Number of times the passcode has been attempted"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time",
-						"description": "Time that the passcode was created"
-					}
-				},
-				"required": [
-					"numberOfAttempts",
-					"createdAt"
-				],
-				"type": "object"
-			},
-			"EmailStatus": {
-				"properties": {
-					"otp": {
-						"$ref": "#/components/schemas/EmailOneTimePassword"
-					},
-					"isVerified": {
-						"type": "boolean"
-					},
-					"email": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"isVerified",
-					"email"
-				],
-				"type": "object"
-			},
-			"EmailOneTimePasswordExpiring": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/EmailOneTimePassword"
-					},
-					{
-						"properties": {
-							"isMaxAttempts": {
-								"type": "boolean"
-							},
-							"isExpired": {
-								"type": "boolean"
-							},
-							"expiresAt": {
-								"type": "string",
-								"format": "date-time"
-							}
-						},
-						"required": [
-							"isMaxAttempts",
-							"isExpired",
-							"expiresAt"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"EmailStatusExpiring": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/EmailStatus"
-					},
-					{
-						"properties": {
-							"otp": {
-								"$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
-								"description": "One time passcode information\nIf there is no active passcode, this will be undefined"
-							}
-						},
-						"type": "object"
-					}
-				],
-				"description": "Verification status of an email address"
-			},
-			"ApiEmailStatusResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/EmailStatusExpiring"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object",
-				"description": "Shows the current verification status of an email address"
-			},
-			"UserAllowedOrganization": {
-				"properties": {
-					"membersCount": {
-						"type": "number",
-						"format": "double"
-					},
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"membersCount",
-					"name",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiUserAllowedOrganizationsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/UserAllowedOrganization"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiJobScheduledResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"jobId": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"jobId"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ValidationErrorType": {
-				"enum": [
-					"chart",
-					"sorting",
-					"filter",
-					"metric",
-					"model",
-					"dimension"
-				],
-				"type": "string"
-			},
-			"ValidationResponseBase": {
-				"properties": {
-					"spaceUuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"errorType": {
-						"$ref": "#/components/schemas/ValidationErrorType"
-					},
-					"error": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"validationId": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"projectUuid",
-					"error",
-					"name",
-					"createdAt",
-					"validationId"
-				],
-				"type": "object"
-			},
-			"ValidationErrorChartResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ValidationResponseBase"
-					},
-					{
-						"properties": {
-							"lastUpdatedAt": {
-								"type": "string",
-								"format": "date-time"
-							},
-							"lastUpdatedBy": {
-								"type": "string"
-							},
-							"fieldName": {
-								"type": "string"
-							},
-							"chartType": {
-								"$ref": "#/components/schemas/ChartKind"
-							},
-							"chartUuid": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"ValidationErrorDashboardResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ValidationResponseBase"
-					},
-					{
-						"properties": {
-							"lastUpdatedAt": {
-								"type": "string",
-								"format": "date-time"
-							},
-							"lastUpdatedBy": {
-								"type": "string"
-							},
-							"fieldName": {
-								"type": "string"
-							},
-							"chartName": {
-								"type": "string"
-							},
-							"dashboardUuid": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"ValidationErrorTableResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ValidationResponseBase"
-					},
-					{
-						"properties": {
-							"dimensionName": {
-								"type": "string"
-							},
-							"modelName": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"ValidationResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ValidationErrorChartResponse"
-					},
-					{
-						"$ref": "#/components/schemas/ValidationErrorDashboardResponse"
-					},
-					{
-						"$ref": "#/components/schemas/ValidationErrorTableResponse"
-					}
-				]
-			},
-			"ApiValidateResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationResponse"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			}
-		},
-		"securitySchemes": {
-			"session_cookie": {
-				"type": "apiKey",
-				"in": "cookie",
-				"name": "connect.sid"
-			},
-			"api_key": {
-				"type": "apiKey",
-				"in": "header",
-				"name": "Authorization",
-				"description": "Value should be 'ApiKey <your key>'"
-			}
-		}
-	},
-	"info": {
-		"title": "Lightdash API",
-		"version": "0.587.0",
-		"description": "Open API documentation for all public Lightdash API endpoints",
-		"license": {
-			"name": "MIT"
-		},
-		"contact": {
-			"name": "Lightdash Support",
-			"email": "support@lightdash.com",
-			"url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
-		}
-	},
-	"openapi": "3.0.0",
-	"paths": {
-		"/api/v1/csv/{jobId}": {
-			"get": {
-				"operationId": "getCsvUrl",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiCsvUrlResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a Csv",
-				"tags": [
-					"Exports"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the jobId for the CSV",
-						"in": "path",
-						"name": "jobId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
-			"get": {
-				"operationId": "getDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the current dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"post": {
-				"operationId": "updateDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update the dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "deleteDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove the dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
-			"get": {
-				"operationId": "getDbtCloudMetrics",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudMetrics"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/groups/{groupUuid}": {
-			"get": {
-				"operationId": "getGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get group details",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "unique id of the group",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "deleteGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"patch": {
-				"operationId": "updateGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateGroup"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/groups/{groupUuid}/members/{userUuid}": {
-			"put": {
-				"operationId": "addUserToGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Add a Lightdash user to a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to add the user to",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the UUID for the user to add to the group",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "removeUserFromGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove a user from a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to remove the user from",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the UUID for the user to remove from the group",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/groups/{groupUuid}/members": {
-			"get": {
-				"operationId": "getGroupMembers",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupMembersResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "View members of a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to view the members of",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org": {
-			"get": {
-				"operationId": "GetMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganization"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			},
-			"put": {
-				"operationId": "CreateOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new organization settings",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateOrganization",
-								"description": "the new organization settings"
-							}
-						}
-					}
-				}
-			},
-			"patch": {
-				"operationId": "UpdateMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new organization settings",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateOrganization",
-								"description": "the new organization settings"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/{organizationUuid}": {
-			"delete": {
-				"operationId": "DeleteMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Deletes an organization and all users inside that organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the organization to delete",
-						"in": "path",
-						"name": "organizationUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org/users": {
-			"get": {
-				"operationId": "ListOrganizationMembers",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets all the members of the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/org/users/{userUuid}": {
-			"patch": {
-				"operationId": "UpdateOrganizationMember",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationMemberProfile"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Updates the membership profile for a user in the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the user to update",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new membership profile",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
-								"description": "the new membership profile"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/user/{userUuid}": {
-			"delete": {
-				"operationId": "DeleteOrganizationMember",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Deletes a user from the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the user to delete",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org/allowedEmailDomains": {
-			"get": {
-				"operationId": "ListOrganizationEmailDomains",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets the allowed email domains for the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			},
-			"patch": {
-				"operationId": "UpdateOrganizationEmailDomains",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets the allowed email domains for the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateAllowedEmailDomains"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/groups": {
-			"post": {
-				"operationId": "CreateGroupInOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new group in the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/Pick_CreateGroup.name_"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "ListGroupsInOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets all the groups in the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
-			"get": {
-				"operationId": "getPinnedItems",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiPinnedItems"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get pinned items",
-				"tags": [
-					"Content"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "project uuid",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the list uuid for the pinned items",
-						"in": "path",
-						"name": "pinnedListUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
-			"patch": {
-				"operationId": "updatePinnedItemsOrder",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiPinnedItems"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update pinned items order",
-				"tags": [
-					"Content"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "project uuid",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the list uuid for the pinned items",
-						"in": "path",
-						"name": "pinnedListUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new order of the pinned items",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"items": {
-									"$ref": "#/components/schemas/UpdatePinnedItemOrder"
-								},
-								"type": "array",
-								"description": "the new order of the pinned items"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/charts": {
-			"get": {
-				"operationId": "ListChartsInProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiChartSummaryListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List all charts in a project",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project to get charts for",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/spaces": {
-			"get": {
-				"operationId": "ListSpacesInProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List all spaces in a project",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project to get spaces for",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
-			"post": {
-				"operationId": "postRunUnderlyingDataQuery",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for underlying data results",
-				"tags": [
-					"Exploring"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "table name",
-						"in": "path",
-						"name": "exploreId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "metricQuery for the chart to run",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RunQueryRequest",
-								"description": "metricQuery for the chart to run"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
-			"post": {
-				"operationId": "postRunQuery",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for explore",
-				"tags": [
-					"Exploring"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "table name",
-						"in": "path",
-						"name": "exploreId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "metricQuery for the chart to run",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RunQueryRequest",
-								"description": "metricQuery for the chart to run"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/saved/{chartUuid}/results": {
-			"post": {
-				"operationId": "postChartResults",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for a chart",
-				"tags": [
-					"Charts"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "chartUuid for the chart to run",
-						"in": "path",
-						"name": "chartUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"filters": {
-										"$ref": "#/components/schemas/Filters"
-									}
-								},
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/schedulers/{projectUuid}/logs": {
-			"get": {
-				"operationId": "getSchedulerLogs",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerLogsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get scheduled logs",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/{schedulerUuid}": {
-			"get": {
-				"operationId": "getScheduler",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"patch": {
-				"operationId": "updateScheduler",
-				"responses": {
-					"201": {
-						"description": "Updated",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new scheduler data",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"description": "the new scheduler data"
-							}
-						}
-					}
-				}
-			},
-			"delete": {
-				"operationId": "deleteScheduler",
-				"responses": {
-					"201": {
-						"description": "Deleted",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"results": {},
-										"status": {
-											"type": "string",
-											"enum": [
-												"ok"
-											],
-											"nullable": false
-										}
-									},
-									"required": [
-										"status"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to delete",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/{schedulerUuid}/jobs": {
-			"get": {
-				"operationId": "getScheduledJobs",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiScheduledJobsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get scheduled jobs",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/job/{jobId}/status": {
-			"get": {
-				"operationId": "getSchedulerJobStatus",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiJobStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a generic job status\nThis method can be used when polling from the frontend",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the jobId for the status to check",
-						"in": "path",
-						"name": "jobId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/share/{nanoId}": {
-			"get": {
-				"operationId": "getShareUrl",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiShareResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a share url from a short url id",
-				"tags": [
-					"Share links"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the short id for the share url",
-						"in": "path",
-						"name": "nanoId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/share": {
-			"post": {
-				"operationId": "CreateShareUrl",
-				"responses": {
-					"201": {
-						"description": "Created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiShareResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Given a full URL generates a short url id that can be used for sharing",
-				"tags": [
-					"Share links"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "a full URL used to generate a short url id",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateShareUrl",
-								"description": "a full URL used to generate a short url id"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/slack/channels": {
-			"get": {
-				"operationId": "getSlackChannels",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSlackChannelsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get slack channels",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/ssh/key-pairs": {
-			"post": {
-				"operationId": "createSshKeyPair",
-				"responses": {
-					"201": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSshKeyPairResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"SSH Keypairs"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/email/otp": {
-			"put": {
-				"operationId": "CreateEmailOneTimePasscode",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiEmailStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/email/status": {
-			"get": {
-				"operationId": "GetEmailVerificationStatus",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiEmailStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the verification status for the current user's primary email",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the one-time passcode sent to the user's primary email",
-						"in": "query",
-						"name": "passcode",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/user/me/allowedOrganizations": {
-			"get": {
-				"operationId": "ListMyAvailableOrganizations",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/joinOrganization/{organizationUuid}": {
-			"post": {
-				"operationId": "JoinOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the organization to join",
-						"in": "path",
-						"name": "organizationUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/user/me": {
-			"delete": {
-				"operationId": "DeleteMe",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete user",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/projects/{projectUuid}/validate": {
-			"post": {
-				"operationId": "ValidateProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiJobScheduledResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the projectId for the validation",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"get": {
-				"operationId": "GetLatestValidationResults",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiValidateResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get validation results for a project. This will return the results of the latest validation job.",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the projectId for the validation",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "boolean to know if this request is made from the settings page, for analytics",
-						"in": "query",
-						"name": "fromSettings",
-						"required": false,
-						"schema": {
-							"type": "boolean"
-						}
-					}
-				]
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "/"
-		}
-	],
-	"tags": [
-		{
-			"name": "My Account",
-			"description": "These routes allow users to manage their own user account."
-		},
-		{
-			"name": "Organizations",
-			"description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
-		},
-		{
-			"name": "Projects",
-			"description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
-		}
-	]
+    "components": {
+        "examples": {},
+        "headers": {},
+        "parameters": {},
+        "requestBodies": {},
+        "responses": {},
+        "schemas": {
+            "ApiErrorPayload": {
+                "properties": {
+                    "error": {
+                        "properties": {
+                            "data": {
+                                "description": "Optional data containing details of the error"
+                            },
+                            "message": {
+                                "type": "string",
+                                "description": "A friendly message summarising the error"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Unique name for the type of error"
+                            },
+                            "statusCode": {
+                                "type": "number",
+                                "format": "integer",
+                                "description": "HTTP status code"
+                            }
+                        },
+                        "required": ["name", "statusCode"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["error"],
+                        "nullable": false
+                    }
+                },
+                "required": ["error", "status"],
+                "type": "object",
+                "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
+            },
+            "ApiCsvUrlResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "status": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["status", "url"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_CreateDbtCloudIntegration.metricsJobId_": {
+                "properties": {
+                    "metricsJobId": {
+                        "type": "string",
+                        "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
+                    }
+                },
+                "required": ["metricsJobId"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "DbtCloudIntegration": {
+                "$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
+                "description": "Configuration for a Lightdash integration with dbt Cloud"
+            },
+            "ApiDbtCloudIntegrationSettings": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DbtCloudIntegration"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "ApiDbtCloudSettingsDeleteSuccess": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "DbtCloudMetric": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "timeGrains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uniqueId": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "label",
+                    "timeGrains",
+                    "description",
+                    "dimensions",
+                    "name",
+                    "uniqueId"
+                ],
+                "type": "object"
+            },
+            "DbtCloudMetadataResponseMetrics": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtCloudMetric"
+                        },
+                        "type": "array",
+                        "description": "A list of dbt metric definitions from the dbt cloud metadata api"
+                    }
+                },
+                "required": ["metrics"],
+                "type": "object",
+                "description": "Response from dbt cloud metadata api containing a list of metric definitions"
+            },
+            "ApiDbtCloudMetrics": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Group": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "The UUID of the organization that the group belongs to"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The time that the group was created"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    },
+                    "uuid": {
+                        "type": "string",
+                        "description": "The group's UUID"
+                    }
+                },
+                "required": ["organizationUuid", "createdAt", "name", "uuid"],
+                "type": "object"
+            },
+            "ApiGroupResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Group"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSuccessEmpty": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "GroupMember": {
+                "properties": {
+                    "lastName": {
+                        "type": "string",
+                        "description": "The user's last name"
+                    },
+                    "firstName": {
+                        "type": "string",
+                        "description": "The user's first name"
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "Primary email address for the user"
+                    },
+                    "userUuid": {
+                        "type": "string",
+                        "description": "Unique id for the user",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["lastName", "firstName", "email", "userUuid"],
+                "type": "object",
+                "description": "A summary for a Lightdash user within a group"
+            },
+            "ApiGroupMembersResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/GroupMember"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Group.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdateGroup": {
+                "$ref": "#/components/schemas/Pick_Group.name_"
+            },
+            "Organization": {
+                "properties": {
+                    "needsProject": {
+                        "type": "boolean",
+                        "description": "The organization needs a project if it doesn't have at least one project."
+                    },
+                    "chartColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "The default color palette for all projects in the organization"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "The unique identifier of the organization",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["name", "organizationUuid"],
+                "type": "object",
+                "description": "Details of a user's Organization"
+            },
+            "ApiOrganization": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Organization"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Organization.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateOrganization": {
+                "$ref": "#/components/schemas/Pick_Organization.name_"
+            },
+            "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    },
+                    "chartColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "The default color palette for all projects in the organization"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpdateOrganization": {
+                "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
+            },
+            "OrganizationMemberRole": {
+                "enum": [
+                    "member",
+                    "viewer",
+                    "interactive_viewer",
+                    "editor",
+                    "developer",
+                    "admin"
+                ],
+                "type": "string"
+            },
+            "OrganizationMemberProfile": {
+                "properties": {
+                    "isInviteExpired": {
+                        "type": "boolean",
+                        "description": "Whether the user's invite to the organization has expired"
+                    },
+                    "isActive": {
+                        "type": "boolean",
+                        "description": "Whether the user has accepted their invite to the organization"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole",
+                        "description": "The role of the user in the organization"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the organization the user is a member of"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the user",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "isActive",
+                    "role",
+                    "organizationUuid",
+                    "email",
+                    "lastName",
+                    "firstName",
+                    "userUuid"
+                ],
+                "type": "object",
+                "description": "Profile for a user's membership in an organization"
+            },
+            "ApiOrganizationMemberProfiles": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationMemberProfile"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiOrganizationMemberProfile": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/OrganizationMemberProfile"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Partial_Pick_OrganizationMemberProfile.role__": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole",
+                        "description": "The role of the user in the organization"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "OrganizationMemberProfileUpdate": {
+                "$ref": "#/components/schemas/Partial_Pick_OrganizationMemberProfile.role__"
+            },
+            "AllowedEmailDomains": {
+                "properties": {
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole"
+                    },
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "projectUuids",
+                    "role",
+                    "emailDomains",
+                    "organizationUuid"
+                ],
+                "type": "object"
+            },
+            "ApiOrganizationAllowedEmailDomains": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AllowedEmailDomains"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole"
+                    },
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["role", "emailDomains", "projectUuids"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_AllowedEmailDomains.organizationUuid_": {
+                "$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "UpdateAllowedEmailDomains": {
+                "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
+            },
+            "Pick_CreateGroup.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiGroupListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Group"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ResourceViewItemType.DASHBOARD": {
+                "enum": ["dashboard"],
+                "type": "string"
+            },
+            "UpdatedByUser": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["userUuid", "firstName", "lastName"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "validationId": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["error", "createdAt", "validationId"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ValidationSummary": {
+                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
+            },
+            "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "validationErrors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name",
+                    "uuid",
+                    "updatedAt",
+                    "spaceUuid",
+                    "views",
+                    "firstViewedAt",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewDashboardItem": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "ResourceViewItemType.CHART": {
+                "enum": ["chart"],
+                "type": "string"
+            },
+            "ChartKind": {
+                "enum": [
+                    "line",
+                    "horizontal_bar",
+                    "vertical_bar",
+                    "scatter",
+                    "area",
+                    "mixed",
+                    "table",
+                    "big_number"
+                ],
+                "type": "string"
+            },
+            "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "validationErrors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationSummary"
+                        },
+                        "type": "array"
+                    },
+                    "chartType": {
+                        "$ref": "#/components/schemas/ChartKind"
+                    }
+                },
+                "required": [
+                    "name",
+                    "uuid",
+                    "updatedAt",
+                    "spaceUuid",
+                    "views",
+                    "firstViewedAt",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewChartItem": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.CHART"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "ResourceViewItemType.SPACE": {
+                "enum": ["space"],
+                "type": "string"
+            },
+            "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder",
+                    "isPrivate"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewSpaceItem": {
+                "properties": {
+                    "data": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
+                            },
+                            {
+                                "properties": {
+                                    "chartCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "dashboardCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "accessListLength": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "access": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "chartCount",
+                                    "dashboardCount",
+                                    "accessListLength",
+                                    "access"
+                                ],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "PinnedItems": {
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/components/schemas/ResourceViewDashboardItem"
+                        },
+                        {
+                            "$ref": "#/components/schemas/ResourceViewChartItem"
+                        },
+                        {
+                            "$ref": "#/components/schemas/ResourceViewSpaceItem"
+                        }
+                    ]
+                },
+                "type": "array"
+            },
+            "ApiPinnedItems": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/PinnedItems"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ResourceViewItemType": {
+                "enum": ["chart", "dashboard", "space"],
+                "type": "string"
+            },
+            "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+                "properties": {
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    }
+                },
+                "required": ["uuid", "pinnedListOrder"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdatePinnedItemOrder": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "spaceUuid",
+                    "pinnedListUuid",
+                    "spaceName"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ChartSummary": {
+                "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+            },
+            "ApiChartSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ChartSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "isPrivate"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "SpaceSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+                    },
+                    {
+                        "properties": {
+                            "access": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["access"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSpaceSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "FieldId": {
+                "type": "string"
+            },
+            "FilterGroupResponse": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "or": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "id": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["or", "id"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "and": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "id": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["and", "id"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Filters": {
+                "properties": {
+                    "metrics": {
+                        "$ref": "#/components/schemas/FilterGroupResponse"
+                    },
+                    "dimensions": {
+                        "$ref": "#/components/schemas/FilterGroupResponse"
+                    }
+                },
+                "type": "object"
+            },
+            "SortField": {
+                "properties": {
+                    "descending": {
+                        "type": "boolean"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    }
+                },
+                "required": ["descending", "fieldId"],
+                "type": "object"
+            },
+            "TableCalculation": {
+                "properties": {
+                    "sql": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "index": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["sql", "displayName", "name"],
+                "type": "object"
+            },
+            "MetricType": {
+                "enum": [
+                    "percentile",
+                    "average",
+                    "count",
+                    "count_distinct",
+                    "sum",
+                    "min",
+                    "max",
+                    "number",
+                    "median",
+                    "string",
+                    "date",
+                    "boolean"
+                ],
+                "type": "string"
+            },
+            "Compact": {
+                "enum": ["thousands", "millions", "billions", "trillions"],
+                "type": "string"
+            },
+            "CompactOrAlias": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/Compact"
+                    },
+                    {
+                        "type": "string",
+                        "enum": [
+                            "K",
+                            "thousand",
+                            "M",
+                            "million",
+                            "B",
+                            "billion",
+                            "T",
+                            "trillion"
+                        ]
+                    }
+                ]
+            },
+            "AdditionalMetric": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/MetricType"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "hidden": {
+                        "type": "boolean"
+                    },
+                    "round": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "compact": {
+                        "$ref": "#/components/schemas/CompactOrAlias"
+                    },
+                    "format": {
+                        "type": "string"
+                    },
+                    "table": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "index": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["type", "sql", "table", "name"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "MetricQueryResponse": {
+                "properties": {
+                    "additionalMetrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/AdditionalMetric"
+                        },
+                        "type": "array"
+                    },
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/TableCalculation"
+                        },
+                        "type": "array"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sorts": {
+                        "items": {
+                            "$ref": "#/components/schemas/SortField"
+                        },
+                        "type": "array"
+                    },
+                    "filters": {
+                        "$ref": "#/components/schemas/Filters"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "tableCalculations",
+                    "limit",
+                    "sorts",
+                    "filters",
+                    "metrics",
+                    "dimensions"
+                ],
+                "type": "object"
+            },
+            "ApiRunQueryResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "rows": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "metricQuery": {
+                                "$ref": "#/components/schemas/MetricQueryResponse"
+                            }
+                        },
+                        "required": ["rows", "metricQuery"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RunQueryRequest": {
+                "properties": {
+                    "csvLimit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "additionalMetrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/AdditionalMetric"
+                        },
+                        "type": "array"
+                    },
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/TableCalculation"
+                        },
+                        "type": "array"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sorts": {
+                        "items": {
+                            "$ref": "#/components/schemas/SortField"
+                        },
+                        "type": "array"
+                    },
+                    "filters": {
+                        "properties": {
+                            "metrics": {},
+                            "dimensions": {}
+                        },
+                        "type": "object"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "tableCalculations",
+                    "limit",
+                    "sorts",
+                    "filters",
+                    "metrics",
+                    "dimensions"
+                ],
+                "type": "object"
+            },
+            "SchedulerFormat": {
+                "enum": ["csv", "image"],
+                "type": "string"
+            },
+            "SchedulerCsvOptions": {
+                "properties": {
+                    "limit": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            {
+                                "type": "string",
+                                "enum": ["table", "all"]
+                            }
+                        ]
+                    },
+                    "formatted": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["limit", "formatted"],
+                "type": "object"
+            },
+            "SchedulerImageOptions": {
+                "properties": {},
+                "type": "object"
+            },
+            "SchedulerOptions": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerCsvOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerImageOptions"
+                    }
+                ]
+            },
+            "SchedulerBase": {
+                "properties": {
+                    "options": {
+                        "$ref": "#/components/schemas/SchedulerOptions"
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedChartUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cron": {
+                        "type": "string"
+                    },
+                    "format": {
+                        "$ref": "#/components/schemas/SchedulerFormat"
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "options",
+                    "dashboardUuid",
+                    "savedChartUuid",
+                    "cron",
+                    "format",
+                    "createdBy",
+                    "updatedAt",
+                    "createdAt",
+                    "name",
+                    "schedulerUuid"
+                ],
+                "type": "object"
+            },
+            "ChartScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedChartUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "DashboardScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "string"
+                            },
+                            "savedChartUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            }
+                        },
+                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Scheduler": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ChartScheduler"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardScheduler"
+                    }
+                ]
+            },
+            "SchedulerSlackTarget": {
+                "properties": {
+                    "channel": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerSlackTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "channel",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerSlackTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerEmailTarget": {
+                "properties": {
+                    "recipient": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerEmailTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "recipient",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerEmailTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerAndTargets": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Scheduler"
+                    },
+                    {
+                        "properties": {
+                            "targets": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["targets"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "SchedulerJobStatus": {
+                "enum": ["scheduled", "started", "completed", "error"],
+                "type": "string"
+            },
+            "Record_string.any_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "SchedulerLog": {
+                "properties": {
+                    "details": {
+                        "$ref": "#/components/schemas/Record_string.any_"
+                    },
+                    "targetType": {
+                        "type": "string",
+                        "enum": ["email", "slack"]
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/SchedulerJobStatus"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "scheduledTime": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "jobGroup": {
+                        "type": "string"
+                    },
+                    "jobId": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "task": {
+                        "type": "string",
+                        "enum": [
+                            "handleScheduledDelivery",
+                            "sendEmailNotification",
+                            "sendSlackNotification",
+                            "downloadCsv",
+                            "compileProject",
+                            "testAndCompileProject",
+                            "validateProject"
+                        ]
+                    }
+                },
+                "required": [
+                    "status",
+                    "createdAt",
+                    "scheduledTime",
+                    "jobId",
+                    "task"
+                ],
+                "type": "object"
+            },
+            "SchedulerWithLogs": {
+                "properties": {
+                    "logs": {
+                        "items": {
+                            "$ref": "#/components/schemas/SchedulerLog"
+                        },
+                        "type": "array"
+                    },
+                    "dashboards": {
+                        "items": {
+                            "properties": {
+                                "dashboardUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["dashboardUuid", "name"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "charts": {
+                        "items": {
+                            "properties": {
+                                "savedChartUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["savedChartUuid", "name"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "users": {
+                        "items": {
+                            "properties": {
+                                "userUuid": {
+                                    "type": "string"
+                                },
+                                "lastName": {
+                                    "type": "string"
+                                },
+                                "firstName": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["userUuid", "lastName", "firstName"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "schedulers": {
+                        "items": {
+                            "$ref": "#/components/schemas/SchedulerAndTargets"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "logs",
+                    "dashboards",
+                    "charts",
+                    "users",
+                    "schedulers"
+                ],
+                "type": "object"
+            },
+            "ApiSchedulerLogsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SchedulerWithLogs"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSchedulerAndTargetsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SchedulerAndTargets"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ScheduledJobs": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": ["id", "date"],
+                "type": "object"
+            },
+            "ApiScheduledJobsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScheduledJobs"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiJobStatusResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "status": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["status"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ShareUrl": {
+                "properties": {
+                    "host": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "shareUrl": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "params": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "The URL path of the full URL"
+                    },
+                    "nanoid": {
+                        "type": "string",
+                        "description": "Unique shareable id"
+                    }
+                },
+                "required": ["params", "path", "nanoid"],
+                "type": "object",
+                "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
+            },
+            "ApiShareResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ShareUrl"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_ShareUrl.path-or-params_": {
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The URL path of the full URL"
+                    },
+                    "params": {
+                        "type": "string"
+                    }
+                },
+                "required": ["path", "params"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateShareUrl": {
+                "$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
+                "description": "Contains the detail of a full URL to generate a short URL id"
+            },
+            "SlackChannel": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "id"],
+                "type": "object"
+            },
+            "ApiSlackChannelsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/SlackChannel"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_SshKeyPair.publicKey_": {
+                "properties": {
+                    "publicKey": {
+                        "type": "string"
+                    }
+                },
+                "required": ["publicKey"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiSshKeyPairResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "EmailOneTimePassword": {
+                "properties": {
+                    "numberOfAttempts": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Number of times the passcode has been attempted"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time that the passcode was created"
+                    }
+                },
+                "required": ["numberOfAttempts", "createdAt"],
+                "type": "object"
+            },
+            "EmailStatus": {
+                "properties": {
+                    "otp": {
+                        "$ref": "#/components/schemas/EmailOneTimePassword"
+                    },
+                    "isVerified": {
+                        "type": "boolean"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": ["isVerified", "email"],
+                "type": "object"
+            },
+            "EmailOneTimePasswordExpiring": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/EmailOneTimePassword"
+                    },
+                    {
+                        "properties": {
+                            "isMaxAttempts": {
+                                "type": "boolean"
+                            },
+                            "isExpired": {
+                                "type": "boolean"
+                            },
+                            "expiresAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "EmailStatusExpiring": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/EmailStatus"
+                    },
+                    {
+                        "properties": {
+                            "otp": {
+                                "$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
+                                "description": "One time passcode information\nIf there is no active passcode, this will be undefined"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ],
+                "description": "Verification status of an email address"
+            },
+            "ApiEmailStatusResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/EmailStatusExpiring"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "Shows the current verification status of an email address"
+            },
+            "UserAllowedOrganization": {
+                "properties": {
+                    "membersCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["membersCount", "name", "organizationUuid"],
+                "type": "object"
+            },
+            "ApiUserAllowedOrganizationsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/UserAllowedOrganization"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiJobScheduledResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "jobId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["jobId"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ValidationErrorType": {
+                "enum": [
+                    "chart",
+                    "sorting",
+                    "filter",
+                    "metric",
+                    "model",
+                    "dimension"
+                ],
+                "type": "string"
+            },
+            "ValidationResponseBase": {
+                "properties": {
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "errorType": {
+                        "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "validationId": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "projectUuid",
+                    "error",
+                    "name",
+                    "createdAt",
+                    "validationId"
+                ],
+                "type": "object"
+            },
+            "ValidationErrorChartResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationResponseBase"
+                    },
+                    {
+                        "properties": {
+                            "lastUpdatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "lastUpdatedBy": {
+                                "type": "string"
+                            },
+                            "fieldName": {
+                                "type": "string"
+                            },
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartKind"
+                            },
+                            "chartUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ValidationErrorDashboardResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationResponseBase"
+                    },
+                    {
+                        "properties": {
+                            "lastUpdatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "lastUpdatedBy": {
+                                "type": "string"
+                            },
+                            "fieldName": {
+                                "type": "string"
+                            },
+                            "chartName": {
+                                "type": "string"
+                            },
+                            "dashboardUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ValidationErrorTableResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationResponseBase"
+                    },
+                    {
+                        "properties": {
+                            "dimensionName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ValidationResponse": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorChartResponse"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorDashboardResponse"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorTableResponse"
+                    }
+                ]
+            },
+            "ApiValidateResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationResponse"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            }
+        },
+        "securitySchemes": {
+            "session_cookie": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "connect.sid"
+            },
+            "api_key": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "Authorization",
+                "description": "Value should be 'ApiKey <your key>'"
+            }
+        }
+    },
+    "info": {
+        "title": "Lightdash API",
+        "version": "0.587.0",
+        "description": "Open API documentation for all public Lightdash API endpoints",
+        "license": {
+            "name": "MIT"
+        },
+        "contact": {
+            "name": "Lightdash Support",
+            "email": "support@lightdash.com",
+            "url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
+        }
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/api/v1/csv/{jobId}": {
+            "get": {
+                "operationId": "getCsvUrl",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCsvUrlResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a Csv",
+                "tags": ["Exports"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the jobId for the CSV",
+                        "in": "path",
+                        "name": "jobId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
+            "get": {
+                "operationId": "getDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the current dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "updateDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "deleteDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove the dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
+            "get": {
+                "operationId": "getDbtCloudMetrics",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudMetrics"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/groups/{groupUuid}": {
+            "get": {
+                "operationId": "getGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get group details",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "unique id of the group",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "deleteGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateGroup"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/groups/{groupUuid}/members/{userUuid}": {
+            "put": {
+                "operationId": "addUserToGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add a Lightdash user to a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to add the user to",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the UUID for the user to add to the group",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "removeUserFromGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove a user from a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to remove the user from",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the UUID for the user to remove from the group",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/groups/{groupUuid}/members": {
+            "get": {
+                "operationId": "getGroupMembers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupMembersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "View members of a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to view the members of",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org": {
+            "get": {
+                "operationId": "GetMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganization"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "CreateOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new organization settings",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateOrganization",
+                                "description": "the new organization settings"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "UpdateMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new organization settings",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateOrganization",
+                                "description": "the new organization settings"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/{organizationUuid}": {
+            "delete": {
+                "operationId": "DeleteMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Deletes an organization and all users inside that organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the organization to delete",
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/users": {
+            "get": {
+                "operationId": "ListOrganizationMembers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all the members of the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/users/{userUuid}": {
+            "patch": {
+                "operationId": "UpdateOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Updates the membership profile for a user in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user to update",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new membership profile",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
+                                "description": "the new membership profile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/user/{userUuid}": {
+            "delete": {
+                "operationId": "DeleteOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Deletes a user from the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user to delete",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/allowedEmailDomains": {
+            "get": {
+                "operationId": "ListOrganizationEmailDomains",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets the allowed email domains for the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "patch": {
+                "operationId": "UpdateOrganizationEmailDomains",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets the allowed email domains for the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAllowedEmailDomains"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/groups": {
+            "post": {
+                "operationId": "CreateGroupInOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates a new group in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pick_CreateGroup.name_"
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "operationId": "ListGroupsInOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all the groups in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
+            "get": {
+                "operationId": "getPinnedItems",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPinnedItems"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get pinned items",
+                "tags": ["Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "project uuid",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the list uuid for the pinned items",
+                        "in": "path",
+                        "name": "pinnedListUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
+            "patch": {
+                "operationId": "updatePinnedItemsOrder",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPinnedItems"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update pinned items order",
+                "tags": ["Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "project uuid",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the list uuid for the pinned items",
+                        "in": "path",
+                        "name": "pinnedListUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new order of the pinned items",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "items": {
+                                    "$ref": "#/components/schemas/UpdatePinnedItemOrder"
+                                },
+                                "type": "array",
+                                "description": "the new order of the pinned items"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/charts": {
+            "get": {
+                "operationId": "ListChartsInProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List all charts in a project",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to get charts for",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces": {
+            "get": {
+                "operationId": "ListSpacesInProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List all spaces in a project",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to get spaces for",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
+            "post": {
+                "operationId": "postRunUnderlyingDataQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for underlying data results",
+                "tags": ["Exploring"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "table name",
+                        "in": "path",
+                        "name": "exploreId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "metricQuery for the chart to run",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunQueryRequest",
+                                "description": "metricQuery for the chart to run"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
+            "post": {
+                "operationId": "postRunQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for explore",
+                "tags": ["Exploring"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "table name",
+                        "in": "path",
+                        "name": "exploreId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "metricQuery for the chart to run",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunQueryRequest",
+                                "description": "metricQuery for the chart to run"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/saved/{chartUuid}/results": {
+            "post": {
+                "operationId": "postChartResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for a chart",
+                "tags": ["Charts"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "chartUuid for the chart to run",
+                        "in": "path",
+                        "name": "chartUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "filters": {
+                                        "$ref": "#/components/schemas/Filters"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/schedulers/{projectUuid}/logs": {
+            "get": {
+                "operationId": "getSchedulerLogs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerLogsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get scheduled logs",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/{schedulerUuid}": {
+            "get": {
+                "operationId": "getScheduler",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateScheduler",
+                "responses": {
+                    "201": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new scheduler data",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "the new scheduler data"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteScheduler",
+                "responses": {
+                    "201": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {},
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to delete",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/{schedulerUuid}/jobs": {
+            "get": {
+                "operationId": "getScheduledJobs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiScheduledJobsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get scheduled jobs",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/job/{jobId}/status": {
+            "get": {
+                "operationId": "getSchedulerJobStatus",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a generic job status\nThis method can be used when polling from the frontend",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the jobId for the status to check",
+                        "in": "path",
+                        "name": "jobId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/share/{nanoId}": {
+            "get": {
+                "operationId": "getShareUrl",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiShareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a share url from a short url id",
+                "tags": ["Share links"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the short id for the share url",
+                        "in": "path",
+                        "name": "nanoId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/share": {
+            "post": {
+                "operationId": "CreateShareUrl",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiShareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Given a full URL generates a short url id that can be used for sharing",
+                "tags": ["Share links"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "a full URL used to generate a short url id",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateShareUrl",
+                                "description": "a full URL used to generate a short url id"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/slack/channels": {
+            "get": {
+                "operationId": "getSlackChannels",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSlackChannelsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get slack channels",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/ssh/key-pairs": {
+            "post": {
+                "operationId": "createSshKeyPair",
+                "responses": {
+                    "201": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSshKeyPairResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["SSH Keypairs"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/email/otp": {
+            "put": {
+                "operationId": "CreateEmailOneTimePasscode",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/email/status": {
+            "get": {
+                "operationId": "GetEmailVerificationStatus",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the verification status for the current user's primary email",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the one-time passcode sent to the user's primary email",
+                        "in": "query",
+                        "name": "passcode",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/user/me/allowedOrganizations": {
+            "get": {
+                "operationId": "ListMyAvailableOrganizations",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/joinOrganization/{organizationUuid}": {
+            "post": {
+                "operationId": "JoinOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the organization to join",
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/user/me": {
+            "delete": {
+                "operationId": "DeleteMe",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete user",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/projects/{projectUuid}/validate": {
+            "post": {
+                "operationId": "ValidateProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the projectId for the validation",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "get": {
+                "operationId": "GetLatestValidationResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiValidateResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get validation results for a project. This will return the results of the latest validation job.",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the projectId for the validation",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "boolean to know if this request is made from the settings page, for analytics",
+                        "in": "query",
+                        "name": "fromSettings",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "tags": [
+        {
+            "name": "My Account",
+            "description": "These routes allow users to manage their own user account."
+        },
+        {
+            "name": "Organizations",
+            "description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
+        },
+        {
+            "name": "Projects",
+            "description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
+        }
+    ]
 }

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -8,6 +8,7 @@ describe('Scheduler model test', () => {
             schedulerUuid: '1',
             status: SchedulerJobStatus.SCHEDULED,
             scheduledTime: new Date(2021, 0, 2),
+            createdAt: new Date(2021, 0, 2),
             jobId: '1',
         };
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartSummary,
+    CreateSchedulerLog,
     Dashboard,
     ForbiddenError,
     isChartScheduler,
@@ -9,7 +10,6 @@ import {
     ScheduledJobs,
     Scheduler,
     SchedulerAndTargets,
-    SchedulerLog,
     SessionUser,
     UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
@@ -196,7 +196,7 @@ export class SchedulerService {
         return schedulerClient.getScheduledJobs(schedulerUuid);
     }
 
-    async logSchedulerJob(log: SchedulerLog): Promise<void> {
+    async logSchedulerJob(log: CreateSchedulerLog): Promise<void> {
         await this.schedulerModel.logSchedulerJob(log);
     }
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -34,11 +34,14 @@ export type SchedulerLog = {
     jobId: string;
     jobGroup?: string;
     scheduledTime: Date;
+    createdAt: Date;
     status: SchedulerJobStatus;
     target?: string;
     targetType?: 'email' | 'slack';
     details?: Record<string, any>;
 };
+
+export type CreateSchedulerLog = Omit<SchedulerLog, 'createdAt'>;
 
 export type SchedulerBase = {
     schedulerUuid: string;
@@ -164,6 +167,8 @@ export type ApiSchedulerAndTargetsResponse = {
 export type SchedulerWithLogs = {
     schedulers: SchedulerAndTargets[];
     users: { firstName: string; lastName: string; userUuid: string }[];
+    charts: { name: string; savedChartUuid: string }[];
+    dashboards: { name: string; dashboardUuid: string }[];
     logs: SchedulerLog[];
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #5369

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

No changes in the UI yet, those will be done in #5369

Changes:
- return relevant chart and dashboard names
- return log created date
- only show logs where delivery scheduled date is between 7 days ago and current time

<img width="1188" alt="Captura de ecrã 2023-06-01, às 13 43 15" src="https://github.com/lightdash/lightdash/assets/9117144/26d99407-96d7-44a5-a27a-5b6aeb532054">
<img width="649" alt="Captura de ecrã 2023-06-01, às 13 43 33" src="https://github.com/lightdash/lightdash/assets/9117144/43a386ff-b089-449c-b145-7f864fb9a5fc">

