### PR TITLE
fix: time format for scheduled deliveries dashboard

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -198,7 +198,7 @@ const Schedulers: FC<SchedulersProps> = ({
                         (log) => log.schedulerUuid === item.schedulerUuid,
                     );
                     return currentLogs.length > 0 ? (
-                        <Group spacing="sm">
+                        <Group spacing="xs">
                             <Text fz="xs" color="gray.6">
                                 {formatTime(currentLogs[0].createdAt)}
                             </Text>
@@ -210,6 +210,7 @@ const Schedulers: FC<SchedulersProps> = ({
                         </Text>
                     );
                 },
+                meta: { style: { width: 200 } },
             },
             {
                 id: 'actions',

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -13,6 +13,7 @@ import {
     IconPhoto,
     IconProgress,
 } from '@tabler/icons-react';
+import moment from 'moment';
 import React from 'react';
 import MantineIcon from '../common/MantineIcon';
 import { IconBox } from '../common/ResourceIcon';
@@ -124,14 +125,8 @@ export const getItemLink = (item: SchedulerItem, projectUuid: string) => {
         : `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view`;
 };
 
-export const formatTime = (date: Date) => {
-    return new Date(date).toLocaleString('en-GB', {
-        timeZone: 'UTC',
-        dateStyle: 'short',
-        timeStyle: 'short',
-        hour12: true,
-    });
-};
+export const formatTime = (date: Date) =>
+    moment(date).format('YYYY/MM/DD HH:mm A');
 
 export const camelCaseToFlat = (str: string | undefined) =>
     str ? str.replace(/([A-Z])/g, ' $1').toLowerCase() : undefined;

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -125,10 +125,11 @@ export const getItemLink = (item: SchedulerItem, projectUuid: string) => {
 };
 
 export const formatTime = (date: Date) => {
-    return new Date(date).toLocaleString('en-US', {
+    return new Date(date).toLocaleString('en-GB', {
         timeZone: 'UTC',
         dateStyle: 'short',
         timeStyle: 'short',
+        hour12: true,
     });
 };
 


### PR DESCRIPTION
Closes: #5821

### Description:
before
<img width="871" alt="Screenshot 2023-06-09 at 15 33 34" src="https://github.com/lightdash/lightdash/assets/67699259/fa57817a-26f4-4232-bf3e-7dba0a11b34b">

after
<img width="874" alt="Screenshot 2023-06-09 at 15 33 16" src="https://github.com/lightdash/lightdash/assets/67699259/1b24ce77-7bfc-4bf6-a359-c4e09a19d322">
