### PR TITLE
feat: Add APIs to add and revoke space-level access

### DIFF
--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -1,4 +1,5 @@
 import {
+    AddSpaceShare,
     ApiErrorPayload,
     ApiSpaceResponse,
     ApiSuccessEmpty,
@@ -166,17 +167,17 @@ export class SpaceController extends Controller {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Post('{spaceUuid}/access')
+    @Post('{spaceUuid}/share')
     @OperationId('AddSpaceShareToUser')
     @Tags('Roles & Permissions')
     async addSpaceShare(
         @Path() projectUuid: string,
         @Path() spaceUuid: string,
-        @Body() userUuid: string,
+        @Body() body: AddSpaceShare,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await spaceService.addSpaceShare(req.user!, spaceUuid, userUuid);
+        await spaceService.addSpaceShare(req.user!, spaceUuid, body.userUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -196,7 +197,7 @@ export class SpaceController extends Controller {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Delete('{spaceUuid}/access/{userUuid}')
+    @Delete('{spaceUuid}/share/{userUuid}')
     @OperationId('RevokeProjectAccessForUser')
     @Tags('Roles & Permissions')
     async revokeProjectAccessForUser(

--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -152,4 +152,64 @@ export class SpaceController extends Controller {
             results,
         };
     }
+
+    /**
+     * Grant a user access to a space
+     * @param projectUuid The uuid of the space's parent project
+     * @parmm spaceUuid The uuid of the space to update
+     * @param userUuid The uuid of the user to grant access to
+     * @param req
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('{spaceUuid}/access')
+    @OperationId('AddSpaceShareToUser')
+    @Tags('Roles & Permissions')
+    async addSpaceShare(
+        @Path() projectUuid: string,
+        @Path() spaceUuid: string,
+        @Body() userUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await spaceService.addSpaceShare(req.user!, spaceUuid, userUuid);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Remove a user's access to a space
+     * @param projectUuid The uuid of the space's parent project
+     * @param spaceUuid The uuid of the space to update
+     * @param userUuid The uuid of the user to revoke access from
+     * @param req
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('{spaceUuid}/access/{userUuid}')
+    @OperationId('RevokeProjectAccessForUser')
+    @Tags('Roles & Permissions')
+    async revokeProjectAccessForUser(
+        @Path() projectUuid: string,
+        @Path() spaceUuid: string,
+        @Path() userUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await spaceService.removeSpaceShare(req.user!, spaceUuid, userUuid);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2036,6 +2036,22 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Pick_Space.name-or-isPrivate_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SpaceShare.userUuid_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AddSpaceShare: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_SpaceShare.userUuid_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SshKeyPair.publicKey_': {
         dataType: 'refAlias',
         type: {
@@ -4562,7 +4578,7 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.post(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/access',
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share',
         ...fetchMiddlewares<RequestHandler>(SpaceController),
         ...fetchMiddlewares<RequestHandler>(
             SpaceController.prototype.addSpaceShare,
@@ -4586,11 +4602,11 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'string',
                 },
-                userUuid: {
+                body: {
                     in: 'body',
-                    name: 'userUuid',
+                    name: 'body',
                     required: true,
-                    dataType: 'string',
+                    ref: 'AddSpaceShare',
                 },
                 req: {
                     in: 'request',
@@ -4620,7 +4636,7 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.delete(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/access/:userUuid',
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share/:userUuid',
         ...fetchMiddlewares<RequestHandler>(SpaceController),
         ...fetchMiddlewares<RequestHandler>(
             SpaceController.prototype.revokeProjectAccessForUser,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4562,6 +4562,122 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.post(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/access',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.addSpaceShare,
+        ),
+
+        function SpaceController_addSpaceShare(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'body',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new SpaceController();
+
+                const promise = controller.addSpaceShare.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/access/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.revokeProjectAccessForUser,
+        ),
+
+        function SpaceController_revokeProjectAccessForUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new SpaceController();
+
+                const promise = controller.revokeProjectAccessForUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
         '/api/v1/ssh/key-pairs',
         ...fetchMiddlewares<RequestHandler>(SshController),
         ...fetchMiddlewares<RequestHandler>(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2676,7 +2676,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.601.4",
+        "version": "0.605.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -4721,6 +4721,126 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/access": {
+            "post": {
+                "operationId": "AddSpaceShareToUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Grant a user access to a space",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "The uuid of the user to grant access to",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "string",
+                                "description": "The uuid of the user to grant access to"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/access/{userUuid}": {
+            "delete": {
+                "operationId": "RevokeProjectAccessForUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove a user's access to a space",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to update",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the user to revoke access from",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/ssh/key-pairs": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2280,6 +2280,19 @@
             "UpdateSpace": {
                 "$ref": "#/components/schemas/Pick_Space.name-or-isPrivate_"
             },
+            "Pick_SpaceShare.userUuid_": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["userUuid"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AddSpaceShare": {
+                "$ref": "#/components/schemas/Pick_SpaceShare.userUuid_"
+            },
             "Pick_SshKeyPair.publicKey_": {
                 "properties": {
                     "publicKey": {
@@ -4723,7 +4736,7 @@
                 }
             }
         },
-        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/access": {
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share": {
             "post": {
                 "operationId": "AddSpaceShareToUser",
                 "responses": {
@@ -4771,20 +4784,18 @@
                     }
                 ],
                 "requestBody": {
-                    "description": "The uuid of the user to grant access to",
                     "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "string",
-                                "description": "The uuid of the user to grant access to"
+                                "$ref": "#/components/schemas/AddSpaceShare"
                             }
                         }
                     }
                 }
             }
         },
-        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/access/{userUuid}": {
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share/{userUuid}": {
             "delete": {
                 "operationId": "RevokeProjectAccessForUser",
                 "responses": {

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -399,44 +399,6 @@ projectRouter.patch(
     },
 );
 
-projectRouter.post(
-    '/spaces/:spaceUUid/share',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    unauthorisedInDemo,
-    async (req, res, next) => {
-        spaceService
-            .addSpaceShare(req.user!, req.params.spaceUUid, req.body.userUuid)
-            .then(() => {
-                res.json({
-                    status: 'ok',
-                });
-            })
-            .catch(next);
-    },
-);
-
-projectRouter.delete(
-    '/spaces/:spaceUUid/share/:userUuid',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    unauthorisedInDemo,
-    async (req, res, next) => {
-        spaceService
-            .removeSpaceShare(
-                req.user!,
-                req.params.spaceUUid,
-                req.params.userUuid,
-            )
-            .then(() => {
-                res.json({
-                    status: 'ok',
-                });
-            })
-            .catch(next);
-    },
-);
-
 projectRouter.get(
     '/dashboards',
     allowApiKeyAuthentication,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -43,3 +43,5 @@ export type ApiSpaceResponse = {
     status: 'ok';
     results: Space;
 };
+
+export type AddSpaceShare = Pick<SpaceShare, 'userUuid'>;


### PR DESCRIPTION
Enhances: https://github.com/lightdash/lightdash/issues/5666

### Description:
Added methods.

- `POST /projects/{projectUuid}/spaces/{spaceUuid}/share`
- `DELETE /projects/{projectUuid}/spaces/{spacesUuid}/share/{userUuid}`

### What we have to do in the pull request
- [x] Update `reouts.ts` and `swagger.json`

