### PR TITLE
fix: total exclusions for certain types

### DIFF
--- a/packages/frontend/src/hooks/useColumnTotals.ts
+++ b/packages/frontend/src/hooks/useColumnTotals.ts
@@ -4,10 +4,7 @@ import {
     Field,
     FieldId,
     getItemId,
-    isAdditionalMetric,
     isDimension,
-    isField,
-    isMetric,
     isTableCalculation,
     Item,
     MetricType,
@@ -26,19 +23,15 @@ export const isSummable = (item: Item) => {
         return false;
     }
 
-    if (isField(item) || isMetric(item) || isAdditionalMetric(item)) {
-        const numericTypes: string[] = [
-            DimensionType.NUMBER,
-            MetricType.NUMBER,
-            MetricType.COUNT,
-            MetricType.SUM,
-        ];
-        const isPercent = item.format === 'percent';
-        const isDatePart = isDimension(item) && item.timeInterval;
-        return numericTypes.includes(item.type) && !isPercent && !isDatePart;
-    }
-
-    return false;
+    const numericTypes: string[] = [
+        DimensionType.NUMBER,
+        MetricType.NUMBER,
+        MetricType.COUNT,
+        MetricType.SUM,
+    ];
+    const isPercent = item.format === 'percent';
+    const isDatePart = isDimension(item) && item.timeInterval;
+    return numericTypes.includes(item.type) && !isPercent && !isDatePart;
 };
 
 const getResultColumnTotals = (

--- a/packages/frontend/src/hooks/useColumnTotals.ts
+++ b/packages/frontend/src/hooks/useColumnTotals.ts
@@ -7,6 +7,9 @@ import {
     isAdditionalMetric,
     isDimension,
     isField,
+    isMetric,
+    isTableCalculation,
+    Item,
     MetricType,
     ResultRow,
     TableCalculation,
@@ -18,20 +21,24 @@ type Args = {
     itemsMap: Record<FieldId, Field | TableCalculation>;
 };
 
-export const isSummable = (item: Field | TableCalculation) => {
-    if (isField(item) || isAdditionalMetric(item)) {
+export const isSummable = (item: Item) => {
+    if (isTableCalculation(item)) {
+        return false;
+    }
+
+    if (isField(item) || isMetric(item) || isAdditionalMetric(item)) {
         const numericTypes: string[] = [
             DimensionType.NUMBER,
             MetricType.NUMBER,
             MetricType.COUNT,
-            MetricType.COUNT_DISTINCT,
             MetricType.SUM,
         ];
         const isPercent = item.format === 'percent';
         const isDatePart = isDimension(item) && item.timeInterval;
         return numericTypes.includes(item.type) && !isPercent && !isDatePart;
     }
-    return true;
+
+    return false;
 };
 
 const getResultColumnTotals = (


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/5540
Closes: https://github.com/lightdash/lightdash/issues/5547

### Description:

- [x] only apply totals to metrics that have: sum, count or number types
- [x] don't show totals for metrics with average, count_distinct, average, median, percentile
- [x] don't show totals for table calculations