### PR TITLE
fix: fix slack channel names on schedulers

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -4,8 +4,9 @@ import {
     SchedulerWithLogs,
 } from '@lightdash/common';
 import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
-import React, { FC, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { useSlackChannels } from '../../hooks/slack/useSlackChannels';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
 import {
@@ -33,6 +34,19 @@ const Schedulers: FC<SchedulersProps> = ({
     dashboards,
 }) => {
     const { classes, theme } = useTableStyles();
+    const { data: allSlackChannels } = useSlackChannels();
+
+    const getSlackChannelName = useCallback(
+        (channelId: string) => {
+            if (allSlackChannels === undefined || allSlackChannels.length === 0)
+                return channelId;
+            const channelName = allSlackChannels.find(
+                (slackChannel) => slackChannel.id === channelId,
+            )?.name;
+            return channelName || channelId;
+        },
+        [allSlackChannels],
+    );
 
     const columns = useMemo<Column[]>(
         () => [
@@ -122,7 +136,7 @@ const Schedulers: FC<SchedulersProps> = ({
                     let slackChannels: string[] = [];
                     currentTargets.map((t) =>
                         isSlackTarget(t)
-                            ? slackChannels.push(t.channel)
+                            ? slackChannels.push(getSlackChannelName(t.channel))
                             : emails.push(t.recipient),
                     );
                     return (
@@ -220,7 +234,15 @@ const Schedulers: FC<SchedulersProps> = ({
                 },
             },
         ],
-        [users, charts, dashboards, projectUuid, logs, theme],
+        [
+            users,
+            charts,
+            dashboards,
+            projectUuid,
+            logs,
+            theme,
+            getSlackChannelName,
+        ],
     );
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5801

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-06-08 15-26-26](https://github.com/lightdash/lightdash/assets/1983672/b13cff6b-402c-4f6b-9bc9-ef630674d45e)


The problem:  We store the channel Ids , not the names in the database. 

Solution: Make a request to slack channels in the FE and get the name from the matching ID 



Alternative solutions and why I didn't do it: 

- Use slack names instead of ids : this works when sending emails, but it is not compatible with the JoinConversation slack API, so we can't use it 
- store channel_name in db: a bit messy, and it might get out of sync, so I didn't like it. 
