### PR TITLE
feat: let users go to tables when model error

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -25,7 +25,8 @@ const getLinkToResource = (
     if (isDashboardValidationError(validationError))
         return `/projects/${projectUuid}/dashboards/${validationError.dashboardUuid}/view`;
 
-    return;
+    if (isTableValidationError(validationError))
+        return `/projects/${projectUuid}/tables`;
 };
 
 const Icon = ({ validationError }: { validationError: ValidationResponse }) => {
@@ -112,7 +113,7 @@ export const ValidatorTable: FC<{
                                   handleOnValidationErrorClick(validationError)
                               }
                           >
-                              <td>
+                              <td width="50%">
                                   <Flex gap="sm" align="center">
                                       <Icon validationError={validationError} />
 
@@ -150,7 +151,7 @@ export const ValidatorTable: FC<{
                                       </Stack>
                                   </Flex>
                               </td>
-                              <td>
+                              <td width="50%">
                                   <ErrorMessage
                                       validationError={validationError}
                                   />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5725

### Description:

When user clicks on model error they get to `/tables` view.


I also made sure the 2 column rows were of equal width