### PR TITLE
feat: add z-index 20 to Indicator in theme

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -102,6 +102,18 @@ export const getMantineThemeOverride = (overrides?: {
             }),
         },
 
+        Indicator: {
+            defaultProps: {
+                withArrow: true,
+            },
+            styles: () => ({
+                // FIXME: this is a hack to fix position of the Indicator under overlays. Remove after Blueprint migration is complete
+                root: {
+                    zIndex: 20,
+                },
+            }),
+        },
+
         Tooltip: {
             defaultProps: {
                 withArrow: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5777

### Description:

Add `z-index` `20` to root `Indicator`, similar to the `Tooltip` root styling approach. 

Example with it working: 
![Screenshot 2023-06-06 at 15 17 28](https://github.com/lightdash/lightdash/assets/7611706/5876a563-383f-4f43-aaea-717d0fe4030b)

Previously, without the overriding, the Indicator had a `z-index` set to `100`, which we don't need. 
Once we fully migrate to using Mantine UI then we can set our own `z-index` scale, if necessary.
