### PR TITLE
fix: invalidate validations query on change of project

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -39,7 +39,10 @@ export const useUpdateActiveProjectMutation = () => {
             Promise.resolve(
                 localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
             ),
-        onSuccess: () => clearProjectCache(queryClient),
+        onSuccess: () => {
+            clearProjectCache(queryClient);
+            queryClient.invalidateQueries(['validations']);
+        },
     });
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5690

### Description:

Invalidate `validations` query when changing active project.


