### PR TITLE
fix: workaround otel metrics env vars

### DIFF
--- a/packages/backend/src/otel.ts
+++ b/packages/backend/src/otel.ts
@@ -1,7 +1,12 @@
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { diag, DiagConsoleLogger } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
 import { Resource } from '@opentelemetry/resources';
+import {
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
 import { core, NodeSDK } from '@opentelemetry/sdk-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
@@ -10,6 +15,7 @@ process.env.OTEL_SDK_DISABLED = process.env.OTEL_SDK_DISABLED || 'true';
 
 // Environment variable configuration
 // OTEL_TRACES_EXPORTER=otlp
+// OTEL_METRICS_EXPORTER=otlp
 // OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 // OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 // OTEL_RESOURCE_ATTRIBUTES=service.name=lightdash,service.version=1.0.0
@@ -18,8 +24,27 @@ if (process.env.OTEL_SDK_DISABLED !== 'true') {
     diag.setLogger(new DiagConsoleLogger(), core.getEnv().OTEL_LOG_LEVEL);
 }
 
+const getMetricReader = (s: string | undefined) => {
+    switch (s) {
+        case 'otlp':
+            return new PeriodicExportingMetricReader({
+                // Expect OTLP to be configured by environment variables
+                exporter: new OTLPMetricExporter({}),
+            });
+        case 'console':
+            return new PeriodicExportingMetricReader({
+                exporter: new ConsoleMetricExporter(),
+            });
+        default:
+            return undefined;
+    }
+};
+
 const sdk = new NodeSDK({
-    // Exporters are auto configured based on environment variables
+    // Trace exporter is auto configured based on environment variables
+
+    // WORKAROUND: for https://github.com/open-telemetry/opentelemetry-js/issues/3193
+    metricReader: getMetricReader(process.env.OTEL_METRICS_EXPORTER),
 
     // Instrumentations enable tracing/profiling of specific libraries.
     // Auto instrumentation includes http,express,knex,pg,winston


### PR DESCRIPTION
We're not exporting metrics with otel because the node sdk isn't picking up the environment variables
