### PR TITLE
feat: configure logs with environment variables

### DIFF
--- a/docs/docs/self-host/customize-deployment/configure-logging-for-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/configure-logging-for-lightdash.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_label: Logging
+---
+
+# Configure logging for Lightdash
+
+By default Lightdash logs to the console in a human readable format. You can configure the logging behaviour, such 
+as logging to a file or using a JSON format, by
+using the following environment variables:
+
+| Variable                       | Description                                                 | Required? | Default                |
+|--------------------------------|-------------------------------------------------------------|-----------|------------------------|
+| `LIGHTDASH_LOG_LEVEL`          | The minimum level of log messages to display                |           | `INFO`                 |
+| `LIGHTDASH_LOG_FORMAT`         | The format of log messages                                  |           | `pretty`               |
+| `LIGHTDASH_LOG_OUTPUTS`        | The outputs to send log messages to                         |           | `console`              |
+| `LIGHTDASH_LOG_CONSOLE_LEVEL`  | The minimum level of log messages to display on the console |           | `LIGHTDAH_LOG_LEVEL`   |
+| `LIGHTDASH_LOG_CONSOLE_FORMAT` | The format of log messages on the console                   |           | `LIGHTDASH_LOG_FORMAT` |
+| `LIGHTDASH_LOG_FILE_LEVEL`     | The minimum level of log messages to write to the log file  |           | `LIGHTDASH_LOG_LEVEL`  |
+| `LIGHTDASH_LOG_FILE_FORMAT`    | The format of log messages in the log file                  |           | `LIGHTDASH_LOG_FORMAT` |
+| `LIGHTDASH_LOG_FILE_PATH`      | The path to the log file                                    |           | `./logs/all.log`       |

--- a/docs/docs/self-host/customize-deployment/environment-variables.mdx
+++ b/docs/docs/self-host/customize-deployment/environment-variables.mdx
@@ -60,3 +60,17 @@ These variables enable you to control Single Sign On (SSO) functionality.
 | `AUTH_ONE_LOGIN_OAUTH_CLIENT_ID`       | Required for One Login SSO                               |           |         |
 | `AUTH_ONE_LOGIN_OAUTH_CLIENT_SECRET`   | Required for One Login SSO                               |           |         |
 | `AUTH_ONE_LOGIN_OAUTH_ISSUER`          | Required for One Login SSO                               |           |         |
+
+# Logging environment variables
+
+| Variable                       | Description                                                 | Required? | Default                |
+|--------------------------------|-------------------------------------------------------------|-----------|------------------------|
+| `LIGHTDASH_LOG_LEVEL`          | The minimum level of log messages to display                |           | `INFO`                 |
+| `LIGHTDASH_LOG_FORMAT`         | The format of log messages                                  |           | `pretty`               |
+| `LIGHTDASH_LOG_OUTPUTS`        | The outputs to send log messages to                         |           | `console`              |
+| `LIGHTDASH_LOG_CONSOLE_LEVEL`  | The minimum level of log messages to display on the console |           | `LIGHTDAH_LOG_LEVEL`   |
+| `LIGHTDASH_LOG_CONSOLE_FORMAT` | The format of log messages on the console                   |           | `LIGHTDASH_LOG_FORMAT` |
+| `LIGHTDASH_LOG_FILE_LEVEL`     | The minimum level of log messages to write to the log file  |           | `LIGHTDASH_LOG_LEVEL`  |
+| `LIGHTDASH_LOG_FILE_FORMAT`    | The format of log messages in the log file                  |           | `LIGHTDASH_LOG_FORMAT` |
+| `LIGHTDASH_LOG_FILE_PATH`      | The path to the log file                                    |           | `./logs/all.log`       |
+

--- a/docs/docs/self-host/self-host-lightdash.mdx
+++ b/docs/docs/self-host/self-host-lightdash.mdx
@@ -107,4 +107,5 @@ common configuration options, including those we recommend before going to produ
 - [Configure a Slack App for Lightdash](./customize-deployment/configure-a-slack-app-for-lightdash.mdx)
 - [Configure environment variables for Lightdash](./customize-deployment/environment-variables.mdx)
 - [Enable headless browser for Lightdash](./customize-deployment/enable-headless-browser-for-lightdash.mdx)
+- [Configure Logging for Lightdash](./customize-deployment/configure-logging-for-lightdash.mdx)
 

--- a/packages/backend/setupJest.ts
+++ b/packages/backend/setupJest.ts
@@ -1,6 +1,7 @@
 import { LightdashMode } from '@lightdash/common';
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { LightdashAnalytics } from './src/analytics/LightdashAnalytics';
+import { LightdashConfig } from './src/config/parseConfig';
 
 enableFetchMocks();
 
