### PR TITLE
fix: land on charts if dashboards are empty

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -1,4 +1,8 @@
-import { assertUnreachable, ResourceViewItem } from '@lightdash/common';
+import {
+    assertUnreachable,
+    DashboardBasicDetails,
+    ResourceViewItem,
+} from '@lightdash/common';
 import {
     Box,
     Divider,
@@ -59,6 +63,7 @@ export enum ResourceViewType {
 interface ResourceViewProps extends ResourceViewCommonProps {
     listProps?: ResourceViewListCommonProps;
     gridProps?: ResourceViewGridCommonProps;
+    dashboards?: DashboardBasicDetails[];
 }
 
 const ResourceView: React.FC<ResourceViewProps> = ({
@@ -71,6 +76,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
     headerProps = {},
     emptyStateProps = {},
     hasReorder = false,
+    dashboards,
 }) => {
     const theme = useMantineTheme();
     const tableTabStyles = useTableTabStyles();
@@ -79,7 +85,11 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         type: ResourceViewItemAction.CLOSE,
     });
 
-    const [activeTabId, setActiveTabId] = useState(tabs?.[0]?.id);
+    const [activeTabId, setActiveTabId] = useState(
+        dashboards?.length === undefined || dashboards?.length === 0
+            ? tabs?.[1]?.id
+            : tabs?.[0]?.id,
+    );
 
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -11,7 +11,6 @@ import {
     useMantineTheme,
 } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import identity from 'lodash-es/identity';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTableTabStyles } from '../../../hooks/styles/useTableTabStyles';
 import ResourceActionHandlers, {
@@ -94,8 +93,8 @@ const ResourceView: React.FC<ResourceViewProps> = ({
             tabs?.map((tab) => [
                 tab.id,
                 allItems
-                    .filter(tab.filter ?? identity)
-                    .sort(tab.sort ?? identity)
+                    .filter(tab.filter ?? (() => true))
+                    .sort(tab.sort ?? (() => 0))
                     .slice(0, maxItems),
             ]),
         );

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -1,8 +1,4 @@
-import {
-    assertUnreachable,
-    DashboardBasicDetails,
-    ResourceViewItem,
-} from '@lightdash/common';
+import { assertUnreachable, ResourceViewItem } from '@lightdash/common';
 import {
     Box,
     Divider,
@@ -63,7 +59,7 @@ export enum ResourceViewType {
 interface ResourceViewProps extends ResourceViewCommonProps {
     listProps?: ResourceViewListCommonProps;
     gridProps?: ResourceViewGridCommonProps;
-    dashboards?: DashboardBasicDetails[];
+    defaultActiveTab?: string;
 }
 
 const ResourceView: React.FC<ResourceViewProps> = ({
@@ -76,7 +72,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
     headerProps = {},
     emptyStateProps = {},
     hasReorder = false,
-    dashboards,
+    defaultActiveTab,
 }) => {
     const theme = useMantineTheme();
     const tableTabStyles = useTableTabStyles();
@@ -86,9 +82,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
     });
 
     const [activeTabId, setActiveTabId] = useState(
-        dashboards?.length === undefined || dashboards?.length === 0
-            ? tabs?.[1]?.id
-            : tabs?.[0]?.id,
+        defaultActiveTab || tabs?.[0]?.id,
     );
 
     const handleAction = useCallback(

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -105,7 +105,8 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         defaultActiveTab ??
             [...itemsByTabs.entries()].find(
                 ([_tabId, items]) => items.length > 0,
-            )?.[0],
+            )?.[0] ??
+            tabs?.[0]?.id,
     );
 
     const sortProps =

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -121,6 +121,11 @@ const Space: FC = () => {
         ...wrapResourceView(chartsInSpace, ResourceViewItemType.CHART),
     ];
 
+    let defaultTab: string = 'all-items';
+    
+    if (dashboards.length > 0) defaultTab = 'dashboards';
+    else if (savedCharts.length > 0) defaultTab = 'charts';
+
     return (
         <Page title={space?.name} withFixedContent withPaddedContent>
             <Stack spacing="xl">
@@ -317,11 +322,7 @@ const Space: FC = () => {
                         icon: <IconLayoutDashboard size={30} />,
                         title: 'No items added yet',
                     }}
-                    defaultActiveTab={
-                        !dashboards || dashboards.length === 0
-                            ? 'charts'
-                            : 'dashboards'
-                    }
+                    defaultActiveTab={defaultTab}
                 />
 
                 {addToSpace && (

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -121,11 +121,6 @@ const Space: FC = () => {
         ...wrapResourceView(chartsInSpace, ResourceViewItemType.CHART),
     ];
 
-    let defaultTab: string = 'all-items';
-    
-    if (dashboards.length > 0) defaultTab = 'dashboards';
-    else if (savedCharts.length > 0) defaultTab = 'charts';
-
     return (
         <Page title={space?.name} withFixedContent withPaddedContent>
             <Stack spacing="xl">
@@ -322,7 +317,6 @@ const Space: FC = () => {
                         icon: <IconLayoutDashboard size={30} />,
                         title: 'No items added yet',
                     }}
-                    defaultActiveTab={defaultTab}
                 />
 
                 {addToSpace && (

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -317,7 +317,11 @@ const Space: FC = () => {
                         icon: <IconLayoutDashboard size={30} />,
                         title: 'No items added yet',
                     }}
-                    dashboards={dashboards}
+                    defaultActiveTab={
+                        !dashboards || dashboards.length === 0
+                            ? 'charts'
+                            : 'dashboards'
+                    }
                 />
 
                 {addToSpace && (

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -317,6 +317,7 @@ const Space: FC = () => {
                         icon: <IconLayoutDashboard size={30} />,
                         title: 'No items added yet',
                     }}
+                    dashboards={dashboards}
                 />
 
                 {addToSpace && (


### PR DESCRIPTION
Closes: #5891 

### Description:
If no dashboards, the default tab will be Charts

### ScreenShots: 
Default tab is Charts,
![image](https://github.com/lightdash/lightdash/assets/55316723/9f55b21f-9981-4071-81d9-de149d099ced)
![image](https://github.com/lightdash/lightdash/assets/55316723/76c91921-f0d6-41d5-95d1-36f888b7cd08)

