### PR TITLE
chore: skip deploy to docker hub on fork PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Setup docker tags
         id: meta


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #522 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Skip `docker` job on forked repositories `pull_request`

Unfortunately it seems that GitHub Actions does not support a similar verification on `workflow` level, only at `job` or `step`, so the workflow will start and end with a `Skipped` status

References:
- https://github.com/orgs/community/discussions/9098
- https://github.com/orgs/community/discussions/26829

<!-- Even better add a screenshot / gif / loom -->
