### PR TITLE
feat: allow API key authentication on `UpdateOrganizationMember`

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -180,7 +180,11 @@ export class OrganizationController extends Controller {
      * @param userUuid the uuid of the user to update
      * @param body the new membership profile
      */
-    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Middlewares([
+        isAuthenticated,
+        allowApiKeyAuthentication,
+        unauthorisedInDemo,
+    ])
     @Patch('/users/{userUuid}')
     @OperationId('UpdateOrganizationMember')
     @Tags('Roles & Permissions')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/5987

### Description:
UpdateOrganizationMember isn't available with the API key authentication due to the lack of allowApiKeyAuthentication.
