### PR TITLE
feat: add clear query shortcut

### DIFF
--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -320,7 +320,10 @@ describe('Explore', () => {
         // clear query hotkeys
         cy.get('body').type('{ctrl}{alt}{k}');
 
-        // verify empty selections
-        cy.findByText('Select a table').should('exist');
+        // verify empty query keeping selected table
+        cy.findByText('Tables', { selector: 'a' })
+            .parent()
+            .should('have.text', 'Tables/Orders');
+        cy.findByText('Pick a metric & select its dimensions').should('exist');
     });
 });

--- a/packages/e2e/cypress/e2e/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/explore.cy.ts
@@ -304,4 +304,23 @@ describe('Explore', () => {
             });
         });
     });
+
+    it('Should clear query using hotkeys', () => {
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
+
+        cy.findByText('Orders').click();
+        cy.findByText('Is completed').click();
+
+        // run query
+        cy.get('button').contains('Run query').click();
+
+        // wait for query to finish
+        cy.findByText('Loading results').should('not.exist');
+
+        // clear query hotkeys
+        cy.get('body').type('{ctrl}{alt}{k}');
+
+        // verify empty selections
+        cy.findByText('Select a table').should('exist');
+    });
 });

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -127,7 +127,9 @@ const ExploreSideBar = memo(() => {
         (context) => context.state.unsavedChartVersion.tableName,
     );
 
-    const clearExplore = useExplorerContext((context) => context.actions.clear);
+    const clearExplore = useExplorerContext(
+        (context) => context.actions.clearExplore,
+    );
     const history = useHistory();
 
     const handleBack = useCallback(() => {

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -47,7 +47,9 @@ export const useExplorerRoute = () => {
     const queryResultsData = useExplorerContext(
         (context) => context.queryResults.data,
     );
-    const clear = useExplorerContext((context) => context.actions.clear);
+    const clearExplore = useExplorerContext(
+        (context) => context.actions.clearExplore,
+    );
     const setTableName = useExplorerContext(
         (context) => context.actions.setTableName,
     );
@@ -71,11 +73,11 @@ export const useExplorerRoute = () => {
 
     useEffect(() => {
         if (!pathParams.tableId) {
-            clear();
+            clearExplore();
         } else {
             setTableName(pathParams.tableId);
         }
-    }, [pathParams.tableId, clear, setTableName]);
+    }, [pathParams.tableId, clearExplore, setTableName]);
 };
 
 export const useExplorerUrlState = (): ExplorerReduceState | undefined => {

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -54,17 +54,14 @@ export const useExplorerRoute = () => {
 
     // Update url params based on pristine state
     useEffect(() => {
-        if (queryResultsData?.metricQuery) {
-            history.replace(
-                getExplorerUrlFromCreateSavedChartVersion(
-                    pathParams.projectUuid,
-                    {
-                        ...unsavedChartVersion,
-                        metricQuery: queryResultsData.metricQuery,
-                    },
-                ),
-            );
-        }
+        history.replace(
+            getExplorerUrlFromCreateSavedChartVersion(pathParams.projectUuid, {
+                ...unsavedChartVersion,
+                metricQuery:
+                    queryResultsData?.metricQuery ??
+                    unsavedChartVersion.metricQuery,
+            }),
+        );
     }, [
         queryResultsData,
         history,

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import { memo } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { useHotkeys } from '@mantine/hooks';
 import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
@@ -24,6 +25,10 @@ const ExplorerWithUrlParams = memo(() => {
         (context) => context.state.unsavedChartVersion.tableName,
     );
     const { data } = useExplore(tableId);
+
+    const clearQuery = useExplorerContext((context) => context.actions.clear);
+    useHotkeys([['mod + alt + k', clearQuery]]);
+
     return (
         <Page
             title={data ? data?.label : 'Tables'}

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -26,7 +26,9 @@ const ExplorerWithUrlParams = memo(() => {
     );
     const { data } = useExplore(tableId);
 
-    const clearQuery = useExplorerContext((context) => context.actions.clear);
+    const clearQuery = useExplorerContext(
+        (context) => context.actions.clearExplore,
+    );
     useHotkeys([['mod + alt + k', clearQuery]]);
 
     return (

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -27,7 +27,7 @@ const ExplorerWithUrlParams = memo(() => {
     const { data } = useExplore(tableId);
 
     const clearQuery = useExplorerContext(
-        (context) => context.actions.clearExplore,
+        (context) => context.actions.clearQuery,
     );
     useHotkeys([['mod + alt + k', clearQuery]]);
 

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -162,7 +162,7 @@ export interface ExplorerContext {
     queryResults: ReturnType<typeof useQueryResults>;
     hasUnfetchedChanges: boolean;
     actions: {
-        clear: () => void;
+        clearExplore: () => void;
         reset: () => void;
         setTableName: (tableName: string) => void;
         removeActiveField: (fieldId: FieldId) => void;
@@ -1105,7 +1105,7 @@ export const ExplorerProvider: FC<{
         });
     }, [mutateAsync, state.shouldFetchResults]);
 
-    const clear = useCallback(async () => {
+    const clearExplore = useCallback(async () => {
         dispatch({
             type: ActionType.RESET,
             payload: defaultState,
@@ -1125,7 +1125,7 @@ export const ExplorerProvider: FC<{
 
     const actions = useMemo(
         () => ({
-            clear,
+            clearExplore,
             reset,
             setTableName,
             removeActiveField,
@@ -1150,7 +1150,7 @@ export const ExplorerProvider: FC<{
             toggleExpandedSection,
         }),
         [
-            clear,
+            clearExplore,
             reset,
             setTableName,
             removeActiveField,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -163,6 +163,7 @@ export interface ExplorerContext {
     hasUnfetchedChanges: boolean;
     actions: {
         clearExplore: () => void;
+        clearQuery: () => void;
         reset: () => void;
         setTableName: (tableName: string) => void;
         removeActiveField: (fieldId: FieldId) => void;
@@ -1113,6 +1114,20 @@ export const ExplorerProvider: FC<{
         resetQueryResults();
     }, [resetQueryResults]);
 
+    const clearQuery = useCallback(async () => {
+        dispatch({
+            type: ActionType.RESET,
+            payload: {
+                ...defaultState,
+                unsavedChartVersion: {
+                    ...defaultState.unsavedChartVersion,
+                    tableName: unsavedChartVersion.tableName,
+                },
+            },
+        });
+        resetQueryResults();
+    }, [resetQueryResults, unsavedChartVersion.tableName]);
+
     const defaultSort = useDefaultSortField(unsavedChartVersion);
 
     const fetchResults = useCallback(() => {
@@ -1126,6 +1141,7 @@ export const ExplorerProvider: FC<{
     const actions = useMemo(
         () => ({
             clearExplore,
+            clearQuery,
             reset,
             setTableName,
             removeActiveField,
@@ -1151,6 +1167,7 @@ export const ExplorerProvider: FC<{
         }),
         [
             clearExplore,
+            clearQuery,
             reset,
             setTableName,
             removeActiveField,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5892

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

If someone with a MacOS could confirm for me that `mod + alt + k` is equivalent as `command + option + k` in MacOS I'd appreciate!
- `Edit`: confirmed, thanks @ZeRego!

I think it would also be interesting to communicate for the user in some way that this shortcut exists 🤔 

`Edit`: Updated video showing that selected table is persisted

https://github.com/lightdash/lightdash/assets/24387035/a21f4130-9a1c-4a1c-85e5-f618ef7bd5ec


