### PR TITLE
refactor: add pinned items context

### DIFF
--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     DashboardBasicDetails,
     PinnedItems,
@@ -7,42 +6,32 @@ import {
 } from '@lightdash/common';
 import { Card, Group, Text } from '@mantine/core';
 import { IconPin } from '@tabler/icons-react';
-import React, { FC } from 'react';
-import { useApp } from '../../providers/AppProvider';
+import { FC } from 'react';
+import { usePinnedItemsContext } from '../../providers/PinnedItemsProvider';
 import MantineIcon from '../common/MantineIcon';
 import MantineLinkButton from '../common/MantineLinkButton';
 import ResourceView, { ResourceViewType } from '../common/ResourceView';
 
 interface Props {
-    data: PinnedItems;
-    projectUuid: string;
-    pinnedListUuid: string;
-    organizationUuid: string;
+    pinnedItems: PinnedItems;
     dashboards: DashboardBasicDetails[];
     savedCharts: SpaceQuery[];
 }
 
 const PinnedItemsPanel: FC<Props> = ({
-    data,
-    projectUuid,
-    pinnedListUuid,
-    organizationUuid,
+    pinnedItems,
     dashboards,
     savedCharts,
 }) => {
-    const { user } = useApp();
-    const userCanManagePinnedItems = user.data?.ability.can(
-        'manage',
-        subject('PinnedItems', { organizationUuid, projectUuid }),
-    );
+    const { userCanManage } = usePinnedItemsContext();
 
     const enablePinnedPanel = dashboards.length + savedCharts.length > 0;
 
-    return data && data.length > 0 ? (
+    return pinnedItems && pinnedItems.length > 0 ? (
         <ResourceView
-            items={data}
+            items={pinnedItems}
             view={ResourceViewType.GRID}
-            hasReorder={userCanManagePinnedItems}
+            hasReorder={userCanManage}
             gridProps={{
                 groups: [
                     [ResourceViewItemType.SPACE],
@@ -53,16 +42,13 @@ const PinnedItemsPanel: FC<Props> = ({
                 ],
             }}
             headerProps={{
-                title: userCanManagePinnedItems
-                    ? 'Pinned items'
-                    : 'Pinned for you',
-                description: userCanManagePinnedItems
+                title: userCanManage ? 'Pinned items' : 'Pinned for you',
+                description: userCanManage
                     ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
                     : 'Your data team have pinned these items to help guide you towards the most relevant content!',
             }}
-            pinnedItemsProps={{ projectUuid, pinnedListUuid }}
         />
-    ) : ((userCanManagePinnedItems && data.length <= 0) || !data) &&
+    ) : ((userCanManage && pinnedItems.length <= 0) || !pinnedItems) &&
       enablePinnedPanel ? (
         // FIXME: update width with Mantine widths
         <Card

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -13,9 +13,9 @@ import {
     Droppable,
     DropResult,
 } from 'react-beautiful-dnd';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
-import { useReorder } from '../../../../hooks/pinning/usePinnedItems';
+import { usePinnedItemsContext } from '../../../../providers/PinnedItemsProvider';
 import { ResourceViewItemActionState } from '../ResourceActionHandlers';
 import { getResourceName, getResourceUrl } from '../resourceUtils';
 import ResourceViewGridChartItem from './ResourceViewGridChartItem';
@@ -25,10 +25,6 @@ import ResourceViewGridSpaceItem from './ResourceViewGridSpaceItem';
 export interface ResourceViewGridCommonProps {
     groups?: ResourceViewItemType[][];
     hasReorder?: boolean;
-    pinnedItemsProps?: {
-        projectUuid: string;
-        pinnedListUuid: string;
-    };
 }
 
 type ResourceViewGridProps = ResourceViewGridCommonProps &
@@ -47,8 +43,10 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
     ],
     onAction,
     hasReorder = false,
-    pinnedItemsProps = { projectUuid: '', pinnedListUuid: '' },
 }) => {
+    const { reorderItems } = usePinnedItemsContext();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
     const groupedItems = useMemo(() => {
         return groups
             .map((group) => {
@@ -72,9 +70,6 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
             .filter((group) => group.items.length > 0);
     }, [hasReorder, groups, items]);
 
-    // this part is strictly for Pinned Items Panel
-    const { projectUuid, pinnedListUuid } = pinnedItemsProps;
-
     // this method converts groupedItems to the format required by the API
     const pinnedItemsOrder = (data: typeof groupedItems) =>
         data.flatMap((group) =>
@@ -85,8 +80,6 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
                 } as ResourceViewItem;
             }),
         );
-
-    const { mutate: reorderItems } = useReorder(projectUuid, pinnedListUuid);
 
     const handleOnDragEnd = (result: DropResult) => {
         const { source: drag, destination: drop } = result;

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -49,10 +49,6 @@ export interface ResourceViewCommonProps {
     emptyStateProps?: ResourceEmptyStateProps;
     view?: ResourceViewType;
     hasReorder?: boolean;
-    pinnedItemsProps?: {
-        projectUuid: string;
-        pinnedListUuid: string;
-    };
 }
 
 export enum ResourceViewType {
@@ -75,7 +71,6 @@ const ResourceView: React.FC<ResourceViewProps> = ({
     headerProps = {},
     emptyStateProps = {},
     hasReorder = false,
-    pinnedItemsProps = { projectUuid: '', pinnedListUuid: '' },
 }) => {
     const theme = useMantineTheme();
     const tableTabStyles = useTableTabStyles();
@@ -223,7 +218,6 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                         groups={gridProps.groups}
                         onAction={handleAction}
                         hasReorder={hasReorder}
-                        pinnedItemsProps={pinnedItemsProps}
                     />
                 ) : (
                     assertUnreachable(view, 'Unknown resource view type')

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import {
 import { useProject } from '../hooks/useProject';
 import { useSavedCharts } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
+import { PinnedItemsProvider } from '../providers/PinnedItemsProvider';
 
 const Home: FC = () => {
     const params = useParams<{ projectUuid: string }>();
@@ -28,7 +29,8 @@ const Home: FC = () => {
     const onboarding = useOnboardingStatus();
 
     const { data: pinnedItems = [], isLoading: pinnedItemsLoading } =
-        usePinnedItems(selectedProjectUuid, project?.data?.pinnedListUuid);
+        usePinnedItems(selectedProjectUuid, project.data?.pinnedListUuid);
+
     // only used for recently updated panel - could be faster
     const { data: dashboards = [], isLoading: dashboardsLoading } =
         useDashboards(selectedProjectUuid);
@@ -79,14 +81,17 @@ const Home: FC = () => {
                             userName={user.data?.firstName}
                             projectUuid={project.data.projectUuid}
                         />
-                        <PinnedItemsPanel
-                            data={pinnedItems}
+                        <PinnedItemsProvider
+                            organizationUuid={project.data.organizationUuid}
                             projectUuid={project.data.projectUuid}
                             pinnedListUuid={project.data.pinnedListUuid || ''}
-                            organizationUuid={project.data.organizationUuid}
-                            dashboards={dashboards}
-                            savedCharts={savedCharts}
-                        />
+                        >
+                            <PinnedItemsPanel
+                                pinnedItems={pinnedItems}
+                                dashboards={dashboards}
+                                savedCharts={savedCharts}
+                            />
+                        </PinnedItemsProvider>
                         <RecentlyUpdatedPanel
                             data={{ dashboards, savedCharts }}
                             projectUuid={project.data.projectUuid}

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -19,13 +19,18 @@ import SpaceActionModal, {
     ActionType,
 } from '../components/common/SpaceActionModal';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { useProject } from '../hooks/useProject';
 import { useSpaces } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
+import { PinnedItemsProvider } from '../providers/PinnedItemsProvider';
 
 const Spaces: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
-    const { data: spaces = [], isLoading } = useSpaces(projectUuid);
+    const { data: spaces = [], isLoading: spaceIsLoading } =
+        useSpaces(projectUuid);
+    const project = useProject(projectUuid);
+    const isLoading = spaceIsLoading || project.isLoading;
 
     const { user, health } = useApp();
 
@@ -79,27 +84,32 @@ const Spaces: FC = () => {
                     )}
                 </Group>
 
-                <ResourceView
-                    view={ResourceViewType.GRID}
-                    items={wrapResourceView(
-                        spaces.map(spaceToResourceViewItem),
-                        ResourceViewItemType.SPACE,
-                    )}
-                    headerProps={{
-                        title: 'Spaces',
-                    }}
-                    emptyStateProps={{
-                        icon: <IconFolders size={30} />,
-                        title: 'No spaces added yet',
-                        action:
-                            !isDemo && userCanManageSpace ? (
-                                <Button onClick={handleCreateSpace}>
-                                    Create space
-                                </Button>
-                            ) : undefined,
-                    }}
-                    pinnedItemsProps={{ projectUuid, pinnedListUuid: '' }}
-                />
+                <PinnedItemsProvider
+                    projectUuid={projectUuid}
+                    organizationUuid={user.data?.organizationUuid ?? ''}
+                    pinnedListUuid={project.data?.pinnedListUuid ?? ''}
+                >
+                    <ResourceView
+                        view={ResourceViewType.GRID}
+                        items={wrapResourceView(
+                            spaces.map(spaceToResourceViewItem),
+                            ResourceViewItemType.SPACE,
+                        )}
+                        headerProps={{
+                            title: 'Spaces',
+                        }}
+                        emptyStateProps={{
+                            icon: <IconFolders size={30} />,
+                            title: 'No spaces added yet',
+                            action:
+                                !isDemo && userCanManageSpace ? (
+                                    <Button onClick={handleCreateSpace}>
+                                        Create space
+                                    </Button>
+                                ) : undefined,
+                        }}
+                    />
+                </PinnedItemsProvider>
             </Stack>
 
             {isCreateModalOpen && (

--- a/packages/frontend/src/providers/PinnedItemsProvider.tsx
+++ b/packages/frontend/src/providers/PinnedItemsProvider.tsx
@@ -1,0 +1,56 @@
+import { subject } from '@casl/ability';
+import { ApiError, PinnedItems } from '@lightdash/common';
+import React, { createContext, useContext } from 'react';
+import { UseMutateFunction } from 'react-query';
+import { useReorder } from '../hooks/pinning/usePinnedItems';
+import { useApp } from './AppProvider';
+
+type PinnedItemsContext = {
+    userCanManage: boolean;
+    reorderItems: UseMutateFunction<
+        PinnedItems,
+        ApiError,
+        PinnedItems,
+        unknown
+    >;
+};
+
+const Context = createContext<PinnedItemsContext | null>(null);
+
+type PinnedItemsProviderProps = {
+    projectUuid: string;
+    pinnedListUuid: string;
+    organizationUuid: string;
+};
+
+export const PinnedItemsProvider: React.FC<PinnedItemsProviderProps> = ({
+    organizationUuid,
+    projectUuid,
+    pinnedListUuid,
+    children,
+}) => {
+    const { user } = useApp();
+    const userCanManage =
+        user.data?.ability.can(
+            'manage',
+            subject('PinnedItems', { organizationUuid, projectUuid }),
+        ) ?? false;
+
+    const { mutate: reorderItems } = useReorder(projectUuid, pinnedListUuid);
+
+    const value: PinnedItemsContext = {
+        userCanManage,
+        reorderItems,
+    };
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export const usePinnedItemsContext = (): PinnedItemsContext => {
+    const context = useContext(Context);
+    if (!context) {
+        throw new Error(
+            'usePinnedItemsContext must be used within a PinnedItemsContext',
+        );
+    }
+    return context;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5470

### Description:

I'm not sure if I implemented the way the issue envisioned.
One downside I noticed is that every time a `ResourceView` type `Grid` is used, it must be wrapped by `PinnedItemsProvider` even if reordering is not enabled. (it happens on `Spaces` page)

Maybe #5847 could solve the prop drilling problem and bring more bonus. I'm opening this PR as draft to discuss it
