### PR TITLE
fix: escape underscore for string filters in the UI

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -29,10 +29,12 @@ export const renderStringFilterSql = (
     const filterType = filter.operator;
     const escapedFilterValues = filter.values?.map((v) =>
         typeof v === 'string'
-            ? v.replaceAll(
-                  stringQuoteChar,
-                  `${escapeStringQuoteChar}${stringQuoteChar}`,
-              )
+            ? v
+                  .replaceAll(
+                      stringQuoteChar,
+                      `${escapeStringQuoteChar}${stringQuoteChar}`,
+                  )
+                  .replaceAll('', '\\_')
             : v,
     );
 


### PR DESCRIPTION
Closes: #4798 

### Description:
before
<img width="1277" alt="Screenshot 2023-06-16 at 14 23 55" src="https://github.com/lightdash/lightdash/assets/67699259/35225baa-b70d-49d1-8f69-8ea8e20f97bc">


after
<img width="1288" alt="Screenshot 2023-06-16 at 15 19 09" src="https://github.com/lightdash/lightdash/assets/67699259/edfb5420-4524-4535-92bf-23cabde99a01">
