### PR TITLE
feat: keep validation if content deleted

### DIFF
--- a/packages/backend/src/database/entities/validation.ts
+++ b/packages/backend/src/database/entities/validation.ts
@@ -1,4 +1,4 @@
-import { ValidationErrorType } from '@lightdash/common';
+import { ValidationErrorType, ValidationSourceType } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export type DbValidationTable = {
@@ -12,6 +12,7 @@ export type DbValidationTable = {
     model_name: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
+    source: ValidationSourceType | null;
 };
 
 export type ValidationTable = Knex.CompositeTableType<DbValidationTable>;

--- a/packages/backend/src/database/migrations/20230609111307_validation_set_null.ts
+++ b/packages/backend/src/database/migrations/20230609111307_validation_set_null.ts
@@ -19,6 +19,8 @@ export async function up(knex: Knex): Promise<void> {
             .references('dashboard_uuid')
             .inTable('dashboards')
             .onDelete('SET NULL');
+
+        table.string('source').nullable();
     });
 }
 
@@ -39,5 +41,7 @@ export async function down(knex: Knex): Promise<void> {
             .references('dashboard_uuid')
             .inTable('dashboards')
             .onDelete('CASCADE');
+
+        table.dropColumn('source');
     });
 }

--- a/packages/backend/src/database/migrations/20230609111307_validation_set_null.ts
+++ b/packages/backend/src/database/migrations/20230609111307_validation_set_null.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex';
+
+const ValidationTableName = 'validations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table.dropForeign('saved_chart_uuid');
+
+        table
+            .foreign('saved_chart_uuid')
+            .references('saved_query_uuid')
+            .inTable('saved_queries')
+            .onDelete('SET NULL');
+
+        table.dropForeign('dashboard_uuid');
+
+        table
+            .foreign('dashboard_uuid')
+            .references('dashboard_uuid')
+            .inTable('dashboards')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table.dropForeign('saved_chart_uuid');
+
+        table
+            .foreign('saved_chart_uuid')
+            .references('saved_query_uuid')
+            .inTable('saved_queries')
+            .onDelete('CASCADE');
+
+        table.dropForeign('dashboard_uuid');
+
+        table
+            .foreign('dashboard_uuid')
+            .references('dashboard_uuid')
+            .inTable('dashboards')
+            .onDelete('CASCADE');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -879,10 +879,32 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartType: {
+        dataType: 'refEnum',
+        enums: ['cartesian', 'table', 'big_number'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ChartSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        chartType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartType' },
+                                { dataType: 'undefined' },
+                            ],
+                        },
+                    },
+                },
+            ],
             validators: {},
         },
     },
