### PR TITLE
fix: fix operator starts with lowercase

### DIFF
--- a/packages/common/src/types/filterGrammar.ts
+++ b/packages/common/src/types/filterGrammar.ts
@@ -178,7 +178,7 @@ export const parseOperator = (
     operator: string,
     isTrue: boolean,
 ): FilterOperator => {
-    switch (operator.toLowerCase()) {
+    switch (operator) {
         case FilterOperator.EQUALS:
             return isTrue ? FilterOperator.EQUALS : FilterOperator.NOT_EQUALS;
         case FilterOperator.INCLUDE:
@@ -194,6 +194,7 @@ export const parseOperator = (
         case '<=':
             return FilterOperator.LESS_THAN_OR_EQUAL;
         case 'null':
+        case 'NULL':
             return isTrue ? FilterOperator.NULL : FilterOperator.NOT_NULL;
         default:
             throw new UnexpectedServerError(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #5791
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

I was forcing operator.lowercase() to compare `null` and `NULL`, but that was affecting other operators that require specific case like `startsWith`
