### PR TITLE
fix: only show selected tables on validation

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -16,6 +16,8 @@ import {
     SessionUser,
     ShareUrl,
     SupportedDbtAdapter,
+    TablesConfiguration,
+    TableSelectionType,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 
@@ -259,4 +261,11 @@ export const exploreError: ExploreError = {
             type: InlineErrorType.METADATA_PARSE_ERROR,
         },
     ],
+};
+
+export const tableConfiguration: TablesConfiguration = {
+    tableSelection: {
+        type: TableSelectionType.ALL,
+        value: [],
+    },
 };

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -112,13 +112,44 @@ export class ValidationService {
                 case TableSelectionType.ALL:
                     return true;
                 case TableSelectionType.WITH_TAGS:
-                    return explore.tags?.some((tag) =>
-                        tablesConfiguration.tableSelection.value?.includes(tag),
+                    const hasSelectedJoinedExploredWithTags = explores.some(
+                        (e) =>
+                            e.joinedTables?.some(
+                                (jt) => jt.table === explore.name,
+                            ) &&
+                            e.tags?.some((tag) =>
+                                tablesConfiguration.tableSelection.value?.includes(
+                                    tag,
+                                ),
+                            ),
                     );
+                    const exploreIsSelectedWithTags = explore.tags?.some(
+                        (tag) =>
+                            tablesConfiguration.tableSelection.value?.includes(
+                                tag,
+                            ),
+                    );
+                    return (
+                        hasSelectedJoinedExploredWithTags ||
+                        exploreIsSelectedWithTags
+                    );
+
                 case TableSelectionType.WITH_NAMES:
-                    return tablesConfiguration.tableSelection.value?.includes(
-                        explore.name,
+                    const hasSelectedJoinedExplored = explores.some(
+                        (e) =>
+                            e.joinedTables?.some(
+                                (jt) => jt.table === explore.name,
+                            ) &&
+                            tablesConfiguration.tableSelection.value?.includes(
+                                e.name,
+                            ),
                     );
+                    const exploreIsSelected =
+                        tablesConfiguration.tableSelection.value?.includes(
+                            explore.name,
+                        );
+
+                    return hasSelectedJoinedExplored || exploreIsSelected;
                 default:
                     return assertUnreachable(
                         tablesConfiguration.tableSelection.type,

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     CompiledField,
     CreateChartValidation,
     CreateDashboardValidation,
@@ -19,6 +20,7 @@ import {
     RequestMethod,
     SessionUser,
     TableCalculation,
+    TableSelectionType,
     ValidationErrorType,
     ValidationResponse,
     ValidationSourceType,
@@ -93,16 +95,46 @@ export class ValidationService {
         return tableCalculationFieldsInSql;
     }
 
-    private static async validateTables(
+    private async validateTables(
         projectUuid: string,
         explores: (Explore | ExploreError)[] | undefined,
     ): Promise<CreateTableValidation[]> {
+        const tablesConfiguration =
+            await this.projectModel.getTablesConfiguration(projectUuid);
+
         // Get existing errors from ExploreError and convert to ValidationInsert
         if (explores === undefined) {
             return [];
         }
+
+        const isTableEnabled = (explore: Explore | ExploreError) => {
+            switch (tablesConfiguration.tableSelection.type) {
+                case TableSelectionType.ALL:
+                    return true;
+                case TableSelectionType.WITH_TAGS:
+                    return explore.tags?.some((tag) =>
+                        tablesConfiguration.tableSelection.value?.includes(tag),
+                    );
+                case TableSelectionType.WITH_NAMES:
+                    return tablesConfiguration.tableSelection.value?.includes(
+                        explore.name,
+                    );
+                default:
+                    return assertUnreachable(
+                        tablesConfiguration.tableSelection.type,
+                        'Invalid table selection type',
+                    );
+            }
+        };
+
         const errors = explores.reduce<CreateTableValidation[]>(
             (acc, explore) => {
+                if (!isTableEnabled(explore)) {
+                    Logger.debug(
+                        `Table ${explore.name} is disabled, skipping validation`,
+                    );
+                    return acc;
+                }
                 if (isExploreError(explore)) {
                     const exploreErrors = explore.errors
                         .filter(
@@ -435,10 +467,7 @@ export class ValidationService {
             return [];
         }
 
-        const tableErrors = await ValidationService.validateTables(
-            projectUuid,
-            explores,
-        );
+        const tableErrors = await this.validateTables(projectUuid, explores);
         const chartErrors = await this.validateCharts(
             projectUuid,
             existingFields,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5942

### How to replicate when selecting tables
<!-- Add a description of the changes proposed in the pull request. -->

I introduce an error on payments table that was appearing on validation.

When  selected customers/orders (not payments): 

![Screenshot from 2023-06-20 16-53-17](https://github.com/lightdash/lightdash/assets/1983672/e4af63ba-df03-4e0b-ad71-3b0fdefe1fc7)


<!-- Even better add a screenshot / gif / loom -->
Before:


![Screenshot from 2023-06-20 16-53-12](https://github.com/lightdash/lightdash/assets/1983672/9a89a110-f16b-4396-a469-cce8b8fe8158)

AFter:


![Screenshot from 2023-06-20 16-53-34](https://github.com/lightdash/lightdash/assets/1983672/1e65e731-a01d-48a6-aeee-14a8e1cc6175)

Logs: 
![Screenshot from 2023-06-20 16-53-46](https://github.com/lightdash/lightdash/assets/1983672/c35ea86b-1c90-455b-b6b6-dac5045c3329)

### How to replicate with tags

I added a tag to orders


![Screenshot from 2023-06-20 17-00-46](https://github.com/lightdash/lightdash/assets/1983672/01e190a2-ffbf-4549-9145-c1afd7248977)

I selected that tag

![Uploading Screenshot from 2023-06-20 17-00-34.png…]()

No "payment errors":


![Screenshot from 2023-06-20 17-00-40](https://github.com/lightdash/lightdash/assets/1983672/06677124-a670-4fa0-a67d-9d699971b770)