@@ -2165,11 +2187,17 @@ const models: TsoaRoute.Models = {
         enums: ['chart', 'sorting', 'filter', 'metric', 'model', 'dimension'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationSourceType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'dashboard', 'table'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ValidationResponseBase: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                source: { ref: 'ValidationSourceType' },
                 spaceUuid: { dataType: 'string' },
                 projectUuid: { dataType: 'string', required: true },
                 errorType: { ref: 'ValidationErrorType', required: true },
@@ -2251,6 +2279,7 @@ const models: TsoaRoute.Models = {
                 createdAt: { dataType: 'datetime', required: true },
                 error: { dataType: 'string', required: true },
                 errorType: { ref: 'ValidationErrorType', required: true },
+                source: { ref: 'ValidationSourceType' },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -954,8 +954,24 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
+            "ChartType": {
+                "enum": ["cartesian", "table", "big_number"],
+                "type": "string"
+            },
             "ChartSummary": {
-                "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+                    },
+                    {
+                        "properties": {
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartType"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "ApiChartSummaryListResponse": {
                 "properties": {
@@ -2438,8 +2454,15 @@
                 ],
                 "type": "string"
             },
+            "ValidationSourceType": {
+                "enum": ["chart", "dashboard", "table"],
+                "type": "string"
+            },
             "ValidationResponseBase": {
                 "properties": {
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
+                    },
                     "spaceUuid": {
                         "type": "string"
                     },
@@ -2561,6 +2584,9 @@
                     },
                     "errorType": {
                         "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
                     }
                 },
                 "required": [
@@ -2650,7 +2676,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.600.0",
+        "version": "0.601.4",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -182,7 +182,7 @@ export class ValidationModel {
                 chartViews: parseInt(validationError.views, 10) || 0,
                 projectUuid: validationError.project_uuid,
                 error: validationError.error,
-                name: validationError.name,
+                name: validationError.name || 'Chart does not exist',
                 lastUpdatedBy: validationError.first_name
                     ? `${validationError.first_name} ${validationError.last_name}`
                     : undefined,
@@ -195,6 +195,7 @@ export class ValidationModel {
                 ),
                 errorType: validationError.error_type,
                 fieldName: validationError.field_name ?? undefined,
+                source: ValidationSourceType.Chart,
             }));
 
         const dashboardValidationErrorsRows: (DbValidationTable &
@@ -267,7 +268,7 @@ export class ValidationModel {
                 dashboardViews: parseInt(validationError.views, 10) || 0,
                 projectUuid: validationError.project_uuid,
                 error: validationError.error,
-                name: validationError.name,
+                name: validationError.name || 'Dashboard does not exist',
                 lastUpdatedBy: validationError.first_name
                     ? `${validationError.first_name} ${validationError.last_name}`
                     : undefined,
@@ -277,6 +278,7 @@ export class ValidationModel {
                 errorType: validationError.error_type,
                 fieldName: validationError.field_name ?? undefined,
                 chartName: validationError.chart_name ?? undefined,
+                source: ValidationSourceType.Dashboard,
             }));
 
         const tableValidationErrorsRows: DbValidationTable[] =
@@ -297,6 +299,7 @@ export class ValidationModel {
                 name: validationError.model_name ?? undefined,
                 validationId: validationError.validation_id,
                 errorType: validationError.error_type,
+                source: ValidationSourceType.Table,
             }));
 
         return [

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -77,6 +77,7 @@ describe('validation', () => {
             name: 'Test chart',
             projectUuid: 'projectUuid',
             chartUuid: 'chartUuid',
+            source: 'chart',
         });
 
         const expectedErrors: string[] = [
@@ -105,6 +106,7 @@ describe('validation', () => {
             name: 'Test chart',
             projectUuid: 'projectUuid',
             chartUuid: 'chartUuid',
+            source: 'chart',
         });
 
         const expectedErrors: string[] = [
@@ -131,6 +133,7 @@ describe('validation', () => {
             error: 'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
             errorType: 'model',
             projectUuid: 'projectUuid',
+            source: 'table',
         });
 
         expect(errors[0].error).toEqual(

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -21,6 +21,7 @@ import {
     TableCalculation,
     ValidationErrorType,
     ValidationResponse,
+    ValidationSourceType,
 } from '@lightdash/common';
 import { analytics } from '../../analytics/client';
 import { schedulerClient } from '../../clients/clients';
@@ -115,6 +116,7 @@ export class ValidationService {
                             errorType: ValidationErrorType.Model,
                             modelName: explore.name,
                             projectUuid,
+                            source: ValidationSourceType.Table,
                         }));
                     return [...acc, ...exploreErrors];
                 }
@@ -154,6 +156,7 @@ export class ValidationService {
                 chartUuid: chart.uuid,
                 name: chart.name,
                 projectUuid: chart.projectUuid,
+                source: ValidationSourceType.Chart,
             };
             const containsFieldId = ({
                 acc,
@@ -313,6 +316,7 @@ export class ValidationService {
                     name: dashboard.name,
                     dashboardUuid: dashboard.uuid,
                     projectUuid: dashboard.projectUuid,
+                    source: ValidationSourceType.Dashboard,
                 };
 
                 const containsFieldId = ({

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -8,6 +8,7 @@ export type ValidationResponseBase = {
     errorType: ValidationErrorType;
     projectUuid: string;
     spaceUuid?: string;
+    source?: ValidationSourceType;
 };
 
 export type ValidationErrorChartResponse = ValidationResponseBase & {
@@ -42,14 +43,20 @@ export type ValidationResponse =
 
 export type CreateTableValidation = Pick<
     ValidationErrorTableResponse,
-    'error' | 'errorType' | 'projectUuid' | 'name'
+    'error' | 'errorType' | 'projectUuid' | 'name' | 'source'
 > & {
     modelName: string;
 };
 
 export type CreateChartValidation = Pick<
     ValidationErrorChartResponse,
-    'error' | 'errorType' | 'fieldName' | 'name' | 'projectUuid' | 'chartUuid'
+    | 'error'
+    | 'errorType'
+    | 'fieldName'
+    | 'name'
+    | 'projectUuid'
+    | 'chartUuid'
+    | 'source'
 >;
 
 export type CreateDashboardValidation = Pick<
@@ -61,6 +68,7 @@ export type CreateDashboardValidation = Pick<
     | 'projectUuid'
     | 'dashboardUuid'
     | 'chartName'
+    | 'source'
 >;
 
 export type CreateValidation =
@@ -91,18 +99,23 @@ export enum ValidationErrorType {
     Dimension = 'dimension',
 }
 
+export enum ValidationSourceType {
+    Chart = 'chart',
+    Dashboard = 'dashboard',
+    Table = 'table',
+}
+
 export const isTableValidationError = (
     error: ValidationResponse | CreateValidation,
 ): error is ValidationErrorTableResponse | CreateTableValidation =>
-    !('chartUuid' in error && error.chartUuid) &&
-    !('dashboardUuid' in error && error.dashboardUuid);
+    error.source === ValidationSourceType.Table;
 
 export const isChartValidationError = (
     error: ValidationResponse | CreateValidation,
 ): error is ValidationErrorChartResponse | CreateChartValidation =>
-    'chartUuid' in error;
+    error.source === ValidationSourceType.Chart;
 
 export const isDashboardValidationError = (
     error: ValidationResponse | CreateValidation,
 ): error is ValidationErrorDashboardResponse | CreateDashboardValidation =>
-    'dashboardUuid' in error;
+    error.source === ValidationSourceType.Dashboard;

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -47,17 +47,10 @@ const getLinkToResource = (
     return;
 };
 
-const isDeleted = (validationError: ValidationResponse) => {
-    if (isChartValidationError(validationError) && !validationError.chartUuid)
-        return true;
-    if (
-        isDashboardValidationError(validationError) &&
-        !validationError.dashboardUuid
-    )
-        return true;
-
-    return false;
-};
+const isDeleted = (validationError: ValidationResponse) =>
+    (isChartValidationError(validationError) && !validationError.chartUuid) ||
+    (isDashboardValidationError(validationError) &&
+        !validationError.dashboardUuid);
 
 const Icon = ({ validationError }: { validationError: ValidationResponse }) => {
     if (isChartValidationError(validationError))

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -35,10 +35,13 @@ const getLinkToResource = (
     validationError: ValidationResponse,
     projectUuid: string,
 ) => {
-    if (isChartValidationError(validationError))
+    if (isChartValidationError(validationError) && validationError.chartUuid)
         return `/projects/${projectUuid}/saved/${validationError.chartUuid}`;
 
-    if (isDashboardValidationError(validationError))
+    if (
+        isDashboardValidationError(validationError) &&
+        validationError.dashboardUuid
+    )
         return `/projects/${projectUuid}/dashboards/${validationError.dashboardUuid}/view`;
 
     return;

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -47,6 +47,18 @@ const getLinkToResource = (
     return;
 };
 
+const isDeleted = (validationError: ValidationResponse) => {
+    if (isChartValidationError(validationError) && !validationError.chartUuid)
+        return true;
+    if (
+        isDashboardValidationError(validationError) &&
+        !validationError.dashboardUuid
+    )
+        return true;
+
+    return false;
+};
+
 const Icon = ({ validationError }: { validationError: ValidationResponse }) => {
     if (isChartValidationError(validationError))
         return getChartIcon(validationError.chartType);
@@ -122,23 +134,26 @@ const TableValidationItem = forwardRef<
                             </Text>
 
                             {(isChartValidationError(validationError) ||
-                                isDashboardValidationError(
-                                    validationError,
-                                )) && (
-                                <Text fz={11} color="gray.6">
-                                    {getViews(validationError)} view
-                                    {getViews(validationError) === 1 ? '' : 's'}
-                                    {' • '}
-                                    {validationError.lastUpdatedBy ? (
-                                        <>
-                                            Last edited by{' '}
-                                            <Text span fw={500}>
-                                                {validationError.lastUpdatedBy}
-                                            </Text>
-                                        </>
-                                    ) : null}
-                                </Text>
-                            )}
+                                isDashboardValidationError(validationError)) &&
+                                !isDeleted(validationError) && (
+                                    <Text fz={11} color="gray.6">
+                                        {getViews(validationError)} view
+                                        {getViews(validationError) === 1
+                                            ? ''
+                                            : 's'}
+                                        {' • '}
+                                        {validationError.lastUpdatedBy ? (
+                                            <>
+                                                Last edited by{' '}
+                                                <Text span fw={500}>
+                                                    {
+                                                        validationError.lastUpdatedBy
+                                                    }
+                                                </Text>
+                                            </>
+                                        ) : null}
+                                    </Text>
+                                )}
                         </Stack>
                     </Flex>
                 </Anchor>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5816

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

![image](https://github.com/lightdash/lightdash/assets/1983672/b75010d2-6f7f-461f-9061-0cfc4e60c160)




### Acceptance criteria

- [x] errors in the validator persist, even if the content is deleted
- [x] the errors are removed if a user dismisses them
- [x] the errors are removed if the content is deleted, then the validator is re-run.
- [ ] if the user clicks on the chart/dashboard link for the error after they have deleted the content, then they are linked to the chart/dashboard but see an error "chart no longer exists" or "dashboard no longer exists" (the same as now when you open a link to a deleted chart/dashboard) 
    - we can't link to the chart because we no longer have the uuid, instead we don't link to anything