### PR TITLE
fix: resource view tabs not visible when there is one item

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -121,7 +121,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                   defaultSort: listProps.defaultSort,
               };
 
-    const hasTabs = tabs && tabs.length > 0 && items.length > 1;
+    const hasTabs = tabs && tabs.length > 0 && items.length > 0;
     const hasHeader = headerProps && (headerProps.title || headerProps.action);
 
     if (hasTabs && headerProps.title) {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/5912

there was a mistake in the logic where it was hiding the tab bar when there was only 1 item.