### PR TITLE
fix: summable field is undefined

### DIFF
--- a/packages/frontend/src/hooks/useColumnTotals.ts
+++ b/packages/frontend/src/hooks/useColumnTotals.ts
@@ -18,7 +18,11 @@ type Args = {
     itemsMap: Record<FieldId, Field | TableCalculation>;
 };
 
-export const isSummable = (item: Item) => {
+export const isSummable = (item: Item | undefined) => {
+    if (!item) {
+        return false;
+    }
+
     if (isTableCalculation(item)) {
         return false;
     }


### PR DESCRIPTION
Closes: #5819 

### Description:

there's an issue in table viz where field is expected but undefined is passed to `isSummable` https://lightdash.sentry.io/issues/4237389485/?project=5959292