### PR TITLE
fix: duplicated chart query

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -588,7 +588,7 @@ export class SavedChartModel {
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
                 pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
-                chartType: 'saved_queries_versions.chart_type',
+                chartType: 'last_saved_query_version.chart_type',
             })
             .leftJoin('spaces', 'saved_queries.space_id', 'spaces.space_id')
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
@@ -598,9 +598,14 @@ export class SavedChartModel {
                 'projects.organization_id',
             )
             .innerJoin(
-                'saved_queries_versions',
-                `${SavedChartsTableName}.saved_query_id`,
-                'saved_queries_versions.saved_query_id',
+                this.database('saved_queries_versions')
+                    .distinctOn('saved_query_id')
+                    .orderBy('saved_query_id')
+                    .orderBy('created_at', 'desc')
+                    .select('chart_type', 'saved_query_id')
+                    .as('last_saved_query_version'),
+                `saved_queries.saved_query_id`,
+                'last_saved_query_version.saved_query_id',
             )
             .leftJoin(
                 PinnedChartTableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5890

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Issue: we were returning 1 chart per version !, I think this was causing the search filter as well. I haven't been able to replicate the search issue after fixing this.

<!-- Even better add a screenshot / gif / loom -->
Before:

![Uploading Screenshot from 2023-06-14 16-34-35.png…]()


After:

![Screenshot from 2023-06-14 16-56-43](https://github.com/lightdash/lightdash/assets/1983672/fd3a681f-29c1-43c5-b8f7-52f5bd12bd49)
