### PR TITLE
fix: dont escape env_var values

### DIFF
--- a/packages/cli/src/dbt/templating.test.ts
+++ b/packages/cli/src/dbt/templating.test.ts
@@ -16,6 +16,16 @@ describe('Templating', () => {
 
     describe('renderProfilesYml', () => {
         describe('env_var()', () => {
+            test('should not escape values', () => {
+                process.env.SPAN = '<span>';
+                expect(renderProfilesYml("{{ env_var('SPAN') }}")).toBe(
+                    '<span>',
+                );
+                process.env.WINDOWS_PATH = 'C:\\example';
+                expect(renderProfilesYml("{{ env_var('WINDOWS_PATH') }}")).toBe(
+                    'C:\\example',
+                );
+            });
             test('should convert env_var functions and return env var values', () => {
                 process.env.DBT_USER = 'test';
                 expect(renderProfilesYml("{{ env_var('DBT_USER') }}")).toBe(

--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -1,7 +1,7 @@
 import * as nunjucks from 'nunjucks';
 
 // jinja filters
-const nunjucksEnv = new nunjucks.Environment();
+const nunjucksEnv = new nunjucks.Environment(null, { autoescape: false });
 nunjucksEnv.addFilter('as_number', (str) => parseFloat(str));
 
 // jinja global functions


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5926 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:

Don't escape jinja templates values when parsing local dbt profile.

