### PR TITLE
fix: apply dashboard filters in scheduled deliveries

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -8,10 +8,8 @@ import {
 import { subject } from '@casl/ability';
 import {
     ChartType,
-    convertDashboardFiltersToFilters,
     DashboardChartTile as IDashboardChartTile,
     DashboardFilterRule,
-    DashboardFilters,
     Field,
     fieldId,
     FilterOperator,
@@ -175,13 +173,11 @@ const ValidDashboardChartTileMinimal: FC<{
     tileUuid: string;
     isTitleHidden?: boolean;
     data: SavedChart;
-    dashboardFilters?: DashboardFilters;
-}> = ({ tileUuid, data, dashboardFilters, isTitleHidden = false }) => {
-    const filters =
-        dashboardFilters !== undefined
-            ? convertDashboardFiltersToFilters(dashboardFilters)
-            : undefined;
-    const { data: resultData, isLoading } = useChartResults(data.uuid, filters);
+}> = ({ tileUuid, data, isTitleHidden = false }) => {
+    const { data: resultData, isLoading } = useChartResults(
+        data.uuid,
+        data.metricQuery.filters,
+    );
     const { data: explore } = useExplore(data.tableName);
 
     return (
@@ -219,7 +215,6 @@ interface DashboardChartTileMainProps
         'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
     > {
     tile: IDashboardChartTile;
-    dashboardFilters?: DashboardFilters;
 }
 
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
@@ -668,7 +663,6 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
             uuid: tileUuid,
             properties: { savedChartUuid, hideTitle },
         },
-        dashboardFilters,
     } = props;
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
@@ -689,7 +683,6 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     tileUuid={tileUuid}
                     isTitleHidden={hideTitle}
                     data={data}
-                    dashboardFilters={dashboardFilters}
                 />
             ) : (
                 <InvalidDashboardChartTile />

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -1,9 +1,5 @@
-import {
-    assertUnreachable,
-    DashboardFilters,
-    DashboardTileTypes,
-} from '@lightdash/common';
-import { FC, useMemo } from 'react';
+import { assertUnreachable, DashboardTileTypes } from '@lightdash/common';
+import { FC } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
 import { useParams } from 'react-router-dom';
 
@@ -28,12 +24,6 @@ const MinimalDashboard: FC = () => {
         isError,
         error,
     } = useDashboardQuery(dashboardUuid);
-
-    const dashboardFilters: DashboardFilters | undefined = useMemo(() => {
-        const searchParams = new URLSearchParams(window.location.search);
-        const filterSearchParam = searchParams.get('filters');
-        return filterSearchParam ? JSON.parse(filterSearchParam) : undefined;
-    }, []);
 
     if (isError) {
         return <>{error.error.message}</>;
@@ -64,7 +54,6 @@ const MinimalDashboard: FC = () => {
                         {tile.type === DashboardTileTypes.SAVED_CHART ? (
                             <ChartTile
                                 key={tile.uuid}
-                                dashboardFilters={dashboardFilters}
                                 minimal
                                 tile={tile}
                                 isEditMode={false}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5726 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We don't need to drill down the dashboard filters anymore since they are applied in `useSavedQueryWithDashboardFilters`.



https://github.com/lightdash/lightdash/assets/9117144/5e2cef1f-f14a-4086-b95f-b5da8c78b4cf

