### PR TITLE
fix: add table icon in front of table names

### DIFF
--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -1,13 +1,11 @@
 import { Colors, Divider, Menu } from '@blueprintjs/core';
 import { ItemListRendererProps } from '@blueprintjs/select';
 import { Field, getItemTableName, TableCalculation } from '@lightdash/common';
+import { Group, Text } from '@mantine/core';
+import { IconTable } from '@tabler/icons-react';
 import React, { FC } from 'react';
 import styled from 'styled-components';
-
-const TableName = styled.span`
-    font-weight: 600;
-    color: ${Colors.GRAY2};
-`;
+import MantineIcon from '../MantineIcon';
 
 type MenuDividerProps = {
     $isFirst: boolean;
@@ -45,8 +43,12 @@ const StickyMenuDivider: FC<StickyMenuDividerProps> = ({ index, title }) => {
     return (
         <MenuDivider $isFirst={index === 0}>
             {index !== 0 && <StyledDivider />}
-
-            <TableName>{title}</TableName>
+            <Group spacing="xxs">
+                <MantineIcon icon={IconTable} color="gray.6" />
+                <Text color="gray.6" fw={600}>
+                    {title}
+                </Text>
+            </Group>
         </MenuDivider>
     );
 };

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -43,8 +43,8 @@ const StickyMenuDivider: FC<StickyMenuDividerProps> = ({ index, title }) => {
     return (
         <MenuDivider $isFirst={index === 0}>
             {index !== 0 && <StyledDivider />}
-            <Group spacing="xxs">
-                <MantineIcon icon={IconTable} color="gray.6" />
+            <Group spacing="xs">
+                <MantineIcon icon={IconTable} color="gray.6" size="lg" />
                 <Text color="gray.6" fw={600}>
                     {title}
                 </Text>


### PR DESCRIPTION
Closes: #5154 

### Description:
before
<img width="1624" alt="Screenshot 2023-06-20 at 16 16 04" src="https://github.com/lightdash/lightdash/assets/67699259/921f1968-f618-4b4f-afa3-8ffe96f89c5a">

after
<img width="1624" alt="Screenshot 2023-06-20 at 16 15 46" src="https://github.com/lightdash/lightdash/assets/67699259/8056c1a4-6efd-48c2-b240-e87a6bf30613">
