### PR TITLE
fix: when space has a chart but no dashboards, it shouldn't be empty

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -84,7 +84,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         type: ResourceViewItemAction.CLOSE,
     });
 
-    const [activeTabId, setActiveTabId] = useState<string | null>(null);
+    const [activeTabId, setActiveTabId] = useState(tabs?.[0].id);
 
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {
@@ -97,11 +97,21 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         let sortedItems = items;
 
         const activeTab = tabs?.find((tab) => tab.id === activeTabId);
-        if (activeTab && activeTab.sort) {
+        console.log('activeTab', activeTab);
+        console.log('items', items);
+        if (
+            activeTab &&
+            activeTab.sort &&
+            items.some((item) => item.type === activeTab.id)
+        ) {
             sortedItems = items.sort(activeTab.sort);
         }
 
-        if (activeTab && activeTab.filter) {
+        if (
+            activeTab &&
+            activeTab.filter &&
+            items.some((item) => item.type === activeTab.id)
+        ) {
             sortedItems = sortedItems.filter(activeTab.filter);
         }
 

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -84,7 +84,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         type: ResourceViewItemAction.CLOSE,
     });
 
-    const [activeTabId, setActiveTabId] = useState(tabs?.[3]?.id);
+    const [activeTabId, setActiveTabId] = useState<string | null>(null);
 
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -84,7 +84,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         type: ResourceViewItemAction.CLOSE,
     });
 
-    const [activeTabId, setActiveTabId] = useState(tabs?.[0]?.id);
+    const [activeTabId, setActiveTabId] = useState(tabs?.[3]?.id);
 
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {


### PR DESCRIPTION
Closes: #5912 

### Description:
before

https://www.loom.com/share/500bef58be1d4e4a8817fcb17fbd9cc0?sid=e321f62f-cbfc-48c6-993a-bc778643bee5

after

https://www.loom.com/share/e19f3857b2e044b58ab6108fe8493462?sid=7356e2a5-8578-4885-abbd-6bf311a849a5