### PR TITLE
fix: get correct key for date filters

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -290,7 +290,7 @@ export class ExploreCompiler {
 
                 const table = tables[refTable];
 
-                // NOTE: date dimensions from explores have their time format uppercased (.e.g. order_date_DAY)
+                // NOTE: date dimensions from explores have their time format uppercased (e.g. order_date_DAY) - see ticket: https://github.com/lightdash/lightdash/issues/5998
                 const dimensionRefName = Object.keys(table.dimensions).find(
                     (key) => key.toLowerCase() === refName.toLowerCase(),
                 );

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -287,7 +287,18 @@ export class ExploreCompiler {
                     fieldRef,
                     metric.table,
                 );
-                const dimensionField = tables[refTable]?.dimensions[refName];
+
+                const table = tables[refTable];
+
+                // NOTE: date dimensions from explores have their time format uppercased (.e.g. order_date_DAY)
+                const dimensionRefName = Object.keys(table.dimensions).find(
+                    (key) => key.toLowerCase() === refName.toLowerCase(),
+                );
+
+                const dimensionField = dimensionRefName
+                    ? table.dimensions[dimensionRefName]
+                    : undefined;
+
                 if (!dimensionField) {
                     throw new CompileError(
                         `Filter for metric "${metric.name}" has a reference to an unknown dimension: ${fieldRef}`,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -290,6 +290,12 @@ export class ExploreCompiler {
 
                 const table = tables[refTable];
 
+                if (!table) {
+                    throw new CompileError(
+                        `Filter for metric "${metric.name}" has a reference to an unknown table`,
+                    );
+                }
+
                 // NOTE: date dimensions from explores have their time format uppercased (e.g. order_date_DAY) - see ticket: https://github.com/lightdash/lightdash/issues/5998
                 const dimensionRefName = Object.keys(table.dimensions).find(
                     (key) => key.toLowerCase() === refName.toLowerCase(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/5973#pullrequestreview-1490373217

Caused by: #5998 

### Description:

Get correct key for date filters. 

Currently, the cached explores return the time format uppercased (e.g. `order_date_DAY`) so the code was breaking for date filters applied to custom metrics due to ref names not matching (`order_date_day` vs `order_date_DAY`). 

Since we can assume that dimensions in an explore `table` are all unique, we can also find the one that matches the lowercased ref. 
