### PR TITLE
fix: scheduled deliveries charts bg should be white

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -100,7 +100,7 @@ export const getLogStatusIcon = (log: Log, theme: MantineTheme) => {
             );
         case SchedulerJobStatus.ERROR:
             return (
-                <Tooltip label={log?.details?.error}>
+                <Tooltip label={log?.details?.error} multiline>
                     <MantineIcon
                         icon={IconAlertTriangleFilled}
                         color="red.6"

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -1,3 +1,4 @@
+import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,7 +16,13 @@ import {
 const StyledLightdashVisualization = styled(LightdashVisualization)`
     min-height: inherit;
 `;
-
+const themeOverride: MantineThemeOverride = {
+    globalStyles: () => ({
+        'html, body': {
+            backgroundColor: 'white',
+        },
+    }),
+};
 const MinimalExplorer: FC = () => {
     const queryResults = useExplorerContext(
         (context) => context.queryResults.data,
@@ -46,11 +53,13 @@ const MinimalExplorer: FC = () => {
             isLoading={isLoadingQueryResults}
             columnOrder={savedChart.tableConfig.columnOrder}
         >
-            <StyledLightdashVisualization
-                // get rid of the classNames once you remove analytics providers
-                className="sentry-block fs-block cohere-block"
-                data-testid="visualization"
-            />
+            <MantineProvider inherit theme={themeOverride}>
+                <StyledLightdashVisualization
+                    // get rid of the classNames once you remove analytics providers
+                    className="sentry-block fs-block cohere-block"
+                    data-testid="visualization"
+                />
+            </MantineProvider>
         </VisualizationProvider>
     );
 };
@@ -97,7 +106,9 @@ const MinimalSavedExplorer: FC = () => {
                     : undefined
             }
         >
-            <MinimalExplorer />
+            <MantineProvider inherit theme={themeOverride}>
+                <MinimalExplorer />
+            </MantineProvider>
         </ExplorerProvider>
     );
 };


### PR DESCRIPTION
Closes:  #5589

### Description:
before
<img width="1624" alt="Screenshot 2023-06-08 at 13 38 20" src="https://github.com/lightdash/lightdash/assets/67699259/1e6aa06c-d531-4a94-a4e5-465012a84f1f">
after
<img width="1624" alt="Screenshot 2023-06-08 at 13 33 24" src="https://github.com/lightdash/lightdash/assets/67699259/0ff4eee0-01bd-4753-898a-c5cf6187084f">
