### PR TITLE
Add the API to get projects of an organization

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -6,6 +6,7 @@ import {
     ApiOrganizationAllowedEmailDomains,
     ApiOrganizationMemberProfile,
     ApiOrganizationMemberProfiles,
+    ApiOrganizationProjects,
     ApiSuccessEmpty,
     CreateGroup,
     CreateOrganization,
@@ -136,6 +137,23 @@ export class OrganizationController extends Controller {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Gets all projects of the current user's organization
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/projects')
+    @OperationId('ListOrganizationProjects')
+    async getProjects(
+        @Request() req: express.Request,
+    ): Promise<ApiOrganizationProjects> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await organizationService.getProjects(req.user!),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -339,6 +339,40 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectType: {
+        dataType: 'refEnum',
+        enums: ['DEFAULT', 'PREVIEW'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OrganizationProject: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'ProjectType', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiOrganizationProjects: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'OrganizationProject' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationMemberRole: {
         dataType: 'refEnum',
         enums: [
@@ -3053,6 +3087,46 @@ export function RegisterRoutes(app: express.Router) {
                 const controller = new OrganizationController();
 
                 const promise = controller.deleteOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/projects',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getProjects,
+        ),
+
+        function OrganizationController_getProjects(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new OrganizationController();
+
+                const promise = controller.getProjects.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -348,6 +348,46 @@
             "UpdateOrganization": {
                 "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
             },
+            "ProjectType": {
+                "enum": ["DEFAULT", "PREVIEW"],
+                "type": "string"
+            },
+            "OrganizationProject": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/ProjectType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string",
+                        "description": "The unique identifier of the project",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["type", "name", "projectUuid"],
+                "type": "object",
+                "description": "Summary of a project under an organization"
+            },
+            "ApiOrganizationProjects": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationProject"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "List of projects in the current organization"
+            },
             "OrganizationMemberRole": {
                 "enum": [
                     "member",
@@ -2676,7 +2716,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.601.4",
+        "version": "0.605.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -3306,6 +3346,37 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/org/projects": {
+            "get": {
+                "operationId": "ListOrganizationProjects",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationProjects"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all projects of the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v1/org/users": {

--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -19,22 +19,6 @@ import {
 
 export const organizationRouter = express.Router();
 
-organizationRouter.get(
-    '/projects',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    async (req, res, next) =>
-        organizationService
-            .getProjects(req.user!)
-            .then((results) => {
-                res.json({
-                    status: 'ok',
-                    results,
-                });
-            })
-            .catch(next),
-);
-
 organizationRouter.post(
     '/projects/precompiled',
     allowApiKeyAuthentication,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/5905

### Description:
The API documentation doesn't contain the API to get all projects in an organization. So, I would like manage the definition with the API spec.