@@ -8,6 +9,11 @@ jest.mock('./src/config/lightdashConfig', () => ({
     lightdashConfig: {
         mode: LightdashMode.DEFAULT,
         database: {},
+        logging: {
+            level: 'debug',
+            outputs: 'console',
+            format: 'pretty',
+        },
     },
 }));
 

--- a/packages/backend/setupJest.ts
+++ b/packages/backend/setupJest.ts
@@ -1,7 +1,6 @@
 import { LightdashMode } from '@lightdash/common';
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { LightdashAnalytics } from './src/analytics/LightdashAnalytics';
-import { LightdashConfig } from './src/config/parseConfig';
 
 enableFetchMocks();
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2,7 +2,6 @@ import { isLightdashMode, LightdashMode, ParseError } from '@lightdash/common';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import lightdashV1JsonSchema from '../jsonSchemas/lightdashConfig/v1.json';
-import Logger from '../logger';
 import { VERSION } from '../version';
 
 export const getIntegerFromEnvironmentVariable = (
@@ -24,6 +23,50 @@ export const getIntegerFromEnvironmentVariable = (
 export type LightdashConfigIn = {
     version: '1.0';
     mode: LightdashMode;
+};
+
+type LoggingLevel = 'error' | 'warn' | 'info' | 'debug';
+const assertIsLoggingLevel = (x: string): x is LoggingLevel =>
+    ['error', 'warn', 'info', 'debug'].includes(x);
+const parseLoggingLevel = (raw: string): LoggingLevel => {
+    if (!assertIsLoggingLevel(raw)) {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_LOG_LEVEL". Value must be one of "error", "warn", "info", "debug" but LIGHTDASH_LOG_LEVEL=${raw}`,
+        );
+    }
+    return raw;
+};
+type LoggingFormat = 'json' | 'plain' | 'pretty';
+const assertIsLoggingFormat = (x: string): x is LoggingFormat =>
+    ['json', 'plain', 'pretty'].includes(x);
+const parseLoggingFormat = (raw: string): LoggingFormat => {
+    if (!assertIsLoggingFormat(raw)) {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_LOG_FORMAT". Value must be one of "json", "plain", "pretty" but LIGHTDASH_LOG_FORMAT=${raw}`,
+        );
+    }
+    return raw;
+};
+type LoggingOutput = 'console' | 'file';
+const assertIsLoggingOutput = (x: string): x is LoggingOutput =>
+    ['console', 'file'].includes(x);
+const parseLoggingOutput = (raw: string): LoggingOutput => {
+    if (!assertIsLoggingOutput(raw)) {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_LOG_OUTPUT". Value must be one of "console", "file" but LIGHTDASH_LOG_OUTPUT=${raw}`,
+        );
+    }
+    return raw;
+};
+export type LoggingConfig = {
+    level: LoggingLevel;
+    format: LoggingFormat;
+    outputs: LoggingOutput[];
+    consoleFormat: LoggingFormat | undefined;
+    consoleLevel: LoggingLevel | undefined;
+    fileFormat: LoggingFormat | undefined;
+    fileLevel: LoggingLevel | undefined;
+    filePath: string;
 };
 
 export type LightdashConfig = {
@@ -62,6 +105,7 @@ export type LightdashConfig = {
         concurrency: number;
         jobTimeout: number;
     };
+    logging: LoggingConfig;
 };
 
 export type SlackConfig = {
@@ -183,8 +227,8 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         process.env.NODE_ENV !== 'development' &&
         siteUrl.includes('localhost')
     ) {
-        Logger.warn(
-            `Using ${siteUrl} as the base SITE_URL for Lightdash. This is not suitable for production. Update with a top level domain using https such as https://lightdash.mycompany.com`,
+        console.log(
+            `WARNIN: Using ${siteUrl} as the base SITE_URL for Lightdash. This is not suitable for production. Update with a top level domain using https such as https://lightdash.mycompany.com`,
         );
     }
 
@@ -323,6 +367,42 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             jobTimeout: process.env.SCHEDULER_JOB_TIMEOUT
                 ? parseInt(process.env.SCHEDULER_JOB_TIMEOUT, 10)
                 : DEFAULT_JOB_TIMEOUT,
+        },
+        logging: {
+            level: parseLoggingLevel(
+                process.env.LIGHTDASH_LOG_LEVEL ||
+                    ((process.env.NODE_ENV || 'development') === 'development'
+                        ? 'debug'
+                        : 'warn'),
+            ),
+            format: parseLoggingFormat(
+                process.env.LIGHTDASH_LOG_FORMAT || 'pretty',
+            ),
+            outputs: (process.env.LIGHTDASH_LOG_OUTPUTS
+                ? process.env.LIGHTDASH_LOG_OUTPUTS.split(',')
+                : ['console']
+            ).map(parseLoggingOutput),
+            consoleFormat:
+                process.env.LIGHTDASH_LOG_CONSOLE_FORMAT === undefined
+                    ? undefined
+                    : parseLoggingFormat(
+                          process.env.LIGHTDASH_LOG_CONSOLE_FORMAT,
+                      ),
+            consoleLevel:
+                process.env.LIGHTDASH_LOG_CONSOLE_LEVEL === undefined
+                    ? undefined
+                    : parseLoggingLevel(
+                          process.env.LIGHTDASH_LOG_CONSOLE_LEVEL,
+                      ),
+            fileFormat:
+                process.env.LIGHTDASH_LOG_FILE_FORMAT === undefined
+                    ? undefined
+                    : parseLoggingFormat(process.env.LIGHTDASH_LOG_FILE_FORMAT),
+            fileLevel:
+                process.env.LIGHTDASH_LOG_FILE_LEVEL === undefined
+                    ? undefined
+                    : parseLoggingLevel(process.env.LIGHTDASH_LOG_FILE_LEVEL),
+            filePath: process.env.LIGHTDASH_LOG_FILE_PATH || './logs/error.log',
         },
     };
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -228,7 +228,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         siteUrl.includes('localhost')
     ) {
         console.log(
-            `WARNIN: Using ${siteUrl} as the base SITE_URL for Lightdash. This is not suitable for production. Update with a top level domain using https such as https://lightdash.mycompany.com`,
+            `WARNING: Using ${siteUrl} as the base SITE_URL for Lightdash. This is not suitable for production. Update with a top-level domain using https such as https://lightdash.mycompany.com`,
         );
     }
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -402,7 +402,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
                 process.env.LIGHTDASH_LOG_FILE_LEVEL === undefined
                     ? undefined
                     : parseLoggingLevel(process.env.LIGHTDASH_LOG_FILE_LEVEL),
