### PR TITLE
chore: update docusaurus port to 3002

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "docusaurus": "docusaurus",
-        "start": "docusaurus start",
+        "start": "docusaurus start --port 3002",
         "build": "docusaurus build",
         "swizzle": "docusaurus swizzle",
         "deploy": "docusaurus deploy",


### PR DESCRIPTION
### Description:

When writing documentation while delivering a feature in the same PR, it's quicker to get some screenshots on local development. 
`docusaurus`'s default port is `3000` which conflicts when running dev environment.

