### PR TITLE
feat: add visual indicator for model errors

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -879,10 +879,32 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartType: {
+        dataType: 'refEnum',
+        enums: ['cartesian', 'table', 'big_number'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ChartSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        chartType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartType' },
+                                { dataType: 'undefined' },
+                            ],
+                        },
+                    },
+                },
+            ],
             validators: {},
         },
     },

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -6,6 +6,7 @@ import { Space } from './space';
 import {
     ValidationErrorChartResponse,
     ValidationErrorDashboardResponse,
+    ValidationErrorTableResponse,
 } from './validation';
 
 export type SpaceSearchResult = Pick<Space, 'uuid' | 'name' | 'uuid'>;
@@ -34,6 +35,16 @@ export type TableSearchResult = Pick<
     explore: string;
     exploreLabel: string;
 };
+
+export type TableErrorSearchResult = Pick<
+    TableSearchResult,
+    'explore' | 'exploreLabel'
+> & {
+    validationErrors: {
+        validationId: ValidationErrorTableResponse['validationId'];
+    }[];
+};
+
 export type FieldSearchResult = Pick<
     Dimension | Metric,
     | 'name'
@@ -58,6 +69,7 @@ export type SearchResult =
     | SpaceSearchResult
     | DashboardSearchResult
     | SavedChartSearchResult
+    | TableErrorSearchResult
     | TableSearchResult
     | FieldSearchResult
     | PageResult;
@@ -70,17 +82,22 @@ export const isFieldSearchResult = (
     value: SearchResult,
 ): value is FieldSearchResult => 'table' in value;
 
+export const isTableErrorSearchResult = (
+    value: SearchResult,
+): value is TableErrorSearchResult =>
+    'explore' in value && 'validationErrors' in value;
+
 export type SearchResults = {
     spaces: SpaceSearchResult[];
     dashboards: DashboardSearchResult[];
     savedCharts: SavedChartSearchResult[];
-    tables: TableSearchResult[];
+    tables: (TableSearchResult | TableErrorSearchResult)[];
     fields: FieldSearchResult[];
     pages: PageResult[];
 };
 
 export const getSearchResultId = (meta: SearchResult | undefined) => {
-    if (!meta) {
+    if (!meta || isTableErrorSearchResult(meta)) {
         return '';
     }
     if (isExploreSearchResult(meta)) {

--- a/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
@@ -91,10 +91,9 @@ export const SearchIconWithIndicator: FC<{
                 ) : (
                     <>
                         There's an error with this{' '}
-                        {searchResult.type === 'saved_chart'
-                            ? 'chart'
-                            : 'dashboard'}
-                        .
+                        {searchResult.type === 'saved_chart' ? 'chart' : null}
+                        {searchResult.type === 'dashboard' ? 'dashboard' : null}
+                        {searchResult.type === 'table' ? 'table' : null}.
                     </>
                 )
             }

--- a/packages/frontend/src/components/NavBar/GlobalSearch/hooks.ts
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/hooks.ts
@@ -88,7 +88,6 @@ export const useDebouncedSearch = (
                     return {
                         type: 'table',
                         typeLabel: 'Table',
-                        prefix: `${item.exploreLabel} - `,
                         title: item.exploreLabel,
                         item: item,
                         location: {

--- a/packages/frontend/src/components/NavBar/GlobalSearch/hooks.ts
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/hooks.ts
@@ -1,4 +1,10 @@
-import { ChartType, fieldId, FieldType, SearchResult } from '@lightdash/common';
+import {
+    ChartType,
+    fieldId,
+    FieldType,
+    isTableErrorSearchResult,
+    SearchResult,
+} from '@lightdash/common';
 import { useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 import useGlobalSearch from '../../../hooks/globalSearch/useGlobalSearch';
@@ -77,21 +83,36 @@ export const useDebouncedSearch = (
             })) || [];
 
         const tables =
-            data?.tables.map<SearchItem>((item) => ({
-                type: 'table',
-                typeLabel:
-                    item.name === item.explore ? 'Table' : 'Joined table',
-                prefix:
-                    item.name === item.explore
-                        ? undefined
-                        : `${item.exploreLabel} - `,
-                title: item.label,
-                description: item.description,
-                item: item,
-                location: {
-                    pathname: `/projects/${projectUuid}/tables/${item.explore}`,
-                },
-            })) || [];
+            data?.tables.map<SearchItem>((item) => {
+                if (isTableErrorSearchResult(item)) {
+                    return {
+                        type: 'table',
+                        typeLabel: 'Table',
+                        prefix: `${item.exploreLabel} - `,
+                        title: item.exploreLabel,
+                        item: item,
+                        location: {
+                            pathname: `/projects/${projectUuid}/tables`,
+                        },
+                    };
+                }
+
+                return {
+                    type: 'table',
+                    typeLabel:
+                        item.name === item.explore ? 'Table' : 'Joined table',
+                    prefix:
+                        item.name === item.explore
+                            ? undefined
+                            : `${item.exploreLabel} - `,
+                    title: item.label,
+                    description: item.description,
+                    item: item,
+                    location: {
+                        pathname: `/projects/${projectUuid}/tables/${item.explore}`,
+                    },
+                };
+            }) || [];
 
         const fields =
             data?.fields.map<SearchItem>((item) => {

--- a/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
@@ -34,7 +34,7 @@ import { SearchIcon, SearchIconWithIndicator } from './SearchIcon';
 
 const itemHasValidationError = (searchItem: SearchItem) =>
     searchItem.item &&
-    ['dashboard', 'saved_chart'].includes(searchItem.type) &&
+    ['dashboard', 'saved_chart', 'table'].includes(searchItem.type) &&
     'validationErrors' in searchItem.item &&
     searchItem.item.validationErrors?.length > 0;
 

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -103,9 +103,6 @@ export const getMantineThemeOverride = (overrides?: {
         },
 
         Indicator: {
-            defaultProps: {
-                withArrow: true,
-            },
             styles: () => ({
                 // FIXME: this is a hack to fix position of the Indicator under overlays. Remove after Blueprint migration is complete
                 root: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5639

### Description:

Add visual indicator for model/table errors. 

Previously, we filtered out the explore errors from the table search results. 
Now, we do 2 things: 
- Get the explores (without errors) 
- Get the explores with errors and compare against the validation table (if they're there, get them)

At the end, we concat the errors to the tables and let the rest of the FE do its work. 


https://github.com/lightdash/lightdash/assets/7611706/acaff509-b7f3-45f7-893e-3ed42589191b