-            filePath: process.env.LIGHTDASH_LOG_FILE_PATH || './logs/error.log',
+            filePath: process.env.LIGHTDASH_LOG_FILE_PATH || './logs/all.log',
         },
     };
 };

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -84,6 +84,16 @@ export const lightdashConfigMock: LightdashConfig = {
         concurrency: 1,
         jobTimeout: 1,
     },
+    logging: {
+        level: 'info',
+        format: 'pretty',
+        outputs: ['console'],
+        consoleFormat: undefined,
+        consoleLevel: undefined,
+        fileFormat: undefined,
+        filePath: '',
+        fileLevel: undefined,
+    },
 };
 
 const dbtCloudIDEProjectConfigMock: DbtCloudIDEProjectConfig = {


### PR DESCRIPTION
Closes: #4291

Allows the user to configure Lightdash logging behaviour using the following environment variables:

- `LIGHTDASH_LOG_LEVEL`: The minimum level of log messages to display. Defaults to `INFO`.
- `LIGHTDASH_LOG_FORMAT`: The format of log messages. Defaults to `pretty`. Can be `plain`, `pretty`, or `json`.
- `LIGHTDASH_LOG_OUTPUTS`: The outputs to send log messages to. Defaults to `console`.
- `LIGHTDASH_LOG_CONSOLE_LEVEL`: The minimum level of log messages to display on the console. Defaults to `LIGHTDAH_LOG_LEVEL`.
- `LIGHTDASH_LOG_CONSOLE_FORMAT`: The format of log messages on the console. Defaults to `LIGHTDASH_LOG_FORMAT`.
- `LIGHTDASH_LOG_FILE_LEVEL`: The minimum level of log messages to write to the log file. Defaults to `LIGHTDASH_LOG_LEVEL`.
- `LIGHTDASH_LOG_FILE_FORMAT`: The format of log messages in the log file. Defaults to `LIGHTDASH_LOG_FORMAT`.
- `LIGHTDASH_LOG_FILE_PATH`: The path to the log file. Defaults to `./logs/all.log`.

Breaking changes:
- The default logging no longer logs to a file

Otherwise the terminal format is by default identical to how it is now.


### Plain output 

<img width="951" alt="CleanShot 2023-06-02 at 20 42 07@2x" src="https://github.com/lightdash/lightdash/assets/11660098/63541569-468e-425c-8598-9a8a1d0c4d37">

### Pretty output (current)

<img width="947" alt="CleanShot 2023-06-02 at 20 42 48@2x" src="https://github.com/lightdash/lightdash/assets/11660098/280615e2-e971-4823-8154-ed2bd7a7646d">


### JSON output

<img width="939" alt="CleanShot 2023-06-02 at 20 46 08@2x" src="https://github.com/lightdash/lightdash/assets/11660098/5d4fca16-89e7-490a-b385-59bf32e7c8a9">


### Complex example

<img width="1462" alt="CleanShot 2023-06-02 at 21 03 18@2x" src="https://github.com/lightdash/lightdash/assets/11660098/3f58a45c-ab12-4ca1-8565-4f3ba3c7e81f">



