### PR TITLE
feat: can edit filters in table results

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -207,7 +207,12 @@ export const CustomMetricModal = () => {
                         <Accordion.Item value="filters">
                             <Accordion.Control>
                                 <Text fw={500} fz="sm">
-                                    Filters{' '}
+                                    Filters
+                                    <Text span fw={400} fz="xs">
+                                        {customMetricFiltersWithIds.length > 0
+                                            ? `(${customMetricFiltersWithIds.length}) `
+                                            : ' '}
+                                    </Text>
                                     <Text span fz="xs" color="gray.5" fw={400}>
                                         (optional)
                                     </Text>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,9 +1,7 @@
 import { Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import {
-    AdditionalMetric,
     fieldId,
-    isAdditionalMetric,
     isField,
     isFilterableField,
     TableCalculation,
@@ -47,17 +45,16 @@ const ContextMenu: FC<ContextMenuProps> = ({
         (context) =>
             context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
-    console.log(additionalMetrics);
 
-    const isItemAdditionalMetric = useMemo(
+    const additionalMetric = useMemo(
         () =>
             !!additionalMetrics &&
             !!item &&
-            additionalMetrics.find(
-                (additionalMetric) => additionalMetric.name === item.name,
-            ),
+            additionalMetrics.find((am) => am.name === item.name),
         [additionalMetrics, item],
     );
+
+    const isItemAdditionalMetric = !!additionalMetric;
 
     const toggleAdditionalMetricModal = useExplorerContext(
         (context) => context.actions.toggleAdditionalMetricModal,
@@ -92,15 +89,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             text={<>Edit custom metric</>}
                             icon="edit"
                             onClick={() => {
-                                if (
-                                    isAdditionalMetric(isItemAdditionalMetric)
-                                ) {
-                                    toggleAdditionalMetricModal({
-                                        item: isItemAdditionalMetric,
-                                        type: (item as AdditionalMetric).type,
-                                        isEditing: true,
-                                    });
-                                }
+                                toggleAdditionalMetricModal({
+                                    item: additionalMetric,
+                                    type: additionalMetric.type,
+                                    isEditing: true,
+                                });
                             }}
                         />
                     </>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,13 +1,15 @@
 import { Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import {
+    AdditionalMetric,
     fieldId,
+    isAdditionalMetric,
     isField,
     isFilterableField,
     TableCalculation,
 } from '@lightdash/common';
 import { IconChevronDown } from '@tabler/icons-react';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
@@ -41,6 +43,25 @@ const ContextMenu: FC<ContextMenuProps> = ({
         (context) => context.actions.removeActiveField,
     );
 
+    const additionalMetrics = useExplorerContext(
+        (context) =>
+            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
+    );
+
+    const isItemAdditionalMetric = useMemo(
+        () =>
+            !!additionalMetrics &&
+            !!item &&
+            additionalMetrics.find(
+                (additionalMetric) => additionalMetric.name === item.name,
+            ),
+        [additionalMetrics, item],
+    );
+
+    const toggleAdditionalMetricModal = useExplorerContext(
+        (context) => context.actions.toggleAdditionalMetricModal,
+    );
+
     if (item && isField(item) && isFilterableField(item)) {
         const itemFieldId = fieldId(item);
         return (
@@ -63,6 +84,26 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
                 <Divider />
+
+                {isItemAdditionalMetric ? (
+                    <>
+                        <MenuItem2
+                            text={<>Edit custom metric</>}
+                            icon="edit"
+                            onClick={() => {
+                                if (
+                                    isAdditionalMetric(isItemAdditionalMetric)
+                                ) {
+                                    toggleAdditionalMetricModal({
+                                        item: isItemAdditionalMetric,
+                                        type: (item as AdditionalMetric).type,
+                                        isEditing: true,
+                                    });
+                                }
+                            }}
+                        />
+                    </>
+                ) : null}
 
                 <MenuItem2
                     text="Remove"

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -85,19 +85,17 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <Divider />
 
                 {isItemAdditionalMetric ? (
-                    <>
-                        <MenuItem2
-                            text={<>Edit custom metric</>}
-                            icon="edit"
-                            onClick={() => {
-                                toggleAdditionalMetricModal({
-                                    item: additionalMetric,
-                                    type: additionalMetric.type,
-                                    isEditing: true,
-                                });
-                            }}
-                        />
-                    </>
+                    <MenuItem2
+                        text={<>Edit custom metric</>}
+                        icon="edit"
+                        onClick={() => {
+                            toggleAdditionalMetricModal({
+                                item: additionalMetric,
+                                type: additionalMetric.type,
+                                isEditing: true,
+                            });
+                        }}
+                    />
                 ) : null}
 
                 <MenuItem2

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -2,6 +2,7 @@ import { Divider, Menu, Position } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import {
     fieldId,
+    getItemId,
     isField,
     isFilterableField,
     TableCalculation,
@@ -50,7 +51,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
         () =>
             !!additionalMetrics &&
             !!item &&
-            additionalMetrics.find((am) => am.name === item.name),
+            additionalMetrics.find((am) => getItemId(am) === getItemId(item)),
         [additionalMetrics, item],
     );
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -47,6 +47,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
         (context) =>
             context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
+    console.log(additionalMetrics);
 
     const isItemAdditionalMetric = useMemo(
         () =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5972

### Description:

Users can edit and add filters to a custom metric when viewing it on the table results of an explore. 

screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/388c22cf-093c-4245-8051-ffd4495e6581


