### PR TITLE
fix: prevent showing pivot table in third parties

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -76,6 +76,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 >
                     {pivotTableData.data ? (
                         <PivotTable
+                            className={className}
                             containerRef={scrollableContainerRef}
                             data={pivotTableData.data}
                             conditionalFormattings={conditionalFormattings}


### PR DESCRIPTION
Closes: -

### Description:

adds third-party block classes to pivot table viz.

![CleanShot 2023-06-12 at 20 41 21@2x](https://github.com/lightdash/lightdash/assets/962095/7b142a73-6ace-418f-ab19-2d523669f973)
![CleanShot 2023-06-12 at 20 40 23@2x](https://github.com/lightdash/lightdash/assets/962095/ef90156f-7a75-4d6a-9c4d-e9538caa522c)
