### PR TITLE
fix: add gap between label and comparison

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -184,7 +184,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                                     size={18}
                                     style={{
                                         display: 'inline',
-                                        margin: '0 7px 0 0px',
+                                        margin: '0 7px 0 0',
                                     }}
                                 />
                             ) : comparisonDiff ===
@@ -194,10 +194,12 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                                     size={18}
                                     style={{
                                         display: 'inline',
-                                        margin: '0 7px 0 3px',
+                                        margin: '0 7px 0 0',
                                     }}
                                 />
-                            ) : null}
+                            ) : (
+                                <span style={{ margin: '0 7px 0 0' }} />
+                            )}
                         </BigNumber>
                     </Tooltip>
                     <BigNumberLabel $fontSize={comparisonFontSize}>


### PR DESCRIPTION
Closes: #5797 

### Description:
before
<img width="717" alt="Screenshot 2023-06-14 at 15 35 57" src="https://github.com/lightdash/lightdash/assets/67699259/d70647b2-531f-4967-b5c9-cb9a9c195f3a">


after
<img width="524" alt="Screenshot 2023-06-14 at 15 34 41" src="https://github.com/lightdash/lightdash/assets/67699259/3ea54767-8b13-4e08-9e13-b76c4117bb7c">
