### PR TITLE
chore: disable fs instrumentation with opentelemetry

### DIFF
--- a/packages/backend/src/otel.ts
+++ b/packages/backend/src/otel.ts
@@ -62,7 +62,7 @@ const sdk = new NodeSDK({
                 requireParentSpan: true,
             },
             '@opentelemetry/instrumentation-fs': {
-                requireParentSpan: true,
+                enabled: false,
             },
         }),
     ],


### PR DESCRIPTION
These spans tell us about timings about filesystem IO, they're very noisy and not that useful