### PR TITLE
fix: remove unexpected columns field in chart config

### DIFF
--- a/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/GeneralSettings.tsx
@@ -238,9 +238,6 @@ const GeneralSettings: FC = () => {
                     }}
                 />
             </FormGroup>
-            <FormGroup label="Columns">
-                <ColumnConfiguration fieldId={''} />
-            </FormGroup>
         </>
     );
 };


### PR DESCRIPTION
Closes: #5971 

### Description:
before
<img width="1624" alt="Screenshot 2023-06-20 at 15 34 48" src="https://github.com/lightdash/lightdash/assets/67699259/f8ac3464-8d2f-489c-bf61-06b48d3e3fd8">

after
<img width="1624" alt="Screenshot 2023-06-20 at 15 34 36" src="https://github.com/lightdash/lightdash/assets/67699259/80f10203-311f-4181-a48f-c5a8e03b2149">
