### PR TITLE
fix: add grouping to explore filters

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -81,6 +81,7 @@ const FilterRuleForm: FC<Props> = ({
                             }
                         }}
                         disabled={!isEditMode}
+                        hasGrouping
                     />
                     <HTMLSelect
                         className={!isEditMode ? 'disabled-filter' : ''}


### PR DESCRIPTION
Closes: #5158 

### Description:
before
<img width="1624" alt="Screenshot 2023-06-20 at 16 36 54" src="https://github.com/lightdash/lightdash/assets/67699259/285f1c48-98da-4948-bce0-190c868f516c">


after
<img width="1624" alt="Screenshot 2023-06-20 at 16 35 16" src="https://github.com/lightdash/lightdash/assets/67699259/fbe7c4dd-4db8-4390-9d92-b83624f2487d">
