### PR TITLE
fix: declare `OrganizationMemberProfileUpdate` without `Partial<>`

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -434,19 +434,13 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_OrganizationMemberProfile.role__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { role: { ref: 'OrganizationMemberRole' } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationMemberProfileUpdate: {
         dataType: 'refAlias',
         type: {
-            ref: 'Partial_Pick_OrganizationMemberProfile.role__',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                role: { ref: 'OrganizationMemberRole', required: true },
+            },
             validators: {},
         },
     },
@@ -491,12 +485,12 @@ const models: TsoaRoute.Models = {
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
-                    role: { ref: 'OrganizationMemberRole', required: true },
                     emailDomains: {
                         dataType: 'array',
                         array: { dataType: 'string' },
                         required: true,
                     },
+                    role: { ref: 'OrganizationMemberRole', required: true },
                     projectUuids: {
                         dataType: 'array',
                         array: { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -475,18 +475,14 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Partial_Pick_OrganizationMemberProfile.role__": {
+            "OrganizationMemberProfileUpdate": {
                 "properties": {
                     "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole",
-                        "description": "The role of the user in the organization"
+                        "$ref": "#/components/schemas/OrganizationMemberRole"
                     }
                 },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "OrganizationMemberProfileUpdate": {
-                "$ref": "#/components/schemas/Partial_Pick_OrganizationMemberProfile.role__"
+                "required": ["role"],
+                "type": "object"
             },
             "AllowedEmailDomains": {
                 "properties": {
@@ -533,14 +529,14 @@
             },
             "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
                 "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole"
-                    },
                     "emailDomains": {
                         "items": {
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole"
                     },
                     "projectUuids": {
                         "items": {
@@ -549,7 +545,7 @@
                         "type": "array"
                     }
                 },
-                "required": ["role", "emailDomains", "projectUuids"],
+                "required": ["emailDomains", "role", "projectUuids"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -37,8 +37,9 @@ export type OrganizationMemberProfile = {
     isInviteExpired?: boolean;
 };
 
-export type OrganizationMemberProfileUpdate = Partial<
-    Pick<OrganizationMemberProfile, 'role'>
+export type OrganizationMemberProfileUpdate = Pick<
+    OrganizationMemberProfile,
+    'role'
 >;
 
 export type ApiOrganizationMemberProfiles = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
We may want to declare `OrganizationMemberProfileUpdate` without `Partial<>`. That make the generated swagger.json more complicated. As a result, some libraries for Open API can't part the complicated recursive declarations. 

https://github.com/lightdash/lightdash/blob/main/packages/common/src/types/organizationMemberProfile.ts#L40-L42
```
export type OrganizationMemberProfileUpdate = Partial<
    Pick<OrganizationMemberProfile, 'role'>
>;
```