### PR TITLE
feat: inter font for tabular data

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -15,6 +15,12 @@
           user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
         -->
         <link rel="manifest" href="/manifest.json" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+            rel="stylesheet"
+        />
 
         <title>Lightdash</title>
     </head>

--- a/packages/frontend/src/components/common/PivotTable/Cell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/Cell.tsx
@@ -15,6 +15,7 @@ export interface CellProps extends BoxProps {
     withBolderFont?: boolean;
     withLighterBoldFont?: boolean;
     withValue?: boolean;
+    withNumericValue?: boolean;
 
     children?: number | string;
 }
@@ -33,6 +34,7 @@ const Cell = forwardRef<HTMLTableCellElement, CellProps>(
             withBolderFont = false,
             withLighterBoldFont = false,
             withValue = false,
+            withNumericValue = false,
 
             children,
 
@@ -58,6 +60,7 @@ const Cell = forwardRef<HTMLTableCellElement, CellProps>(
                         classes.root,
                         withGrayBackground ? classes.withGrayBackground : null,
                         withAlignRight ? classes.withAlignRight : null,
+                        withNumericValue ? classes.withNumericValue : null,
                         withMinimalWidth ? classes.withMinimalWidth : null,
                         withBolderFont ? classes.withBolderFont : null,
                         withLighterBoldFont

--- a/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
@@ -3,6 +3,7 @@ import {
     Field,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
+    isNumericItem,
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
@@ -97,6 +98,7 @@ const ValueCell: FC<ValueCellProps> = ({
         >
             <Cell
                 withValue={!!formattedValue}
+                withNumericValue={isNumericItem(item)}
                 className={cx(
                     {
                         [classes.conditionalFormatting]: conditionalFormatting,

--- a/packages/frontend/src/components/common/PivotTable/tableStyles.tsx
+++ b/packages/frontend/src/components/common/PivotTable/tableStyles.tsx
@@ -120,6 +120,8 @@ export const usePivotTableCellStyles = createStyles<
         textOverflow: 'ellipsis',
         overflow: 'hidden',
 
+        fontFamily: "'Inter', sans-serif",
+
         fontWeight: 400,
         fontSize: 13,
 
@@ -192,6 +194,11 @@ export const usePivotTableCellStyles = createStyles<
         ':hover:not([data-expanded="true"]):not([data-copied="true"])': {
             outline: `1px solid ${theme.colors.gray[6]}`,
         },
+    },
+
+    withNumericValue: {
+        fontFeatureSettings: '"tnum"',
+        textAlign: 'right',
     },
 
     withLargeText: {

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -1,5 +1,6 @@
 import { MantineProvider as MantineProviderBase } from '@mantine/core';
 import { FC } from 'react';
+
 import { getMantineThemeOverride } from '../mantineTheme';
 
 const MantineProvider: FC = ({ children }) => {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/5694

- [ ] Use `Inter` tabular version for the cells
- [ ] Bump font size down to 13px from 14px
- [ ] BONUS: aligns numeric values to right

### Description:

<img width="1431" alt="CleanShot 2023-06-19 at 14 43 31@2x" src="https://github.com/lightdash/lightdash/assets/962095/50f1b5a9-9d00-4397-90e0-cf388d956a0d">
