### PR TITLE
feat: organization default project

### DIFF
--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -80,3 +80,8 @@ Once you've selected the default roles for your allowed email domains, make sure
 Now, when a user tries to join Lightdash, they will be prompted to join your workspace if they have one of your allowed email domains.
 
 <img src={JoinWorkspace} width="431" height="381" style={{display: "block", margin: "0 auto 20px auto"}}/>
+
+### Default project
+
+In the organization settings you can set a default project. If a user has access to this project, this is the project
+they will see when they first log in to Lightdash for the first time.

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -83,5 +83,5 @@ Now, when a user tries to join Lightdash, they will be prompted to join your wor
 
 ### Default project
 
-In the organization settings you can set a default project. If a user has access to this project, this is the project
-they will see when they first log in to Lightdash for the first time.
+In the organization settings you can set a default project. This is the project users will see when they log in for the
+first time or from a new device. If a user does not have access, they will see their next accessible project.

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -144,16 +144,33 @@ type QueryExecutionEvent = BaseTrack & {
     };
 };
 
-type TrackOrganizationEvent = BaseTrack & {
-    event:
-        | 'organization.created'
-        | 'organization.updated'
-        | 'organization.deleted';
+type CreateOrganizationEvent = BaseTrack & {
+    event: 'organization.created';
     properties: {
         type: string;
         organizationId: string;
         organizationName: string;
-        defaultColourPaletteUpdated?: boolean;
+    };
+};
+
+type UpdateOrganizationEvent = BaseTrack & {
+    event: 'organization.updated';
+    properties: {
+        type: string;
+        organizationId: string;
+        organizationName: string;
+        defaultProjectUuid: string | undefined;
+        defaultColourPaletteUpdated: boolean;
+        defaultProjectUuidUpdated: boolean;
+    };
+};
+
+type DeleteOrganizationEvent = BaseTrack & {
+    event: 'organization.deleted';
+    properties: {
+        type: string;
+        organizationId: string;
+        organizationName: string;
     };
 };
 
@@ -682,7 +699,9 @@ type Track =
     | DeletedDashboardEvent
     | CreateDashboardOrVersionEvent
     | ProjectTablesConfigurationEvent
-    | TrackOrganizationEvent
+    | CreateOrganizationEvent
+    | UpdateOrganizationEvent
+    | DeleteOrganizationEvent
     | OrganizationAllowedEmailDomainUpdatedEvent
     | LoginEvent
     | IdentityLinkedEvent

--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -6,11 +6,15 @@ export type DbOrganization = {
     organization_name: string;
     created_at: Date;
     chart_colors?: string[];
+    default_project_uuid: string | null;
 };
 
 export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;
 export type DbOrganizationUpdate = Partial<
-    Pick<DbOrganization, 'organization_name' | 'chart_colors'>
+    Pick<
+        DbOrganization,
+        'organization_name' | 'chart_colors' | 'default_project_uuid'
+    >
 >;
 
 export type OrganizationTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20230623082425_add-prg-default-project.ts
+++ b/packages/backend/src/database/migrations/20230623082425_add-prg-default-project.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table
+            .uuid('default_project_uuid')
+            .references('project_uuid')
+            .inTable('projects')
+            .nullable()
+            .unique()
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('default_project_uuid');
+    });
+}

--- a/packages/backend/src/database/migrations/20230623082425_add-prg-default-project.ts
+++ b/packages/backend/src/database/migrations/20230623082425_add-prg-default-project.ts
@@ -7,7 +7,6 @@ export async function up(knex: Knex): Promise<void> {
             .references('project_uuid')
             .inTable('projects')
             .nullable()
-            .unique()
             .onDelete('SET NULL');
     });
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1,16 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import {
-    Controller,
-    fetchMiddlewares,
-    FieldErrors,
-    HttpStatusCodeLiteral,
-    TsoaResponse,
-    TsoaRoute,
-    ValidateError,
-    ValidationService,
-} from '@tsoa/runtime';
+import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute, HttpStatusCodeLiteral, TsoaResponse, fetchMiddlewares } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CsvController } from './../controllers/csvController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -40,3059 +31,1066 @@ import { SshController } from './../controllers/sshController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ValidationController } from './../controllers/validationController';
 import type { RequestHandler } from 'express';
 import * as express from 'express';
-import { ValidationController } from './../controllers/validationController';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
-    ApiErrorPayload: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                error: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        data: { dataType: 'any' },
-                        message: { dataType: 'string' },
-                        name: { dataType: 'string', required: true },
-                        statusCode: { dataType: 'double', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['error'], required: true },
-            },
-            validators: {},
-        },
+    "ApiErrorPayload": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"any"},"message":{"dataType":"string"},"name":{"dataType":"string","required":true},"statusCode":{"dataType":"double","required":true}},"required":true},"status":{"dataType":"enum","enums":["error"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiCsvUrlResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: { dataType: 'string', required: true },
-                        url: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiCsvUrlResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true},"url":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateDbtCloudIntegration.metricsJobId_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metricsJobId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Pick_CreateDbtCloudIntegration.metricsJobId_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metricsJobId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudIntegration: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateDbtCloudIntegration.metricsJobId_',
-            validators: {},
-        },
+    "DbtCloudIntegration": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateDbtCloudIntegration.metricsJobId_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudIntegrationSettings: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DbtCloudIntegration' },
-                        { dataType: 'undefined' },
-                    ],
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudIntegrationSettings": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"union","subSchemas":[{"ref":"DbtCloudIntegration"},{"dataType":"undefined"}],"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudSettingsDeleteSuccess: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { dataType: 'undefined', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudSettingsDeleteSuccess": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudMetric: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                label: { dataType: 'string', required: true },
-                timeGrains: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                description: { dataType: 'string', required: true },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                name: { dataType: 'string', required: true },
-                uniqueId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "DbtCloudMetric": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"label":{"dataType":"string","required":true},"timeGrains":{"dataType":"array","array":{"dataType":"string"},"required":true},"description":{"dataType":"string","required":true},"dimensions":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true},"uniqueId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudMetadataResponseMetrics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'DbtCloudMetric' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "DbtCloudMetadataResponseMetrics": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"DbtCloudMetric"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDbtCloudMetrics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    ref: 'DbtCloudMetadataResponseMetrics',
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiDbtCloudMetrics": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"DbtCloudMetadataResponseMetrics","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Group: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                organizationUuid: { dataType: 'string', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                name: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Group": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organizationUuid":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Group', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiGroupResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Group","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSuccessEmpty: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { dataType: 'undefined', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiSuccessEmpty": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    GroupMember: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "GroupMember": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupMembersResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'GroupMember' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiGroupMembersResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"GroupMember"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Group.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "Pick_Group.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateGroup: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_Group.name_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Organization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                needsProject: { dataType: 'boolean' },
-                chartColors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
-                name: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "UpdateGroup": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_Group.name_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Organization', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Organization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"defaultProjectUuid":{"dataType":"string"},"needsProject":{"dataType":"boolean"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Organization.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "ApiOrganization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Organization","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateOrganization: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_Organization.name_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Omit_Organization.organizationUuid-or-needsProject__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string' },
-                chartColors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
-            },
-            validators: {},
-        },
+    "Pick_Organization.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateOrganization: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Partial_Omit_Organization.organizationUuid-or-needsProject__',
-            validators: {},
-        },
+    "CreateOrganization": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_Organization.name_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ProjectType: {
-        dataType: 'refEnum',
-        enums: ['DEFAULT', 'PREVIEW'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationProject: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                type: { ref: 'ProjectType', required: true },
-                name: { dataType: 'string', required: true },
-                projectUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"defaultProjectUuid":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationProjects: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'OrganizationProject' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "UpdateOrganization": {
+        "dataType": "refAlias",
+        "type": {"ref":"Partial_Omit_Organization.organizationUuid-or-needsProject__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberRole: {
-        dataType: 'refEnum',
-        enums: [
-            'member',
-            'viewer',
-            'interactive_viewer',
-            'editor',
-            'developer',
-            'admin',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberProfile: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                isInviteExpired: { dataType: 'boolean' },
-                isActive: { dataType: 'boolean', required: true },
-                role: { ref: 'OrganizationMemberRole', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ProjectType": {
+        "dataType": "refEnum",
+        "enums": ["DEFAULT","PREVIEW"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationMemberProfiles: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'OrganizationMemberProfile',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "OrganizationProject": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"ProjectType","required":true},"name":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationMemberProfile: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'OrganizationMemberProfile', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiOrganizationProjects": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationProject"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberProfileUpdate: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                role: { ref: 'OrganizationMemberRole', required: true },
-            },
-            validators: {},
-        },
+    "OrganizationMemberRole": {
+        "dataType": "refEnum",
+        "enums": ["member","viewer","interactive_viewer","editor","developer","admin"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'OrganizationMemberRole.EDITOR': {
-        dataType: 'refEnum',
-        enums: ['editor'],
+    "OrganizationMemberProfile": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isInviteExpired":{"dataType":"boolean"},"isActive":{"dataType":"boolean","required":true},"role":{"ref":"OrganizationMemberRole","required":true},"organizationUuid":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'OrganizationMemberRole.INTERACTIVE_VIEWER': {
-        dataType: 'refEnum',
-        enums: ['interactive_viewer'],
+    "ApiOrganizationMemberProfiles": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'OrganizationMemberRole.VIEWER': {
-        dataType: 'refEnum',
-        enums: ['viewer'],
+    "ApiOrganizationMemberProfile": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"OrganizationMemberProfile","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'OrganizationMemberRole.MEMBER': {
-        dataType: 'refEnum',
-        enums: ['member'],
+    "OrganizationMemberProfileUpdate": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AllowedEmailDomainsRole: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'OrganizationMemberRole.EDITOR' },
-                { ref: 'OrganizationMemberRole.INTERACTIVE_VIEWER' },
-                { ref: 'OrganizationMemberRole.VIEWER' },
-                { ref: 'OrganizationMemberRole.MEMBER' },
-            ],
-            validators: {},
-        },
+    "OrganizationMemberRole.EDITOR": {
+        "dataType": "refEnum",
+        "enums": ["editor"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                projectUuids: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                role: { ref: 'AllowedEmailDomainsRole', required: true },
-                emailDomains: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "OrganizationMemberRole.INTERACTIVE_VIEWER": {
+        "dataType": "refEnum",
+        "enums": ["interactive_viewer"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiOrganizationAllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'AllowedEmailDomains', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "OrganizationMemberRole.VIEWER": {
+        "dataType": "refEnum",
+        "enums": ["viewer"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    emailDomains: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                    role: { ref: 'AllowedEmailDomainsRole', required: true },
-                    projectUuids: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
+    "OrganizationMemberRole.MEMBER": {
+        "dataType": "refEnum",
+        "enums": ["member"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_AllowedEmailDomains.organizationUuid_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__',
-            validators: {},
-        },
+    "AllowedEmailDomainsRole": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"OrganizationMemberRole.EDITOR"},{"ref":"OrganizationMemberRole.INTERACTIVE_VIEWER"},{"ref":"OrganizationMemberRole.VIEWER"},{"ref":"OrganizationMemberRole.MEMBER"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateAllowedEmailDomains: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_AllowedEmailDomains.organizationUuid_',
-            validators: {},
-        },
+    "AllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"AllowedEmailDomainsRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateGroup.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
+    "ApiOrganizationAllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"AllowedEmailDomains","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'Group' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"AllowedEmailDomainsRole","required":true},"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.DASHBOARD': {
-        dataType: 'refEnum',
-        enums: ['dashboard'],
+    "Omit_AllowedEmailDomains.organizationUuid_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdatedByUser: {
-        dataType: 'refObject',
-        properties: {
-            userUuid: { dataType: 'string', required: true },
-            firstName: { dataType: 'string', required: true },
-            lastName: { dataType: 'string', required: true },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ValidationResponse.error-or-createdAt-or-validationId_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                validationId: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                error: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "UpdateAllowedEmailDomains": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_AllowedEmailDomains.organizationUuid_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationSummary: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationId_',
-            validators: {},
-        },
+    "Pick_CreateGroup.name_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    views: { dataType: 'double', required: true },
-                    firstViewedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    validationErrors: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'refAlias',
-                            ref: 'ValidationSummary',
-                        },
-                    },
-                },
-                validators: {},
-            },
-        },
+    "ApiGroupListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"Group"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewDashboardItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.DASHBOARD', required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewItemType.DASHBOARD": {
+        "dataType": "refEnum",
+        "enums": ["dashboard"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.CHART': {
-        dataType: 'refEnum',
-        enums: ['chart'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartKind: {
-        dataType: 'refEnum',
-        enums: [
-            'line',
-            'horizontal_bar',
-            'vertical_bar',
-            'scatter',
-            'area',
-            'mixed',
-            'pie',
-            'table',
-            'big_number',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    views: { dataType: 'double', required: true },
-                    firstViewedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    validationErrors: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'refAlias',
-                            ref: 'ValidationSummary',
-                        },
-                    },
-                    chartType: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'ChartKind' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
+    "UpdatedByUser": {
+        "dataType": "refObject",
+        "properties": {
+            "userUuid": {"dataType":"string","required":true},
+            "firstName": {"dataType":"string","required":true},
+            "lastName": {"dataType":"string","required":true},
         },
+        "additionalProperties": false,
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewChartItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.CHART', required: true },
-            },
-            validators: {},
-        },
+    "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"validationId":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true},"error":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.SPACE': {
-        dataType: 'refEnum',
-        enums: ['space'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    projectUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    isPrivate: { dataType: 'boolean', required: true },
-                },
-                validators: {},
-            },
-        },
+    "ValidationSummary": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_ValidationResponse.error-or-createdAt-or-validationId_","validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewSpaceItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    dataType: 'intersection',
-                    subSchemas: [
-                        {
-                            ref: 'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_',
-                        },
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                chartCount: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                dashboardCount: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                accessListLength: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                access: {
-                                    dataType: 'array',
-                                    array: { dataType: 'string' },
-                                    required: true,
-                                },
-                            },
-                        },
-                    ],
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.SPACE', required: true },
-            },
-            validators: {},
-        },
+    "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    PinnedItems: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'array',
-            array: {
-                dataType: 'union',
-                subSchemas: [
-                    { ref: 'ResourceViewDashboardItem' },
-                    { ref: 'ResourceViewChartItem' },
-                    { ref: 'ResourceViewSpaceItem' },
-                ],
-            },
-            validators: {},
-        },
+    "ResourceViewDashboardItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.DASHBOARD","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiPinnedItems: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'PinnedItems', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewItemType.CHART": {
+        "dataType": "refEnum",
+        "enums": ["chart"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewItemType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'space'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                uuid: { dataType: 'string', required: true },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "ChartKind": {
+        "dataType": "refEnum",
+        "enums": ["line","horizontal_bar","vertical_bar","scatter","area","mixed","pie","table","big_number"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdatePinnedItemOrder: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                data: {
-                    ref: 'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_',
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType', required: true },
-            },
-            validators: {},
-        },
+    "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.DBT': {
-        dataType: 'refEnum',
-        enums: ['dbt'],
+    "ResourceViewChartItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.CHART","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtProjectEnvironmentVariable: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                value: { dataType: 'string', required: true },
-                key: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ResourceViewItemType.SPACE": {
+        "dataType": "refEnum",
+        "enums": ["space"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtProjectType: {
-        dataType: 'refEnum',
-        enums: [
-            'dbt',
-            'dbt_cloud_ide',
-            'github',
-            'gitlab',
-            'bitbucket',
-            'azure_devops',
-            'none',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtLocalProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.DBT', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            profiles_dir: { dataType: 'string' },
-            project_dir: { dataType: 'string' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.DBT_CLOUD_IDE': {
-        dataType: 'refEnum',
-        enums: ['dbt_cloud_ide'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtCloudIDEProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.DBT_CLOUD_IDE', required: true },
-            api_key: { dataType: 'string', required: true },
-            account_id: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
-                required: true,
-            },
-            environment_id: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
-                required: true,
-            },
-            project_id: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
-                required: true,
-            },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.GITHUB': {
-        dataType: 'refEnum',
-        enums: ['github'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtGithubProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.GITHUB', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            personal_access_token: { dataType: 'string', required: true },
-            repository: { dataType: 'string', required: true },
-            branch: { dataType: 'string', required: true },
-            project_sub_path: { dataType: 'string', required: true },
-            host_domain: { dataType: 'string' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.BITBUCKET': {
-        dataType: 'refEnum',
-        enums: ['bitbucket'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtBitBucketProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.BITBUCKET', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            username: { dataType: 'string', required: true },
-            personal_access_token: { dataType: 'string', required: true },
-            repository: { dataType: 'string', required: true },
-            branch: { dataType: 'string', required: true },
-            project_sub_path: { dataType: 'string', required: true },
-            host_domain: { dataType: 'string' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.GITLAB': {
-        dataType: 'refEnum',
-        enums: ['gitlab'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtGitlabProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.GITLAB', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            personal_access_token: { dataType: 'string', required: true },
-            repository: { dataType: 'string', required: true },
-            branch: { dataType: 'string', required: true },
-            project_sub_path: { dataType: 'string', required: true },
-            host_domain: { dataType: 'string' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.AZURE_DEVOPS': {
-        dataType: 'refEnum',
-        enums: ['azure_devops'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtAzureDevOpsProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.AZURE_DEVOPS', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            personal_access_token: { dataType: 'string', required: true },
-            organization: { dataType: 'string', required: true },
-            project: { dataType: 'string', required: true },
-            repository: { dataType: 'string', required: true },
-            branch: { dataType: 'string', required: true },
-            project_sub_path: { dataType: 'string', required: true },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DbtProjectType.NONE': {
-        dataType: 'refEnum',
-        enums: ['none'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtNoneProjectConfig: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'DbtProjectType.NONE', required: true },
-            target: { dataType: 'string' },
-            environment: {
-                dataType: 'array',
-                array: {
-                    dataType: 'refAlias',
-                    ref: 'DbtProjectEnvironmentVariable',
-                },
-            },
-            hideRefreshButton: { dataType: 'boolean' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DbtProjectConfig: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'DbtLocalProjectConfig' },
-                { ref: 'DbtCloudIDEProjectConfig' },
-                { ref: 'DbtGithubProjectConfig' },
-                { ref: 'DbtBitBucketProjectConfig' },
-                { ref: 'DbtGitlabProjectConfig' },
-                { ref: 'DbtAzureDevOpsProjectConfig' },
-                { ref: 'DbtNoneProjectConfig' },
-            ],
-            validators: {},
-        },
+    "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.SNOWFLAKE': {
-        dataType: 'refEnum',
-        enums: ['snowflake'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    WeekDay: {
-        dataType: 'refEnum',
-        enums: [0, 1, 2, 3, 4, 5, 6],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    role: { dataType: 'string' },
-                    type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
-                    account: { dataType: 'string', required: true },
-                    database: { dataType: 'string', required: true },
-                    warehouse: { dataType: 'string', required: true },
-                    schema: { dataType: 'string', required: true },
-                    threads: { dataType: 'double' },
-                    clientSessionKeepAlive: { dataType: 'boolean' },
-                    queryTag: { dataType: 'string' },
-                    accessUrl: { dataType: 'string' },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                },
-                validators: {},
-            },
-        },
+    "ResourceViewSpaceItem": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartCount":{"dataType":"double","required":true},"dashboardCount":{"dataType":"double","required":true},"accessListLength":{"dataType":"double","required":true},"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"required":true},"type":{"ref":"ResourceViewItemType.SPACE","required":true}},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
-        },
+    "PinnedItems": {
+        "dataType": "refAlias",
+        "type": {"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"ResourceViewDashboardItem"},{"ref":"ResourceViewChartItem"},{"ref":"ResourceViewSpaceItem"}]},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SnowflakeCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
-        },
+    "ApiPinnedItems": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"PinnedItems","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.REDSHIFT': {
-        dataType: 'refEnum',
-        enums: ['redshift'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    type: { ref: 'WarehouseTypes.REDSHIFT', required: true },
-                    schema: { dataType: 'string', required: true },
-                    threads: { dataType: 'double' },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                    useSshTunnel: { dataType: 'boolean' },
-                    sshTunnelHost: { dataType: 'string' },
-                    sshTunnelPort: { dataType: 'double' },
-                    sshTunnelUser: { dataType: 'string' },
-                    sshTunnelPublicKey: { dataType: 'string' },
-                    host: { dataType: 'string', required: true },
-                    port: { dataType: 'double', required: true },
-                    dbname: { dataType: 'string', required: true },
-                    keepalivesIdle: { dataType: 'double' },
-                    sslmode: { dataType: 'string' },
-                    ra3Node: { dataType: 'boolean' },
-                },
-                validators: {},
-            },
-        },
+    "ResourceViewItemType": {
+        "dataType": "refEnum",
+        "enums": ["chart","dashboard","space"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
-        },
+    "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"uuid":{"dataType":"string","required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    RedshiftCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
-        },
+    "UpdatePinnedItemOrder": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_","required":true},"type":{"ref":"ResourceViewItemType","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.POSTGRES': {
-        dataType: 'refEnum',
-        enums: ['postgres'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    role: { dataType: 'string' },
-                    type: { ref: 'WarehouseTypes.POSTGRES', required: true },
-                    schema: { dataType: 'string', required: true },
-                    threads: { dataType: 'double' },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                    useSshTunnel: { dataType: 'boolean' },
-                    sshTunnelHost: { dataType: 'string' },
-                    sshTunnelPort: { dataType: 'double' },
-                    sshTunnelUser: { dataType: 'string' },
-                    sshTunnelPublicKey: { dataType: 'string' },
-                    host: { dataType: 'string', required: true },
-                    port: { dataType: 'double', required: true },
-                    dbname: { dataType: 'string', required: true },
-                    keepalivesIdle: { dataType: 'double' },
-                    sslmode: { dataType: 'string' },
-                    searchPath: { dataType: 'string' },
-                },
-                validators: {},
-            },
-        },
+    "DbtProjectType.DBT": {
+        "dataType": "refEnum",
+        "enums": ["dbt"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
-        },
+    "DbtProjectEnvironmentVariable": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"value":{"dataType":"string","required":true},"key":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    PostgresCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
-        },
+    "DbtProjectType": {
+        "dataType": "refEnum",
+        "enums": ["dbt","dbt_cloud_ide","github","gitlab","bitbucket","azure_devops","none"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.BIGQUERY': {
-        dataType: 'refEnum',
-        enums: ['bigquery'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    type: { ref: 'WarehouseTypes.BIGQUERY', required: true },
-                    threads: { dataType: 'double' },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                    project: { dataType: 'string', required: true },
-                    dataset: { dataType: 'string', required: true },
-                    timeoutSeconds: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                    priority: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'enum', enums: ['interactive'] },
-                            { dataType: 'enum', enums: ['batch'] },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                    retries: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                    location: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                    maximumBytesBilled: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
+    "DbtLocalProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.DBT","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "profiles_dir": {"dataType":"string"},
+            "project_dir": {"dataType":"string"},
         },
+        "additionalProperties": false,
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
-        },
+    "DbtProjectType.DBT_CLOUD_IDE": {
+        "dataType": "refEnum",
+        "enums": ["dbt_cloud_ide"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    BigqueryCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
+    "DbtCloudIDEProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.DBT_CLOUD_IDE","required":true},
+            "api_key": {"dataType":"string","required":true},
+            "account_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
+            "environment_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
+            "project_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.DATABRICKS': {
-        dataType: 'refEnum',
-        enums: ['databricks'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    type: { ref: 'WarehouseTypes.DATABRICKS', required: true },
-                    database: { dataType: 'string', required: true },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                    catalog: { dataType: 'string' },
-                    serverHostName: { dataType: 'string', required: true },
-                    httpPath: { dataType: 'string', required: true },
-                },
-                validators: {},
-            },
-        },
+    "DbtProjectType.GITHUB": {
+        "dataType": "refEnum",
+        "enums": ["github"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
+    "DbtGithubProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.GITHUB","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "personal_access_token": {"dataType":"string","required":true},
+            "repository": {"dataType":"string","required":true},
+            "branch": {"dataType":"string","required":true},
+            "project_sub_path": {"dataType":"string","required":true},
+            "host_domain": {"dataType":"string"},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DatabricksCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
-        },
+    "DbtProjectType.BITBUCKET": {
+        "dataType": "refEnum",
+        "enums": ["bitbucket"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'WarehouseTypes.TRINO': {
-        dataType: 'refEnum',
-        enums: ['trino'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    type: { ref: 'WarehouseTypes.TRINO', required: true },
-                    schema: { dataType: 'string', required: true },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                    },
-                    host: { dataType: 'string', required: true },
-                    port: { dataType: 'double', required: true },
-                    dbname: { dataType: 'string', required: true },
-                    http_scheme: { dataType: 'string', required: true },
-                },
-                validators: {},
-            },
+    "DbtBitBucketProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.BITBUCKET","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "username": {"dataType":"string","required":true},
+            "personal_access_token": {"dataType":"string","required":true},
+            "repository": {"dataType":"string","required":true},
+            "branch": {"dataType":"string","required":true},
+            "project_sub_path": {"dataType":"string","required":true},
+            "host_domain": {"dataType":"string"},
         },
+        "additionalProperties": false,
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__',
-            validators: {},
-        },
+    "DbtProjectType.GITLAB": {
+        "dataType": "refEnum",
+        "enums": ["gitlab"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    TrinoCredentials: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_',
-            validators: {},
+    "DbtGitlabProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.GITLAB","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "personal_access_token": {"dataType":"string","required":true},
+            "repository": {"dataType":"string","required":true},
+            "branch": {"dataType":"string","required":true},
+            "project_sub_path": {"dataType":"string","required":true},
+            "host_domain": {"dataType":"string"},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    WarehouseCredentials: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'SnowflakeCredentials' },
-                { ref: 'RedshiftCredentials' },
-                { ref: 'PostgresCredentials' },
-                { ref: 'BigqueryCredentials' },
-                { ref: 'DatabricksCredentials' },
-                { ref: 'TrinoCredentials' },
-            ],
-            validators: {},
-        },
+    "DbtProjectType.AZURE_DEVOPS": {
+        "dataType": "refEnum",
+        "enums": ["azure_devops"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Project: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                copiedFromProjectUuid: { dataType: 'string' },
-                pinnedListUuid: { dataType: 'string' },
-                warehouseConnection: { ref: 'WarehouseCredentials' },
-                dbtConnection: { ref: 'DbtProjectConfig', required: true },
-                type: { ref: 'ProjectType', required: true },
-                name: { dataType: 'string', required: true },
-                projectUuid: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
+    "DbtAzureDevOpsProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.AZURE_DEVOPS","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "personal_access_token": {"dataType":"string","required":true},
+            "organization": {"dataType":"string","required":true},
+            "project": {"dataType":"string","required":true},
+            "repository": {"dataType":"string","required":true},
+            "branch": {"dataType":"string","required":true},
+            "project_sub_path": {"dataType":"string","required":true},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiProjectResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Project', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "DbtProjectType.NONE": {
+        "dataType": "refEnum",
+        "enums": ["none"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    projectUuid: { dataType: 'string', required: true },
-                    spaceUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    spaceName: { dataType: 'string', required: true },
-                },
-                validators: {},
-            },
+    "DbtNoneProjectConfig": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"DbtProjectType.NONE","required":true},
+            "target": {"dataType":"string"},
+            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
+            "hideRefreshButton": {"dataType":"boolean"},
         },
+        "additionalProperties": false,
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartType: {
-        dataType: 'refEnum',
-        enums: ['cartesian', 'table', 'big_number', 'pie'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartSummary: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        chartType: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'ChartType' },
-                                { dataType: 'undefined' },
-                            ],
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "DbtProjectConfig": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"DbtLocalProjectConfig"},{"ref":"DbtCloudIDEProjectConfig"},{"ref":"DbtGithubProjectConfig"},{"ref":"DbtBitBucketProjectConfig"},{"ref":"DbtGitlabProjectConfig"},{"ref":"DbtAzureDevOpsProjectConfig"},{"ref":"DbtNoneProjectConfig"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiChartSummaryListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "WarehouseTypes.SNOWFLAKE": {
+        "dataType": "refEnum",
+        "enums": ["snowflake"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    projectUuid: { dataType: 'string', required: true },
-                    isPrivate: { dataType: 'boolean', required: true },
-                },
-                validators: {},
-            },
-        },
+    "WeekDay": {
+        "dataType": "refEnum",
+        "enums": [0,1,2,3,4,5,6],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceSummary: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        access: {
-                            dataType: 'array',
-                            array: { dataType: 'string' },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"dataType":"string"},"type":{"ref":"WarehouseTypes.SNOWFLAKE","required":true},"account":{"dataType":"string","required":true},"database":{"dataType":"string","required":true},"warehouse":{"dataType":"string","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"clientSessionKeepAlive":{"dataType":"boolean"},"queryTag":{"dataType":"string"},"accessUrl":{"dataType":"string"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSpaceSummaryListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceSummary' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ProjectMemberRole: {
-        dataType: 'refEnum',
-        enums: ['viewer', 'interactive_viewer', 'editor', 'developer', 'admin'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ProjectMemberProfile: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
-                role: { ref: 'ProjectMemberRole', required: true },
-                projectUuid: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SnowflakeCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiProjectAccessListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'ProjectMemberProfile',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "WarehouseTypes.REDSHIFT": {
+        "dataType": "refEnum",
+        "enums": ["redshift"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateProjectMember: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                sendEmail: { dataType: 'boolean', required: true },
-                role: { ref: 'ProjectMemberRole', required: true },
-                email: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.REDSHIFT","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"useSshTunnel":{"dataType":"boolean"},"sshTunnelHost":{"dataType":"string"},"sshTunnelPort":{"dataType":"double"},"sshTunnelUser":{"dataType":"string"},"sshTunnelPublicKey":{"dataType":"string"},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"keepalivesIdle":{"dataType":"double"},"sslmode":{"dataType":"string"},"ra3Node":{"dataType":"boolean"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateProjectMember: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                role: { ref: 'ProjectMemberRole', required: true },
-            },
-            validators: {},
-        },
+    "Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    FieldId: {
-        dataType: 'refAlias',
-        type: { dataType: 'string', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    FilterGroupResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        or: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        id: { dataType: 'string', required: true },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        and: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        id: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "RedshiftCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Filters: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                metrics: { ref: 'FilterGroupResponse' },
-                dimensions: { ref: 'FilterGroupResponse' },
-            },
-            validators: {},
-        },
+    "WarehouseTypes.POSTGRES": {
+        "dataType": "refEnum",
+        "enums": ["postgres"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SortField: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                descending: { dataType: 'boolean', required: true },
-                fieldId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"dataType":"string"},"type":{"ref":"WarehouseTypes.POSTGRES","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"useSshTunnel":{"dataType":"boolean"},"sshTunnelHost":{"dataType":"string"},"sshTunnelPort":{"dataType":"double"},"sshTunnelUser":{"dataType":"string"},"sshTunnelPublicKey":{"dataType":"string"},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"keepalivesIdle":{"dataType":"double"},"sslmode":{"dataType":"string"},"searchPath":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    TableCalculationFormatType: {
-        dataType: 'refEnum',
-        enums: ['default', 'percent', 'currency', 'number'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    NumberSeparator: {
-        dataType: 'refEnum',
-        enums: [
-            'default',
-            'commaPeriod',
-            'spacePeriod',
-            'periodComma',
-            'noSeparatorPeriod',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Compact: {
-        dataType: 'refEnum',
-        enums: ['thousands', 'millions', 'billions', 'trillions'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    TableCalculationFormat: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                suffix: { dataType: 'string' },
-                prefix: { dataType: 'string' },
-                compact: { ref: 'Compact' },
-                currency: { dataType: 'string' },
-                separator: { ref: 'NumberSeparator' },
-                round: { dataType: 'double' },
-                type: { ref: 'TableCalculationFormatType', required: true },
-            },
-            validators: {},
-        },
+    "Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    TableCalculation: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                format: { ref: 'TableCalculationFormat' },
-                sql: { dataType: 'string', required: true },
-                displayName: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-                index: { dataType: 'double' },
-            },
-            validators: {},
-        },
+    "PostgresCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MetricType: {
-        dataType: 'refEnum',
-        enums: [
-            'percentile',
-            'average',
-            'count',
-            'count_distinct',
-            'sum',
-            'min',
-            'max',
-            'number',
-            'median',
-            'string',
-            'date',
-            'boolean',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CompactOrAlias: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'Compact' },
-                {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['K'] },
-                        { dataType: 'enum', enums: ['thousand'] },
-                        { dataType: 'enum', enums: ['M'] },
-                        { dataType: 'enum', enums: ['million'] },
-                        { dataType: 'enum', enums: ['B'] },
-                        { dataType: 'enum', enums: ['billion'] },
-                        { dataType: 'enum', enums: ['T'] },
-                        { dataType: 'enum', enums: ['trillion'] },
-                    ],
-                },
-            ],
-            validators: {},
-        },
+    "WarehouseTypes.BIGQUERY": {
+        "dataType": "refEnum",
+        "enums": ["bigquery"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ConditionalOperator: {
-        dataType: 'refEnum',
-        enums: [
-            'isNull',
-            'notNull',
-            'equals',
-            'notEquals',
-            'startsWith',
-            'endsWith',
-            'include',
-            'doesNotInclude',
-            'lessThan',
-            'lessThanOrEqual',
-            'greaterThan',
-            'greaterThanOrEqual',
-            'inThePast',
-            'inTheNext',
-            'inTheCurrent',
-            'inBetween',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MetricFilterRule: {
-        dataType: 'refObject',
-        properties: {
-            values: { dataType: 'array', array: { dataType: 'any' } },
-            operator: { ref: 'ConditionalOperator', required: true },
-            id: { dataType: 'string', required: true },
-            target: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    fieldRef: { dataType: 'string', required: true },
-                },
-                required: true,
-            },
-            settings: { dataType: 'any' },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AdditionalMetric: {
-        dataType: 'refObject',
-        properties: {
-            label: { dataType: 'string' },
-            type: { ref: 'MetricType', required: true },
-            description: { dataType: 'string' },
-            sql: { dataType: 'string', required: true },
-            hidden: { dataType: 'boolean' },
-            round: { dataType: 'double' },
-            compact: { ref: 'CompactOrAlias' },
-            format: { dataType: 'string' },
-            table: { dataType: 'string', required: true },
-            name: { dataType: 'string', required: true },
-            index: { dataType: 'double' },
-            filters: {
-                dataType: 'array',
-                array: { dataType: 'refObject', ref: 'MetricFilterRule' },
-            },
-            baseDimensionName: { dataType: 'string' },
-            uuid: {
-                dataType: 'union',
-                subSchemas: [
-                    { dataType: 'string' },
-                    { dataType: 'enum', enums: [null] },
-                ],
-            },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MetricQueryResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                additionalMetrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
-                },
-                tableCalculations: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
-                    required: true,
-                },
-                limit: { dataType: 'double', required: true },
-                sorts: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SortField' },
-                    required: true,
-                },
-                filters: { ref: 'Filters', required: true },
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.BIGQUERY","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"project":{"dataType":"string","required":true},"dataset":{"dataType":"string","required":true},"timeoutSeconds":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true},"priority":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["interactive"]},{"dataType":"enum","enums":["batch"]},{"dataType":"undefined"}],"required":true},"retries":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true},"location":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true},"maximumBytesBilled":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiRunQueryResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        rows: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                            required: true,
-                        },
-                        metricQuery: {
-                            ref: 'MetricQueryResponse',
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    RunQueryRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                csvLimit: { dataType: 'double' },
-                additionalMetrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
-                },
-                tableCalculations: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
-                    required: true,
-                },
-                limit: { dataType: 'double', required: true },
-                sorts: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SortField' },
-                    required: true,
-                },
-                filters: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        metrics: { dataType: 'any' },
-                        dimensions: { dataType: 'any' },
-                    },
-                    required: true,
-                },
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'FieldId' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "BigqueryCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerFormat: {
-        dataType: 'refEnum',
-        enums: ['csv', 'image'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerCsvOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                limit: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['table'] },
-                        { dataType: 'enum', enums: ['all'] },
-                        { dataType: 'double' },
-                    ],
-                    required: true,
-                },
-                formatted: { dataType: 'boolean', required: true },
-            },
-            validators: {},
-        },
+    "WarehouseTypes.DATABRICKS": {
+        "dataType": "refEnum",
+        "enums": ["databricks"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerImageOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            validators: {},
-        },
+    "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.DATABRICKS","required":true},"database":{"dataType":"string","required":true},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"catalog":{"dataType":"string"},"serverHostName":{"dataType":"string","required":true},"httpPath":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'SchedulerCsvOptions' },
-                { ref: 'SchedulerImageOptions' },
-            ],
-            validators: {},
-        },
+    "Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerBase: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                options: { ref: 'SchedulerOptions', required: true },
-                dashboardUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedChartUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                cron: { dataType: 'string', required: true },
-                format: { ref: 'SchedulerFormat', required: true },
-                createdBy: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                name: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "DatabricksCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dashboardUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedChartUuid: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "WarehouseTypes.TRINO": {
+        "dataType": "refEnum",
+        "enums": ["trino"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DashboardScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dashboardUuid: { dataType: 'string', required: true },
-                        savedChartUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.TRINO","required":true},"schema":{"dataType":"string","required":true},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"http_scheme":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Scheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ChartScheduler' },
-                { ref: 'DashboardScheduler' },
-            ],
-            validators: {},
-        },
+    "Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerSlackTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                channel: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerSlackTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "TrinoCredentials": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerEmailTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                recipient: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerEmailTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "WarehouseCredentials": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"SnowflakeCredentials"},{"ref":"RedshiftCredentials"},{"ref":"PostgresCredentials"},{"ref":"BigqueryCredentials"},{"ref":"DatabricksCredentials"},{"ref":"TrinoCredentials"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerAndTargets: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'Scheduler' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        targets: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { ref: 'SchedulerSlackTarget' },
-                                    { ref: 'SchedulerEmailTarget' },
-                                ],
-                            },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Project": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"copiedFromProjectUuid":{"dataType":"string"},"pinnedListUuid":{"dataType":"string"},"warehouseConnection":{"ref":"WarehouseCredentials"},"dbtConnection":{"ref":"DbtProjectConfig","required":true},"type":{"ref":"ProjectType","required":true},"name":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerJobStatus: {
-        dataType: 'refEnum',
-        enums: ['scheduled', 'started', 'completed', 'error'],
+    "ApiProjectResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Project","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.any_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            validators: {},
-        },
+    "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"spaceName":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerLog: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                details: { ref: 'Record_string.any_' },
-                targetType: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['email'] },
-                        { dataType: 'enum', enums: ['slack'] },
-                    ],
-                },
-                target: { dataType: 'string' },
-                status: { ref: 'SchedulerJobStatus', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                scheduledTime: { dataType: 'datetime', required: true },
-                jobGroup: { dataType: 'string' },
-                jobId: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string' },
-                task: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'enum',
-                            enums: ['handleScheduledDelivery'],
-                        },
-                        { dataType: 'enum', enums: ['sendEmailNotification'] },
-                        { dataType: 'enum', enums: ['sendSlackNotification'] },
-                        { dataType: 'enum', enums: ['downloadCsv'] },
-                        { dataType: 'enum', enums: ['compileProject'] },
-                        { dataType: 'enum', enums: ['testAndCompileProject'] },
-                        { dataType: 'enum', enums: ['validateProject'] },
-                    ],
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "ChartType": {
+        "dataType": "refEnum",
+        "enums": ["cartesian","table","big_number","pie"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerWithLogs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                logs: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerLog' },
-                    required: true,
-                },
-                dashboards: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            dashboardUuid: {
-                                dataType: 'string',
-                                required: true,
-                            },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                charts: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            savedChartUuid: {
-                                dataType: 'string',
-                                required: true,
-                            },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                users: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            userUuid: { dataType: 'string', required: true },
-                            lastName: { dataType: 'string', required: true },
-                            firstName: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                schedulers: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
+    "ChartSummary": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartType"},{"dataType":"undefined"}]}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSchedulerLogsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'SchedulerWithLogs', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiChartSummaryListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ChartSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSchedulerAndTargetsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'SchedulerAndTargets', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ScheduledJobs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                id: { dataType: 'string', required: true },
-                date: { dataType: 'datetime', required: true },
-            },
-            validators: {},
-        },
+    "SpaceSummary": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiScheduledJobsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ScheduledJobs' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiSpaceSummaryListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiJobStatusResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ProjectMemberRole": {
+        "dataType": "refEnum",
+        "enums": ["viewer","interactive_viewer","editor","developer","admin"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ShareUrl: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                host: { dataType: 'string' },
-                url: { dataType: 'string' },
-                shareUrl: { dataType: 'string' },
-                organizationUuid: { dataType: 'string' },
-                createdByUserUuid: { dataType: 'string' },
-                params: { dataType: 'string', required: true },
-                path: { dataType: 'string', required: true },
-                nanoid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ProjectMemberProfile": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"role":{"ref":"ProjectMemberRole","required":true},"projectUuid":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiShareResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'ShareUrl', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ApiProjectAccessListResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ProjectMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ShareUrl.path-or-params_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                path: { dataType: 'string', required: true },
-                params: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "CreateProjectMember": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"sendEmail":{"dataType":"boolean","required":true},"role":{"ref":"ProjectMemberRole","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateShareUrl: {
-        dataType: 'refAlias',
-        type: { ref: 'Pick_ShareUrl.path-or-params_', validators: {} },
+    "UpdateProjectMember": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"ProjectMemberRole","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SlackChannel: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string', required: true },
-                id: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "FieldId": {
+        "dataType": "refAlias",
+        "type": {"dataType":"string","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSlackChannelsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SlackChannel' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "FilterGroupResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"or":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}},{"dataType":"nestedObjectLiteral","nestedProperties":{"and":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
+    "Filters": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"ref":"FilterGroupResponse"},"dimensions":{"ref":"FilterGroupResponse"}},"validators":{}},
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ViewStatistics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                firstViewedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                views: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
+    "SortField": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"descending":{"dataType":"boolean","required":true},"fieldId":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceQuery: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_',
-                },
-                { ref: 'ViewStatistics' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        validationErrors: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'refAlias',
-                                ref: 'ValidationSummary',
-                            },
-                        },
-                        chartType: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'ChartKind' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "TableCalculationFormatType": {
+        "dataType": "refEnum",
+        "enums": ["default","percent","currency","number"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    organizationUuid: { dataType: 'string', required: true },
-                    uuid: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    projectUuid: { dataType: 'string', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    views: { dataType: 'double', required: true },
-                    firstViewedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
+    "NumberSeparator": {
+        "dataType": "refEnum",
+        "enums": ["default","commaPeriod","spacePeriod","periodComma","noSeparatorPeriod"],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DashboardBasicDetails: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_',
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        validationErrors: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'refAlias',
-                                ref: 'ValidationSummary',
-                            },
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Compact": {
+        "dataType": "refEnum",
+        "enums": ["thousands","millions","billions","trillions"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceDashboard: {
-        dataType: 'refAlias',
-        type: { ref: 'DashboardBasicDetails', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceShare: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                role: { ref: 'ProjectMemberRole', required: true },
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "TableCalculationFormat": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"suffix":{"dataType":"string"},"prefix":{"dataType":"string"},"compact":{"ref":"Compact"},"currency":{"dataType":"string"},"separator":{"ref":"NumberSeparator"},"round":{"dataType":"double"},"type":{"ref":"TableCalculationFormatType","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Space: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                pinnedListUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                access: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
-                    required: true,
-                },
-                dashboards: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceDashboard' },
-                    required: true,
-                },
-                projectUuid: { dataType: 'string', required: true },
-                queries: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceQuery' },
-                    required: true,
-                },
-                isPrivate: { dataType: 'boolean', required: true },
-                name: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "TableCalculation": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"format":{"ref":"TableCalculationFormat"},"sql":{"dataType":"string","required":true},"displayName":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"index":{"dataType":"double"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSpaceResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Space', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "MetricType": {
+        "dataType": "refEnum",
+        "enums": ["percentile","average","count","count_distinct","sum","min","max","number","median","string","date","boolean"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateSpace: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                access: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
-                },
-                isPrivate: { dataType: 'boolean' },
-                name: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "CompactOrAlias": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"Compact"},{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["K"]},{"dataType":"enum","enums":["thousand"]},{"dataType":"enum","enums":["M"]},{"dataType":"enum","enums":["million"]},{"dataType":"enum","enums":["B"]},{"dataType":"enum","enums":["billion"]},{"dataType":"enum","enums":["T"]},{"dataType":"enum","enums":["trillion"]}]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateSpace: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                isPrivate: { dataType: 'boolean', required: true },
-                name: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "ConditionalOperator": {
+        "dataType": "refEnum",
+        "enums": ["isNull","notNull","equals","notEquals","startsWith","endsWith","include","doesNotInclude","lessThan","lessThanOrEqual","greaterThan","greaterThanOrEqual","inThePast","inTheNext","inTheCurrent","inBetween"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AddSpaceShare: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
+    "MetricFilterRule": {
+        "dataType": "refObject",
+        "properties": {
+            "values": {"dataType":"array","array":{"dataType":"any"}},
+            "operator": {"ref":"ConditionalOperator","required":true},
+            "id": {"dataType":"string","required":true},
+            "target": {"dataType":"nestedObjectLiteral","nestedProperties":{"fieldRef":{"dataType":"string","required":true}},"required":true},
+            "settings": {"dataType":"any"},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SshKeyPair.publicKey_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                publicKey: { dataType: 'string', required: true },
-            },
-            validators: {},
+    "AdditionalMetric": {
+        "dataType": "refObject",
+        "properties": {
+            "label": {"dataType":"string"},
+            "type": {"ref":"MetricType","required":true},
+            "description": {"dataType":"string"},
+            "sql": {"dataType":"string","required":true},
+            "hidden": {"dataType":"boolean"},
+            "round": {"dataType":"double"},
+            "compact": {"ref":"CompactOrAlias"},
+            "format": {"dataType":"string"},
+            "table": {"dataType":"string","required":true},
+            "name": {"dataType":"string","required":true},
+            "index": {"dataType":"double"},
+            "filters": {"dataType":"array","array":{"dataType":"refObject","ref":"MetricFilterRule"}},
+            "baseDimensionName": {"dataType":"string"},
+            "uuid": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
         },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSshKeyPairResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Pick_SshKeyPair.publicKey_', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "MetricQueryResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"ref":"Filters","required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailOneTimePassword: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                numberOfAttempts: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-            },
-            validators: {},
-        },
+    "ApiRunQueryResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"rows":{"dataType":"array","array":{"dataType":"any"},"required":true},"metricQuery":{"ref":"MetricQueryResponse","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailStatus: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                otp: { ref: 'EmailOneTimePassword' },
-                isVerified: { dataType: 'boolean', required: true },
-                email: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "RunQueryRequest": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"csvLimit":{"dataType":"double"},"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"any"},"dimensions":{"dataType":"any"}},"required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailOneTimePasswordExpiring: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'EmailOneTimePassword' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        isMaxAttempts: { dataType: 'boolean', required: true },
-                        isExpired: { dataType: 'boolean', required: true },
-                        expiresAt: { dataType: 'datetime', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "SchedulerFormat": {
+        "dataType": "refEnum",
+        "enums": ["csv","image"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailStatusExpiring: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'EmailStatus' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        otp: { ref: 'EmailOneTimePasswordExpiring' },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "SchedulerCsvOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"limit":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["table"]},{"dataType":"enum","enums":["all"]},{"dataType":"double"}],"required":true},"formatted":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiEmailStatusResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'EmailStatusExpiring', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerImageOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAllowedOrganization: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                membersCount: { dataType: 'double', required: true },
-                name: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    "SchedulerOptions": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"SchedulerCsvOptions"},{"ref":"SchedulerImageOptions"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUserAllowedOrganizationsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'UserAllowedOrganization',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerBase": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"options":{"ref":"SchedulerOptions","required":true},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"savedChartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"cron":{"dataType":"string","required":true},"format":{"ref":"SchedulerFormat","required":true},"createdBy":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiJobScheduledResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        jobId: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "ChartScheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"enum","enums":[null],"required":true},"savedChartUuid":{"dataType":"string","required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'sorting', 'filter', 'metric', 'model', 'dimension'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationSourceType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'table'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationResponseBase: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                source: { ref: 'ValidationSourceType' },
-                spaceUuid: { dataType: 'string' },
-                projectUuid: { dataType: 'string', required: true },
-                errorType: { ref: 'ValidationErrorType', required: true },
-                error: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
+    "DashboardScheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"savedChartUuid":{"dataType":"enum","enums":[null],"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorChartResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ValidationResponseBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        chartName: { dataType: 'string' },
-                        chartViews: { dataType: 'double', required: true },
-                        lastUpdatedAt: { dataType: 'datetime' },
-                        lastUpdatedBy: { dataType: 'string' },
-                        fieldName: { dataType: 'string' },
-                        chartType: { ref: 'ChartKind' },
-                        chartUuid: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "Scheduler": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ChartScheduler"},{"ref":"DashboardScheduler"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorDashboardResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ValidationResponseBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dashboardViews: { dataType: 'double', required: true },
-                        lastUpdatedAt: { dataType: 'datetime' },
-                        lastUpdatedBy: { dataType: 'string' },
-                        fieldName: { dataType: 'string' },
-                        chartName: { dataType: 'string' },
-                        dashboardUuid: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "SchedulerSlackTarget": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"channel":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerSlackTargetUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                projectUuid: { dataType: 'string', required: true },
-                spaceUuid: { dataType: 'string' },
-                validationId: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                error: { dataType: 'string', required: true },
-                errorType: { ref: 'ValidationErrorType', required: true },
-                source: { ref: 'ValidationSourceType' },
-            },
-            validators: {},
-        },
+    "SchedulerEmailTarget": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"recipient":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerEmailTargetUuid":{"dataType":"string","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_ValidationResponseBase.name_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__',
-            validators: {},
-        },
+    "SchedulerAndTargets": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Scheduler"},{"dataType":"nestedObjectLiteral","nestedProperties":{"targets":{"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"SchedulerSlackTarget"},{"ref":"SchedulerEmailTarget"}]},"required":true}}}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationErrorTableResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'Omit_ValidationResponseBase.name_' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+    "SchedulerJobStatus": {
+        "dataType": "refEnum",
+        "enums": ["scheduled","started","completed","error"],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ValidationResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ValidationErrorChartResponse' },
-                { ref: 'ValidationErrorDashboardResponse' },
-                { ref: 'ValidationErrorTableResponse' },
-            ],
-            validators: {},
-        },
+    "Record_string.any_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiValidateResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ValidationResponse' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerLog": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"details":{"ref":"Record_string.any_"},"targetType":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["email"]},{"dataType":"enum","enums":["slack"]}]},"target":{"dataType":"string"},"status":{"ref":"SchedulerJobStatus","required":true},"createdAt":{"dataType":"datetime","required":true},"scheduledTime":{"dataType":"datetime","required":true},"jobGroup":{"dataType":"string"},"jobId":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string"},"task":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["handleScheduledDelivery"]},{"dataType":"enum","enums":["sendEmailNotification"]},{"dataType":"enum","enums":["sendSlackNotification"]},{"dataType":"enum","enums":["downloadCsv"]},{"dataType":"enum","enums":["compileProject"]},{"dataType":"enum","enums":["testAndCompileProject"]},{"dataType":"enum","enums":["validateProject"]}],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiValidationDismissResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
+    "SchedulerWithLogs": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"logs":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerLog"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"charts":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"savedChartUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"users":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true}}},"required":true},"schedulers":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerAndTargets"},"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiSchedulerLogsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerWithLogs","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiSchedulerAndTargetsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerAndTargets","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ScheduledJobs": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"dataType":"string","required":true},"date":{"dataType":"datetime","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiScheduledJobsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ScheduledJobs"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiJobStatusResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ShareUrl": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"host":{"dataType":"string"},"url":{"dataType":"string"},"shareUrl":{"dataType":"string"},"organizationUuid":{"dataType":"string"},"createdByUserUuid":{"dataType":"string"},"params":{"dataType":"string","required":true},"path":{"dataType":"string","required":true},"nanoid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiShareResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"ShareUrl","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_ShareUrl.path-or-params_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"path":{"dataType":"string","required":true},"params":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateShareUrl": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_ShareUrl.path-or-params_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "SlackChannel": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiSlackChannelsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SlackChannel"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ViewStatistics": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"views":{"dataType":"double","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "SpaceQuery": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"},{"ref":"ViewStatistics"},{"dataType":"nestedObjectLiteral","nestedProperties":{"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"projectUuid":{"dataType":"string","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DashboardBasicDetails": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "SpaceDashboard": {
+        "dataType": "refAlias",
+        "type": {"ref":"DashboardBasicDetails","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "SpaceShare": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"ProjectMemberRole","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Space": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"access":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceShare"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceDashboard"},"required":true},"projectUuid":{"dataType":"string","required":true},"queries":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceQuery"},"required":true},"isPrivate":{"dataType":"boolean","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiSpaceResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Space","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateSpace": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceShare"}},"isPrivate":{"dataType":"boolean"},"name":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UpdateSpace": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isPrivate":{"dataType":"boolean","required":true},"name":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AddSpaceShare": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_SshKeyPair.publicKey_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"publicKey":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiSshKeyPairResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Pick_SshKeyPair.publicKey_","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailOneTimePassword": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"numberOfAttempts":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailStatus": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePassword"},"isVerified":{"dataType":"boolean","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailOneTimePasswordExpiring": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailOneTimePassword"},{"dataType":"nestedObjectLiteral","nestedProperties":{"isMaxAttempts":{"dataType":"boolean","required":true},"isExpired":{"dataType":"boolean","required":true},"expiresAt":{"dataType":"datetime","required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmailStatusExpiring": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailStatus"},{"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePasswordExpiring"}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiEmailStatusResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"EmailStatusExpiring","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserAllowedOrganization": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"membersCount":{"dataType":"double","required":true},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiUserAllowedOrganizationsResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"UserAllowedOrganization"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiJobScheduledResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"jobId":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorType": {
+        "dataType": "refEnum",
+        "enums": ["chart","sorting","filter","metric","model","dimension"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationSourceType": {
+        "dataType": "refEnum",
+        "enums": ["chart","dashboard","table"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationResponseBase": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"source":{"ref":"ValidationSourceType"},"spaceUuid":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType","required":true},"error":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorChartResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartName":{"dataType":"string"},"chartViews":{"dataType":"double","required":true},"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartType":{"ref":"ChartKind"},"chartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorDashboardResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardViews":{"dataType":"double","required":true},"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartName":{"dataType":"string"},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string"},"validationId":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true},"error":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType","required":true},"source":{"ref":"ValidationSourceType"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Omit_ValidationResponseBase.name_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationErrorTableResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"Omit_ValidationResponseBase.name_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ValidationErrorChartResponse"},{"ref":"ValidationErrorDashboardResponse"},{"ref":"ValidationErrorTableResponse"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiValidateResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationResponse"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiValidationDismissResponse": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -3105,25 +1103,14 @@ export function RegisterRoutes(app: express.Router) {
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
-    app.get(
-        '/api/v1/csv/:jobId',
-        ...fetchMiddlewares<RequestHandler>(CsvController),
-        ...fetchMiddlewares<RequestHandler>(CsvController.prototype.get),
+        app.get('/api/v1/csv/:jobId',
+            ...(fetchMiddlewares<RequestHandler>(CsvController)),
+            ...(fetchMiddlewares<RequestHandler>(CsvController.prototype.get)),
 
-        function CsvController_get(request: any, response: any, next: any) {
+            function CsvController_get(request: any, response: any, next: any) {
             const args = {
-                jobId: {
-                    in: 'path',
-                    name: 'jobId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3134,42 +1121,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new CsvController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.getSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getSettings)),
 
-        function DbtCloudIntegrationController_getSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_getSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3180,42 +1147,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.getSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.updateSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.updateSettings)),
 
-        function DbtCloudIntegrationController_updateSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_updateSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3226,42 +1173,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.updateSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.deleteSettings,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.deleteSettings)),
 
-        function DbtCloudIntegrationController_deleteSettings(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_deleteSettings(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3272,42 +1199,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.deleteSettings.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteSettings.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
-        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
-        ...fetchMiddlewares<RequestHandler>(
-            DbtCloudIntegrationController.prototype.getMetrics,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
+            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getMetrics)),
 
-        function DbtCloudIntegrationController_getMetrics(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function DbtCloudIntegrationController_getMetrics(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3318,42 +1225,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-                const promise = controller.getMetrics.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getMetrics.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.getGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroup)),
 
-        function GroupsController_getGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_getGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3364,42 +1251,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.getGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.deleteGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.deleteGroup)),
 
-        function GroupsController_deleteGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_deleteGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3410,48 +1277,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.deleteGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/groups/:groupUuid/members/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.addUserToGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/groups/:groupUuid/members/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.addUserToGroup)),
 
-        function GroupsController_addUserToGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_addUserToGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3462,48 +1304,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.addUserToGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.addUserToGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/groups/:groupUuid/members/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.removeUserFromGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/groups/:groupUuid/members/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.removeUserFromGroup)),
 
-        function GroupsController_removeUserFromGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_removeUserFromGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3514,42 +1331,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.removeUserFromGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.removeUserFromGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/groups/:groupUuid/members',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.getGroupMembers,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/groups/:groupUuid/members',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroupMembers)),
 
-        function GroupsController_getGroupMembers(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_getGroupMembers(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3560,48 +1357,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.getGroupMembers.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getGroupMembers.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/groups/:groupUuid',
-        ...fetchMiddlewares<RequestHandler>(GroupsController),
-        ...fetchMiddlewares<RequestHandler>(
-            GroupsController.prototype.updateGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/groups/:groupUuid',
+            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
+            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.updateGroup)),
 
-        function GroupsController_updateGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function GroupsController_updateGroup(request: any, response: any, next: any) {
             const args = {
-                groupUuid: {
-                    in: 'path',
-                    name: 'groupUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateGroup',
-                },
+                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateGroup"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3612,36 +1384,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-                const promise = controller.updateGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganization)),
 
-        function OrganizationController_getOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3652,42 +1409,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.createOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createOrganization)),
 
-        function OrganizationController_createOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_createOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateOrganization',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateOrganization"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3698,42 +1435,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.createOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.updateOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganization)),
 
-        function OrganizationController_updateOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateOrganization',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateOrganization"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3744,42 +1461,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.updateOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/org/:organizationUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.deleteOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/org/:organizationUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteOrganization)),
 
-        function OrganizationController_deleteOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_deleteOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                organizationUuid: {
-                    in: 'path',
-                    name: 'organizationUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3790,36 +1487,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.deleteOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/projects',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getProjects,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/projects',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getProjects)),
 
-        function OrganizationController_getProjects(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getProjects(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3830,36 +1512,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getProjects.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getProjects.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/users',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganizationMembers,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/users',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationMembers)),
 
-        function OrganizationController_getOrganizationMembers(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganizationMembers(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3870,48 +1537,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getOrganizationMembers.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationMembers.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org/users/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.updateOrganizationMember,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org/users/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationMember)),
 
-        function OrganizationController_updateOrganizationMember(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganizationMember(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'OrganizationMemberProfileUpdate',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"OrganizationMemberProfileUpdate"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3922,42 +1564,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.updateOrganizationMember.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganizationMember.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/org/user/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.deleteUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/org/user/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteUser)),
 
-        function OrganizationController_deleteUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_deleteUser(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -3968,36 +1590,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.deleteUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/allowedEmailDomains',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganizationAllowedEmailDomains,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/allowedEmailDomains',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationAllowedEmailDomains)),
 
-        function OrganizationController_getOrganizationAllowedEmailDomains(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_getOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4008,44 +1615,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise =
-                    controller.getOrganizationAllowedEmailDomains.apply(
-                        controller,
-                        validatedArgs as any,
-                    );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/org/allowedEmailDomains',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype
-                .updateOrganizationAllowedEmailDomains,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/org/allowedEmailDomains',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationAllowedEmailDomains)),
 
-        function OrganizationController_updateOrganizationAllowedEmailDomains(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_updateOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateAllowedEmailDomains',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateAllowedEmailDomains"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4056,43 +1641,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise =
-                    controller.updateOrganizationAllowedEmailDomains.apply(
-                        controller,
-                        validatedArgs as any,
-                    );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.updateOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/org/groups',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.createGroup,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/org/groups',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createGroup)),
 
-        function OrganizationController_createGroup(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_createGroup(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'Pick_CreateGroup.name_',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"ref":"Pick_CreateGroup.name_"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4103,36 +1667,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.createGroup.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createGroup.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/org/groups',
-        ...fetchMiddlewares<RequestHandler>(OrganizationController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.listGroupsInOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/org/groups',
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
+            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.listGroupsInOrganization)),
 
-        function OrganizationController_listGroupsInOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function OrganizationController_listGroupsInOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4143,42 +1692,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.listGroupsInOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.listGroupsInOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
-        ...fetchMiddlewares<RequestHandler>(PinningController),
-        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
+            ...(fetchMiddlewares<RequestHandler>(PinningController)),
+            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.get)),
 
-        function PinningController_get(request: any, response: any, next: any) {
+            function PinningController_get(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                pinnedListUuid: {
-                    in: 'path',
-                    name: 'pinnedListUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4189,56 +1719,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
-        ...fetchMiddlewares<RequestHandler>(PinningController),
-        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.post),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
+            ...(fetchMiddlewares<RequestHandler>(PinningController)),
+            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.post)),
 
-        function PinningController_post(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function PinningController_post(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                pinnedListUuid: {
-                    in: 'path',
-                    name: 'pinnedListUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'UpdatePinnedItemOrder',
-                    },
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"dataType":"array","array":{"dataType":"refAlias","ref":"UpdatePinnedItemOrder"}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4249,42 +1747,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-                const promise = controller.post.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.post.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getProject,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getProject)),
 
-        function ProjectController_getProject(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getProject(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4295,42 +1773,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getProject.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getProject.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/charts',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getChartsInProject,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/charts',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getChartsInProject)),
 
-        function ProjectController_getChartsInProject(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getChartsInProject(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4341,42 +1799,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getChartsInProject.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getChartsInProject.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/spaces',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getSpacesInProject,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/spaces',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getSpacesInProject)),
 
-        function ProjectController_getSpacesInProject(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getSpacesInProject(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4387,42 +1825,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getSpacesInProject.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getSpacesInProject.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/access',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.getProjectAccessList,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/access',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getProjectAccessList)),
 
-        function ProjectController_getProjectAccessList(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_getProjectAccessList(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4433,48 +1851,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.getProjectAccessList.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getProjectAccessList.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/access',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.grantProjectAccessToUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/access',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.grantProjectAccessToUser)),
 
-        function ProjectController_grantProjectAccessToUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_grantProjectAccessToUser(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateProjectMember',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateProjectMember"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4485,54 +1878,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.grantProjectAccessToUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.grantProjectAccessToUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/projects/:projectUuid/access/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.updateProjectAccessForUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/projects/:projectUuid/access/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.updateProjectAccessForUser)),
 
-        function ProjectController_updateProjectAccessForUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_updateProjectAccessForUser(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateProjectMember',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateProjectMember"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4543,48 +1906,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.updateProjectAccessForUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.updateProjectAccessForUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/access/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.revokeProjectAccessForUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/access/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
+            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.revokeProjectAccessForUser)),
 
-        function ProjectController_revokeProjectAccessForUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ProjectController_revokeProjectAccessForUser(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4595,54 +1933,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-                const promise = controller.revokeProjectAccessForUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.revokeProjectAccessForUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
-        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
-        ...fetchMiddlewares<RequestHandler>(
-            RunViewChartQueryController.prototype.postUnderlyingData,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postUnderlyingData)),
 
-        function RunViewChartQueryController_postUnderlyingData(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function RunViewChartQueryController_postUnderlyingData(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'RunQueryRequest',
-                },
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                exploreId: {
-                    in: 'path',
-                    name: 'exploreId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4653,54 +1961,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-                const promise = controller.postUnderlyingData.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postUnderlyingData.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
-        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
-        ...fetchMiddlewares<RequestHandler>(
-            RunViewChartQueryController.prototype.postRunQuery,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
+            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postRunQuery)),
 
-        function RunViewChartQueryController_postRunQuery(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function RunViewChartQueryController_postRunQuery(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'RunQueryRequest',
-                },
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                exploreId: {
-                    in: 'path',
-                    name: 'exploreId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4711,49 +1989,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-                const promise = controller.postRunQuery.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postRunQuery.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/saved/:chartUuid/results',
-        ...fetchMiddlewares<RequestHandler>(SavedChartController),
-        ...fetchMiddlewares<RequestHandler>(
-            SavedChartController.prototype.postDashboardTile,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/saved/:chartUuid/results',
+            ...(fetchMiddlewares<RequestHandler>(SavedChartController)),
+            ...(fetchMiddlewares<RequestHandler>(SavedChartController.prototype.postDashboardTile)),
 
-        function SavedChartController_postDashboardTile(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SavedChartController_postDashboardTile(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: { filters: { ref: 'Filters' } },
-                },
-                chartUuid: {
-                    in: 'path',
-                    name: 'chartUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"filters":{"ref":"Filters"}}},
+                    chartUuid: {"in":"path","name":"chartUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4764,42 +2016,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SavedChartController();
 
-                const promise = controller.postDashboardTile.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.postDashboardTile.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:projectUuid/logs',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getLogs,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:projectUuid/logs',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getLogs)),
 
-        function SchedulerController_getLogs(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getLogs(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4810,40 +2042,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getLogs.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getLogs.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get)),
 
-        function SchedulerController_get(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_get(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4854,48 +2068,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.patch,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.patch)),
 
-        function SchedulerController_patch(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_patch(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'any',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"dataType":"any"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4906,42 +2095,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.patch.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.patch.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/schedulers/:schedulerUuid',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.delete,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/schedulers/:schedulerUuid',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.delete)),
 
-        function SchedulerController_delete(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_delete(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4952,42 +2121,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.delete.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.delete.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/:schedulerUuid/jobs',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getJobs,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/:schedulerUuid/jobs',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getJobs)),
 
-        function SchedulerController_getJobs(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getJobs(request: any, response: any, next: any) {
             const args = {
-                schedulerUuid: {
-                    in: 'path',
-                    name: 'schedulerUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -4998,42 +2147,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getJobs.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getJobs.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/schedulers/job/:jobId/status',
-        ...fetchMiddlewares<RequestHandler>(SchedulerController),
-        ...fetchMiddlewares<RequestHandler>(
-            SchedulerController.prototype.getSchedulerStatus,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/schedulers/job/:jobId/status',
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
+            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getSchedulerStatus)),
 
-        function SchedulerController_getSchedulerStatus(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SchedulerController_getSchedulerStatus(request: any, response: any, next: any) {
             const args = {
-                jobId: {
-                    in: 'path',
-                    name: 'jobId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5044,36 +2173,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-                const promise = controller.getSchedulerStatus.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getSchedulerStatus.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/share/:nanoId',
-        ...fetchMiddlewares<RequestHandler>(ShareController),
-        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/share/:nanoId',
+            ...(fetchMiddlewares<RequestHandler>(ShareController)),
+            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.get)),
 
-        function ShareController_get(request: any, response: any, next: any) {
+            function ShareController_get(request: any, response: any, next: any) {
             const args = {
-                nanoId: {
-                    in: 'path',
-                    name: 'nanoId',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    nanoId: {"in":"path","name":"nanoId","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5084,40 +2199,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/share',
-        ...fetchMiddlewares<RequestHandler>(ShareController),
-        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.create),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/share',
+            ...(fetchMiddlewares<RequestHandler>(ShareController)),
+            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.create)),
 
-        function ShareController_create(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ShareController_create(request: any, response: any, next: any) {
             const args = {
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateShareUrl',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateShareUrl"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5128,30 +2225,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-                const promise = controller.create.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.create.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/slack/channels',
-        ...fetchMiddlewares<RequestHandler>(SlackController),
-        ...fetchMiddlewares<RequestHandler>(SlackController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/slack/channels',
+            ...(fetchMiddlewares<RequestHandler>(SlackController)),
+            ...(fetchMiddlewares<RequestHandler>(SlackController.prototype.get)),
 
-        function SlackController_get(request: any, response: any, next: any) {
+            function SlackController_get(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5162,46 +2250,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SlackController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(SpaceController.prototype.getSpace),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.getSpace)),
 
-        function SpaceController_getSpace(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_getSpace(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                spaceUuid: {
-                    in: 'path',
-                    name: 'spaceUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5212,48 +2277,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.getSpace.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.getSpace.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/spaces',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(
-            SpaceController.prototype.createSpace,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/spaces',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.createSpace)),
 
-        function SpaceController_createSpace(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_createSpace(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'CreateSpace',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"CreateSpace"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5264,48 +2304,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.createSpace.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.createSpace.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(
-            SpaceController.prototype.deleteSpace,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.deleteSpace)),
 
-        function SpaceController_deleteSpace(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_deleteSpace(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                spaceUuid: {
-                    in: 'path',
-                    name: 'spaceUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5316,54 +2331,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.deleteSpace.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 204, next);
+
+              const promise = controller.deleteSpace.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 204, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.patch(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(
-            SpaceController.prototype.updateSpace,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.patch('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.updateSpace)),
 
-        function SpaceController_updateSpace(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_updateSpace(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                spaceUuid: {
-                    in: 'path',
-                    name: 'spaceUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateSpace',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"UpdateSpace"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5374,54 +2359,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.updateSpace.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.updateSpace.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(
-            SpaceController.prototype.addSpaceShare,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/spaces/:spaceUuid/share',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.addSpaceShare)),
 
-        function SpaceController_addSpaceShare(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_addSpaceShare(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                spaceUuid: {
-                    in: 'path',
-                    name: 'spaceUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'AddSpaceShare',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
+                    body: {"in":"body","name":"body","required":true,"ref":"AddSpaceShare"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5432,54 +2387,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.addSpaceShare.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.addSpaceShare.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share/:userUuid',
-        ...fetchMiddlewares<RequestHandler>(SpaceController),
-        ...fetchMiddlewares<RequestHandler>(
-            SpaceController.prototype.revokeSpaceAccessForUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/spaces/:spaceUuid/share/:userUuid',
+            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
+            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.revokeSpaceAccessForUser)),
 
-        function SpaceController_revokeSpaceAccessForUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SpaceController_revokeSpaceAccessForUser(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                spaceUuid: {
-                    in: 'path',
-                    name: 'spaceUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                userUuid: {
-                    in: 'path',
-                    name: 'userUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
+                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5490,36 +2415,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-                const promise = controller.revokeSpaceAccessForUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.revokeSpaceAccessForUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/ssh/key-pairs',
-        ...fetchMiddlewares<RequestHandler>(SshController),
-        ...fetchMiddlewares<RequestHandler>(
-            SshController.prototype.createSshKeyPair,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/ssh/key-pairs',
+            ...(fetchMiddlewares<RequestHandler>(SshController)),
+            ...(fetchMiddlewares<RequestHandler>(SshController.prototype.createSshKeyPair)),
 
-        function SshController_createSshKeyPair(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function SshController_createSshKeyPair(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5530,36 +2440,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SshController();
 
-                const promise = controller.createSshKeyPair.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 201, next);
+
+              const promise = controller.createSshKeyPair.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.put(
-        '/api/v1/user/me/email/otp',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.createEmailOneTimePasscode,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.put('/api/v1/user/me/email/otp',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.createEmailOneTimePasscode)),
 
-        function UserController_createEmailOneTimePasscode(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_createEmailOneTimePasscode(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5570,37 +2465,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.createEmailOneTimePasscode.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.createEmailOneTimePasscode.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/user/me/email/status',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.getEmailVerificationStatus,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/user/me/email/status',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getEmailVerificationStatus)),
 
-        function UserController_getEmailVerificationStatus(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_getEmailVerificationStatus(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                passcode: { in: 'query', name: 'passcode', dataType: 'string' },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    passcode: {"in":"query","name":"passcode","dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5611,36 +2491,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.getEmailVerificationStatus.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getEmailVerificationStatus.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/user/me/allowedOrganizations',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.getOrganizationsUserCanJoin,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/user/me/allowedOrganizations',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getOrganizationsUserCanJoin)),
 
-        function UserController_getOrganizationsUserCanJoin(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_getOrganizationsUserCanJoin(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5651,42 +2516,22 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.getOrganizationsUserCanJoin.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.getOrganizationsUserCanJoin.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/user/me/joinOrganization/:organizationUuid',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.joinOrganization,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/user/me/joinOrganization/:organizationUuid',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.joinOrganization)),
 
-        function UserController_joinOrganization(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_joinOrganization(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                organizationUuid: {
-                    in: 'path',
-                    name: 'organizationUuid',
-                    required: true,
-                    dataType: 'string',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5697,36 +2542,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.joinOrganization.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.joinOrganization.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/user/me',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.deleteUser,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/user/me',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.deleteUser)),
 
-        function UserController_deleteUser(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function UserController_deleteUser(request: any, response: any, next: any) {
             const args = {
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5737,54 +2567,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-                const promise = controller.deleteUser.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, undefined, next);
+
+              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/validate',
-        ...fetchMiddlewares<RequestHandler>(ValidationController),
-        ...fetchMiddlewares<RequestHandler>(
-            ValidationController.prototype.post,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/api/v1/projects/:projectUuid/validate',
+            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
+            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.post)),
 
-        function ValidationController_post(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ValidationController_post(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        explores: {
-                            dataType: 'array',
-                            array: { dataType: 'any' },
-                        },
-                    },
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"explores":{"dataType":"array","array":{"dataType":"any"}}}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5795,46 +2594,24 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-                const promise = controller.post.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.post.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.get(
-        '/api/v1/projects/:projectUuid/validate',
-        ...fetchMiddlewares<RequestHandler>(ValidationController),
-        ...fetchMiddlewares<RequestHandler>(ValidationController.prototype.get),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/api/v1/projects/:projectUuid/validate',
+            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
+            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.get)),
 
-        function ValidationController_get(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ValidationController_get(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                fromSettings: {
-                    in: 'query',
-                    name: 'fromSettings',
-                    dataType: 'boolean',
-                },
-                jobId: { in: 'query', name: 'jobId', dataType: 'string' },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                    fromSettings: {"in":"query","name":"fromSettings","dataType":"boolean"},
+                    jobId: {"in":"query","name":"jobId","dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5845,48 +2622,23 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-                const promise = controller.get.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.get.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.delete(
-        '/api/v1/projects/:projectUuid/validate/:validationId',
-        ...fetchMiddlewares<RequestHandler>(ValidationController),
-        ...fetchMiddlewares<RequestHandler>(
-            ValidationController.prototype.dismiss,
-        ),
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.delete('/api/v1/projects/:projectUuid/validate/:validationId',
+            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
+            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.dismiss)),
 
-        function ValidationController_dismiss(
-            request: any,
-            response: any,
-            next: any,
-        ) {
+            function ValidationController_dismiss(request: any, response: any, next: any) {
             const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                validationId: {
-                    in: 'path',
-                    name: 'validationId',
-                    required: true,
-                    dataType: 'double',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
+                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
+                    validationId: {"in":"path","name":"validationId","required":true,"dataType":"double"},
+                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -5897,37 +2649,25 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-                const promise = controller.dismiss.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
+
+              const promise = controller.dismiss.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function isController(object: any): object is Controller {
-        return (
-            'getHeaders' in object &&
-            'getStatus' in object &&
-            'setStatus' in object
-        );
+        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
     }
 
-    function promiseHandler(
-        controllerObj: any,
-        promise: any,
-        response: any,
-        successStatus: any,
-        next: any,
-    ) {
+    function promiseHandler(controllerObj: any, promise: any, response: any, successStatus: any, next: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 let statusCode = successStatus;
@@ -5939,31 +2679,21 @@ export function RegisterRoutes(app: express.Router) {
 
                 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-                returnHandler(response, statusCode, data, headers);
+                returnHandler(response, statusCode, data, headers)
             })
             .catch((error: any) => next(error));
     }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function returnHandler(
-        response: any,
-        statusCode?: number,
-        data?: any,
-        headers: any = {},
-    ) {
+    function returnHandler(response: any, statusCode?: number, data?: any, headers: any = {}) {
         if (response.headersSent) {
             return;
         }
         Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
         });
-        if (
-            data &&
-            typeof data.pipe === 'function' &&
-            data.readable &&
-            typeof data._read === 'function'
-        ) {
+        if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
             data.pipe(response);
         } else if (data !== null && data !== undefined) {
             response.status(statusCode || 200).json(data);
@@ -5974,108 +2704,38 @@ export function RegisterRoutes(app: express.Router) {
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function responder(
-        response: any,
-    ): TsoaResponse<HttpStatusCodeLiteral, unknown> {
-        return function (status, data, headers) {
+    function responder(response: any): TsoaResponse<HttpStatusCodeLiteral, unknown>  {
+        return function(status, data, headers) {
             returnHandler(response, status, data, headers);
         };
-    }
+    };
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function getValidatedArgs(args: any, request: any, response: any): any[] {
-        const fieldErrors: FieldErrors = {};
+        const fieldErrors: FieldErrors  = {};
         const values = Object.keys(args).map((key) => {
             const name = args[key].name;
             switch (args[key].in) {
                 case 'request':
                     return request;
                 case 'query':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.query[name],
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'path':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.params[name],
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'header':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.header(name),
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'body':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.body,
-                        name,
-                        fieldErrors,
-                        undefined,
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'body-prop':
-                    return validationService.ValidateParam(
-                        args[key],
-                        request.body[name],
-                        name,
-                        fieldErrors,
-                        'body.',
-                        { noImplicitAdditionalProperties: 'throw-on-extras' },
-                    );
+                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {"noImplicitAdditionalProperties":"throw-on-extras"});
                 case 'formData':
                     if (args[key].dataType === 'file') {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.file,
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
-                    } else if (
-                        args[key].dataType === 'array' &&
-                        args[key].array.dataType === 'file'
-                    ) {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.files,
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
+                        return validationService.ValidateParam(args[key], request.file, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    } else if (args[key].dataType === 'array' && args[key].array.dataType === 'file') {
+                        return validationService.ValidateParam(args[key], request.files, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                     } else {
-                        return validationService.ValidateParam(
-                            args[key],
-                            request.body[name],
-                            name,
-                            fieldErrors,
-                            undefined,
-                            {
-                                noImplicitAdditionalProperties:
-                                    'throw-on-extras',
-                            },
-                        );
+                        return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
                     }
                 case 'res':
                     return responder(response);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1,7 +1,16 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute, HttpStatusCodeLiteral, TsoaResponse, fetchMiddlewares } from '@tsoa/runtime';
+import {
+    Controller,
+    fetchMiddlewares,
+    FieldErrors,
+    HttpStatusCodeLiteral,
+    TsoaResponse,
+    TsoaRoute,
+    ValidateError,
+    ValidationService,
+} from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CsvController } from './../controllers/csvController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -31,1066 +40,3061 @@ import { SshController } from './../controllers/sshController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { ValidationController } from './../controllers/validationController';
 import type { RequestHandler } from 'express';
 import * as express from 'express';
+import { ValidationController } from './../controllers/validationController';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
-    "ApiErrorPayload": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"any"},"message":{"dataType":"string"},"name":{"dataType":"string","required":true},"statusCode":{"dataType":"double","required":true}},"required":true},"status":{"dataType":"enum","enums":["error"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiCsvUrlResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true},"url":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateDbtCloudIntegration.metricsJobId_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metricsJobId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudIntegration": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateDbtCloudIntegration.metricsJobId_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudIntegrationSettings": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"union","subSchemas":[{"ref":"DbtCloudIntegration"},{"dataType":"undefined"}],"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudSettingsDeleteSuccess": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudMetric": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"label":{"dataType":"string","required":true},"timeGrains":{"dataType":"array","array":{"dataType":"string"},"required":true},"description":{"dataType":"string","required":true},"dimensions":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true},"uniqueId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudMetadataResponseMetrics": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"DbtCloudMetric"},"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiDbtCloudMetrics": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"DbtCloudMetadataResponseMetrics","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Group": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organizationUuid":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Group","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSuccessEmpty": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"undefined","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "GroupMember": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupMembersResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"GroupMember"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Group.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateGroup": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_Group.name_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Organization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"defaultProjectUuid":{"dataType":"string"},"needsProject":{"dataType":"boolean"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Organization","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Organization.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateOrganization": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_Organization.name_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string"},"chartColors":{"dataType":"array","array":{"dataType":"string"}},"defaultProjectUuid":{"dataType":"string"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateOrganization": {
-        "dataType": "refAlias",
-        "type": {"ref":"Partial_Omit_Organization.organizationUuid-or-needsProject__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ProjectType": {
-        "dataType": "refEnum",
-        "enums": ["DEFAULT","PREVIEW"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationProject": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"ProjectType","required":true},"name":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationProjects": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationProject"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole": {
-        "dataType": "refEnum",
-        "enums": ["member","viewer","interactive_viewer","editor","developer","admin"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberProfile": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isInviteExpired":{"dataType":"boolean"},"isActive":{"dataType":"boolean","required":true},"role":{"ref":"OrganizationMemberRole","required":true},"organizationUuid":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationMemberProfiles": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"OrganizationMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationMemberProfile": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"OrganizationMemberProfile","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberProfileUpdate": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"OrganizationMemberRole","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole.EDITOR": {
-        "dataType": "refEnum",
-        "enums": ["editor"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole.INTERACTIVE_VIEWER": {
-        "dataType": "refEnum",
-        "enums": ["interactive_viewer"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole.VIEWER": {
-        "dataType": "refEnum",
-        "enums": ["viewer"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrganizationMemberRole.MEMBER": {
-        "dataType": "refEnum",
-        "enums": ["member"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AllowedEmailDomainsRole": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"OrganizationMemberRole.EDITOR"},{"ref":"OrganizationMemberRole.INTERACTIVE_VIEWER"},{"ref":"OrganizationMemberRole.VIEWER"},{"ref":"OrganizationMemberRole.MEMBER"}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"AllowedEmailDomainsRole","required":true},"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiOrganizationAllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"AllowedEmailDomains","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"emailDomains":{"dataType":"array","array":{"dataType":"string"},"required":true},"role":{"ref":"AllowedEmailDomainsRole","required":true},"projectUuids":{"dataType":"array","array":{"dataType":"string"},"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_AllowedEmailDomains.organizationUuid_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateAllowedEmailDomains": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_AllowedEmailDomains.organizationUuid_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateGroup.name_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiGroupListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"Group"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.DASHBOARD": {
-        "dataType": "refEnum",
-        "enums": ["dashboard"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdatedByUser": {
-        "dataType": "refObject",
-        "properties": {
-            "userUuid": {"dataType":"string","required":true},
-            "firstName": {"dataType":"string","required":true},
-            "lastName": {"dataType":"string","required":true},
+    ApiErrorPayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                error: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        data: { dataType: 'any' },
+                        message: { dataType: 'string' },
+                        name: { dataType: 'string', required: true },
+                        statusCode: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['error'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"validationId":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true},"error":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationSummary": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_ValidationResponse.error-or-createdAt-or-validationId_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewDashboardItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.DASHBOARD","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.CHART": {
-        "dataType": "refEnum",
-        "enums": ["chart"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartKind": {
-        "dataType": "refEnum",
-        "enums": ["line","horizontal_bar","vertical_bar","scatter","area","mixed","pie","table","big_number"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewChartItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_","required":true},"type":{"ref":"ResourceViewItemType.CHART","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType.SPACE": {
-        "dataType": "refEnum",
-        "enums": ["space"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewSpaceItem": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartCount":{"dataType":"double","required":true},"dashboardCount":{"dataType":"double","required":true},"accessListLength":{"dataType":"double","required":true},"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"required":true},"type":{"ref":"ResourceViewItemType.SPACE","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "PinnedItems": {
-        "dataType": "refAlias",
-        "type": {"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"ResourceViewDashboardItem"},{"ref":"ResourceViewChartItem"},{"ref":"ResourceViewSpaceItem"}]},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiPinnedItems": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"PinnedItems","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResourceViewItemType": {
-        "dataType": "refEnum",
-        "enums": ["chart","dashboard","space"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"uuid":{"dataType":"string","required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdatePinnedItemOrder": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"data":{"ref":"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_","required":true},"type":{"ref":"ResourceViewItemType","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.DBT": {
-        "dataType": "refEnum",
-        "enums": ["dbt"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectEnvironmentVariable": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"value":{"dataType":"string","required":true},"key":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType": {
-        "dataType": "refEnum",
-        "enums": ["dbt","dbt_cloud_ide","github","gitlab","bitbucket","azure_devops","none"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtLocalProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.DBT","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "profiles_dir": {"dataType":"string"},
-            "project_dir": {"dataType":"string"},
+    ApiCsvUrlResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        status: { dataType: 'string', required: true },
+                        url: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.DBT_CLOUD_IDE": {
-        "dataType": "refEnum",
-        "enums": ["dbt_cloud_ide"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtCloudIDEProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.DBT_CLOUD_IDE","required":true},
-            "api_key": {"dataType":"string","required":true},
-            "account_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
-            "environment_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
-            "project_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"}],"required":true},
+    'Pick_CreateDbtCloudIntegration.metricsJobId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metricsJobId: { dataType: 'string', required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.GITHUB": {
-        "dataType": "refEnum",
-        "enums": ["github"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtGithubProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.GITHUB","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "personal_access_token": {"dataType":"string","required":true},
-            "repository": {"dataType":"string","required":true},
-            "branch": {"dataType":"string","required":true},
-            "project_sub_path": {"dataType":"string","required":true},
-            "host_domain": {"dataType":"string"},
+    DbtCloudIntegration: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateDbtCloudIntegration.metricsJobId_',
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.BITBUCKET": {
-        "dataType": "refEnum",
-        "enums": ["bitbucket"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtBitBucketProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.BITBUCKET","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "username": {"dataType":"string","required":true},
-            "personal_access_token": {"dataType":"string","required":true},
-            "repository": {"dataType":"string","required":true},
-            "branch": {"dataType":"string","required":true},
-            "project_sub_path": {"dataType":"string","required":true},
-            "host_domain": {"dataType":"string"},
+    ApiDbtCloudIntegrationSettings: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DbtCloudIntegration' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.GITLAB": {
-        "dataType": "refEnum",
-        "enums": ["gitlab"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtGitlabProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.GITLAB","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "personal_access_token": {"dataType":"string","required":true},
-            "repository": {"dataType":"string","required":true},
-            "branch": {"dataType":"string","required":true},
-            "project_sub_path": {"dataType":"string","required":true},
-            "host_domain": {"dataType":"string"},
+    ApiDbtCloudSettingsDeleteSuccess: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { dataType: 'undefined', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.AZURE_DEVOPS": {
-        "dataType": "refEnum",
-        "enums": ["azure_devops"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtAzureDevOpsProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.AZURE_DEVOPS","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "personal_access_token": {"dataType":"string","required":true},
-            "organization": {"dataType":"string","required":true},
-            "project": {"dataType":"string","required":true},
-            "repository": {"dataType":"string","required":true},
-            "branch": {"dataType":"string","required":true},
-            "project_sub_path": {"dataType":"string","required":true},
+    DbtCloudMetric: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string', required: true },
+                timeGrains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                description: { dataType: 'string', required: true },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uniqueId: { dataType: 'string', required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectType.NONE": {
-        "dataType": "refEnum",
-        "enums": ["none"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtNoneProjectConfig": {
-        "dataType": "refObject",
-        "properties": {
-            "type": {"ref":"DbtProjectType.NONE","required":true},
-            "target": {"dataType":"string"},
-            "environment": {"dataType":"array","array":{"dataType":"refAlias","ref":"DbtProjectEnvironmentVariable"}},
-            "hideRefreshButton": {"dataType":"boolean"},
+    DbtCloudMetadataResponseMetrics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DbtCloudMetric' },
+                    required: true,
+                },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DbtProjectConfig": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"DbtLocalProjectConfig"},{"ref":"DbtCloudIDEProjectConfig"},{"ref":"DbtGithubProjectConfig"},{"ref":"DbtBitBucketProjectConfig"},{"ref":"DbtGitlabProjectConfig"},{"ref":"DbtAzureDevOpsProjectConfig"},{"ref":"DbtNoneProjectConfig"}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.SNOWFLAKE": {
-        "dataType": "refEnum",
-        "enums": ["snowflake"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WeekDay": {
-        "dataType": "refEnum",
-        "enums": [0,1,2,3,4,5,6],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"dataType":"string"},"type":{"ref":"WarehouseTypes.SNOWFLAKE","required":true},"account":{"dataType":"string","required":true},"database":{"dataType":"string","required":true},"warehouse":{"dataType":"string","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"clientSessionKeepAlive":{"dataType":"boolean"},"queryTag":{"dataType":"string"},"accessUrl":{"dataType":"string"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SnowflakeCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.REDSHIFT": {
-        "dataType": "refEnum",
-        "enums": ["redshift"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.REDSHIFT","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"useSshTunnel":{"dataType":"boolean"},"sshTunnelHost":{"dataType":"string"},"sshTunnelPort":{"dataType":"double"},"sshTunnelUser":{"dataType":"string"},"sshTunnelPublicKey":{"dataType":"string"},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"keepalivesIdle":{"dataType":"double"},"sslmode":{"dataType":"string"},"ra3Node":{"dataType":"boolean"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "RedshiftCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.POSTGRES": {
-        "dataType": "refEnum",
-        "enums": ["postgres"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"dataType":"string"},"type":{"ref":"WarehouseTypes.POSTGRES","required":true},"schema":{"dataType":"string","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"useSshTunnel":{"dataType":"boolean"},"sshTunnelHost":{"dataType":"string"},"sshTunnelPort":{"dataType":"double"},"sshTunnelUser":{"dataType":"string"},"sshTunnelPublicKey":{"dataType":"string"},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"keepalivesIdle":{"dataType":"double"},"sslmode":{"dataType":"string"},"searchPath":{"dataType":"string"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "PostgresCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.BIGQUERY": {
-        "dataType": "refEnum",
-        "enums": ["bigquery"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.BIGQUERY","required":true},"threads":{"dataType":"double"},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"project":{"dataType":"string","required":true},"dataset":{"dataType":"string","required":true},"timeoutSeconds":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true},"priority":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["interactive"]},{"dataType":"enum","enums":["batch"]},{"dataType":"undefined"}],"required":true},"retries":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true},"location":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true},"maximumBytesBilled":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"undefined"}],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "BigqueryCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.DATABRICKS": {
-        "dataType": "refEnum",
-        "enums": ["databricks"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.DATABRICKS","required":true},"database":{"dataType":"string","required":true},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"catalog":{"dataType":"string"},"serverHostName":{"dataType":"string","required":true},"httpPath":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DatabricksCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseTypes.TRINO": {
-        "dataType": "refEnum",
-        "enums": ["trino"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"type":{"ref":"WarehouseTypes.TRINO","required":true},"schema":{"dataType":"string","required":true},"startOfWeek":{"dataType":"union","subSchemas":[{"ref":"WeekDay"},{"dataType":"enum","enums":[null]}]},"host":{"dataType":"string","required":true},"port":{"dataType":"double","required":true},"dbname":{"dataType":"string","required":true},"http_scheme":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TrinoCredentials": {
-        "dataType": "refAlias",
-        "type": {"ref":"Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "WarehouseCredentials": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"SnowflakeCredentials"},{"ref":"RedshiftCredentials"},{"ref":"PostgresCredentials"},{"ref":"BigqueryCredentials"},{"ref":"DatabricksCredentials"},{"ref":"TrinoCredentials"}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Project": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"copiedFromProjectUuid":{"dataType":"string"},"pinnedListUuid":{"dataType":"string"},"warehouseConnection":{"ref":"WarehouseCredentials"},"dbtConnection":{"ref":"DbtProjectConfig","required":true},"type":{"ref":"ProjectType","required":true},"name":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiProjectResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Project","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"spaceName":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartType": {
-        "dataType": "refEnum",
-        "enums": ["cartesian","table","big_number","pie"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartSummary": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartType"},{"dataType":"undefined"}]}}}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiChartSummaryListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ChartSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"projectUuid":{"dataType":"string","required":true},"isPrivate":{"dataType":"boolean","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SpaceSummary": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"string"},"required":true}}}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSpaceSummaryListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceSummary"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ProjectMemberRole": {
-        "dataType": "refEnum",
-        "enums": ["viewer","interactive_viewer","editor","developer","admin"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ProjectMemberProfile": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"role":{"ref":"ProjectMemberRole","required":true},"projectUuid":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiProjectAccessListResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ProjectMemberProfile"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateProjectMember": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"sendEmail":{"dataType":"boolean","required":true},"role":{"ref":"ProjectMemberRole","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateProjectMember": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"ProjectMemberRole","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FieldId": {
-        "dataType": "refAlias",
-        "type": {"dataType":"string","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterGroupResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"or":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}},{"dataType":"nestedObjectLiteral","nestedProperties":{"and":{"dataType":"array","array":{"dataType":"any"},"required":true},"id":{"dataType":"string","required":true}}}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Filters": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"ref":"FilterGroupResponse"},"dimensions":{"ref":"FilterGroupResponse"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SortField": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"descending":{"dataType":"boolean","required":true},"fieldId":{"dataType":"string","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TableCalculationFormatType": {
-        "dataType": "refEnum",
-        "enums": ["default","percent","currency","number"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "NumberSeparator": {
-        "dataType": "refEnum",
-        "enums": ["default","commaPeriod","spacePeriod","periodComma","noSeparatorPeriod"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Compact": {
-        "dataType": "refEnum",
-        "enums": ["thousands","millions","billions","trillions"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TableCalculationFormat": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"suffix":{"dataType":"string"},"prefix":{"dataType":"string"},"compact":{"ref":"Compact"},"currency":{"dataType":"string"},"separator":{"ref":"NumberSeparator"},"round":{"dataType":"double"},"type":{"ref":"TableCalculationFormatType","required":true}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "TableCalculation": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"format":{"ref":"TableCalculationFormat"},"sql":{"dataType":"string","required":true},"displayName":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"index":{"dataType":"double"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MetricType": {
-        "dataType": "refEnum",
-        "enums": ["percentile","average","count","count_distinct","sum","min","max","number","median","string","date","boolean"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CompactOrAlias": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"Compact"},{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["K"]},{"dataType":"enum","enums":["thousand"]},{"dataType":"enum","enums":["M"]},{"dataType":"enum","enums":["million"]},{"dataType":"enum","enums":["B"]},{"dataType":"enum","enums":["billion"]},{"dataType":"enum","enums":["T"]},{"dataType":"enum","enums":["trillion"]}]}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ConditionalOperator": {
-        "dataType": "refEnum",
-        "enums": ["isNull","notNull","equals","notEquals","startsWith","endsWith","include","doesNotInclude","lessThan","lessThanOrEqual","greaterThan","greaterThanOrEqual","inThePast","inTheNext","inTheCurrent","inBetween"],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MetricFilterRule": {
-        "dataType": "refObject",
-        "properties": {
-            "values": {"dataType":"array","array":{"dataType":"any"}},
-            "operator": {"ref":"ConditionalOperator","required":true},
-            "id": {"dataType":"string","required":true},
-            "target": {"dataType":"nestedObjectLiteral","nestedProperties":{"fieldRef":{"dataType":"string","required":true}},"required":true},
-            "settings": {"dataType":"any"},
+    ApiDbtCloudMetrics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'DbtCloudMetadataResponseMetrics',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AdditionalMetric": {
-        "dataType": "refObject",
-        "properties": {
-            "label": {"dataType":"string"},
-            "type": {"ref":"MetricType","required":true},
-            "description": {"dataType":"string"},
-            "sql": {"dataType":"string","required":true},
-            "hidden": {"dataType":"boolean"},
-            "round": {"dataType":"double"},
-            "compact": {"ref":"CompactOrAlias"},
-            "format": {"dataType":"string"},
-            "table": {"dataType":"string","required":true},
-            "name": {"dataType":"string","required":true},
-            "index": {"dataType":"double"},
-            "filters": {"dataType":"array","array":{"dataType":"refObject","ref":"MetricFilterRule"}},
-            "baseDimensionName": {"dataType":"string"},
-            "uuid": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
+    Group: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
         },
-        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MetricQueryResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"ref":"Filters","required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
+    ApiGroupResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Group', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiRunQueryResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"rows":{"dataType":"array","array":{"dataType":"any"},"required":true},"metricQuery":{"ref":"MetricQueryResponse","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ApiSuccessEmpty: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { dataType: 'undefined', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "RunQueryRequest": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"csvLimit":{"dataType":"double"},"additionalMetrics":{"dataType":"array","array":{"dataType":"refObject","ref":"AdditionalMetric"}},"tableCalculations":{"dataType":"array","array":{"dataType":"refAlias","ref":"TableCalculation"},"required":true},"limit":{"dataType":"double","required":true},"sorts":{"dataType":"array","array":{"dataType":"refAlias","ref":"SortField"},"required":true},"filters":{"dataType":"nestedObjectLiteral","nestedProperties":{"metrics":{"dataType":"any"},"dimensions":{"dataType":"any"}},"required":true},"metrics":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true},"dimensions":{"dataType":"array","array":{"dataType":"refAlias","ref":"FieldId"},"required":true}},"validators":{}},
+    GroupMember: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                email: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerFormat": {
-        "dataType": "refEnum",
-        "enums": ["csv","image"],
+    ApiGroupMembersResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GroupMember' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerCsvOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"limit":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["table"]},{"dataType":"enum","enums":["all"]},{"dataType":"double"}],"required":true},"formatted":{"dataType":"boolean","required":true}},"validators":{}},
+    'Pick_Group.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerImageOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    UpdateGroup: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_Group.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerOptions": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"SchedulerCsvOptions"},{"ref":"SchedulerImageOptions"}],"validators":{}},
+    Organization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                defaultProjectUuid: { dataType: 'string' },
+                needsProject: { dataType: 'boolean' },
+                chartColors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                name: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerBase": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"options":{"ref":"SchedulerOptions","required":true},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"savedChartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"cron":{"dataType":"string","required":true},"format":{"ref":"SchedulerFormat","required":true},"createdBy":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"name":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true}},"validators":{}},
+    ApiOrganization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Organization', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ChartScheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"enum","enums":[null],"required":true},"savedChartUuid":{"dataType":"string","required":true}}}],"validators":{}},
+    'Pick_Organization.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DashboardScheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"SchedulerBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"savedChartUuid":{"dataType":"enum","enums":[null],"required":true}}}],"validators":{}},
+    CreateOrganization: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_Organization.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Scheduler": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ChartScheduler"},{"ref":"DashboardScheduler"}],"validators":{}},
+    'Partial_Omit_Organization.organizationUuid-or-needsProject__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string' },
+                chartColors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                defaultProjectUuid: { dataType: 'string' },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerSlackTarget": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"channel":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerSlackTargetUuid":{"dataType":"string","required":true}},"validators":{}},
+    UpdateOrganization: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Partial_Omit_Organization.organizationUuid-or-needsProject__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerEmailTarget": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"recipient":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string","required":true},"updatedAt":{"dataType":"datetime","required":true},"createdAt":{"dataType":"datetime","required":true},"schedulerEmailTargetUuid":{"dataType":"string","required":true}},"validators":{}},
+    ProjectType: {
+        dataType: 'refEnum',
+        enums: ['DEFAULT', 'PREVIEW'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerAndTargets": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Scheduler"},{"dataType":"nestedObjectLiteral","nestedProperties":{"targets":{"dataType":"array","array":{"dataType":"union","subSchemas":[{"ref":"SchedulerSlackTarget"},{"ref":"SchedulerEmailTarget"}]},"required":true}}}],"validators":{}},
+    OrganizationProject: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'ProjectType', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerJobStatus": {
-        "dataType": "refEnum",
-        "enums": ["scheduled","started","completed","error"],
+    ApiOrganizationProjects: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'OrganizationProject' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Record_string.any_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    OrganizationMemberRole: {
+        dataType: 'refEnum',
+        enums: [
+            'member',
+            'viewer',
+            'interactive_viewer',
+            'editor',
+            'developer',
+            'admin',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerLog": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"details":{"ref":"Record_string.any_"},"targetType":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["email"]},{"dataType":"enum","enums":["slack"]}]},"target":{"dataType":"string"},"status":{"ref":"SchedulerJobStatus","required":true},"createdAt":{"dataType":"datetime","required":true},"scheduledTime":{"dataType":"datetime","required":true},"jobGroup":{"dataType":"string"},"jobId":{"dataType":"string","required":true},"schedulerUuid":{"dataType":"string"},"task":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["handleScheduledDelivery"]},{"dataType":"enum","enums":["sendEmailNotification"]},{"dataType":"enum","enums":["sendSlackNotification"]},{"dataType":"enum","enums":["downloadCsv"]},{"dataType":"enum","enums":["compileProject"]},{"dataType":"enum","enums":["testAndCompileProject"]},{"dataType":"enum","enums":["validateProject"]}],"required":true}},"validators":{}},
+    OrganizationMemberProfile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                isInviteExpired: { dataType: 'boolean' },
+                isActive: { dataType: 'boolean', required: true },
+                role: { ref: 'OrganizationMemberRole', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                email: { dataType: 'string', required: true },
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SchedulerWithLogs": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"logs":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerLog"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"charts":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"savedChartUuid":{"dataType":"string","required":true},"name":{"dataType":"string","required":true}}},"required":true},"users":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true}}},"required":true},"schedulers":{"dataType":"array","array":{"dataType":"refAlias","ref":"SchedulerAndTargets"},"required":true}},"validators":{}},
+    ApiOrganizationMemberProfiles: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'OrganizationMemberProfile',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSchedulerLogsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerWithLogs","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ApiOrganizationMemberProfile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'OrganizationMemberProfile', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSchedulerAndTargetsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"SchedulerAndTargets","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    OrganizationMemberProfileUpdate: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                role: { ref: 'OrganizationMemberRole', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ScheduledJobs": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"dataType":"string","required":true},"date":{"dataType":"datetime","required":true}},"validators":{}},
+    'OrganizationMemberRole.EDITOR': {
+        dataType: 'refEnum',
+        enums: ['editor'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiScheduledJobsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ScheduledJobs"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'OrganizationMemberRole.INTERACTIVE_VIEWER': {
+        dataType: 'refEnum',
+        enums: ['interactive_viewer'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiJobStatusResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'OrganizationMemberRole.VIEWER': {
+        dataType: 'refEnum',
+        enums: ['viewer'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ShareUrl": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"host":{"dataType":"string"},"url":{"dataType":"string"},"shareUrl":{"dataType":"string"},"organizationUuid":{"dataType":"string"},"createdByUserUuid":{"dataType":"string"},"params":{"dataType":"string","required":true},"path":{"dataType":"string","required":true},"nanoid":{"dataType":"string","required":true}},"validators":{}},
+    'OrganizationMemberRole.MEMBER': {
+        dataType: 'refEnum',
+        enums: ['member'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiShareResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"ShareUrl","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    AllowedEmailDomainsRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'OrganizationMemberRole.EDITOR' },
+                { ref: 'OrganizationMemberRole.INTERACTIVE_VIEWER' },
+                { ref: 'OrganizationMemberRole.VIEWER' },
+                { ref: 'OrganizationMemberRole.MEMBER' },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ShareUrl.path-or-params_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"path":{"dataType":"string","required":true},"params":{"dataType":"string","required":true}},"validators":{}},
+    AllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                role: { ref: 'AllowedEmailDomainsRole', required: true },
+                emailDomains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateShareUrl": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_ShareUrl.path-or-params_","validators":{}},
+    ApiOrganizationAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AllowedEmailDomains', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SlackChannel": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    emailDomains: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                    role: { ref: 'AllowedEmailDomainsRole', required: true },
+                    projectUuids: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AllowedEmailDomains.organizationUuid_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSlackChannelsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"SlackChannel"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    UpdateAllowedEmailDomains: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_AllowedEmailDomains.organizationUuid_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
+    'Pick_CreateGroup.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ViewStatistics": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"views":{"dataType":"double","required":true}},"validators":{}},
+    ApiGroupListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'Group' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SpaceQuery": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"},{"ref":"ViewStatistics"},{"dataType":"nestedObjectLiteral","nestedProperties":{"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}},"chartType":{"dataType":"union","subSchemas":[{"ref":"ChartKind"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    'ResourceViewItemType.DASHBOARD': {
+        dataType: 'refEnum',
+        enums: ['dashboard'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"description":{"dataType":"string"},"updatedAt":{"dataType":"datetime","required":true},"projectUuid":{"dataType":"string","required":true},"updatedByUser":{"ref":"UpdatedByUser"},"spaceUuid":{"dataType":"string","required":true},"views":{"dataType":"double","required":true},"firstViewedAt":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"validators":{}},
+    UpdatedByUser: {
+        dataType: 'refObject',
+        properties: {
+            userUuid: { dataType: 'string', required: true },
+            firstName: { dataType: 'string', required: true },
+            lastName: { dataType: 'string', required: true },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "DashboardBasicDetails": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"validationErrors":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationSummary"}}}}],"validators":{}},
+    'Pick_ValidationResponse.error-or-createdAt-or-validationId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                validationId: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                error: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SpaceDashboard": {
-        "dataType": "refAlias",
-        "type": {"ref":"DashboardBasicDetails","validators":{}},
+    ValidationSummary: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationId_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SpaceShare": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"role":{"ref":"ProjectMemberRole","required":true},"lastName":{"dataType":"string","required":true},"firstName":{"dataType":"string","required":true},"userUuid":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    validationErrors: {
+                        dataType: 'array',
+                        array: {
+                            dataType: 'refAlias',
+                            ref: 'ValidationSummary',
+                        },
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewDashboardItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.DASHBOARD', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Space": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"pinnedListOrder":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"pinnedListUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"access":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceShare"},"required":true},"dashboards":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceDashboard"},"required":true},"projectUuid":{"dataType":"string","required":true},"queries":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceQuery"},"required":true},"isPrivate":{"dataType":"boolean","required":true},"name":{"dataType":"string","required":true},"uuid":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    'ResourceViewItemType.CHART': {
+        dataType: 'refEnum',
+        enums: ['chart'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSpaceResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Space","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ChartKind: {
+        dataType: 'refEnum',
+        enums: [
+            'line',
+            'horizontal_bar',
+            'vertical_bar',
+            'scatter',
+            'area',
+            'mixed',
+            'pie',
+            'table',
+            'big_number',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateSpace": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"access":{"dataType":"array","array":{"dataType":"refAlias","ref":"SpaceShare"}},"isPrivate":{"dataType":"boolean"},"name":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    validationErrors: {
+                        dataType: 'array',
+                        array: {
+                            dataType: 'refAlias',
+                            ref: 'ValidationSummary',
+                        },
+                    },
+                    chartType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ChartKind' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewChartItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.CHART', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateSpace": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"isPrivate":{"dataType":"boolean","required":true},"name":{"dataType":"string","required":true}},"validators":{}},
+    'ResourceViewItemType.SPACE': {
+        dataType: 'refEnum',
+        enums: ['space'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AddSpaceShare": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"userUuid":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    isPrivate: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewSpaceItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        {
+                            ref: 'Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_',
+                        },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                chartCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                dashboardCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                accessListLength: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                access: {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.SPACE', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_SshKeyPair.publicKey_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"publicKey":{"dataType":"string","required":true}},"validators":{}},
+    PinnedItems: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'array',
+            array: {
+                dataType: 'union',
+                subSchemas: [
+                    { ref: 'ResourceViewDashboardItem' },
+                    { ref: 'ResourceViewChartItem' },
+                    { ref: 'ResourceViewSpaceItem' },
+                ],
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiSshKeyPairResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"Pick_SshKeyPair.publicKey_","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    ApiPinnedItems: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'PinnedItems', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailOneTimePassword": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"numberOfAttempts":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true}},"validators":{}},
+    ResourceViewItemType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'dashboard', 'space'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailStatus": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePassword"},"isVerified":{"dataType":"boolean","required":true},"email":{"dataType":"string","required":true}},"validators":{}},
+    'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                uuid: { dataType: 'string', required: true },
+                pinnedListOrder: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailOneTimePasswordExpiring": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailOneTimePassword"},{"dataType":"nestedObjectLiteral","nestedProperties":{"isMaxAttempts":{"dataType":"boolean","required":true},"isExpired":{"dataType":"boolean","required":true},"expiresAt":{"dataType":"datetime","required":true}}}],"validators":{}},
+    UpdatePinnedItemOrder: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                data: {
+                    ref: 'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_',
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "EmailStatusExpiring": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"EmailStatus"},{"dataType":"nestedObjectLiteral","nestedProperties":{"otp":{"ref":"EmailOneTimePasswordExpiring"}}}],"validators":{}},
+    'DbtProjectType.DBT': {
+        dataType: 'refEnum',
+        enums: ['dbt'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiEmailStatusResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"ref":"EmailStatusExpiring","required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    DbtProjectEnvironmentVariable: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                value: { dataType: 'string', required: true },
+                key: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UserAllowedOrganization": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"membersCount":{"dataType":"double","required":true},"name":{"dataType":"string","required":true},"organizationUuid":{"dataType":"string","required":true}},"validators":{}},
+    DbtProjectType: {
+        dataType: 'refEnum',
+        enums: [
+            'dbt',
+            'dbt_cloud_ide',
+            'github',
+            'gitlab',
+            'bitbucket',
+            'azure_devops',
+            'none',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiUserAllowedOrganizationsResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"UserAllowedOrganization"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    DbtLocalProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.DBT', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            profiles_dir: { dataType: 'string' },
+            project_dir: { dataType: 'string' },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiJobScheduledResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"nestedObjectLiteral","nestedProperties":{"jobId":{"dataType":"string","required":true}},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'DbtProjectType.DBT_CLOUD_IDE': {
+        dataType: 'refEnum',
+        enums: ['dbt_cloud_ide'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorType": {
-        "dataType": "refEnum",
-        "enums": ["chart","sorting","filter","metric","model","dimension"],
+    DbtCloudIDEProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.DBT_CLOUD_IDE', required: true },
+            api_key: { dataType: 'string', required: true },
+            account_id: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
+                required: true,
+            },
+            environment_id: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
+                required: true,
+            },
+            project_id: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'double' }],
+                required: true,
+            },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationSourceType": {
-        "dataType": "refEnum",
-        "enums": ["chart","dashboard","table"],
+    'DbtProjectType.GITHUB': {
+        dataType: 'refEnum',
+        enums: ['github'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationResponseBase": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"source":{"ref":"ValidationSourceType"},"spaceUuid":{"dataType":"string"},"projectUuid":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType","required":true},"error":{"dataType":"string","required":true},"name":{"dataType":"string","required":true},"createdAt":{"dataType":"datetime","required":true},"validationId":{"dataType":"double","required":true}},"validators":{}},
+    DbtGithubProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.GITHUB', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            personal_access_token: { dataType: 'string', required: true },
+            repository: { dataType: 'string', required: true },
+            branch: { dataType: 'string', required: true },
+            project_sub_path: { dataType: 'string', required: true },
+            host_domain: { dataType: 'string' },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorChartResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"chartName":{"dataType":"string"},"chartViews":{"dataType":"double","required":true},"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartType":{"ref":"ChartKind"},"chartUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    'DbtProjectType.BITBUCKET': {
+        dataType: 'refEnum',
+        enums: ['bitbucket'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorDashboardResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"ValidationResponseBase"},{"dataType":"nestedObjectLiteral","nestedProperties":{"dashboardViews":{"dataType":"double","required":true},"lastUpdatedAt":{"dataType":"datetime"},"lastUpdatedBy":{"dataType":"string"},"fieldName":{"dataType":"string"},"chartName":{"dataType":"string"},"dashboardUuid":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    DbtBitBucketProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.BITBUCKET', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            username: { dataType: 'string', required: true },
+            personal_access_token: { dataType: 'string', required: true },
+            repository: { dataType: 'string', required: true },
+            branch: { dataType: 'string', required: true },
+            project_sub_path: { dataType: 'string', required: true },
+            host_domain: { dataType: 'string' },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"projectUuid":{"dataType":"string","required":true},"spaceUuid":{"dataType":"string"},"validationId":{"dataType":"double","required":true},"createdAt":{"dataType":"datetime","required":true},"error":{"dataType":"string","required":true},"errorType":{"ref":"ValidationErrorType","required":true},"source":{"ref":"ValidationSourceType"}},"validators":{}},
+    'DbtProjectType.GITLAB': {
+        dataType: 'refEnum',
+        enums: ['gitlab'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_ValidationResponseBase.name_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__","validators":{}},
+    DbtGitlabProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.GITLAB', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            personal_access_token: { dataType: 'string', required: true },
+            repository: { dataType: 'string', required: true },
+            branch: { dataType: 'string', required: true },
+            project_sub_path: { dataType: 'string', required: true },
+            host_domain: { dataType: 'string' },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationErrorTableResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"intersection","subSchemas":[{"ref":"Omit_ValidationResponseBase.name_"},{"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"undefined"}],"required":true}}}],"validators":{}},
+    'DbtProjectType.AZURE_DEVOPS': {
+        dataType: 'refEnum',
+        enums: ['azure_devops'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidationResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ValidationErrorChartResponse"},{"ref":"ValidationErrorDashboardResponse"},{"ref":"ValidationErrorTableResponse"}],"validators":{}},
+    DbtAzureDevOpsProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.AZURE_DEVOPS', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            personal_access_token: { dataType: 'string', required: true },
+            organization: { dataType: 'string', required: true },
+            project: { dataType: 'string', required: true },
+            repository: { dataType: 'string', required: true },
+            branch: { dataType: 'string', required: true },
+            project_sub_path: { dataType: 'string', required: true },
+        },
+        additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiValidateResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"results":{"dataType":"array","array":{"dataType":"refAlias","ref":"ValidationResponse"},"required":true},"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    'DbtProjectType.NONE': {
+        dataType: 'refEnum',
+        enums: ['none'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ApiValidationDismissResponse": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"status":{"dataType":"enum","enums":["ok"],"required":true}},"validators":{}},
+    DbtNoneProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.NONE', required: true },
+            target: { dataType: 'string' },
+            environment: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refAlias',
+                    ref: 'DbtProjectEnvironmentVariable',
+                },
+            },
+            hideRefreshButton: { dataType: 'boolean' },
+        },
+        additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtProjectConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'DbtLocalProjectConfig' },
+                { ref: 'DbtCloudIDEProjectConfig' },
+                { ref: 'DbtGithubProjectConfig' },
+                { ref: 'DbtBitBucketProjectConfig' },
+                { ref: 'DbtGitlabProjectConfig' },
+                { ref: 'DbtAzureDevOpsProjectConfig' },
+                { ref: 'DbtNoneProjectConfig' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.SNOWFLAKE': {
+        dataType: 'refEnum',
+        enums: ['snowflake'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    WeekDay: {
+        dataType: 'refEnum',
+        enums: [0, 1, 2, 3, 4, 5, 6],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    role: { dataType: 'string' },
+                    type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
+                    account: { dataType: 'string', required: true },
+                    database: { dataType: 'string', required: true },
+                    warehouse: { dataType: 'string', required: true },
+                    schema: { dataType: 'string', required: true },
+                    threads: { dataType: 'double' },
+                    clientSessionKeepAlive: { dataType: 'boolean' },
+                    queryTag: { dataType: 'string' },
+                    accessUrl: { dataType: 'string' },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SnowflakeCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.REDSHIFT': {
+        dataType: 'refEnum',
+        enums: ['redshift'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.REDSHIFT', required: true },
+                    schema: { dataType: 'string', required: true },
+                    threads: { dataType: 'double' },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                    useSshTunnel: { dataType: 'boolean' },
+                    sshTunnelHost: { dataType: 'string' },
+                    sshTunnelPort: { dataType: 'double' },
+                    sshTunnelUser: { dataType: 'string' },
+                    sshTunnelPublicKey: { dataType: 'string' },
+                    host: { dataType: 'string', required: true },
+                    port: { dataType: 'double', required: true },
+                    dbname: { dataType: 'string', required: true },
+                    keepalivesIdle: { dataType: 'double' },
+                    sslmode: { dataType: 'string' },
+                    ra3Node: { dataType: 'boolean' },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RedshiftCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.POSTGRES': {
+        dataType: 'refEnum',
+        enums: ['postgres'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    role: { dataType: 'string' },
+                    type: { ref: 'WarehouseTypes.POSTGRES', required: true },
+                    schema: { dataType: 'string', required: true },
+                    threads: { dataType: 'double' },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                    useSshTunnel: { dataType: 'boolean' },
+                    sshTunnelHost: { dataType: 'string' },
+                    sshTunnelPort: { dataType: 'double' },
+                    sshTunnelUser: { dataType: 'string' },
+                    sshTunnelPublicKey: { dataType: 'string' },
+                    host: { dataType: 'string', required: true },
+                    port: { dataType: 'double', required: true },
+                    dbname: { dataType: 'string', required: true },
+                    keepalivesIdle: { dataType: 'double' },
+                    sslmode: { dataType: 'string' },
+                    searchPath: { dataType: 'string' },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PostgresCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.BIGQUERY': {
+        dataType: 'refEnum',
+        enums: ['bigquery'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.BIGQUERY', required: true },
+                    threads: { dataType: 'double' },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                    project: { dataType: 'string', required: true },
+                    dataset: { dataType: 'string', required: true },
+                    timeoutSeconds: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    priority: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'enum', enums: ['interactive'] },
+                            { dataType: 'enum', enums: ['batch'] },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    retries: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    location: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    maximumBytesBilled: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    BigqueryCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.DATABRICKS': {
+        dataType: 'refEnum',
+        enums: ['databricks'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.DATABRICKS', required: true },
+                    database: { dataType: 'string', required: true },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                    catalog: { dataType: 'string' },
+                    serverHostName: { dataType: 'string', required: true },
+                    httpPath: { dataType: 'string', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DatabricksCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WarehouseTypes.TRINO': {
+        dataType: 'refEnum',
+        enums: ['trino'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: { ref: 'WarehouseTypes.TRINO', required: true },
+                    schema: { dataType: 'string', required: true },
+                    startOfWeek: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WeekDay' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                    },
+                    host: { dataType: 'string', required: true },
+                    port: { dataType: 'double', required: true },
+                    dbname: { dataType: 'string', required: true },
+                    http_scheme: { dataType: 'string', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TrinoCredentials: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    WarehouseCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'SnowflakeCredentials' },
+                { ref: 'RedshiftCredentials' },
+                { ref: 'PostgresCredentials' },
+                { ref: 'BigqueryCredentials' },
+                { ref: 'DatabricksCredentials' },
+                { ref: 'TrinoCredentials' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Project: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                copiedFromProjectUuid: { dataType: 'string' },
+                pinnedListUuid: { dataType: 'string' },
+                warehouseConnection: { ref: 'WarehouseCredentials' },
+                dbtConnection: { ref: 'DbtProjectConfig', required: true },
+                type: { ref: 'ProjectType', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Project', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    projectUuid: { dataType: 'string', required: true },
+                    spaceUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    spaceName: { dataType: 'string', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartType: {
+        dataType: 'refEnum',
+        enums: ['cartesian', 'table', 'big_number', 'pie'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        chartType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartType' },
+                                { dataType: 'undefined' },
+                            ],
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiChartSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    isPrivate: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        access: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSpaceSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceSummary' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectMemberRole: {
+        dataType: 'refEnum',
+        enums: ['viewer', 'interactive_viewer', 'editor', 'developer', 'admin'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectMemberProfile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                email: { dataType: 'string', required: true },
+                role: { ref: 'ProjectMemberRole', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectAccessListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'ProjectMemberProfile',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateProjectMember: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sendEmail: { dataType: 'boolean', required: true },
+                role: { ref: 'ProjectMemberRole', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateProjectMember: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                role: { ref: 'ProjectMemberRole', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FieldId: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterGroupResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        or: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        id: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        and: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        id: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Filters: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: { ref: 'FilterGroupResponse' },
+                dimensions: { ref: 'FilterGroupResponse' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SortField: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                descending: { dataType: 'boolean', required: true },
+                fieldId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableCalculationFormatType: {
+        dataType: 'refEnum',
+        enums: ['default', 'percent', 'currency', 'number'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    NumberSeparator: {
+        dataType: 'refEnum',
+        enums: [
+            'default',
+            'commaPeriod',
+            'spacePeriod',
+            'periodComma',
+            'noSeparatorPeriod',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Compact: {
+        dataType: 'refEnum',
+        enums: ['thousands', 'millions', 'billions', 'trillions'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableCalculationFormat: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                suffix: { dataType: 'string' },
+                prefix: { dataType: 'string' },
+                compact: { ref: 'Compact' },
+                currency: { dataType: 'string' },
+                separator: { ref: 'NumberSeparator' },
+                round: { dataType: 'double' },
+                type: { ref: 'TableCalculationFormatType', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableCalculation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                format: { ref: 'TableCalculationFormat' },
+                sql: { dataType: 'string', required: true },
+                displayName: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                index: { dataType: 'double' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricType: {
+        dataType: 'refEnum',
+        enums: [
+            'percentile',
+            'average',
+            'count',
+            'count_distinct',
+            'sum',
+            'min',
+            'max',
+            'number',
+            'median',
+            'string',
+            'date',
+            'boolean',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CompactOrAlias: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'Compact' },
+                {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['K'] },
+                        { dataType: 'enum', enums: ['thousand'] },
+                        { dataType: 'enum', enums: ['M'] },
+                        { dataType: 'enum', enums: ['million'] },
+                        { dataType: 'enum', enums: ['B'] },
+                        { dataType: 'enum', enums: ['billion'] },
+                        { dataType: 'enum', enums: ['T'] },
+                        { dataType: 'enum', enums: ['trillion'] },
+                    ],
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ConditionalOperator: {
+        dataType: 'refEnum',
+        enums: [
+            'isNull',
+            'notNull',
+            'equals',
+            'notEquals',
+            'startsWith',
+            'endsWith',
+            'include',
+            'doesNotInclude',
+            'lessThan',
+            'lessThanOrEqual',
+            'greaterThan',
+            'greaterThanOrEqual',
+            'inThePast',
+            'inTheNext',
+            'inTheCurrent',
+            'inBetween',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricFilterRule: {
+        dataType: 'refObject',
+        properties: {
+            values: { dataType: 'array', array: { dataType: 'any' } },
+            operator: { ref: 'ConditionalOperator', required: true },
+            id: { dataType: 'string', required: true },
+            target: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    fieldRef: { dataType: 'string', required: true },
+                },
+                required: true,
+            },
+            settings: { dataType: 'any' },
+        },
+        additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AdditionalMetric: {
+        dataType: 'refObject',
+        properties: {
+            label: { dataType: 'string' },
+            type: { ref: 'MetricType', required: true },
+            description: { dataType: 'string' },
+            sql: { dataType: 'string', required: true },
+            hidden: { dataType: 'boolean' },
+            round: { dataType: 'double' },
+            compact: { ref: 'CompactOrAlias' },
+            format: { dataType: 'string' },
+            table: { dataType: 'string', required: true },
+            name: { dataType: 'string', required: true },
+            index: { dataType: 'double' },
+            filters: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'MetricFilterRule' },
+            },
+            baseDimensionName: { dataType: 'string' },
+            uuid: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'string' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+            },
+        },
+        additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricQueryResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                additionalMetrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
+                },
+                tableCalculations: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
+                    required: true,
+                },
+                limit: { dataType: 'double', required: true },
+                sorts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SortField' },
+                    required: true,
+                },
+                filters: { ref: 'Filters', required: true },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRunQueryResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        rows: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                            required: true,
+                        },
+                        metricQuery: {
+                            ref: 'MetricQueryResponse',
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RunQueryRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                csvLimit: { dataType: 'double' },
+                additionalMetrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'AdditionalMetric' },
+                },
+                tableCalculations: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'TableCalculation' },
+                    required: true,
+                },
+                limit: { dataType: 'double', required: true },
+                sorts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SortField' },
+                    required: true,
+                },
+                filters: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        metrics: { dataType: 'any' },
+                        dimensions: { dataType: 'any' },
+                    },
+                    required: true,
+                },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'FieldId' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerFormat: {
+        dataType: 'refEnum',
+        enums: ['csv', 'image'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerCsvOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                limit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['table'] },
+                        { dataType: 'enum', enums: ['all'] },
+                        { dataType: 'double' },
+                    ],
+                    required: true,
+                },
+                formatted: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerImageOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'SchedulerCsvOptions' },
+                { ref: 'SchedulerImageOptions' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                options: { ref: 'SchedulerOptions', required: true },
+                dashboardUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedChartUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                cron: { dataType: 'string', required: true },
+                format: { ref: 'SchedulerFormat', required: true },
+                createdBy: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                name: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedChartUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: { dataType: 'string', required: true },
+                        savedChartUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Scheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ChartScheduler' },
+                { ref: 'DashboardScheduler' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerSlackTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                channel: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerSlackTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerEmailTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                recipient: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerEmailTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerAndTargets: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Scheduler' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        targets: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'SchedulerSlackTarget' },
+                                    { ref: 'SchedulerEmailTarget' },
+                                ],
+                            },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerJobStatus: {
+        dataType: 'refEnum',
+        enums: ['scheduled', 'started', 'completed', 'error'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.any_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerLog: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                details: { ref: 'Record_string.any_' },
+                targetType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['email'] },
+                        { dataType: 'enum', enums: ['slack'] },
+                    ],
+                },
+                target: { dataType: 'string' },
+                status: { ref: 'SchedulerJobStatus', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                scheduledTime: { dataType: 'datetime', required: true },
+                jobGroup: { dataType: 'string' },
+                jobId: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string' },
+                task: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'enum',
+                            enums: ['handleScheduledDelivery'],
+                        },
+                        { dataType: 'enum', enums: ['sendEmailNotification'] },
+                        { dataType: 'enum', enums: ['sendSlackNotification'] },
+                        { dataType: 'enum', enums: ['downloadCsv'] },
+                        { dataType: 'enum', enums: ['compileProject'] },
+                        { dataType: 'enum', enums: ['testAndCompileProject'] },
+                        { dataType: 'enum', enums: ['validateProject'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerWithLogs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                logs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SchedulerLog' },
+                    required: true,
+                },
+                dashboards: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            dashboardUuid: {
+                                dataType: 'string',
+                                required: true,
+                            },
+                            name: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                charts: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            savedChartUuid: {
+                                dataType: 'string',
+                                required: true,
+                            },
+                            name: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                users: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            userUuid: { dataType: 'string', required: true },
+                            lastName: { dataType: 'string', required: true },
+                            firstName: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                schedulers: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSchedulerLogsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SchedulerWithLogs', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSchedulerAndTargetsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SchedulerAndTargets', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScheduledJobs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                id: { dataType: 'string', required: true },
+                date: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiScheduledJobsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ScheduledJobs' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiJobStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        status: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ShareUrl: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                host: { dataType: 'string' },
+                url: { dataType: 'string' },
+                shareUrl: { dataType: 'string' },
+                organizationUuid: { dataType: 'string' },
+                createdByUserUuid: { dataType: 'string' },
+                params: { dataType: 'string', required: true },
+                path: { dataType: 'string', required: true },
+                nanoid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiShareResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ShareUrl', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_ShareUrl.path-or-params_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                path: { dataType: 'string', required: true },
+                params: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateShareUrl: {
+        dataType: 'refAlias',
+        type: { ref: 'Pick_ShareUrl.path-or-params_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SlackChannel: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSlackChannelsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SlackChannel' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ViewStatistics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                firstViewedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                views: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceQuery: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_',
+                },
+                { ref: 'ViewStatistics' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        validationErrors: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ValidationSummary',
+                            },
+                        },
+                        chartType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartKind' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
+                    spaceUuid: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardBasicDetails: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        validationErrors: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ValidationSummary',
+                            },
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceDashboard: {
+        dataType: 'refAlias',
+        type: { ref: 'DashboardBasicDetails', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceShare: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                role: { ref: 'ProjectMemberRole', required: true },
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Space: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pinnedListOrder: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                pinnedListUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                access: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
+                    required: true,
+                },
+                dashboards: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceDashboard' },
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+                queries: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceQuery' },
+                    required: true,
+                },
+                isPrivate: { dataType: 'boolean', required: true },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSpaceResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Space', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateSpace: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                access: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
+                },
+                isPrivate: { dataType: 'boolean' },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateSpace: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                isPrivate: { dataType: 'boolean', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AddSpaceShare: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SshKeyPair.publicKey_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                publicKey: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSshKeyPairResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Pick_SshKeyPair.publicKey_', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePassword: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                numberOfAttempts: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                otp: { ref: 'EmailOneTimePassword' },
+                isVerified: { dataType: 'boolean', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePasswordExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailOneTimePassword' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        isMaxAttempts: { dataType: 'boolean', required: true },
+                        isExpired: { dataType: 'boolean', required: true },
+                        expiresAt: { dataType: 'datetime', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailStatusExpiring: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'EmailStatus' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        otp: { ref: 'EmailOneTimePasswordExpiring' },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiEmailStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'EmailStatusExpiring', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAllowedOrganization: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                membersCount: { dataType: 'double', required: true },
+                name: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserAllowedOrganizationsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'UserAllowedOrganization',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiJobScheduledResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        jobId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'sorting', 'filter', 'metric', 'model', 'dimension'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationSourceType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'dashboard', 'table'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationResponseBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { ref: 'ValidationSourceType' },
+                spaceUuid: { dataType: 'string' },
+                projectUuid: { dataType: 'string', required: true },
+                errorType: { ref: 'ValidationErrorType', required: true },
+                error: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                validationId: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorChartResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ValidationResponseBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        chartName: { dataType: 'string' },
+                        chartViews: { dataType: 'double', required: true },
+                        lastUpdatedAt: { dataType: 'datetime' },
+                        lastUpdatedBy: { dataType: 'string' },
+                        fieldName: { dataType: 'string' },
+                        chartType: { ref: 'ChartKind' },
+                        chartUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorDashboardResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ValidationResponseBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardViews: { dataType: 'double', required: true },
+                        lastUpdatedAt: { dataType: 'datetime' },
+                        lastUpdatedBy: { dataType: 'string' },
+                        fieldName: { dataType: 'string' },
+                        chartName: { dataType: 'string' },
+                        dashboardUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuid: { dataType: 'string', required: true },
+                spaceUuid: { dataType: 'string' },
+                validationId: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                error: { dataType: 'string', required: true },
+                errorType: { ref: 'ValidationErrorType', required: true },
+                source: { ref: 'ValidationSourceType' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_ValidationResponseBase.name_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationErrorTableResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Omit_ValidationResponseBase.name_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValidationResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ValidationErrorChartResponse' },
+                { ref: 'ValidationErrorDashboardResponse' },
+                { ref: 'ValidationErrorTableResponse' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiValidateResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ValidationResponse' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiValidationDismissResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -1103,14 +3107,25 @@ export function RegisterRoutes(app: express.Router) {
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
-        app.get('/api/v1/csv/:jobId',
-            ...(fetchMiddlewares<RequestHandler>(CsvController)),
-            ...(fetchMiddlewares<RequestHandler>(CsvController.prototype.get)),
+    app.get(
+        '/api/v1/csv/:jobId',
+        ...fetchMiddlewares<RequestHandler>(CsvController),
+        ...fetchMiddlewares<RequestHandler>(CsvController.prototype.get),
 
-            function CsvController_get(request: any, response: any, next: any) {
+        function CsvController_get(request: any, response: any, next: any) {
             const args = {
-                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                jobId: {
+                    in: 'path',
+                    name: 'jobId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1121,22 +3136,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new CsvController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.getSettings,
+        ),
 
-            function DbtCloudIntegrationController_getSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_getSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1147,22 +3182,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.getSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.updateSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.updateSettings,
+        ),
 
-            function DbtCloudIntegrationController_updateSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_updateSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1173,22 +3228,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.updateSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.deleteSettings)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/settings',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.deleteSettings,
+        ),
 
-            function DbtCloudIntegrationController_deleteSettings(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_deleteSettings(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1199,22 +3274,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.deleteSettings.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteSettings.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController)),
-            ...(fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController.prototype.getMetrics)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/integrations/dbt-cloud/metrics',
+        ...fetchMiddlewares<RequestHandler>(DbtCloudIntegrationController),
+        ...fetchMiddlewares<RequestHandler>(
+            DbtCloudIntegrationController.prototype.getMetrics,
+        ),
 
-            function DbtCloudIntegrationController_getMetrics(request: any, response: any, next: any) {
+        function DbtCloudIntegrationController_getMetrics(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1225,22 +3320,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new DbtCloudIntegrationController();
 
-
-              const promise = controller.getMetrics.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getMetrics.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.getGroup,
+        ),
 
-            function GroupsController_getGroup(request: any, response: any, next: any) {
+        function GroupsController_getGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1251,22 +3366,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.getGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.deleteGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.deleteGroup,
+        ),
 
-            function GroupsController_deleteGroup(request: any, response: any, next: any) {
+        function GroupsController_deleteGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1277,23 +3412,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.deleteGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/groups/:groupUuid/members/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.addUserToGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/groups/:groupUuid/members/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.addUserToGroup,
+        ),
 
-            function GroupsController_addUserToGroup(request: any, response: any, next: any) {
+        function GroupsController_addUserToGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1304,23 +3464,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.addUserToGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.addUserToGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/groups/:groupUuid/members/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.removeUserFromGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/groups/:groupUuid/members/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.removeUserFromGroup,
+        ),
 
-            function GroupsController_removeUserFromGroup(request: any, response: any, next: any) {
+        function GroupsController_removeUserFromGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1331,22 +3516,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.removeUserFromGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.removeUserFromGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/groups/:groupUuid/members',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.getGroupMembers)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/groups/:groupUuid/members',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.getGroupMembers,
+        ),
 
-            function GroupsController_getGroupMembers(request: any, response: any, next: any) {
+        function GroupsController_getGroupMembers(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1357,23 +3562,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.getGroupMembers.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getGroupMembers.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/groups/:groupUuid',
-            ...(fetchMiddlewares<RequestHandler>(GroupsController)),
-            ...(fetchMiddlewares<RequestHandler>(GroupsController.prototype.updateGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/groups/:groupUuid',
+        ...fetchMiddlewares<RequestHandler>(GroupsController),
+        ...fetchMiddlewares<RequestHandler>(
+            GroupsController.prototype.updateGroup,
+        ),
 
-            function GroupsController_updateGroup(request: any, response: any, next: any) {
+        function GroupsController_updateGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    groupUuid: {"in":"path","name":"groupUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateGroup"},
+                groupUuid: {
+                    in: 'path',
+                    name: 'groupUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateGroup',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1384,21 +3614,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new GroupsController();
 
-
-              const promise = controller.updateGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganization,
+        ),
 
-            function OrganizationController_getOrganization(request: any, response: any, next: any) {
+        function OrganizationController_getOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1409,22 +3654,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.createOrganization,
+        ),
 
-            function OrganizationController_createOrganization(request: any, response: any, next: any) {
+        function OrganizationController_createOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateOrganization"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateOrganization',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1435,22 +3700,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.createOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.updateOrganization,
+        ),
 
-            function OrganizationController_updateOrganization(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateOrganization"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateOrganization',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1461,22 +3746,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/org/:organizationUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/org/:organizationUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.deleteOrganization,
+        ),
 
-            function OrganizationController_deleteOrganization(request: any, response: any, next: any) {
+        function OrganizationController_deleteOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                organizationUuid: {
+                    in: 'path',
+                    name: 'organizationUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1487,21 +3792,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.deleteOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/projects',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getProjects)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/projects',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getProjects,
+        ),
 
-            function OrganizationController_getProjects(request: any, response: any, next: any) {
+        function OrganizationController_getProjects(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1512,21 +3832,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getProjects.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getProjects.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/users',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationMembers)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/users',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationMembers,
+        ),
 
-            function OrganizationController_getOrganizationMembers(request: any, response: any, next: any) {
+        function OrganizationController_getOrganizationMembers(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1537,23 +3872,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganizationMembers.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganizationMembers.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org/users/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationMember)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org/users/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.updateOrganizationMember,
+        ),
 
-            function OrganizationController_updateOrganizationMember(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganizationMember(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"OrganizationMemberProfileUpdate"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'OrganizationMemberProfileUpdate',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1564,22 +3924,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganizationMember.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.updateOrganizationMember.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/org/user/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.deleteUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/org/user/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.deleteUser,
+        ),
 
-            function OrganizationController_deleteUser(request: any, response: any, next: any) {
+        function OrganizationController_deleteUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1590,21 +3970,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/allowedEmailDomains',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.getOrganizationAllowedEmailDomains)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationAllowedEmailDomains,
+        ),
 
-            function OrganizationController_getOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
+        function OrganizationController_getOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1615,22 +4010,44 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.getOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise =
+                    controller.getOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/org/allowedEmailDomains',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.updateOrganizationAllowedEmailDomains)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/org/allowedEmailDomains',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype
+                .updateOrganizationAllowedEmailDomains,
+        ),
 
-            function OrganizationController_updateOrganizationAllowedEmailDomains(request: any, response: any, next: any) {
+        function OrganizationController_updateOrganizationAllowedEmailDomains(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateAllowedEmailDomains"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateAllowedEmailDomains',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1641,22 +4058,43 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.updateOrganizationAllowedEmailDomains.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise =
+                    controller.updateOrganizationAllowedEmailDomains.apply(
+                        controller,
+                        validatedArgs as any,
+                    );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/org/groups',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.createGroup)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/org/groups',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.createGroup,
+        ),
 
-            function OrganizationController_createGroup(request: any, response: any, next: any) {
+        function OrganizationController_createGroup(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"ref":"Pick_CreateGroup.name_"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'Pick_CreateGroup.name_',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1667,21 +4105,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.createGroup.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createGroup.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/org/groups',
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController)),
-            ...(fetchMiddlewares<RequestHandler>(OrganizationController.prototype.listGroupsInOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/groups',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.listGroupsInOrganization,
+        ),
 
-            function OrganizationController_listGroupsInOrganization(request: any, response: any, next: any) {
+        function OrganizationController_listGroupsInOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1692,23 +4145,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-
-              const promise = controller.listGroupsInOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.listGroupsInOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
-            ...(fetchMiddlewares<RequestHandler>(PinningController)),
-            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items',
+        ...fetchMiddlewares<RequestHandler>(PinningController),
+        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.get),
 
-            function PinningController_get(request: any, response: any, next: any) {
+        function PinningController_get(request: any, response: any, next: any) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                pinnedListUuid: {
+                    in: 'path',
+                    name: 'pinnedListUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1719,24 +4191,56 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
-            ...(fetchMiddlewares<RequestHandler>(PinningController)),
-            ...(fetchMiddlewares<RequestHandler>(PinningController.prototype.post)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/projects/:projectUuid/pinned-lists/:pinnedListUuid/items/order',
+        ...fetchMiddlewares<RequestHandler>(PinningController),
+        ...fetchMiddlewares<RequestHandler>(PinningController.prototype.post),
 
-            function PinningController_post(request: any, response: any, next: any) {
+        function PinningController_post(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    pinnedListUuid: {"in":"path","name":"pinnedListUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"dataType":"array","array":{"dataType":"refAlias","ref":"UpdatePinnedItemOrder"}},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                pinnedListUuid: {
+                    in: 'path',
+                    name: 'pinnedListUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'UpdatePinnedItemOrder',
+                    },
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1747,22 +4251,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new PinningController();
 
-
-              const promise = controller.post.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.post.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getProject)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getProject,
+        ),
 
-            function ProjectController_getProject(request: any, response: any, next: any) {
+        function ProjectController_getProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1773,22 +4297,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getProject.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/charts',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getChartsInProject)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/charts',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getChartsInProject,
+        ),
 
-            function ProjectController_getChartsInProject(request: any, response: any, next: any) {
+        function ProjectController_getChartsInProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1799,22 +4343,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getChartsInProject.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getChartsInProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/spaces',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getSpacesInProject)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/spaces',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getSpacesInProject,
+        ),
 
-            function ProjectController_getSpacesInProject(request: any, response: any, next: any) {
+        function ProjectController_getSpacesInProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1825,22 +4389,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getSpacesInProject.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getSpacesInProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/access',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.getProjectAccessList)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/access',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getProjectAccessList,
+        ),
 
-            function ProjectController_getProjectAccessList(request: any, response: any, next: any) {
+        function ProjectController_getProjectAccessList(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1851,23 +4435,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.getProjectAccessList.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getProjectAccessList.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/access',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.grantProjectAccessToUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/access',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.grantProjectAccessToUser,
+        ),
 
-            function ProjectController_grantProjectAccessToUser(request: any, response: any, next: any) {
+        function ProjectController_grantProjectAccessToUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateProjectMember"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateProjectMember',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1878,24 +4487,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.grantProjectAccessToUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.grantProjectAccessToUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/projects/:projectUuid/access/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.updateProjectAccessForUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/projects/:projectUuid/access/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.updateProjectAccessForUser,
+        ),
 
-            function ProjectController_updateProjectAccessForUser(request: any, response: any, next: any) {
+        function ProjectController_updateProjectAccessForUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateProjectMember"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateProjectMember',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1906,23 +4545,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.updateProjectAccessForUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.updateProjectAccessForUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/access/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(ProjectController)),
-            ...(fetchMiddlewares<RequestHandler>(ProjectController.prototype.revokeProjectAccessForUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/access/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.revokeProjectAccessForUser,
+        ),
 
-            function ProjectController_revokeProjectAccessForUser(request: any, response: any, next: any) {
+        function ProjectController_revokeProjectAccessForUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1933,24 +4597,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ProjectController();
 
-
-              const promise = controller.revokeProjectAccessForUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.revokeProjectAccessForUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postUnderlyingData)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
+        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
+        ...fetchMiddlewares<RequestHandler>(
+            RunViewChartQueryController.prototype.postUnderlyingData,
+        ),
 
-            function RunViewChartQueryController_postUnderlyingData(request: any, response: any, next: any) {
+        function RunViewChartQueryController_postUnderlyingData(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'RunQueryRequest',
+                },
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                exploreId: {
+                    in: 'path',
+                    name: 'exploreId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1961,24 +4655,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-
-              const promise = controller.postUnderlyingData.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postUnderlyingData.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController)),
-            ...(fetchMiddlewares<RequestHandler>(RunViewChartQueryController.prototype.postRunQuery)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
+        ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
+        ...fetchMiddlewares<RequestHandler>(
+            RunViewChartQueryController.prototype.postRunQuery,
+        ),
 
-            function RunViewChartQueryController_postRunQuery(request: any, response: any, next: any) {
+        function RunViewChartQueryController_postRunQuery(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"RunQueryRequest"},
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    exploreId: {"in":"path","name":"exploreId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'RunQueryRequest',
+                },
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                exploreId: {
+                    in: 'path',
+                    name: 'exploreId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1989,23 +4713,49 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-
-              const promise = controller.postRunQuery.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postRunQuery.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/saved/:chartUuid/results',
-            ...(fetchMiddlewares<RequestHandler>(SavedChartController)),
-            ...(fetchMiddlewares<RequestHandler>(SavedChartController.prototype.postDashboardTile)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/saved/:chartUuid/results',
+        ...fetchMiddlewares<RequestHandler>(SavedChartController),
+        ...fetchMiddlewares<RequestHandler>(
+            SavedChartController.prototype.postDashboardTile,
+        ),
 
-            function SavedChartController_postDashboardTile(request: any, response: any, next: any) {
+        function SavedChartController_postDashboardTile(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"filters":{"ref":"Filters"}}},
-                    chartUuid: {"in":"path","name":"chartUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: { filters: { ref: 'Filters' } },
+                },
+                chartUuid: {
+                    in: 'path',
+                    name: 'chartUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2016,22 +4766,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SavedChartController();
 
-
-              const promise = controller.postDashboardTile.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.postDashboardTile.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:projectUuid/logs',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getLogs)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:projectUuid/logs',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getLogs,
+        ),
 
-            function SchedulerController_getLogs(request: any, response: any, next: any) {
+        function SchedulerController_getLogs(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2042,22 +4812,40 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getLogs.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getLogs.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(SchedulerController.prototype.get),
 
-            function SchedulerController_get(request: any, response: any, next: any) {
+        function SchedulerController_get(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2068,23 +4856,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.patch)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.patch,
+        ),
 
-            function SchedulerController_patch(request: any, response: any, next: any) {
+        function SchedulerController_patch(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"dataType":"any"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'any',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2095,22 +4908,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.patch.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.patch.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/schedulers/:schedulerUuid',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.delete)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/schedulers/:schedulerUuid',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.delete,
+        ),
 
-            function SchedulerController_delete(request: any, response: any, next: any) {
+        function SchedulerController_delete(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2121,22 +4954,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.delete.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.delete.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/:schedulerUuid/jobs',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getJobs)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/:schedulerUuid/jobs',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getJobs,
+        ),
 
-            function SchedulerController_getJobs(request: any, response: any, next: any) {
+        function SchedulerController_getJobs(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    schedulerUuid: {"in":"path","name":"schedulerUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                schedulerUuid: {
+                    in: 'path',
+                    name: 'schedulerUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2147,22 +5000,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getJobs.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getJobs.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/schedulers/job/:jobId/status',
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController)),
-            ...(fetchMiddlewares<RequestHandler>(SchedulerController.prototype.getSchedulerStatus)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/schedulers/job/:jobId/status',
+        ...fetchMiddlewares<RequestHandler>(SchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SchedulerController.prototype.getSchedulerStatus,
+        ),
 
-            function SchedulerController_getSchedulerStatus(request: any, response: any, next: any) {
+        function SchedulerController_getSchedulerStatus(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    jobId: {"in":"path","name":"jobId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                jobId: {
+                    in: 'path',
+                    name: 'jobId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2173,22 +5046,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SchedulerController();
 
-
-              const promise = controller.getSchedulerStatus.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getSchedulerStatus.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/share/:nanoId',
-            ...(fetchMiddlewares<RequestHandler>(ShareController)),
-            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/share/:nanoId',
+        ...fetchMiddlewares<RequestHandler>(ShareController),
+        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.get),
 
-            function ShareController_get(request: any, response: any, next: any) {
+        function ShareController_get(request: any, response: any, next: any) {
             const args = {
-                    nanoId: {"in":"path","name":"nanoId","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                nanoId: {
+                    in: 'path',
+                    name: 'nanoId',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2199,22 +5086,40 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/share',
-            ...(fetchMiddlewares<RequestHandler>(ShareController)),
-            ...(fetchMiddlewares<RequestHandler>(ShareController.prototype.create)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/share',
+        ...fetchMiddlewares<RequestHandler>(ShareController),
+        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.create),
 
-            function ShareController_create(request: any, response: any, next: any) {
+        function ShareController_create(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateShareUrl"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateShareUrl',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2225,21 +5130,30 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ShareController();
 
-
-              const promise = controller.create.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.create.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/slack/channels',
-            ...(fetchMiddlewares<RequestHandler>(SlackController)),
-            ...(fetchMiddlewares<RequestHandler>(SlackController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/slack/channels',
+        ...fetchMiddlewares<RequestHandler>(SlackController),
+        ...fetchMiddlewares<RequestHandler>(SlackController.prototype.get),
 
-            function SlackController_get(request: any, response: any, next: any) {
+        function SlackController_get(request: any, response: any, next: any) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2250,23 +5164,46 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SlackController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.getSpace)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(SpaceController.prototype.getSpace),
 
-            function SpaceController_getSpace(request: any, response: any, next: any) {
+        function SpaceController_getSpace(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2277,23 +5214,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.getSpace.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.getSpace.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/spaces',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.createSpace)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/spaces',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.createSpace,
+        ),
 
-            function SpaceController_createSpace(request: any, response: any, next: any) {
+        function SpaceController_createSpace(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"CreateSpace"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateSpace',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2304,23 +5266,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.createSpace.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.createSpace.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.deleteSpace)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.deleteSpace,
+        ),
 
-            function SpaceController_deleteSpace(request: any, response: any, next: any) {
+        function SpaceController_deleteSpace(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2331,24 +5318,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.deleteSpace.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 204, next);
+                const promise = controller.deleteSpace.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 204, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.patch('/api/v1/projects/:projectUuid/spaces/:spaceUuid',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.updateSpace)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.updateSpace,
+        ),
 
-            function SpaceController_updateSpace(request: any, response: any, next: any) {
+        function SpaceController_updateSpace(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"UpdateSpace"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateSpace',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2359,24 +5376,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.updateSpace.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.updateSpace.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/spaces/:spaceUuid/share',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.addSpaceShare)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.addSpaceShare,
+        ),
 
-            function SpaceController_addSpaceShare(request: any, response: any, next: any) {
+        function SpaceController_addSpaceShare(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
-                    body: {"in":"body","name":"body","required":true,"ref":"AddSpaceShare"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'AddSpaceShare',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2387,24 +5434,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.addSpaceShare.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.addSpaceShare.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/spaces/:spaceUuid/share/:userUuid',
-            ...(fetchMiddlewares<RequestHandler>(SpaceController)),
-            ...(fetchMiddlewares<RequestHandler>(SpaceController.prototype.revokeSpaceAccessForUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/share/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.revokeSpaceAccessForUser,
+        ),
 
-            function SpaceController_revokeSpaceAccessForUser(request: any, response: any, next: any) {
+        function SpaceController_revokeSpaceAccessForUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    spaceUuid: {"in":"path","name":"spaceUuid","required":true,"dataType":"string"},
-                    userUuid: {"in":"path","name":"userUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                spaceUuid: {
+                    in: 'path',
+                    name: 'spaceUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2415,21 +5492,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SpaceController();
 
-
-              const promise = controller.revokeSpaceAccessForUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.revokeSpaceAccessForUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/ssh/key-pairs',
-            ...(fetchMiddlewares<RequestHandler>(SshController)),
-            ...(fetchMiddlewares<RequestHandler>(SshController.prototype.createSshKeyPair)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/ssh/key-pairs',
+        ...fetchMiddlewares<RequestHandler>(SshController),
+        ...fetchMiddlewares<RequestHandler>(
+            SshController.prototype.createSshKeyPair,
+        ),
 
-            function SshController_createSshKeyPair(request: any, response: any, next: any) {
+        function SshController_createSshKeyPair(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2440,21 +5532,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new SshController();
 
-
-              const promise = controller.createSshKeyPair.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 201, next);
+                const promise = controller.createSshKeyPair.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 201, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.put('/api/v1/user/me/email/otp',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.createEmailOneTimePasscode)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/user/me/email/otp',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.createEmailOneTimePasscode,
+        ),
 
-            function UserController_createEmailOneTimePasscode(request: any, response: any, next: any) {
+        function UserController_createEmailOneTimePasscode(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2465,22 +5572,37 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.createEmailOneTimePasscode.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.createEmailOneTimePasscode.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/user/me/email/status',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getEmailVerificationStatus)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/user/me/email/status',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getEmailVerificationStatus,
+        ),
 
-            function UserController_getEmailVerificationStatus(request: any, response: any, next: any) {
+        function UserController_getEmailVerificationStatus(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    passcode: {"in":"query","name":"passcode","dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                passcode: { in: 'query', name: 'passcode', dataType: 'string' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2491,21 +5613,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.getEmailVerificationStatus.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getEmailVerificationStatus.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/user/me/allowedOrganizations',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getOrganizationsUserCanJoin)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/user/me/allowedOrganizations',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getOrganizationsUserCanJoin,
+        ),
 
-            function UserController_getOrganizationsUserCanJoin(request: any, response: any, next: any) {
+        function UserController_getOrganizationsUserCanJoin(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2516,22 +5653,42 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.getOrganizationsUserCanJoin.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.getOrganizationsUserCanJoin.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/user/me/joinOrganization/:organizationUuid',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.joinOrganization)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/user/me/joinOrganization/:organizationUuid',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.joinOrganization,
+        ),
 
-            function UserController_joinOrganization(request: any, response: any, next: any) {
+        function UserController_joinOrganization(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    organizationUuid: {"in":"path","name":"organizationUuid","required":true,"dataType":"string"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                organizationUuid: {
+                    in: 'path',
+                    name: 'organizationUuid',
+                    required: true,
+                    dataType: 'string',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2542,21 +5699,36 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.joinOrganization.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.joinOrganization.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/user/me',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.deleteUser)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/user/me',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.deleteUser,
+        ),
 
-            function UserController_deleteUser(request: any, response: any, next: any) {
+        function UserController_deleteUser(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2567,23 +5739,54 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new UserController();
 
-
-              const promise = controller.deleteUser.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, undefined, next);
+                const promise = controller.deleteUser.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.post('/api/v1/projects/:projectUuid/validate',
-            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
-            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.post)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/validate',
+        ...fetchMiddlewares<RequestHandler>(ValidationController),
+        ...fetchMiddlewares<RequestHandler>(
+            ValidationController.prototype.post,
+        ),
 
-            function ValidationController_post(request: any, response: any, next: any) {
+        function ValidationController_post(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"explores":{"dataType":"array","array":{"dataType":"any"}}}},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        explores: {
+                            dataType: 'array',
+                            array: { dataType: 'any' },
+                        },
+                    },
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2594,24 +5797,46 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-
-              const promise = controller.post.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.post.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.get('/api/v1/projects/:projectUuid/validate',
-            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
-            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.get)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/validate',
+        ...fetchMiddlewares<RequestHandler>(ValidationController),
+        ...fetchMiddlewares<RequestHandler>(ValidationController.prototype.get),
 
-            function ValidationController_get(request: any, response: any, next: any) {
+        function ValidationController_get(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
-                    fromSettings: {"in":"query","name":"fromSettings","dataType":"boolean"},
-                    jobId: {"in":"query","name":"jobId","dataType":"string"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                fromSettings: {
+                    in: 'query',
+                    name: 'fromSettings',
+                    dataType: 'boolean',
+                },
+                jobId: { in: 'query', name: 'jobId', dataType: 'string' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2622,23 +5847,48 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-
-              const promise = controller.get.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.get.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/api/v1/projects/:projectUuid/validate/:validationId',
-            ...(fetchMiddlewares<RequestHandler>(ValidationController)),
-            ...(fetchMiddlewares<RequestHandler>(ValidationController.prototype.dismiss)),
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.delete(
+        '/api/v1/projects/:projectUuid/validate/:validationId',
+        ...fetchMiddlewares<RequestHandler>(ValidationController),
+        ...fetchMiddlewares<RequestHandler>(
+            ValidationController.prototype.dismiss,
+        ),
 
-            function ValidationController_dismiss(request: any, response: any, next: any) {
+        function ValidationController_dismiss(
+            request: any,
+            response: any,
+            next: any,
+        ) {
             const args = {
-                    projectUuid: {"in":"path","name":"projectUuid","required":true,"dataType":"string"},
-                    validationId: {"in":"path","name":"validationId","required":true,"dataType":"double"},
-                    req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                validationId: {
+                    in: 'path',
+                    name: 'validationId',
+                    required: true,
+                    dataType: 'double',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -2649,25 +5899,37 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new ValidationController();
 
-
-              const promise = controller.dismiss.apply(controller, validatedArgs as any);
-              promiseHandler(controller, promise, response, 200, next);
+                const promise = controller.dismiss.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
+        },
+    );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function isController(object: any): object is Controller {
-        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
+        return (
+            'getHeaders' in object &&
+            'getStatus' in object &&
+            'setStatus' in object
+        );
     }
 
-    function promiseHandler(controllerObj: any, promise: any, response: any, successStatus: any, next: any) {
+    function promiseHandler(
+        controllerObj: any,
+        promise: any,
+        response: any,
+        successStatus: any,
+        next: any,
+    ) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 let statusCode = successStatus;
@@ -2679,21 +5941,31 @@ export function RegisterRoutes(app: express.Router) {
 
                 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-                returnHandler(response, statusCode, data, headers)
+                returnHandler(response, statusCode, data, headers);
             })
             .catch((error: any) => next(error));
     }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function returnHandler(response: any, statusCode?: number, data?: any, headers: any = {}) {
+    function returnHandler(
+        response: any,
+        statusCode?: number,
+        data?: any,
+        headers: any = {},
+    ) {
         if (response.headersSent) {
             return;
         }
         Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
         });
-        if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
+        if (
+            data &&
+            typeof data.pipe === 'function' &&
+            data.readable &&
+            typeof data._read === 'function'
+        ) {
             data.pipe(response);
         } else if (data !== null && data !== undefined) {
             response.status(statusCode || 200).json(data);
@@ -2704,38 +5976,108 @@ export function RegisterRoutes(app: express.Router) {
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-    function responder(response: any): TsoaResponse<HttpStatusCodeLiteral, unknown>  {
-        return function(status, data, headers) {
+    function responder(
+        response: any,
+    ): TsoaResponse<HttpStatusCodeLiteral, unknown> {
+        return function (status, data, headers) {
             returnHandler(response, status, data, headers);
         };
-    };
+    }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function getValidatedArgs(args: any, request: any, response: any): any[] {
-        const fieldErrors: FieldErrors  = {};
+        const fieldErrors: FieldErrors = {};
         const values = Object.keys(args).map((key) => {
             const name = args[key].name;
             switch (args[key].in) {
                 case 'request':
                     return request;
                 case 'query':
-                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.query[name],
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'path':
-                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.params[name],
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'header':
-                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.header(name),
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'body':
-                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.body,
+                        name,
+                        fieldErrors,
+                        undefined,
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'body-prop':
-                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {"noImplicitAdditionalProperties":"throw-on-extras"});
+                    return validationService.ValidateParam(
+                        args[key],
+                        request.body[name],
+                        name,
+                        fieldErrors,
+                        'body.',
+                        { noImplicitAdditionalProperties: 'throw-on-extras' },
+                    );
                 case 'formData':
                     if (args[key].dataType === 'file') {
-                        return validationService.ValidateParam(args[key], request.file, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
-                    } else if (args[key].dataType === 'array' && args[key].array.dataType === 'file') {
-                        return validationService.ValidateParam(args[key], request.files, name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.file,
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
+                    } else if (
+                        args[key].dataType === 'array' &&
+                        args[key].array.dataType === 'file'
+                    ) {
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.files,
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
                     } else {
-                        return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, undefined, {"noImplicitAdditionalProperties":"throw-on-extras"});
+                        return validationService.ValidateParam(
+                            args[key],
+                            request.body[name],
+                            name,
+                            fieldErrors,
+                            undefined,
+                            {
+                                noImplicitAdditionalProperties:
+                                    'throw-on-extras',
+                            },
+                        );
                     }
                 case 'res':
                     return responder(response);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1,6269 +1,6864 @@
 {
-    "components": {
-        "examples": {},
-        "headers": {},
-        "parameters": {},
-        "requestBodies": {},
-        "responses": {},
-        "schemas": {
-            "ApiErrorPayload": {
-                "properties": {
-                    "error": {
-                        "properties": {
-                            "data": {
-                                "description": "Optional data containing details of the error"
-                            },
-                            "message": {
-                                "type": "string",
-                                "description": "A friendly message summarising the error"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Unique name for the type of error"
-                            },
-                            "statusCode": {
-                                "type": "number",
-                                "format": "integer",
-                                "description": "HTTP status code"
-                            }
-                        },
-                        "required": ["name", "statusCode"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["error"],
-                        "nullable": false
-                    }
-                },
-                "required": ["error", "status"],
-                "type": "object",
-                "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
-            },
-            "ApiCsvUrlResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "status": {
-                                "type": "string"
-                            },
-                            "url": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["status", "url"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_CreateDbtCloudIntegration.metricsJobId_": {
-                "properties": {
-                    "metricsJobId": {
-                        "type": "string",
-                        "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
-                    }
-                },
-                "required": ["metricsJobId"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "DbtCloudIntegration": {
-                "$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
-                "description": "Configuration for a Lightdash integration with dbt Cloud"
-            },
-            "ApiDbtCloudIntegrationSettings": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/DbtCloudIntegration"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "ApiDbtCloudSettingsDeleteSuccess": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "DbtCloudMetric": {
-                "properties": {
-                    "label": {
-                        "type": "string"
-                    },
-                    "timeGrains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "uniqueId": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "label",
-                    "timeGrains",
-                    "description",
-                    "dimensions",
-                    "name",
-                    "uniqueId"
-                ],
-                "type": "object"
-            },
-            "DbtCloudMetadataResponseMetrics": {
-                "properties": {
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtCloudMetric"
-                        },
-                        "type": "array",
-                        "description": "A list of dbt metric definitions from the dbt cloud metadata api"
-                    }
-                },
-                "required": ["metrics"],
-                "type": "object",
-                "description": "Response from dbt cloud metadata api containing a list of metric definitions"
-            },
-            "ApiDbtCloudMetrics": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Group": {
-                "properties": {
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "The UUID of the organization that the group belongs to"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The time that the group was created"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    },
-                    "uuid": {
-                        "type": "string",
-                        "description": "The group's UUID"
-                    }
-                },
-                "required": ["organizationUuid", "createdAt", "name", "uuid"],
-                "type": "object"
-            },
-            "ApiGroupResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Group"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiSuccessEmpty": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "GroupMember": {
-                "properties": {
-                    "lastName": {
-                        "type": "string",
-                        "description": "The user's last name"
-                    },
-                    "firstName": {
-                        "type": "string",
-                        "description": "The user's first name"
-                    },
-                    "email": {
-                        "type": "string",
-                        "description": "Primary email address for the user"
-                    },
-                    "userUuid": {
-                        "type": "string",
-                        "description": "Unique id for the user",
-                        "format": "uuid"
-                    }
-                },
-                "required": ["lastName", "firstName", "email", "userUuid"],
-                "type": "object",
-                "description": "A summary for a Lightdash user within a group"
-            },
-            "ApiGroupMembersResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/GroupMember"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Group.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "UpdateGroup": {
-                "$ref": "#/components/schemas/Pick_Group.name_"
-            },
-            "Organization": {
-                "properties": {
-                    "needsProject": {
-                        "type": "boolean",
-                        "description": "The organization needs a project if it doesn't have at least one project."
-                    },
-                    "chartColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "description": "The default color palette for all projects in the organization"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "The unique identifier of the organization",
-                        "format": "uuid"
-                    }
-                },
-                "required": ["name", "organizationUuid"],
-                "type": "object",
-                "description": "Details of a user's Organization"
-            },
-            "ApiOrganization": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Organization"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Organization.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "CreateOrganization": {
-                "$ref": "#/components/schemas/Pick_Organization.name_"
-            },
-            "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the organization"
-                    },
-                    "chartColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "description": "The default color palette for all projects in the organization"
-                    }
-                },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "UpdateOrganization": {
-                "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
-            },
-            "ProjectType": {
-                "enum": ["DEFAULT", "PREVIEW"],
-                "type": "string"
-            },
-            "OrganizationProject": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/ProjectType"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string",
-                        "description": "The unique identifier of the project",
-                        "format": "uuid"
-                    }
-                },
-                "required": ["type", "name", "projectUuid"],
-                "type": "object",
-                "description": "Summary of a project under an organization"
-            },
-            "ApiOrganizationProjects": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/OrganizationProject"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object",
-                "description": "List of projects in the current organization"
-            },
-            "OrganizationMemberRole": {
-                "enum": [
-                    "member",
-                    "viewer",
-                    "interactive_viewer",
-                    "editor",
-                    "developer",
-                    "admin"
-                ],
-                "type": "string"
-            },
-            "OrganizationMemberProfile": {
-                "properties": {
-                    "isInviteExpired": {
-                        "type": "boolean",
-                        "description": "Whether the user's invite to the organization has expired"
-                    },
-                    "isActive": {
-                        "type": "boolean",
-                        "description": "Whether the user has accepted their invite to the organization"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole",
-                        "description": "The role of the user in the organization"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "description": "Unique identifier for the organization the user is a member of"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string",
-                        "description": "Unique identifier for the user",
-                        "format": "uuid"
-                    }
-                },
-                "required": [
-                    "isActive",
-                    "role",
-                    "organizationUuid",
-                    "email",
-                    "lastName",
-                    "firstName",
-                    "userUuid"
-                ],
-                "type": "object",
-                "description": "Profile for a user's membership in an organization"
-            },
-            "ApiOrganizationMemberProfiles": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/OrganizationMemberProfile"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiOrganizationMemberProfile": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/OrganizationMemberProfile"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "OrganizationMemberProfileUpdate": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole"
-                    }
-                },
-                "required": ["role"],
-                "type": "object"
-            },
-            "OrganizationMemberRole.EDITOR": {
-                "enum": ["editor"],
-                "type": "string"
-            },
-            "OrganizationMemberRole.INTERACTIVE_VIEWER": {
-                "enum": ["interactive_viewer"],
-                "type": "string"
-            },
-            "OrganizationMemberRole.VIEWER": {
-                "enum": ["viewer"],
-                "type": "string"
-            },
-            "OrganizationMemberRole.MEMBER": {
-                "enum": ["member"],
-                "type": "string"
-            },
-            "AllowedEmailDomainsRole": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/OrganizationMemberRole.EDITOR"
-                    },
-                    {
-                        "$ref": "#/components/schemas/OrganizationMemberRole.INTERACTIVE_VIEWER"
-                    },
-                    {
-                        "$ref": "#/components/schemas/OrganizationMemberRole.VIEWER"
-                    },
-                    {
-                        "$ref": "#/components/schemas/OrganizationMemberRole.MEMBER"
-                    }
-                ]
-            },
-            "AllowedEmailDomains": {
-                "properties": {
-                    "projectUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/AllowedEmailDomainsRole"
-                    },
-                    "emailDomains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "projectUuids",
-                    "role",
-                    "emailDomains",
-                    "organizationUuid"
-                ],
-                "type": "object"
-            },
-            "ApiOrganizationAllowedEmailDomains": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/AllowedEmailDomains"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-                "properties": {
-                    "emailDomains": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/AllowedEmailDomainsRole"
-                    },
-                    "projectUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": ["emailDomains", "role", "projectUuids"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_AllowedEmailDomains.organizationUuid_": {
-                "$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "UpdateAllowedEmailDomains": {
-                "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
-            },
-            "Pick_CreateGroup.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "A friendly name for the group"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ApiGroupListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/Group"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ResourceViewItemType.DASHBOARD": {
-                "enum": ["dashboard"],
-                "type": "string"
-            },
-            "UpdatedByUser": {
-                "properties": {
-                    "userUuid": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    }
-                },
-                "required": ["userUuid", "firstName", "lastName"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-                "properties": {
-                    "validationId": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "error": {
-                        "type": "string"
-                    }
-                },
-                "required": ["validationId", "createdAt", "error"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ValidationSummary": {
-                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
-            },
-            "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "validationErrors": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationSummary"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "views",
-                    "firstViewedAt",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewDashboardItem": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "ResourceViewItemType.CHART": {
-                "enum": ["chart"],
-                "type": "string"
-            },
-            "ChartKind": {
-                "enum": [
-                    "line",
-                    "horizontal_bar",
-                    "vertical_bar",
-                    "scatter",
-                    "area",
-                    "mixed",
-                    "pie",
-                    "table",
-                    "big_number"
-                ],
-                "type": "string"
-            },
-            "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "validationErrors": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationSummary"
-                        },
-                        "type": "array"
-                    },
-                    "chartType": {
-                        "$ref": "#/components/schemas/ChartKind"
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "views",
-                    "firstViewedAt",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewChartItem": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.CHART"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "ResourceViewItemType.SPACE": {
-                "enum": ["space"],
-                "type": "string"
-            },
-            "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder",
-                    "isPrivate"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ResourceViewSpaceItem": {
-                "properties": {
-                    "data": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
-                            },
-                            {
-                                "properties": {
-                                    "chartCount": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "dashboardCount": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "accessListLength": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "access": {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    }
-                                },
-                                "required": [
-                                    "chartCount",
-                                    "dashboardCount",
-                                    "accessListLength",
-                                    "access"
-                                ],
-                                "type": "object"
-                            }
-                        ]
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "PinnedItems": {
-                "items": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/components/schemas/ResourceViewDashboardItem"
-                        },
-                        {
-                            "$ref": "#/components/schemas/ResourceViewChartItem"
-                        },
-                        {
-                            "$ref": "#/components/schemas/ResourceViewSpaceItem"
-                        }
-                    ]
-                },
-                "type": "array"
-            },
-            "ApiPinnedItems": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/PinnedItems"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ResourceViewItemType": {
-                "enum": ["chart", "dashboard", "space"],
-                "type": "string"
-            },
-            "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-                "properties": {
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "required": ["uuid", "pinnedListOrder"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "UpdatePinnedItemOrder": {
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType"
-                    }
-                },
-                "required": ["data", "type"],
-                "type": "object"
-            },
-            "DbtProjectType.DBT": {
-                "enum": ["dbt"],
-                "type": "string"
-            },
-            "DbtProjectEnvironmentVariable": {
-                "properties": {
-                    "value": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    }
-                },
-                "required": ["value", "key"],
-                "type": "object"
-            },
-            "DbtProjectType": {
-                "enum": [
-                    "dbt",
-                    "dbt_cloud_ide",
-                    "github",
-                    "gitlab",
-                    "bitbucket",
-                    "azure_devops",
-                    "none"
-                ],
-                "type": "string"
-            },
-            "DbtLocalProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.DBT"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "profiles_dir": {
-                        "type": "string"
-                    },
-                    "project_dir": {
-                        "type": "string"
-                    }
-                },
-                "required": ["type"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.DBT_CLOUD_IDE": {
-                "enum": ["dbt_cloud_ide"],
-                "type": "string"
-            },
-            "DbtCloudIDEProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.DBT_CLOUD_IDE"
-                    },
-                    "api_key": {
-                        "type": "string"
-                    },
-                    "account_id": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        ]
-                    },
-                    "environment_id": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        ]
-                    },
-                    "project_id": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        ]
-                    }
-                },
-                "required": [
-                    "type",
-                    "api_key",
-                    "account_id",
-                    "environment_id",
-                    "project_id"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.GITHUB": {
-                "enum": ["github"],
-                "type": "string"
-            },
-            "DbtGithubProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.GITHUB"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "personal_access_token": {
-                        "type": "string"
-                    },
-                    "repository": {
-                        "type": "string"
-                    },
-                    "branch": {
-                        "type": "string"
-                    },
-                    "project_sub_path": {
-                        "type": "string"
-                    },
-                    "host_domain": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type",
-                    "personal_access_token",
-                    "repository",
-                    "branch",
-                    "project_sub_path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.BITBUCKET": {
-                "enum": ["bitbucket"],
-                "type": "string"
-            },
-            "DbtBitBucketProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.BITBUCKET"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "username": {
-                        "type": "string"
-                    },
-                    "personal_access_token": {
-                        "type": "string"
-                    },
-                    "repository": {
-                        "type": "string"
-                    },
-                    "branch": {
-                        "type": "string"
-                    },
-                    "project_sub_path": {
-                        "type": "string"
-                    },
-                    "host_domain": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type",
-                    "username",
-                    "personal_access_token",
-                    "repository",
-                    "branch",
-                    "project_sub_path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.GITLAB": {
-                "enum": ["gitlab"],
-                "type": "string"
-            },
-            "DbtGitlabProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.GITLAB"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "personal_access_token": {
-                        "type": "string"
-                    },
-                    "repository": {
-                        "type": "string"
-                    },
-                    "branch": {
-                        "type": "string"
-                    },
-                    "project_sub_path": {
-                        "type": "string"
-                    },
-                    "host_domain": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type",
-                    "personal_access_token",
-                    "repository",
-                    "branch",
-                    "project_sub_path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.AZURE_DEVOPS": {
-                "enum": ["azure_devops"],
-                "type": "string"
-            },
-            "DbtAzureDevOpsProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.AZURE_DEVOPS"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "personal_access_token": {
-                        "type": "string"
-                    },
-                    "organization": {
-                        "type": "string"
-                    },
-                    "project": {
-                        "type": "string"
-                    },
-                    "repository": {
-                        "type": "string"
-                    },
-                    "branch": {
-                        "type": "string"
-                    },
-                    "project_sub_path": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type",
-                    "personal_access_token",
-                    "organization",
-                    "project",
-                    "repository",
-                    "branch",
-                    "project_sub_path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectType.NONE": {
-                "enum": ["none"],
-                "type": "string"
-            },
-            "DbtNoneProjectConfig": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DbtProjectType.NONE"
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "items": {
-                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-                        },
-                        "type": "array"
-                    },
-                    "hideRefreshButton": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["type"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "DbtProjectConfig": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/DbtLocalProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtCloudIDEProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtGithubProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtBitBucketProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtGitlabProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtAzureDevOpsProjectConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DbtNoneProjectConfig"
-                    }
-                ]
-            },
-            "WarehouseTypes.SNOWFLAKE": {
-                "enum": ["snowflake"],
-                "type": "string"
-            },
-            "WeekDay": {
-                "enum": [0, 1, 2, 3, 4, 5, 6],
-                "type": "number"
-            },
-            "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "role": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
-                    },
-                    "account": {
-                        "type": "string"
-                    },
-                    "database": {
-                        "type": "string"
-                    },
-                    "warehouse": {
-                        "type": "string"
-                    },
-                    "schema": {
-                        "type": "string"
-                    },
-                    "threads": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "clientSessionKeepAlive": {
-                        "type": "boolean"
-                    },
-                    "queryTag": {
-                        "type": "string"
-                    },
-                    "accessUrl": {
-                        "type": "string"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "required": [
-                    "type",
-                    "account",
-                    "database",
-                    "warehouse",
-                    "schema"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "SnowflakeCredentials": {
-                "$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseTypes.REDSHIFT": {
-                "enum": ["redshift"],
-                "type": "string"
-            },
-            "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
-                    },
-                    "schema": {
-                        "type": "string"
-                    },
-                    "threads": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "useSshTunnel": {
-                        "type": "boolean"
-                    },
-                    "sshTunnelHost": {
-                        "type": "string"
-                    },
-                    "sshTunnelPort": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sshTunnelUser": {
-                        "type": "string"
-                    },
-                    "sshTunnelPublicKey": {
-                        "type": "string"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "port": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "dbname": {
-                        "type": "string"
-                    },
-                    "keepalivesIdle": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sslmode": {
-                        "type": "string"
-                    },
-                    "ra3Node": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["type", "schema", "host", "port", "dbname"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "RedshiftCredentials": {
-                "$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseTypes.POSTGRES": {
-                "enum": ["postgres"],
-                "type": "string"
-            },
-            "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "role": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
-                    },
-                    "schema": {
-                        "type": "string"
-                    },
-                    "threads": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "useSshTunnel": {
-                        "type": "boolean"
-                    },
-                    "sshTunnelHost": {
-                        "type": "string"
-                    },
-                    "sshTunnelPort": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sshTunnelUser": {
-                        "type": "string"
-                    },
-                    "sshTunnelPublicKey": {
-                        "type": "string"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "port": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "dbname": {
-                        "type": "string"
-                    },
-                    "keepalivesIdle": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sslmode": {
-                        "type": "string"
-                    },
-                    "searchPath": {
-                        "type": "string"
-                    }
-                },
-                "required": ["type", "schema", "host", "port", "dbname"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "PostgresCredentials": {
-                "$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseTypes.BIGQUERY": {
-                "enum": ["bigquery"],
-                "type": "string"
-            },
-            "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
-                    },
-                    "threads": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "project": {
-                        "type": "string"
-                    },
-                    "dataset": {
-                        "type": "string"
-                    },
-                    "timeoutSeconds": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "priority": {
-                        "type": "string",
-                        "enum": ["interactive", "batch"]
-                    },
-                    "retries": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "location": {
-                        "type": "string"
-                    },
-                    "maximumBytesBilled": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["type", "project", "dataset"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "BigqueryCredentials": {
-                "$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseTypes.DATABRICKS": {
-                "enum": ["databricks"],
-                "type": "string"
-            },
-            "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
-                    },
-                    "database": {
-                        "type": "string"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "catalog": {
-                        "type": "string"
-                    },
-                    "serverHostName": {
-                        "type": "string"
-                    },
-                    "httpPath": {
-                        "type": "string"
-                    }
-                },
-                "required": ["type", "database", "serverHostName", "httpPath"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "DatabricksCredentials": {
-                "$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseTypes.TRINO": {
-                "enum": ["trino"],
-                "type": "string"
-            },
-            "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.TRINO"
-                    },
-                    "schema": {
-                        "type": "string"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "port": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "dbname": {
-                        "type": "string"
-                    },
-                    "http_scheme": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type",
-                    "schema",
-                    "host",
-                    "port",
-                    "dbname",
-                    "http_scheme"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
-                "$ref": "#/components/schemas/Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "TrinoCredentials": {
-                "$ref": "#/components/schemas/Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_"
-            },
-            "WarehouseCredentials": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/SnowflakeCredentials"
-                    },
-                    {
-                        "$ref": "#/components/schemas/RedshiftCredentials"
-                    },
-                    {
-                        "$ref": "#/components/schemas/PostgresCredentials"
-                    },
-                    {
-                        "$ref": "#/components/schemas/BigqueryCredentials"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DatabricksCredentials"
-                    },
-                    {
-                        "$ref": "#/components/schemas/TrinoCredentials"
-                    }
-                ]
-            },
-            "Project": {
-                "properties": {
-                    "copiedFromProjectUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string"
-                    },
-                    "warehouseConnection": {
-                        "$ref": "#/components/schemas/WarehouseCredentials"
-                    },
-                    "dbtConnection": {
-                        "$ref": "#/components/schemas/DbtProjectConfig"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ProjectType"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "dbtConnection",
-                    "type",
-                    "name",
-                    "projectUuid",
-                    "organizationUuid"
-                ],
-                "type": "object"
-            },
-            "ApiProjectResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Project"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "spaceName": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "spaceUuid",
-                    "pinnedListUuid",
-                    "spaceName"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ChartType": {
-                "enum": ["cartesian", "table", "big_number", "pie"],
-                "type": "string"
-            },
-            "ChartSummary": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
-                    },
-                    {
-                        "properties": {
-                            "chartType": {
-                                "$ref": "#/components/schemas/ChartType"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "ApiChartSummaryListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ChartSummary"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "projectUuid",
-                    "isPrivate"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "SpaceSummary": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
-                    },
-                    {
-                        "properties": {
-                            "access": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["access"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "ApiSpaceSummaryListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceSummary"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ProjectMemberRole": {
-                "enum": [
-                    "viewer",
-                    "interactive_viewer",
-                    "editor",
-                    "developer",
-                    "admin"
-                ],
-                "type": "string"
-            },
-            "ProjectMemberProfile": {
-                "properties": {
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/ProjectMemberRole"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "lastName",
-                    "firstName",
-                    "email",
-                    "role",
-                    "projectUuid",
-                    "userUuid"
-                ],
-                "type": "object"
-            },
-            "ApiProjectAccessListResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ProjectMemberProfile"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "CreateProjectMember": {
-                "properties": {
-                    "sendEmail": {
-                        "type": "boolean"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/ProjectMemberRole"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "required": ["sendEmail", "role", "email"],
-                "type": "object"
-            },
-            "UpdateProjectMember": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/ProjectMemberRole"
-                    }
-                },
-                "required": ["role"],
-                "type": "object"
-            },
-            "FieldId": {
-                "type": "string"
-            },
-            "FilterGroupResponse": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "or": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "id": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["or", "id"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "and": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "id": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["and", "id"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Filters": {
-                "properties": {
-                    "metrics": {
-                        "$ref": "#/components/schemas/FilterGroupResponse"
-                    },
-                    "dimensions": {
-                        "$ref": "#/components/schemas/FilterGroupResponse"
-                    }
-                },
-                "type": "object"
-            },
-            "SortField": {
-                "properties": {
-                    "descending": {
-                        "type": "boolean"
-                    },
-                    "fieldId": {
-                        "type": "string"
-                    }
-                },
-                "required": ["descending", "fieldId"],
-                "type": "object"
-            },
-            "TableCalculationFormatType": {
-                "enum": ["default", "percent", "currency", "number"],
-                "type": "string"
-            },
-            "NumberSeparator": {
-                "enum": [
-                    "default",
-                    "commaPeriod",
-                    "spacePeriod",
-                    "periodComma",
-                    "noSeparatorPeriod"
-                ],
-                "type": "string"
-            },
-            "Compact": {
-                "enum": ["thousands", "millions", "billions", "trillions"],
-                "type": "string"
-            },
-            "TableCalculationFormat": {
-                "properties": {
-                    "suffix": {
-                        "type": "string"
-                    },
-                    "prefix": {
-                        "type": "string"
-                    },
-                    "compact": {
-                        "$ref": "#/components/schemas/Compact"
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "separator": {
-                        "$ref": "#/components/schemas/NumberSeparator"
-                    },
-                    "round": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/TableCalculationFormatType"
-                    }
-                },
-                "required": ["type"],
-                "type": "object"
-            },
-            "TableCalculation": {
-                "properties": {
-                    "format": {
-                        "$ref": "#/components/schemas/TableCalculationFormat"
-                    },
-                    "sql": {
-                        "type": "string"
-                    },
-                    "displayName": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "index": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["sql", "displayName", "name"],
-                "type": "object"
-            },
-            "MetricType": {
-                "enum": [
-                    "percentile",
-                    "average",
-                    "count",
-                    "count_distinct",
-                    "sum",
-                    "min",
-                    "max",
-                    "number",
-                    "median",
-                    "string",
-                    "date",
-                    "boolean"
-                ],
-                "type": "string"
-            },
-            "CompactOrAlias": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/Compact"
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "K",
-                            "thousand",
-                            "M",
-                            "million",
-                            "B",
-                            "billion",
-                            "T",
-                            "trillion"
-                        ]
-                    }
-                ]
-            },
-            "ConditionalOperator": {
-                "enum": [
-                    "isNull",
-                    "notNull",
-                    "equals",
-                    "notEquals",
-                    "startsWith",
-                    "endsWith",
-                    "include",
-                    "doesNotInclude",
-                    "lessThan",
-                    "lessThanOrEqual",
-                    "greaterThan",
-                    "greaterThanOrEqual",
-                    "inThePast",
-                    "inTheNext",
-                    "inTheCurrent",
-                    "inBetween"
-                ],
-                "type": "string"
-            },
-            "MetricFilterRule": {
-                "properties": {
-                    "values": {
-                        "items": {},
-                        "type": "array"
-                    },
-                    "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "target": {
-                        "properties": {
-                            "fieldRef": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["fieldRef"],
-                        "type": "object"
-                    },
-                    "settings": {}
-                },
-                "required": ["operator", "id", "target"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "AdditionalMetric": {
-                "properties": {
-                    "label": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/MetricType"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "sql": {
-                        "type": "string"
-                    },
-                    "hidden": {
-                        "type": "boolean"
-                    },
-                    "round": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "compact": {
-                        "$ref": "#/components/schemas/CompactOrAlias"
-                    },
-                    "format": {
-                        "type": "string"
-                    },
-                    "table": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "index": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "filters": {
-                        "items": {
-                            "$ref": "#/components/schemas/MetricFilterRule"
-                        },
-                        "type": "array"
-                    },
-                    "baseDimensionName": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "required": ["type", "sql", "table", "name"],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "MetricQueryResponse": {
-                "properties": {
-                    "additionalMetrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/AdditionalMetric"
-                        },
-                        "type": "array"
-                    },
-                    "tableCalculations": {
-                        "items": {
-                            "$ref": "#/components/schemas/TableCalculation"
-                        },
-                        "type": "array"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sorts": {
-                        "items": {
-                            "$ref": "#/components/schemas/SortField"
-                        },
-                        "type": "array"
-                    },
-                    "filters": {
-                        "$ref": "#/components/schemas/Filters"
-                    },
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "tableCalculations",
-                    "limit",
-                    "sorts",
-                    "filters",
-                    "metrics",
-                    "dimensions"
-                ],
-                "type": "object"
-            },
-            "ApiRunQueryResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "rows": {
-                                "items": {},
-                                "type": "array"
-                            },
-                            "metricQuery": {
-                                "$ref": "#/components/schemas/MetricQueryResponse"
-                            }
-                        },
-                        "required": ["rows", "metricQuery"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "RunQueryRequest": {
-                "properties": {
-                    "csvLimit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "additionalMetrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/AdditionalMetric"
-                        },
-                        "type": "array"
-                    },
-                    "tableCalculations": {
-                        "items": {
-                            "$ref": "#/components/schemas/TableCalculation"
-                        },
-                        "type": "array"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "sorts": {
-                        "items": {
-                            "$ref": "#/components/schemas/SortField"
-                        },
-                        "type": "array"
-                    },
-                    "filters": {
-                        "properties": {
-                            "metrics": {},
-                            "dimensions": {}
-                        },
-                        "type": "object"
-                    },
-                    "metrics": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "$ref": "#/components/schemas/FieldId"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "tableCalculations",
-                    "limit",
-                    "sorts",
-                    "filters",
-                    "metrics",
-                    "dimensions"
-                ],
-                "type": "object"
-            },
-            "SchedulerFormat": {
-                "enum": ["csv", "image"],
-                "type": "string"
-            },
-            "SchedulerCsvOptions": {
-                "properties": {
-                    "limit": {
-                        "anyOf": [
-                            {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            {
-                                "type": "string",
-                                "enum": ["table", "all"]
-                            }
-                        ]
-                    },
-                    "formatted": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["limit", "formatted"],
-                "type": "object"
-            },
-            "SchedulerImageOptions": {
-                "properties": {},
-                "type": "object"
-            },
-            "SchedulerOptions": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerCsvOptions"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SchedulerImageOptions"
-                    }
-                ]
-            },
-            "SchedulerBase": {
-                "properties": {
-                    "options": {
-                        "$ref": "#/components/schemas/SchedulerOptions"
-                    },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedChartUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cron": {
-                        "type": "string"
-                    },
-                    "format": {
-                        "$ref": "#/components/schemas/SchedulerFormat"
-                    },
-                    "createdBy": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "options",
-                    "dashboardUuid",
-                    "savedChartUuid",
-                    "cron",
-                    "format",
-                    "createdBy",
-                    "updatedAt",
-                    "createdAt",
-                    "name",
-                    "schedulerUuid"
-                ],
-                "type": "object"
-            },
-            "ChartScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "dashboardUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedChartUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["dashboardUuid", "savedChartUuid"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "DashboardScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "dashboardUuid": {
-                                "type": "string"
-                            },
-                            "savedChartUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            }
-                        },
-                        "required": ["dashboardUuid", "savedChartUuid"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Scheduler": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ChartScheduler"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DashboardScheduler"
-                    }
-                ]
-            },
-            "SchedulerSlackTarget": {
-                "properties": {
-                    "channel": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerSlackTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "channel",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerSlackTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerEmailTarget": {
-                "properties": {
-                    "recipient": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerEmailTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "recipient",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerEmailTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerAndTargets": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Scheduler"
-                    },
-                    {
-                        "properties": {
-                            "targets": {
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
-                                        }
-                                    ]
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["targets"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "SchedulerJobStatus": {
-                "enum": ["scheduled", "started", "completed", "error"],
-                "type": "string"
-            },
-            "Record_string.any_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
-            "SchedulerLog": {
-                "properties": {
-                    "details": {
-                        "$ref": "#/components/schemas/Record_string.any_"
-                    },
-                    "targetType": {
-                        "type": "string",
-                        "enum": ["email", "slack"]
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/SchedulerJobStatus"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "scheduledTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "jobGroup": {
-                        "type": "string"
-                    },
-                    "jobId": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "task": {
-                        "type": "string",
-                        "enum": [
-                            "handleScheduledDelivery",
-                            "sendEmailNotification",
-                            "sendSlackNotification",
-                            "downloadCsv",
-                            "compileProject",
-                            "testAndCompileProject",
-                            "validateProject"
-                        ]
-                    }
-                },
-                "required": [
-                    "status",
-                    "createdAt",
-                    "scheduledTime",
-                    "jobId",
-                    "task"
-                ],
-                "type": "object"
-            },
-            "SchedulerWithLogs": {
-                "properties": {
-                    "logs": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerLog"
-                        },
-                        "type": "array"
-                    },
-                    "dashboards": {
-                        "items": {
-                            "properties": {
-                                "dashboardUuid": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["dashboardUuid", "name"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "charts": {
-                        "items": {
-                            "properties": {
-                                "savedChartUuid": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["savedChartUuid", "name"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "users": {
-                        "items": {
-                            "properties": {
-                                "userUuid": {
-                                    "type": "string"
-                                },
-                                "lastName": {
-                                    "type": "string"
-                                },
-                                "firstName": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["userUuid", "lastName", "firstName"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "schedulers": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerAndTargets"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "logs",
-                    "dashboards",
-                    "charts",
-                    "users",
-                    "schedulers"
-                ],
-                "type": "object"
-            },
-            "ApiSchedulerLogsResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/SchedulerWithLogs"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiSchedulerAndTargetsResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/SchedulerAndTargets"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ScheduledJobs": {
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
-                "required": ["id", "date"],
-                "type": "object"
-            },
-            "ApiScheduledJobsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ScheduledJobs"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiJobStatusResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "status": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["status"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ShareUrl": {
-                "properties": {
-                    "host": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "shareUrl": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "createdByUserUuid": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "params": {
-                        "type": "string"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "The URL path of the full URL"
-                    },
-                    "nanoid": {
-                        "type": "string",
-                        "description": "Unique shareable id"
-                    }
-                },
-                "required": ["params", "path", "nanoid"],
-                "type": "object",
-                "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
-            },
-            "ApiShareResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/ShareUrl"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_ShareUrl.path-or-params_": {
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "The URL path of the full URL"
-                    },
-                    "params": {
-                        "type": "string"
-                    }
-                },
-                "required": ["path", "params"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "CreateShareUrl": {
-                "$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
-                "description": "Contains the detail of a full URL to generate a short URL id"
-            },
-            "SlackChannel": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name", "id"],
-                "type": "object"
-            },
-            "ApiSlackChannelsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SlackChannel"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ViewStatistics": {
-                "properties": {
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["firstViewedAt", "views"],
-                "type": "object"
-            },
-            "SpaceQuery": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ViewStatistics"
-                    },
-                    {
-                        "properties": {
-                            "validationErrors": {
-                                "items": {
-                                    "$ref": "#/components/schemas/ValidationSummary"
-                                },
-                                "type": "array"
-                            },
-                            "chartType": {
-                                "$ref": "#/components/schemas/ChartKind"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "required": [
-                    "name",
-                    "organizationUuid",
-                    "uuid",
-                    "updatedAt",
-                    "projectUuid",
-                    "spaceUuid",
-                    "views",
-                    "firstViewedAt",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "DashboardBasicDetails": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"
-                    },
-                    {
-                        "properties": {
-                            "validationErrors": {
-                                "items": {
-                                    "$ref": "#/components/schemas/ValidationSummary"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "SpaceDashboard": {
-                "$ref": "#/components/schemas/DashboardBasicDetails"
-            },
-            "SpaceShare": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/ProjectMemberRole"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["role", "lastName", "firstName", "userUuid"],
-                "type": "object"
-            },
-            "Space": {
-                "properties": {
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "access": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceShare"
-                        },
-                        "type": "array"
-                    },
-                    "dashboards": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceDashboard"
-                        },
-                        "type": "array"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "queries": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceQuery"
-                        },
-                        "type": "array"
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "pinnedListOrder",
-                    "pinnedListUuid",
-                    "access",
-                    "dashboards",
-                    "projectUuid",
-                    "queries",
-                    "isPrivate",
-                    "name",
-                    "uuid",
-                    "organizationUuid"
-                ],
-                "type": "object"
-            },
-            "ApiSpaceResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Space"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "CreateSpace": {
-                "properties": {
-                    "access": {
-                        "items": {
-                            "$ref": "#/components/schemas/SpaceShare"
-                        },
-                        "type": "array"
-                    },
-                    "isPrivate": {
-                        "type": "boolean"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"],
-                "type": "object"
-            },
-            "UpdateSpace": {
-                "properties": {
-                    "isPrivate": {
-                        "type": "boolean"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "required": ["isPrivate", "name"],
-                "type": "object"
-            },
-            "AddSpaceShare": {
-                "properties": {
-                    "userUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["userUuid"],
-                "type": "object"
-            },
-            "Pick_SshKeyPair.publicKey_": {
-                "properties": {
-                    "publicKey": {
-                        "type": "string"
-                    }
-                },
-                "required": ["publicKey"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ApiSshKeyPairResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "EmailOneTimePassword": {
-                "properties": {
-                    "numberOfAttempts": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Number of times the passcode has been attempted"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Time that the passcode was created"
-                    }
-                },
-                "required": ["numberOfAttempts", "createdAt"],
-                "type": "object"
-            },
-            "EmailStatus": {
-                "properties": {
-                    "otp": {
-                        "$ref": "#/components/schemas/EmailOneTimePassword"
-                    },
-                    "isVerified": {
-                        "type": "boolean"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "required": ["isVerified", "email"],
-                "type": "object"
-            },
-            "EmailOneTimePasswordExpiring": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/EmailOneTimePassword"
-                    },
-                    {
-                        "properties": {
-                            "isMaxAttempts": {
-                                "type": "boolean"
-                            },
-                            "isExpired": {
-                                "type": "boolean"
-                            },
-                            "expiresAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            }
-                        },
-                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "EmailStatusExpiring": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/EmailStatus"
-                    },
-                    {
-                        "properties": {
-                            "otp": {
-                                "$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
-                                "description": "One time passcode information\nIf there is no active passcode, this will be undefined"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ],
-                "description": "Verification status of an email address"
-            },
-            "ApiEmailStatusResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/EmailStatusExpiring"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object",
-                "description": "Shows the current verification status of an email address"
-            },
-            "UserAllowedOrganization": {
-                "properties": {
-                    "membersCount": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["membersCount", "name", "organizationUuid"],
-                "type": "object"
-            },
-            "ApiUserAllowedOrganizationsResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/UserAllowedOrganization"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiJobScheduledResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "jobId": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["jobId"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ValidationErrorType": {
-                "enum": [
-                    "chart",
-                    "sorting",
-                    "filter",
-                    "metric",
-                    "model",
-                    "dimension"
-                ],
-                "type": "string"
-            },
-            "ValidationSourceType": {
-                "enum": ["chart", "dashboard", "table"],
-                "type": "string"
-            },
-            "ValidationResponseBase": {
-                "properties": {
-                    "source": {
-                        "$ref": "#/components/schemas/ValidationSourceType"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "errorType": {
-                        "$ref": "#/components/schemas/ValidationErrorType"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "validationId": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": [
-                    "projectUuid",
-                    "errorType",
-                    "error",
-                    "name",
-                    "createdAt",
-                    "validationId"
-                ],
-                "type": "object"
-            },
-            "ValidationErrorChartResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationResponseBase"
-                    },
-                    {
-                        "properties": {
-                            "chartName": {
-                                "type": "string"
-                            },
-                            "chartViews": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "lastUpdatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "lastUpdatedBy": {
-                                "type": "string"
-                            },
-                            "fieldName": {
-                                "type": "string"
-                            },
-                            "chartType": {
-                                "$ref": "#/components/schemas/ChartKind"
-                            },
-                            "chartUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["chartViews"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "ValidationErrorDashboardResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationResponseBase"
-                    },
-                    {
-                        "properties": {
-                            "dashboardViews": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "lastUpdatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "lastUpdatedBy": {
-                                "type": "string"
-                            },
-                            "fieldName": {
-                                "type": "string"
-                            },
-                            "chartName": {
-                                "type": "string"
-                            },
-                            "dashboardUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["dashboardViews"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
-                "properties": {
-                    "projectUuid": {
-                        "type": "string"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "validationId": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "errorType": {
-                        "$ref": "#/components/schemas/ValidationErrorType"
-                    },
-                    "source": {
-                        "$ref": "#/components/schemas/ValidationSourceType"
-                    }
-                },
-                "required": [
-                    "projectUuid",
-                    "validationId",
-                    "createdAt",
-                    "error",
-                    "errorType"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_ValidationResponseBase.name_": {
-                "$ref": "#/components/schemas/Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "ValidationErrorTableResponse": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Omit_ValidationResponseBase.name_"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "ValidationResponse": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorChartResponse"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorDashboardResponse"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ValidationErrorTableResponse"
-                    }
-                ]
-            },
-            "ApiValidateResponse": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationResponse"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiValidationDismissResponse": {
-                "properties": {
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            }
-        },
-        "securitySchemes": {
-            "session_cookie": {
-                "type": "apiKey",
-                "in": "cookie",
-                "name": "connect.sid"
-            },
-            "api_key": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "Authorization",
-                "description": "Value should be 'ApiKey <your key>'"
-            }
-        }
-    },
-    "info": {
-        "title": "Lightdash API",
-        "version": "0.630.0",
-        "description": "Open API documentation for all public Lightdash API endpoints",
-        "license": {
-            "name": "MIT"
-        },
-        "contact": {
-            "name": "Lightdash Support",
-            "email": "support@lightdash.com",
-            "url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
-        }
-    },
-    "openapi": "3.0.0",
-    "paths": {
-        "/api/v1/csv/{jobId}": {
-            "get": {
-                "operationId": "getCsvUrl",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiCsvUrlResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a Csv",
-                "tags": ["Exports"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the jobId for the CSV",
-                        "in": "path",
-                        "name": "jobId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
-            "get": {
-                "operationId": "getDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the current dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "updateDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "deleteDbtCloudIntegrationSettings",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
-            "get": {
-                "operationId": "getDbtCloudMetrics",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDbtCloudMetrics"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/groups/{groupUuid}": {
-            "get": {
-                "operationId": "getGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get group details",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "unique id of the group",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "deleteGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "patch": {
-                "operationId": "updateGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateGroup"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/groups/{groupUuid}/members/{userUuid}": {
-            "put": {
-                "operationId": "addUserToGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Add a Lightdash user to a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to add the user to",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the UUID for the user to add to the group",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "removeUserFromGroup",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove a user from a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to remove the user from",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the UUID for the user to remove from the group",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/groups/{groupUuid}/members": {
-            "get": {
-                "operationId": "getGroupMembers",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupMembersResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "View members of a group",
-                "tags": ["User Groups"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the UUID for the group to view the members of",
-                        "in": "path",
-                        "name": "groupUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org": {
-            "get": {
-                "operationId": "GetMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganization"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            },
-            "put": {
-                "operationId": "CreateOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new organization settings",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateOrganization",
-                                "description": "the new organization settings"
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "operationId": "UpdateMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new organization settings",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateOrganization",
-                                "description": "the new organization settings"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/{organizationUuid}": {
-            "delete": {
-                "operationId": "DeleteMyOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deletes an organization and all users inside that organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the organization to delete",
-                        "in": "path",
-                        "name": "organizationUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org/projects": {
-            "get": {
-                "operationId": "ListOrganizationProjects",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationProjects"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets all projects of the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/org/users": {
-            "get": {
-                "operationId": "ListOrganizationMembers",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets all the members of the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/org/users/{userUuid}": {
-            "patch": {
-                "operationId": "UpdateOrganizationMember",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Updates the membership profile for a user in the current user's organization",
-                "tags": ["Roles & Permissions", "Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the user to update",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new membership profile",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
-                                "description": "the new membership profile"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/user/{userUuid}": {
-            "delete": {
-                "operationId": "DeleteOrganizationMember",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deletes a user from the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the user to delete",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/org/allowedEmailDomains": {
-            "get": {
-                "operationId": "ListOrganizationEmailDomains",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            },
-            "patch": {
-                "operationId": "UpdateOrganizationEmailDomains",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Updates the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new allowed email domains",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateAllowedEmailDomains",
-                                "description": "the new allowed email domains"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/org/groups": {
-            "post": {
-                "operationId": "CreateGroupInOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Creates a new group in the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the new group details",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Pick_CreateGroup.name_",
-                                "description": "the new group details"
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "operationId": "ListGroupsInOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Gets all the groups in the current user's organization",
-                "tags": ["Organizations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
-            "get": {
-                "operationId": "getPinnedItems",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiPinnedItems"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get pinned items",
-                "tags": ["Content"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "project uuid",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the list uuid for the pinned items",
-                        "in": "path",
-                        "name": "pinnedListUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
-            "patch": {
-                "operationId": "updatePinnedItemsOrder",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiPinnedItems"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update pinned items order",
-                "tags": ["Content"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "project uuid",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the list uuid for the pinned items",
-                        "in": "path",
-                        "name": "pinnedListUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new order of the pinned items",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "items": {
-                                    "$ref": "#/components/schemas/UpdatePinnedItemOrder"
-                                },
-                                "type": "array",
-                                "description": "the new order of the pinned items"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}": {
-            "get": {
-                "operationId": "GetProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiProjectResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a project of an organiztion",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/charts": {
-            "get": {
-                "operationId": "ListChartsInProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List all charts in a project",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project to get charts for",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/spaces": {
-            "get": {
-                "operationId": "ListSpacesInProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List all spaces in a project",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project to get spaces for",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "CreateSpaceInProject",
-                "responses": {
-                    "200": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSpaceResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Create a new space inside a project",
-                "tags": ["Roles & Permissions", "Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateSpace"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/access": {
-            "get": {
-                "operationId": "GetProjectAccessList",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiProjectAccessListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
-                "tags": ["Roles & Permissions", "Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "GrantProjectAccessToUser",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Grant a user access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateProjectMember"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/access/{userUuid}": {
-            "patch": {
-                "operationId": "UpdateProjectAccessForUser",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a user's access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateProjectMember"
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "RevokeProjectAccessForUser",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove a user's access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
-            "post": {
-                "operationId": "postRunUnderlyingDataQuery",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for underlying data results",
-                "tags": ["Exploring"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "table name",
-                        "in": "path",
-                        "name": "exploreId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "metricQuery for the chart to run",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunQueryRequest",
-                                "description": "metricQuery for the chart to run"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
-            "post": {
-                "operationId": "postRunQuery",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for explore",
-                "tags": ["Exploring"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "table name",
-                        "in": "path",
-                        "name": "exploreId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "metricQuery for the chart to run",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunQueryRequest",
-                                "description": "metricQuery for the chart to run"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/saved/{chartUuid}/results": {
-            "post": {
-                "operationId": "postChartResults",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Run a query for a chart",
-                "tags": ["Charts"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "chartUuid for the chart to run",
-                        "in": "path",
-                        "name": "chartUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "filters": {
-                                        "$ref": "#/components/schemas/Filters"
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/schedulers/{projectUuid}/logs": {
-            "get": {
-                "operationId": "getSchedulerLogs",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerLogsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get scheduled logs",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/{schedulerUuid}": {
-            "get": {
-                "operationId": "getScheduler",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "patch": {
-                "operationId": "updateScheduler",
-                "responses": {
-                    "201": {
-                        "description": "Updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the new scheduler data",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "description": "the new scheduler data"
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "operationId": "deleteScheduler",
-                "responses": {
-                    "201": {
-                        "description": "Deleted",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "results": {},
-                                        "status": {
-                                            "type": "string",
-                                            "enum": ["ok"],
-                                            "nullable": false
-                                        }
-                                    },
-                                    "required": ["status"],
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete a scheduler",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to delete",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/{schedulerUuid}/jobs": {
-            "get": {
-                "operationId": "getScheduledJobs",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiScheduledJobsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get scheduled jobs",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the scheduler to update",
-                        "in": "path",
-                        "name": "schedulerUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/schedulers/job/{jobId}/status": {
-            "get": {
-                "operationId": "getSchedulerJobStatus",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiJobStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a generic job status\nThis method can be used when polling from the frontend",
-                "tags": ["Schedulers"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the jobId for the status to check",
-                        "in": "path",
-                        "name": "jobId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/share/{nanoId}": {
-            "get": {
-                "operationId": "getShareUrl",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiShareResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get a share url from a short url id",
-                "tags": ["Share links"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the short id for the share url",
-                        "in": "path",
-                        "name": "nanoId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/share": {
-            "post": {
-                "operationId": "CreateShareUrl",
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiShareResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Given a full URL generates a short url id that can be used for sharing",
-                "tags": ["Share links"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "a full URL used to generate a short url id",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateShareUrl",
-                                "description": "a full URL used to generate a short url id"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/slack/channels": {
-            "get": {
-                "operationId": "getSlackChannels",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSlackChannelsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get slack channels",
-                "tags": ["Integrations"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}": {
-            "get": {
-                "operationId": "GetSpace",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSpaceResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get details for a space in a project",
-                "tags": ["Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The uuid of the space to get",
-                        "in": "path",
-                        "name": "spaceUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "delete": {
-                "operationId": "DeleteSpace",
-                "responses": {
-                    "204": {
-                        "description": "Deleted",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete a space from a project",
-                "tags": ["Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The uuid of the space to delete",
-                        "in": "path",
-                        "name": "spaceUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "patch": {
-                "operationId": "UpdateSpace",
-                "responses": {
-                    "200": {
-                        "description": "Updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSpaceResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Update a space in a project",
-                "tags": ["Roles & Permissions", "Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The uuid of the space to update",
-                        "in": "path",
-                        "name": "spaceUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateSpace"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share": {
-            "post": {
-                "operationId": "AddSpaceShareToUser",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Grant a user access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "path",
-                        "name": "spaceUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AddSpaceShare"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share/{userUuid}": {
-            "delete": {
-                "operationId": "RevokeSpaceAccessForUser",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Remove a user's access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "The uuid of the space's parent project",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The uuid of the space to update",
-                        "in": "path",
-                        "name": "spaceUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The uuid of the user to revoke access from",
-                        "in": "path",
-                        "name": "userUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/ssh/key-pairs": {
-            "post": {
-                "operationId": "createSshKeyPair",
-                "responses": {
-                    "201": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSshKeyPairResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["SSH Keypairs"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/email/otp": {
-            "put": {
-                "operationId": "CreateEmailOneTimePasscode",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/email/status": {
-            "get": {
-                "operationId": "GetEmailVerificationStatus",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get the verification status for the current user's primary email",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the one-time passcode sent to the user's primary email",
-                        "in": "query",
-                        "name": "passcode",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/user/me/allowedOrganizations": {
-            "get": {
-                "operationId": "ListMyAvailableOrganizations",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/user/me/joinOrganization/{organizationUuid}": {
-            "post": {
-                "operationId": "JoinOrganization",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the uuid of the organization to join",
-                        "in": "path",
-                        "name": "organizationUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/user/me": {
-            "delete": {
-                "operationId": "DeleteMe",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Delete user",
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/projects/{projectUuid}/validate": {
-            "post": {
-                "operationId": "ValidateProject",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the projectId for the validation",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "explores": {
-                                        "items": {},
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object",
-                                "description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview"
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "operationId": "GetLatestValidationResults",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiValidateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get validation results for a project. This will return the results of the latest validation job.",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "the projectId for the validation",
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "boolean to know if this request is made from the settings page, for analytics",
-                        "in": "query",
-                        "name": "fromSettings",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    },
-                    {
-                        "description": "optional jobId to get results for a specific job, used on CLI",
-                        "in": "query",
-                        "name": "jobId",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/projects/{projectUuid}/validate/{validationId}": {
-            "delete": {
-                "operationId": "DeleteValidationDismiss",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiValidationDismissResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deletes a single validation error.",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "the projectId for the validation",
-                        "in": "path",
-                        "name": "validationId",
-                        "required": true,
-                        "schema": {
-                            "format": "double",
-                            "type": "number"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    "servers": [
-        {
-            "url": "/"
-        }
-    ],
-    "tags": [
-        {
-            "name": "My Account",
-            "description": "These routes allow users to manage their own user account."
-        },
-        {
-            "name": "Organizations",
-            "description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
-        },
-        {
-            "name": "Projects",
-            "description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
-        },
-        {
-            "name": "Spaces",
-            "description": "Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins."
-        },
-        {
-            "name": "Roles & Permissions",
-            "description": "These routes allow users to manage roles and permissions for their organization.",
-            "externalDocs": {
-                "url": "https://docs.lightdash.com/references/roles"
-            }
-        }
-    ]
+	"components": {
+		"examples": {},
+		"headers": {},
+		"parameters": {},
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"ApiErrorPayload": {
+				"properties": {
+					"error": {
+						"properties": {
+							"data": {
+								"description": "Optional data containing details of the error"
+							},
+							"message": {
+								"type": "string",
+								"description": "A friendly message summarising the error"
+							},
+							"name": {
+								"type": "string",
+								"description": "Unique name for the type of error"
+							},
+							"statusCode": {
+								"type": "number",
+								"format": "integer",
+								"description": "HTTP status code"
+							}
+						},
+						"required": [
+							"name",
+							"statusCode"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"error"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"error",
+					"status"
+				],
+				"type": "object",
+				"description": "The Error object is returned from the api any time there is an error.\nThe message contains"
+			},
+			"ApiCsvUrlResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"status": {
+								"type": "string"
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"status",
+							"url"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_CreateDbtCloudIntegration.metricsJobId_": {
+				"properties": {
+					"metricsJobId": {
+						"type": "string",
+						"description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
+					}
+				},
+				"required": [
+					"metricsJobId"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"DbtCloudIntegration": {
+				"$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
+				"description": "Configuration for a Lightdash integration with dbt Cloud"
+			},
+			"ApiDbtCloudIntegrationSettings": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/DbtCloudIntegration"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiDbtCloudSettingsDeleteSuccess": {
+				"properties": {
+					"results": {},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"DbtCloudMetric": {
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"timeGrains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"description": {
+						"type": "string"
+					},
+					"dimensions": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"name": {
+						"type": "string"
+					},
+					"uniqueId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"label",
+					"timeGrains",
+					"description",
+					"dimensions",
+					"name",
+					"uniqueId"
+				],
+				"type": "object"
+			},
+			"DbtCloudMetadataResponseMetrics": {
+				"properties": {
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/DbtCloudMetric"
+						},
+						"type": "array",
+						"description": "A list of dbt metric definitions from the dbt cloud metadata api"
+					}
+				},
+				"required": [
+					"metrics"
+				],
+				"type": "object",
+				"description": "Response from dbt cloud metadata api containing a list of metric definitions"
+			},
+			"ApiDbtCloudMetrics": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Group": {
+				"properties": {
+					"organizationUuid": {
+						"type": "string",
+						"description": "The UUID of the organization that the group belongs to"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"description": "The time that the group was created"
+					},
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					},
+					"uuid": {
+						"type": "string",
+						"description": "The group's UUID"
+					}
+				},
+				"required": [
+					"organizationUuid",
+					"createdAt",
+					"name",
+					"uuid"
+				],
+				"type": "object"
+			},
+			"ApiGroupResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Group"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiSuccessEmpty": {
+				"properties": {
+					"results": {},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			},
+			"GroupMember": {
+				"properties": {
+					"lastName": {
+						"type": "string",
+						"description": "The user's last name"
+					},
+					"firstName": {
+						"type": "string",
+						"description": "The user's first name"
+					},
+					"email": {
+						"type": "string",
+						"description": "Primary email address for the user"
+					},
+					"userUuid": {
+						"type": "string",
+						"description": "Unique id for the user",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"lastName",
+					"firstName",
+					"email",
+					"userUuid"
+				],
+				"type": "object",
+				"description": "A summary for a Lightdash user within a group"
+			},
+			"ApiGroupMembersResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/GroupMember"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Group.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"UpdateGroup": {
+				"$ref": "#/components/schemas/Pick_Group.name_"
+			},
+			"Organization": {
+				"properties": {
+					"defaultProjectUuid": {
+						"type": "string",
+						"description": "The project a user sees when they first log in to the organization"
+					},
+					"needsProject": {
+						"type": "boolean",
+						"description": "The organization needs a project if it doesn't have at least one project."
+					},
+					"chartColors": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array",
+						"description": "The default color palette for all projects in the organization"
+					},
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"description": "The unique identifier of the organization",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid"
+				],
+				"type": "object",
+				"description": "Details of a user's Organization"
+			},
+			"ApiOrganization": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Organization"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Organization.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateOrganization": {
+				"$ref": "#/components/schemas/Pick_Organization.name_"
+			},
+			"Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The name of the organization"
+					},
+					"chartColors": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array",
+						"description": "The default color palette for all projects in the organization"
+					},
+					"defaultProjectUuid": {
+						"type": "string",
+						"description": "The project a user sees when they first log in to the organization"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"UpdateOrganization": {
+				"$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
+			},
+			"ProjectType": {
+				"enum": [
+					"DEFAULT",
+					"PREVIEW"
+				],
+				"type": "string"
+			},
+			"OrganizationProject": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/ProjectType"
+					},
+					"name": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string",
+						"description": "The unique identifier of the project",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"type",
+					"name",
+					"projectUuid"
+				],
+				"type": "object",
+				"description": "Summary of a project under an organization"
+			},
+			"ApiOrganizationProjects": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/OrganizationProject"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object",
+				"description": "List of projects in the current organization"
+			},
+			"OrganizationMemberRole": {
+				"enum": [
+					"member",
+					"viewer",
+					"interactive_viewer",
+					"editor",
+					"developer",
+					"admin"
+				],
+				"type": "string"
+			},
+			"OrganizationMemberProfile": {
+				"properties": {
+					"isInviteExpired": {
+						"type": "boolean",
+						"description": "Whether the user's invite to the organization has expired"
+					},
+					"isActive": {
+						"type": "boolean",
+						"description": "Whether the user has accepted their invite to the organization"
+					},
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole",
+						"description": "The role of the user in the organization"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"description": "Unique identifier for the organization the user is a member of"
+					},
+					"email": {
+						"type": "string"
+					},
+					"lastName": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"userUuid": {
+						"type": "string",
+						"description": "Unique identifier for the user",
+						"format": "uuid"
+					}
+				},
+				"required": [
+					"isActive",
+					"role",
+					"organizationUuid",
+					"email",
+					"lastName",
+					"firstName",
+					"userUuid"
+				],
+				"type": "object",
+				"description": "Profile for a user's membership in an organization"
+			},
+			"ApiOrganizationMemberProfiles": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/OrganizationMemberProfile"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiOrganizationMemberProfile": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/OrganizationMemberProfile"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"OrganizationMemberProfileUpdate": {
+				"properties": {
+					"role": {
+						"$ref": "#/components/schemas/OrganizationMemberRole"
+					}
+				},
+				"required": [
+					"role"
+				],
+				"type": "object"
+			},
+			"OrganizationMemberRole.EDITOR": {
+				"enum": [
+					"editor"
+				],
+				"type": "string"
+			},
+			"OrganizationMemberRole.INTERACTIVE_VIEWER": {
+				"enum": [
+					"interactive_viewer"
+				],
+				"type": "string"
+			},
+			"OrganizationMemberRole.VIEWER": {
+				"enum": [
+					"viewer"
+				],
+				"type": "string"
+			},
+			"OrganizationMemberRole.MEMBER": {
+				"enum": [
+					"member"
+				],
+				"type": "string"
+			},
+			"AllowedEmailDomainsRole": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/OrganizationMemberRole.EDITOR"
+					},
+					{
+						"$ref": "#/components/schemas/OrganizationMemberRole.INTERACTIVE_VIEWER"
+					},
+					{
+						"$ref": "#/components/schemas/OrganizationMemberRole.VIEWER"
+					},
+					{
+						"$ref": "#/components/schemas/OrganizationMemberRole.MEMBER"
+					}
+				]
+			},
+			"AllowedEmailDomains": {
+				"properties": {
+					"projectUuids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"role": {
+						"$ref": "#/components/schemas/AllowedEmailDomainsRole"
+					},
+					"emailDomains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"projectUuids",
+					"role",
+					"emailDomains",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiOrganizationAllowedEmailDomains": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/AllowedEmailDomains"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+				"properties": {
+					"emailDomains": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"role": {
+						"$ref": "#/components/schemas/AllowedEmailDomainsRole"
+					},
+					"projectUuids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"emailDomains",
+					"role",
+					"projectUuids"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_AllowedEmailDomains.organizationUuid_": {
+				"$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"UpdateAllowedEmailDomains": {
+				"$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
+			},
+			"Pick_CreateGroup.name_": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "A friendly name for the group"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ApiGroupListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/Group"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.DASHBOARD": {
+				"enum": [
+					"dashboard"
+				],
+				"type": "string"
+			},
+			"UpdatedByUser": {
+				"properties": {
+					"userUuid": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"lastName": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"userUuid",
+					"firstName",
+					"lastName"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+				"properties": {
+					"validationId": {
+						"type": "number",
+						"format": "double"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"error": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"validationId",
+					"createdAt",
+					"error"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ValidationSummary": {
+				"$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
+			},
+			"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					},
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"validationErrors": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationSummary"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"name",
+					"uuid",
+					"updatedAt",
+					"spaceUuid",
+					"views",
+					"firstViewedAt",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewDashboardItem": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.CHART": {
+				"enum": [
+					"chart"
+				],
+				"type": "string"
+			},
+			"ChartKind": {
+				"enum": [
+					"line",
+					"horizontal_bar",
+					"vertical_bar",
+					"scatter",
+					"area",
+					"mixed",
+					"pie",
+					"table",
+					"big_number"
+				],
+				"type": "string"
+			},
+			"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					},
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"validationErrors": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationSummary"
+						},
+						"type": "array"
+					},
+					"chartType": {
+						"$ref": "#/components/schemas/ChartKind"
+					}
+				},
+				"required": [
+					"name",
+					"uuid",
+					"updatedAt",
+					"spaceUuid",
+					"views",
+					"firstViewedAt",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewChartItem": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.CHART"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType.SPACE": {
+				"enum": [
+					"space"
+				],
+				"type": "string"
+			},
+			"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"isPrivate": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"pinnedListUuid",
+					"pinnedListOrder",
+					"isPrivate"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ResourceViewSpaceItem": {
+				"properties": {
+					"data": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
+							},
+							{
+								"properties": {
+									"chartCount": {
+										"type": "number",
+										"format": "double"
+									},
+									"dashboardCount": {
+										"type": "number",
+										"format": "double"
+									},
+									"accessListLength": {
+										"type": "number",
+										"format": "double"
+									},
+									"access": {
+										"items": {
+											"type": "string"
+										},
+										"type": "array"
+									}
+								},
+								"required": [
+									"chartCount",
+									"dashboardCount",
+									"accessListLength",
+									"access"
+								],
+								"type": "object"
+							}
+						]
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType.SPACE"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"PinnedItems": {
+				"items": {
+					"anyOf": [
+						{
+							"$ref": "#/components/schemas/ResourceViewDashboardItem"
+						},
+						{
+							"$ref": "#/components/schemas/ResourceViewChartItem"
+						},
+						{
+							"$ref": "#/components/schemas/ResourceViewSpaceItem"
+						}
+					]
+				},
+				"type": "array"
+			},
+			"ApiPinnedItems": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/PinnedItems"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ResourceViewItemType": {
+				"enum": [
+					"chart",
+					"dashboard",
+					"space"
+				],
+				"type": "string"
+			},
+			"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+				"properties": {
+					"uuid": {
+						"type": "string"
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					}
+				},
+				"required": [
+					"uuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"UpdatePinnedItemOrder": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ResourceViewItemType"
+					}
+				},
+				"required": [
+					"data",
+					"type"
+				],
+				"type": "object"
+			},
+			"DbtProjectType.DBT": {
+				"enum": [
+					"dbt"
+				],
+				"type": "string"
+			},
+			"DbtProjectEnvironmentVariable": {
+				"properties": {
+					"value": {
+						"type": "string"
+					},
+					"key": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"value",
+					"key"
+				],
+				"type": "object"
+			},
+			"DbtProjectType": {
+				"enum": [
+					"dbt",
+					"dbt_cloud_ide",
+					"github",
+					"gitlab",
+					"bitbucket",
+					"azure_devops",
+					"none"
+				],
+				"type": "string"
+			},
+			"DbtLocalProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.DBT"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"profiles_dir": {
+						"type": "string"
+					},
+					"project_dir": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.DBT_CLOUD_IDE": {
+				"enum": [
+					"dbt_cloud_ide"
+				],
+				"type": "string"
+			},
+			"DbtCloudIDEProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.DBT_CLOUD_IDE"
+					},
+					"api_key": {
+						"type": "string"
+					},
+					"account_id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"environment_id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"project_id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					}
+				},
+				"required": [
+					"type",
+					"api_key",
+					"account_id",
+					"environment_id",
+					"project_id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.GITHUB": {
+				"enum": [
+					"github"
+				],
+				"type": "string"
+			},
+			"DbtGithubProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.GITHUB"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"personal_access_token": {
+						"type": "string"
+					},
+					"repository": {
+						"type": "string"
+					},
+					"branch": {
+						"type": "string"
+					},
+					"project_sub_path": {
+						"type": "string"
+					},
+					"host_domain": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"personal_access_token",
+					"repository",
+					"branch",
+					"project_sub_path"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.BITBUCKET": {
+				"enum": [
+					"bitbucket"
+				],
+				"type": "string"
+			},
+			"DbtBitBucketProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.BITBUCKET"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"username": {
+						"type": "string"
+					},
+					"personal_access_token": {
+						"type": "string"
+					},
+					"repository": {
+						"type": "string"
+					},
+					"branch": {
+						"type": "string"
+					},
+					"project_sub_path": {
+						"type": "string"
+					},
+					"host_domain": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"username",
+					"personal_access_token",
+					"repository",
+					"branch",
+					"project_sub_path"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.GITLAB": {
+				"enum": [
+					"gitlab"
+				],
+				"type": "string"
+			},
+			"DbtGitlabProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.GITLAB"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"personal_access_token": {
+						"type": "string"
+					},
+					"repository": {
+						"type": "string"
+					},
+					"branch": {
+						"type": "string"
+					},
+					"project_sub_path": {
+						"type": "string"
+					},
+					"host_domain": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"personal_access_token",
+					"repository",
+					"branch",
+					"project_sub_path"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.AZURE_DEVOPS": {
+				"enum": [
+					"azure_devops"
+				],
+				"type": "string"
+			},
+			"DbtAzureDevOpsProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.AZURE_DEVOPS"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"personal_access_token": {
+						"type": "string"
+					},
+					"organization": {
+						"type": "string"
+					},
+					"project": {
+						"type": "string"
+					},
+					"repository": {
+						"type": "string"
+					},
+					"branch": {
+						"type": "string"
+					},
+					"project_sub_path": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"personal_access_token",
+					"organization",
+					"project",
+					"repository",
+					"branch",
+					"project_sub_path"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectType.NONE": {
+				"enum": [
+					"none"
+				],
+				"type": "string"
+			},
+			"DbtNoneProjectConfig": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/DbtProjectType.NONE"
+					},
+					"target": {
+						"type": "string"
+					},
+					"environment": {
+						"items": {
+							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+						},
+						"type": "array"
+					},
+					"hideRefreshButton": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"type"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DbtProjectConfig": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/DbtLocalProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtCloudIDEProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtGithubProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtBitBucketProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtGitlabProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtAzureDevOpsProjectConfig"
+					},
+					{
+						"$ref": "#/components/schemas/DbtNoneProjectConfig"
+					}
+				]
+			},
+			"WarehouseTypes.SNOWFLAKE": {
+				"enum": [
+					"snowflake"
+				],
+				"type": "string"
+			},
+			"WeekDay": {
+				"enum": [
+					0,
+					1,
+					2,
+					3,
+					4,
+					5,
+					6
+				],
+				"type": "number"
+			},
+			"Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"role": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
+					},
+					"account": {
+						"type": "string"
+					},
+					"database": {
+						"type": "string"
+					},
+					"warehouse": {
+						"type": "string"
+					},
+					"schema": {
+						"type": "string"
+					},
+					"threads": {
+						"type": "number",
+						"format": "double"
+					},
+					"clientSessionKeepAlive": {
+						"type": "boolean"
+					},
+					"queryTag": {
+						"type": "string"
+					},
+					"accessUrl": {
+						"type": "string"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"type",
+					"account",
+					"database",
+					"warehouse",
+					"schema"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"SnowflakeCredentials": {
+				"$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseTypes.REDSHIFT": {
+				"enum": [
+					"redshift"
+				],
+				"type": "string"
+			},
+			"Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+					},
+					"schema": {
+						"type": "string"
+					},
+					"threads": {
+						"type": "number",
+						"format": "double"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					},
+					"useSshTunnel": {
+						"type": "boolean"
+					},
+					"sshTunnelHost": {
+						"type": "string"
+					},
+					"sshTunnelPort": {
+						"type": "number",
+						"format": "double"
+					},
+					"sshTunnelUser": {
+						"type": "string"
+					},
+					"sshTunnelPublicKey": {
+						"type": "string"
+					},
+					"host": {
+						"type": "string"
+					},
+					"port": {
+						"type": "number",
+						"format": "double"
+					},
+					"dbname": {
+						"type": "string"
+					},
+					"keepalivesIdle": {
+						"type": "number",
+						"format": "double"
+					},
+					"sslmode": {
+						"type": "string"
+					},
+					"ra3Node": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"type",
+					"schema",
+					"host",
+					"port",
+					"dbname"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"RedshiftCredentials": {
+				"$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseTypes.POSTGRES": {
+				"enum": [
+					"postgres"
+				],
+				"type": "string"
+			},
+			"Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"role": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
+					},
+					"schema": {
+						"type": "string"
+					},
+					"threads": {
+						"type": "number",
+						"format": "double"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					},
+					"useSshTunnel": {
+						"type": "boolean"
+					},
+					"sshTunnelHost": {
+						"type": "string"
+					},
+					"sshTunnelPort": {
+						"type": "number",
+						"format": "double"
+					},
+					"sshTunnelUser": {
+						"type": "string"
+					},
+					"sshTunnelPublicKey": {
+						"type": "string"
+					},
+					"host": {
+						"type": "string"
+					},
+					"port": {
+						"type": "number",
+						"format": "double"
+					},
+					"dbname": {
+						"type": "string"
+					},
+					"keepalivesIdle": {
+						"type": "number",
+						"format": "double"
+					},
+					"sslmode": {
+						"type": "string"
+					},
+					"searchPath": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"schema",
+					"host",
+					"port",
+					"dbname"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"PostgresCredentials": {
+				"$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseTypes.BIGQUERY": {
+				"enum": [
+					"bigquery"
+				],
+				"type": "string"
+			},
+			"Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
+					},
+					"threads": {
+						"type": "number",
+						"format": "double"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					},
+					"project": {
+						"type": "string"
+					},
+					"dataset": {
+						"type": "string"
+					},
+					"timeoutSeconds": {
+						"type": "number",
+						"format": "double"
+					},
+					"priority": {
+						"type": "string",
+						"enum": [
+							"interactive",
+							"batch"
+						]
+					},
+					"retries": {
+						"type": "number",
+						"format": "double"
+					},
+					"location": {
+						"type": "string"
+					},
+					"maximumBytesBilled": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"type",
+					"project",
+					"dataset"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"BigqueryCredentials": {
+				"$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseTypes.DATABRICKS": {
+				"enum": [
+					"databricks"
+				],
+				"type": "string"
+			},
+			"Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
+					},
+					"database": {
+						"type": "string"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					},
+					"catalog": {
+						"type": "string"
+					},
+					"serverHostName": {
+						"type": "string"
+					},
+					"httpPath": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"database",
+					"serverHostName",
+					"httpPath"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"DatabricksCredentials": {
+				"$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseTypes.TRINO": {
+				"enum": [
+					"trino"
+				],
+				"type": "string"
+			},
+			"Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/WarehouseTypes.TRINO"
+					},
+					"schema": {
+						"type": "string"
+					},
+					"startOfWeek": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/WeekDay"
+							}
+						],
+						"nullable": true
+					},
+					"host": {
+						"type": "string"
+					},
+					"port": {
+						"type": "number",
+						"format": "double"
+					},
+					"dbname": {
+						"type": "string"
+					},
+					"http_scheme": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"schema",
+					"host",
+					"port",
+					"dbname",
+					"http_scheme"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
+				"$ref": "#/components/schemas/Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"TrinoCredentials": {
+				"$ref": "#/components/schemas/Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_"
+			},
+			"WarehouseCredentials": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/SnowflakeCredentials"
+					},
+					{
+						"$ref": "#/components/schemas/RedshiftCredentials"
+					},
+					{
+						"$ref": "#/components/schemas/PostgresCredentials"
+					},
+					{
+						"$ref": "#/components/schemas/BigqueryCredentials"
+					},
+					{
+						"$ref": "#/components/schemas/DatabricksCredentials"
+					},
+					{
+						"$ref": "#/components/schemas/TrinoCredentials"
+					}
+				]
+			},
+			"Project": {
+				"properties": {
+					"copiedFromProjectUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string"
+					},
+					"warehouseConnection": {
+						"$ref": "#/components/schemas/WarehouseCredentials"
+					},
+					"dbtConnection": {
+						"$ref": "#/components/schemas/DbtProjectConfig"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ProjectType"
+					},
+					"name": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"dbtConnection",
+					"type",
+					"name",
+					"projectUuid",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiProjectResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Project"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"spaceName": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"spaceUuid",
+					"pinnedListUuid",
+					"spaceName"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ChartType": {
+				"enum": [
+					"cartesian",
+					"table",
+					"big_number",
+					"pie"
+				],
+				"type": "string"
+			},
+			"ChartSummary": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+					},
+					{
+						"properties": {
+							"chartType": {
+								"$ref": "#/components/schemas/ChartType"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"ApiChartSummaryListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ChartSummary"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"isPrivate": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"projectUuid",
+					"isPrivate"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"SpaceSummary": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+					},
+					{
+						"properties": {
+							"access": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"access"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"ApiSpaceSummaryListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceSummary"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ProjectMemberRole": {
+				"enum": [
+					"viewer",
+					"interactive_viewer",
+					"editor",
+					"developer",
+					"admin"
+				],
+				"type": "string"
+			},
+			"ProjectMemberProfile": {
+				"properties": {
+					"lastName": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"role": {
+						"$ref": "#/components/schemas/ProjectMemberRole"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"userUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"lastName",
+					"firstName",
+					"email",
+					"role",
+					"projectUuid",
+					"userUuid"
+				],
+				"type": "object"
+			},
+			"ApiProjectAccessListResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ProjectMemberProfile"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"CreateProjectMember": {
+				"properties": {
+					"sendEmail": {
+						"type": "boolean"
+					},
+					"role": {
+						"$ref": "#/components/schemas/ProjectMemberRole"
+					},
+					"email": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"sendEmail",
+					"role",
+					"email"
+				],
+				"type": "object"
+			},
+			"UpdateProjectMember": {
+				"properties": {
+					"role": {
+						"$ref": "#/components/schemas/ProjectMemberRole"
+					}
+				},
+				"required": [
+					"role"
+				],
+				"type": "object"
+			},
+			"FieldId": {
+				"type": "string"
+			},
+			"FilterGroupResponse": {
+				"anyOf": [
+					{
+						"properties": {
+							"or": {
+								"items": {},
+								"type": "array"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"or",
+							"id"
+						],
+						"type": "object"
+					},
+					{
+						"properties": {
+							"and": {
+								"items": {},
+								"type": "array"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"and",
+							"id"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"Filters": {
+				"properties": {
+					"metrics": {
+						"$ref": "#/components/schemas/FilterGroupResponse"
+					},
+					"dimensions": {
+						"$ref": "#/components/schemas/FilterGroupResponse"
+					}
+				},
+				"type": "object"
+			},
+			"SortField": {
+				"properties": {
+					"descending": {
+						"type": "boolean"
+					},
+					"fieldId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"descending",
+					"fieldId"
+				],
+				"type": "object"
+			},
+			"TableCalculationFormatType": {
+				"enum": [
+					"default",
+					"percent",
+					"currency",
+					"number"
+				],
+				"type": "string"
+			},
+			"NumberSeparator": {
+				"enum": [
+					"default",
+					"commaPeriod",
+					"spacePeriod",
+					"periodComma",
+					"noSeparatorPeriod"
+				],
+				"type": "string"
+			},
+			"Compact": {
+				"enum": [
+					"thousands",
+					"millions",
+					"billions",
+					"trillions"
+				],
+				"type": "string"
+			},
+			"TableCalculationFormat": {
+				"properties": {
+					"suffix": {
+						"type": "string"
+					},
+					"prefix": {
+						"type": "string"
+					},
+					"compact": {
+						"$ref": "#/components/schemas/Compact"
+					},
+					"currency": {
+						"type": "string"
+					},
+					"separator": {
+						"$ref": "#/components/schemas/NumberSeparator"
+					},
+					"round": {
+						"type": "number",
+						"format": "double"
+					},
+					"type": {
+						"$ref": "#/components/schemas/TableCalculationFormatType"
+					}
+				},
+				"required": [
+					"type"
+				],
+				"type": "object"
+			},
+			"TableCalculation": {
+				"properties": {
+					"format": {
+						"$ref": "#/components/schemas/TableCalculationFormat"
+					},
+					"sql": {
+						"type": "string"
+					},
+					"displayName": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"index": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"sql",
+					"displayName",
+					"name"
+				],
+				"type": "object"
+			},
+			"MetricType": {
+				"enum": [
+					"percentile",
+					"average",
+					"count",
+					"count_distinct",
+					"sum",
+					"min",
+					"max",
+					"number",
+					"median",
+					"string",
+					"date",
+					"boolean"
+				],
+				"type": "string"
+			},
+			"CompactOrAlias": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/Compact"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"K",
+							"thousand",
+							"M",
+							"million",
+							"B",
+							"billion",
+							"T",
+							"trillion"
+						]
+					}
+				]
+			},
+			"ConditionalOperator": {
+				"enum": [
+					"isNull",
+					"notNull",
+					"equals",
+					"notEquals",
+					"startsWith",
+					"endsWith",
+					"include",
+					"doesNotInclude",
+					"lessThan",
+					"lessThanOrEqual",
+					"greaterThan",
+					"greaterThanOrEqual",
+					"inThePast",
+					"inTheNext",
+					"inTheCurrent",
+					"inBetween"
+				],
+				"type": "string"
+			},
+			"MetricFilterRule": {
+				"properties": {
+					"values": {
+						"items": {},
+						"type": "array"
+					},
+					"operator": {
+						"$ref": "#/components/schemas/ConditionalOperator"
+					},
+					"id": {
+						"type": "string"
+					},
+					"target": {
+						"properties": {
+							"fieldRef": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"fieldRef"
+						],
+						"type": "object"
+					},
+					"settings": {}
+				},
+				"required": [
+					"operator",
+					"id",
+					"target"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AdditionalMetric": {
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/MetricType"
+					},
+					"description": {
+						"type": "string"
+					},
+					"sql": {
+						"type": "string"
+					},
+					"hidden": {
+						"type": "boolean"
+					},
+					"round": {
+						"type": "number",
+						"format": "double"
+					},
+					"compact": {
+						"$ref": "#/components/schemas/CompactOrAlias"
+					},
+					"format": {
+						"type": "string"
+					},
+					"table": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"index": {
+						"type": "number",
+						"format": "double"
+					},
+					"filters": {
+						"items": {
+							"$ref": "#/components/schemas/MetricFilterRule"
+						},
+						"type": "array"
+					},
+					"baseDimensionName": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string",
+						"nullable": true
+					}
+				},
+				"required": [
+					"type",
+					"sql",
+					"table",
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MetricQueryResponse": {
+				"properties": {
+					"additionalMetrics": {
+						"items": {
+							"$ref": "#/components/schemas/AdditionalMetric"
+						},
+						"type": "array"
+					},
+					"tableCalculations": {
+						"items": {
+							"$ref": "#/components/schemas/TableCalculation"
+						},
+						"type": "array"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sorts": {
+						"items": {
+							"$ref": "#/components/schemas/SortField"
+						},
+						"type": "array"
+					},
+					"filters": {
+						"$ref": "#/components/schemas/Filters"
+					},
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					},
+					"dimensions": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"tableCalculations",
+					"limit",
+					"sorts",
+					"filters",
+					"metrics",
+					"dimensions"
+				],
+				"type": "object"
+			},
+			"ApiRunQueryResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"rows": {
+								"items": {},
+								"type": "array"
+							},
+							"metricQuery": {
+								"$ref": "#/components/schemas/MetricQueryResponse"
+							}
+						},
+						"required": [
+							"rows",
+							"metricQuery"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"RunQueryRequest": {
+				"properties": {
+					"csvLimit": {
+						"type": "number",
+						"format": "double"
+					},
+					"additionalMetrics": {
+						"items": {
+							"$ref": "#/components/schemas/AdditionalMetric"
+						},
+						"type": "array"
+					},
+					"tableCalculations": {
+						"items": {
+							"$ref": "#/components/schemas/TableCalculation"
+						},
+						"type": "array"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sorts": {
+						"items": {
+							"$ref": "#/components/schemas/SortField"
+						},
+						"type": "array"
+					},
+					"filters": {
+						"properties": {
+							"metrics": {},
+							"dimensions": {}
+						},
+						"type": "object"
+					},
+					"metrics": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					},
+					"dimensions": {
+						"items": {
+							"$ref": "#/components/schemas/FieldId"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"tableCalculations",
+					"limit",
+					"sorts",
+					"filters",
+					"metrics",
+					"dimensions"
+				],
+				"type": "object"
+			},
+			"SchedulerFormat": {
+				"enum": [
+					"csv",
+					"image"
+				],
+				"type": "string"
+			},
+			"SchedulerCsvOptions": {
+				"properties": {
+					"limit": {
+						"anyOf": [
+							{
+								"type": "number",
+								"format": "double"
+							},
+							{
+								"type": "string",
+								"enum": [
+									"table",
+									"all"
+								]
+							}
+						]
+					},
+					"formatted": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"limit",
+					"formatted"
+				],
+				"type": "object"
+			},
+			"SchedulerImageOptions": {
+				"properties": {},
+				"type": "object"
+			},
+			"SchedulerOptions": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerCsvOptions"
+					},
+					{
+						"$ref": "#/components/schemas/SchedulerImageOptions"
+					}
+				]
+			},
+			"SchedulerBase": {
+				"properties": {
+					"options": {
+						"$ref": "#/components/schemas/SchedulerOptions"
+					},
+					"dashboardUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"savedChartUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"cron": {
+						"type": "string"
+					},
+					"format": {
+						"$ref": "#/components/schemas/SchedulerFormat"
+					},
+					"createdBy": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"name": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"options",
+					"dashboardUuid",
+					"savedChartUuid",
+					"cron",
+					"format",
+					"createdBy",
+					"updatedAt",
+					"createdAt",
+					"name",
+					"schedulerUuid"
+				],
+				"type": "object"
+			},
+			"ChartScheduler": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerBase"
+					},
+					{
+						"properties": {
+							"dashboardUuid": {
+								"type": "number",
+								"enum": [
+									null
+								],
+								"nullable": true
+							},
+							"savedChartUuid": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"dashboardUuid",
+							"savedChartUuid"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"DashboardScheduler": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/SchedulerBase"
+					},
+					{
+						"properties": {
+							"dashboardUuid": {
+								"type": "string"
+							},
+							"savedChartUuid": {
+								"type": "number",
+								"enum": [
+									null
+								],
+								"nullable": true
+							}
+						},
+						"required": [
+							"dashboardUuid",
+							"savedChartUuid"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"Scheduler": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ChartScheduler"
+					},
+					{
+						"$ref": "#/components/schemas/DashboardScheduler"
+					}
+				]
+			},
+			"SchedulerSlackTarget": {
+				"properties": {
+					"channel": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"schedulerSlackTargetUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"channel",
+					"schedulerUuid",
+					"updatedAt",
+					"createdAt",
+					"schedulerSlackTargetUuid"
+				],
+				"type": "object"
+			},
+			"SchedulerEmailTarget": {
+				"properties": {
+					"recipient": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"schedulerEmailTargetUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"recipient",
+					"schedulerUuid",
+					"updatedAt",
+					"createdAt",
+					"schedulerEmailTargetUuid"
+				],
+				"type": "object"
+			},
+			"SchedulerAndTargets": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Scheduler"
+					},
+					{
+						"properties": {
+							"targets": {
+								"items": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/SchedulerSlackTarget"
+										},
+										{
+											"$ref": "#/components/schemas/SchedulerEmailTarget"
+										}
+									]
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"targets"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"SchedulerJobStatus": {
+				"enum": [
+					"scheduled",
+					"started",
+					"completed",
+					"error"
+				],
+				"type": "string"
+			},
+			"Record_string.any_": {
+				"properties": {},
+				"type": "object",
+				"description": "Construct a type with a set of properties K of type T"
+			},
+			"SchedulerLog": {
+				"properties": {
+					"details": {
+						"$ref": "#/components/schemas/Record_string.any_"
+					},
+					"targetType": {
+						"type": "string",
+						"enum": [
+							"email",
+							"slack"
+						]
+					},
+					"target": {
+						"type": "string"
+					},
+					"status": {
+						"$ref": "#/components/schemas/SchedulerJobStatus"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"scheduledTime": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"jobGroup": {
+						"type": "string"
+					},
+					"jobId": {
+						"type": "string"
+					},
+					"schedulerUuid": {
+						"type": "string"
+					},
+					"task": {
+						"type": "string",
+						"enum": [
+							"handleScheduledDelivery",
+							"sendEmailNotification",
+							"sendSlackNotification",
+							"downloadCsv",
+							"compileProject",
+							"testAndCompileProject",
+							"validateProject"
+						]
+					}
+				},
+				"required": [
+					"status",
+					"createdAt",
+					"scheduledTime",
+					"jobId",
+					"task"
+				],
+				"type": "object"
+			},
+			"SchedulerWithLogs": {
+				"properties": {
+					"logs": {
+						"items": {
+							"$ref": "#/components/schemas/SchedulerLog"
+						},
+						"type": "array"
+					},
+					"dashboards": {
+						"items": {
+							"properties": {
+								"dashboardUuid": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"dashboardUuid",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"charts": {
+						"items": {
+							"properties": {
+								"savedChartUuid": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"savedChartUuid",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"users": {
+						"items": {
+							"properties": {
+								"userUuid": {
+									"type": "string"
+								},
+								"lastName": {
+									"type": "string"
+								},
+								"firstName": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"userUuid",
+								"lastName",
+								"firstName"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"schedulers": {
+						"items": {
+							"$ref": "#/components/schemas/SchedulerAndTargets"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"logs",
+					"dashboards",
+					"charts",
+					"users",
+					"schedulers"
+				],
+				"type": "object"
+			},
+			"ApiSchedulerLogsResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/SchedulerWithLogs"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiSchedulerAndTargetsResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/SchedulerAndTargets"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ScheduledJobs": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"date": {
+						"type": "string",
+						"format": "date-time"
+					}
+				},
+				"required": [
+					"id",
+					"date"
+				],
+				"type": "object"
+			},
+			"ApiScheduledJobsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ScheduledJobs"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiJobStatusResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"status": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"status"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ShareUrl": {
+				"properties": {
+					"host": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					},
+					"shareUrl": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"createdByUserUuid": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"params": {
+						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "The URL path of the full URL"
+					},
+					"nanoid": {
+						"type": "string",
+						"description": "Unique shareable id"
+					}
+				},
+				"required": [
+					"params",
+					"path",
+					"nanoid"
+				],
+				"type": "object",
+				"description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
+			},
+			"ApiShareResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/ShareUrl"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_ShareUrl.path-or-params_": {
+				"properties": {
+					"path": {
+						"type": "string",
+						"description": "The URL path of the full URL"
+					},
+					"params": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"path",
+					"params"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateShareUrl": {
+				"$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
+				"description": "Contains the detail of a full URL to generate a short URL id"
+			},
+			"SlackChannel": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"id"
+				],
+				"type": "object"
+			},
+			"ApiSlackChannelsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/SlackChannel"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					}
+				},
+				"required": [
+					"name",
+					"uuid",
+					"updatedAt",
+					"spaceUuid",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ViewStatistics": {
+				"properties": {
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"firstViewedAt",
+					"views"
+				],
+				"type": "object"
+			},
+			"SpaceQuery": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
+					},
+					{
+						"$ref": "#/components/schemas/ViewStatistics"
+					},
+					{
+						"properties": {
+							"validationErrors": {
+								"items": {
+									"$ref": "#/components/schemas/ValidationSummary"
+								},
+								"type": "array"
+							},
+							"chartType": {
+								"$ref": "#/components/schemas/ChartKind"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"updatedByUser": {
+						"$ref": "#/components/schemas/UpdatedByUser"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"views": {
+						"type": "number",
+						"format": "double"
+					},
+					"firstViewedAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						],
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					}
+				},
+				"required": [
+					"name",
+					"organizationUuid",
+					"uuid",
+					"updatedAt",
+					"projectUuid",
+					"spaceUuid",
+					"views",
+					"firstViewedAt",
+					"pinnedListUuid",
+					"pinnedListOrder"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"DashboardBasicDetails": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"
+					},
+					{
+						"properties": {
+							"validationErrors": {
+								"items": {
+									"$ref": "#/components/schemas/ValidationSummary"
+								},
+								"type": "array"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"SpaceDashboard": {
+				"$ref": "#/components/schemas/DashboardBasicDetails"
+			},
+			"SpaceShare": {
+				"properties": {
+					"role": {
+						"$ref": "#/components/schemas/ProjectMemberRole"
+					},
+					"lastName": {
+						"type": "string"
+					},
+					"firstName": {
+						"type": "string"
+					},
+					"userUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"role",
+					"lastName",
+					"firstName",
+					"userUuid"
+				],
+				"type": "object"
+			},
+			"Space": {
+				"properties": {
+					"pinnedListOrder": {
+						"type": "number",
+						"format": "double",
+						"nullable": true
+					},
+					"pinnedListUuid": {
+						"type": "string",
+						"nullable": true
+					},
+					"access": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceShare"
+						},
+						"type": "array"
+					},
+					"dashboards": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceDashboard"
+						},
+						"type": "array"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"queries": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceQuery"
+						},
+						"type": "array"
+					},
+					"isPrivate": {
+						"type": "boolean"
+					},
+					"name": {
+						"type": "string"
+					},
+					"uuid": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"pinnedListOrder",
+					"pinnedListUuid",
+					"access",
+					"dashboards",
+					"projectUuid",
+					"queries",
+					"isPrivate",
+					"name",
+					"uuid",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiSpaceResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Space"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"CreateSpace": {
+				"properties": {
+					"access": {
+						"items": {
+							"$ref": "#/components/schemas/SpaceShare"
+						},
+						"type": "array"
+					},
+					"isPrivate": {
+						"type": "boolean"
+					},
+					"name": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object"
+			},
+			"UpdateSpace": {
+				"properties": {
+					"isPrivate": {
+						"type": "boolean"
+					},
+					"name": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"isPrivate",
+					"name"
+				],
+				"type": "object"
+			},
+			"AddSpaceShare": {
+				"properties": {
+					"userUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"userUuid"
+				],
+				"type": "object"
+			},
+			"Pick_SshKeyPair.publicKey_": {
+				"properties": {
+					"publicKey": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"publicKey"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ApiSshKeyPairResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"EmailOneTimePassword": {
+				"properties": {
+					"numberOfAttempts": {
+						"type": "number",
+						"format": "double",
+						"description": "Number of times the passcode has been attempted"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"description": "Time that the passcode was created"
+					}
+				},
+				"required": [
+					"numberOfAttempts",
+					"createdAt"
+				],
+				"type": "object"
+			},
+			"EmailStatus": {
+				"properties": {
+					"otp": {
+						"$ref": "#/components/schemas/EmailOneTimePassword"
+					},
+					"isVerified": {
+						"type": "boolean"
+					},
+					"email": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"isVerified",
+					"email"
+				],
+				"type": "object"
+			},
+			"EmailOneTimePasswordExpiring": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/EmailOneTimePassword"
+					},
+					{
+						"properties": {
+							"isMaxAttempts": {
+								"type": "boolean"
+							},
+							"isExpired": {
+								"type": "boolean"
+							},
+							"expiresAt": {
+								"type": "string",
+								"format": "date-time"
+							}
+						},
+						"required": [
+							"isMaxAttempts",
+							"isExpired",
+							"expiresAt"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"EmailStatusExpiring": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/EmailStatus"
+					},
+					{
+						"properties": {
+							"otp": {
+								"$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
+								"description": "One time passcode information\nIf there is no active passcode, this will be undefined"
+							}
+						},
+						"type": "object"
+					}
+				],
+				"description": "Verification status of an email address"
+			},
+			"ApiEmailStatusResponse": {
+				"properties": {
+					"results": {
+						"$ref": "#/components/schemas/EmailStatusExpiring"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object",
+				"description": "Shows the current verification status of an email address"
+			},
+			"UserAllowedOrganization": {
+				"properties": {
+					"membersCount": {
+						"type": "number",
+						"format": "double"
+					},
+					"name": {
+						"type": "string"
+					},
+					"organizationUuid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"membersCount",
+					"name",
+					"organizationUuid"
+				],
+				"type": "object"
+			},
+			"ApiUserAllowedOrganizationsResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/UserAllowedOrganization"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiJobScheduledResponse": {
+				"properties": {
+					"results": {
+						"properties": {
+							"jobId": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"jobId"
+						],
+						"type": "object"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ValidationErrorType": {
+				"enum": [
+					"chart",
+					"sorting",
+					"filter",
+					"metric",
+					"model",
+					"dimension"
+				],
+				"type": "string"
+			},
+			"ValidationSourceType": {
+				"enum": [
+					"chart",
+					"dashboard",
+					"table"
+				],
+				"type": "string"
+			},
+			"ValidationResponseBase": {
+				"properties": {
+					"source": {
+						"$ref": "#/components/schemas/ValidationSourceType"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"projectUuid": {
+						"type": "string"
+					},
+					"errorType": {
+						"$ref": "#/components/schemas/ValidationErrorType"
+					},
+					"error": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"validationId": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"projectUuid",
+					"errorType",
+					"error",
+					"name",
+					"createdAt",
+					"validationId"
+				],
+				"type": "object"
+			},
+			"ValidationErrorChartResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/ValidationResponseBase"
+					},
+					{
+						"properties": {
+							"chartName": {
+								"type": "string"
+							},
+							"chartViews": {
+								"type": "number",
+								"format": "double"
+							},
+							"lastUpdatedAt": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"lastUpdatedBy": {
+								"type": "string"
+							},
+							"fieldName": {
+								"type": "string"
+							},
+							"chartType": {
+								"$ref": "#/components/schemas/ChartKind"
+							},
+							"chartUuid": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"chartViews"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"ValidationErrorDashboardResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/ValidationResponseBase"
+					},
+					{
+						"properties": {
+							"dashboardViews": {
+								"type": "number",
+								"format": "double"
+							},
+							"lastUpdatedAt": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"lastUpdatedBy": {
+								"type": "string"
+							},
+							"fieldName": {
+								"type": "string"
+							},
+							"chartName": {
+								"type": "string"
+							},
+							"dashboardUuid": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"dashboardViews"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
+				"properties": {
+					"projectUuid": {
+						"type": "string"
+					},
+					"spaceUuid": {
+						"type": "string"
+					},
+					"validationId": {
+						"type": "number",
+						"format": "double"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"error": {
+						"type": "string"
+					},
+					"errorType": {
+						"$ref": "#/components/schemas/ValidationErrorType"
+					},
+					"source": {
+						"$ref": "#/components/schemas/ValidationSourceType"
+					}
+				},
+				"required": [
+					"projectUuid",
+					"validationId",
+					"createdAt",
+					"error",
+					"errorType"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_ValidationResponseBase.name_": {
+				"$ref": "#/components/schemas/Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"ValidationErrorTableResponse": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Omit_ValidationResponseBase.name_"
+					},
+					{
+						"properties": {
+							"name": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				]
+			},
+			"ValidationResponse": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ValidationErrorChartResponse"
+					},
+					{
+						"$ref": "#/components/schemas/ValidationErrorDashboardResponse"
+					},
+					{
+						"$ref": "#/components/schemas/ValidationErrorTableResponse"
+					}
+				]
+			},
+			"ApiValidateResponse": {
+				"properties": {
+					"results": {
+						"items": {
+							"$ref": "#/components/schemas/ValidationResponse"
+						},
+						"type": "array"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"results",
+					"status"
+				],
+				"type": "object"
+			},
+			"ApiValidationDismissResponse": {
+				"properties": {
+					"status": {
+						"type": "string",
+						"enum": [
+							"ok"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"status"
+				],
+				"type": "object"
+			}
+		},
+		"securitySchemes": {
+			"session_cookie": {
+				"type": "apiKey",
+				"in": "cookie",
+				"name": "connect.sid"
+			},
+			"api_key": {
+				"type": "apiKey",
+				"in": "header",
+				"name": "Authorization",
+				"description": "Value should be 'ApiKey <your key>'"
+			}
+		}
+	},
+	"info": {
+		"title": "Lightdash API",
+		"version": "0.632.0",
+		"description": "Open API documentation for all public Lightdash API endpoints",
+		"license": {
+			"name": "MIT"
+		},
+		"contact": {
+			"name": "Lightdash Support",
+			"email": "support@lightdash.com",
+			"url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
+		}
+	},
+	"openapi": "3.0.0",
+	"paths": {
+		"/api/v1/csv/{jobId}": {
+			"get": {
+				"operationId": "getCsvUrl",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiCsvUrlResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a Csv",
+				"tags": [
+					"Exports"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the jobId for the CSV",
+						"in": "path",
+						"name": "jobId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
+			"get": {
+				"operationId": "getDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the current dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"post": {
+				"operationId": "updateDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update the dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "deleteDbtCloudIntegrationSettings",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove the dbt Cloud integration settings for a project",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
+			"get": {
+				"operationId": "getDbtCloudMetrics",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiDbtCloudMetrics"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/groups/{groupUuid}": {
+			"get": {
+				"operationId": "getGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get group details",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "unique id of the group",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "deleteGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"patch": {
+				"operationId": "updateGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateGroup"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/groups/{groupUuid}/members/{userUuid}": {
+			"put": {
+				"operationId": "addUserToGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Add a Lightdash user to a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to add the user to",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the UUID for the user to add to the group",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "removeUserFromGroup",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove a user from a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to remove the user from",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the UUID for the user to remove from the group",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/groups/{groupUuid}/members": {
+			"get": {
+				"operationId": "getGroupMembers",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupMembersResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "View members of a group",
+				"tags": [
+					"User Groups"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the UUID for the group to view the members of",
+						"in": "path",
+						"name": "groupUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org": {
+			"get": {
+				"operationId": "GetMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganization"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			},
+			"put": {
+				"operationId": "CreateOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new organization settings",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateOrganization",
+								"description": "the new organization settings"
+							}
+						}
+					}
+				}
+			},
+			"patch": {
+				"operationId": "UpdateMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new organization settings",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateOrganization",
+								"description": "the new organization settings"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/{organizationUuid}": {
+			"delete": {
+				"operationId": "DeleteMyOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Deletes an organization and all users inside that organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the organization to delete",
+						"in": "path",
+						"name": "organizationUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org/projects": {
+			"get": {
+				"operationId": "ListOrganizationProjects",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationProjects"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets all projects of the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/org/users": {
+			"get": {
+				"operationId": "ListOrganizationMembers",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets all the members of the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/org/users/{userUuid}": {
+			"patch": {
+				"operationId": "UpdateOrganizationMember",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Updates the membership profile for a user in the current user's organization",
+				"tags": [
+					"Roles & Permissions",
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the user to update",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new membership profile",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
+								"description": "the new membership profile"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/user/{userUuid}": {
+			"delete": {
+				"operationId": "DeleteOrganizationMember",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Deletes a user from the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the user to delete",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/org/allowedEmailDomains": {
+			"get": {
+				"operationId": "ListOrganizationEmailDomains",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets the allowed email domains for the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			},
+			"patch": {
+				"operationId": "UpdateOrganizationEmailDomains",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Updates the allowed email domains for the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new allowed email domains",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAllowedEmailDomains",
+								"description": "the new allowed email domains"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/org/groups": {
+			"post": {
+				"operationId": "CreateGroupInOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a new group in the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "the new group details",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_CreateGroup.name_",
+								"description": "the new group details"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "ListGroupsInOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiGroupListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Gets all the groups in the current user's organization",
+				"tags": [
+					"Organizations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
+			"get": {
+				"operationId": "getPinnedItems",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiPinnedItems"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get pinned items",
+				"tags": [
+					"Content"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "project uuid",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the list uuid for the pinned items",
+						"in": "path",
+						"name": "pinnedListUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
+			"patch": {
+				"operationId": "updatePinnedItemsOrder",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiPinnedItems"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update pinned items order",
+				"tags": [
+					"Content"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "project uuid",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the list uuid for the pinned items",
+						"in": "path",
+						"name": "pinnedListUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new order of the pinned items",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"items": {
+									"$ref": "#/components/schemas/UpdatePinnedItemOrder"
+								},
+								"type": "array",
+								"description": "the new order of the pinned items"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}": {
+			"get": {
+				"operationId": "GetProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiProjectResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a project of an organiztion",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/charts": {
+			"get": {
+				"operationId": "ListChartsInProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiChartSummaryListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List all charts in a project",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project to get charts for",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/spaces": {
+			"get": {
+				"operationId": "ListSpacesInProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List all spaces in a project",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project to get spaces for",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"post": {
+				"operationId": "CreateSpaceInProject",
+				"responses": {
+					"200": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSpaceResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Create a new space inside a project",
+				"tags": [
+					"Roles & Permissions",
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSpace"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/access": {
+			"get": {
+				"operationId": "GetProjectAccessList",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiProjectAccessListResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
+				"tags": [
+					"Roles & Permissions",
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"post": {
+				"operationId": "GrantProjectAccessToUser",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Grant a user access to a project",
+				"tags": [
+					"Roles & Permissions",
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateProjectMember"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/access/{userUuid}": {
+			"patch": {
+				"operationId": "UpdateProjectAccessForUser",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a user's access to a project",
+				"tags": [
+					"Roles & Permissions",
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateProjectMember"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "RevokeProjectAccessForUser",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove a user's access to a project",
+				"tags": [
+					"Roles & Permissions",
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
+			"post": {
+				"operationId": "postRunUnderlyingDataQuery",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for underlying data results",
+				"tags": [
+					"Exploring"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "table name",
+						"in": "path",
+						"name": "exploreId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "metricQuery for the chart to run",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RunQueryRequest",
+								"description": "metricQuery for the chart to run"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
+			"post": {
+				"operationId": "postRunQuery",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for explore",
+				"tags": [
+					"Exploring"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "table name",
+						"in": "path",
+						"name": "exploreId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "metricQuery for the chart to run",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RunQueryRequest",
+								"description": "metricQuery for the chart to run"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/saved/{chartUuid}/results": {
+			"post": {
+				"operationId": "postChartResults",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiRunQueryResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Run a query for a chart",
+				"tags": [
+					"Charts"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "chartUuid for the chart to run",
+						"in": "path",
+						"name": "chartUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"filters": {
+										"$ref": "#/components/schemas/Filters"
+									}
+								},
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/schedulers/{projectUuid}/logs": {
+			"get": {
+				"operationId": "getSchedulerLogs",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerLogsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get scheduled logs",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/{schedulerUuid}": {
+			"get": {
+				"operationId": "getScheduler",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"patch": {
+				"operationId": "updateScheduler",
+				"responses": {
+					"201": {
+						"description": "Updated",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the new scheduler data",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"description": "the new scheduler data"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "deleteScheduler",
+				"responses": {
+					"201": {
+						"description": "Deleted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"results": {},
+										"status": {
+											"type": "string",
+											"enum": [
+												"ok"
+											],
+											"nullable": false
+										}
+									},
+									"required": [
+										"status"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a scheduler",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to delete",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/{schedulerUuid}/jobs": {
+			"get": {
+				"operationId": "getScheduledJobs",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiScheduledJobsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get scheduled jobs",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the scheduler to update",
+						"in": "path",
+						"name": "schedulerUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/schedulers/job/{jobId}/status": {
+			"get": {
+				"operationId": "getSchedulerJobStatus",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiJobStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a generic job status\nThis method can be used when polling from the frontend",
+				"tags": [
+					"Schedulers"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the jobId for the status to check",
+						"in": "path",
+						"name": "jobId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/share/{nanoId}": {
+			"get": {
+				"operationId": "getShareUrl",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiShareResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a share url from a short url id",
+				"tags": [
+					"Share links"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the short id for the share url",
+						"in": "path",
+						"name": "nanoId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/share": {
+			"post": {
+				"operationId": "CreateShareUrl",
+				"responses": {
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiShareResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Given a full URL generates a short url id that can be used for sharing",
+				"tags": [
+					"Share links"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "a full URL used to generate a short url id",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateShareUrl",
+								"description": "a full URL used to generate a short url id"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/slack/channels": {
+			"get": {
+				"operationId": "getSlackChannels",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSlackChannelsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get slack channels",
+				"tags": [
+					"Integrations"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}": {
+			"get": {
+				"operationId": "GetSpace",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSpaceResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get details for a space in a project",
+				"tags": [
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The uuid of the space to get",
+						"in": "path",
+						"name": "spaceUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "DeleteSpace",
+				"responses": {
+					"204": {
+						"description": "Deleted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a space from a project",
+				"tags": [
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The uuid of the space to delete",
+						"in": "path",
+						"name": "spaceUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"patch": {
+				"operationId": "UpdateSpace",
+				"responses": {
+					"200": {
+						"description": "Updated",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSpaceResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update a space in a project",
+				"tags": [
+					"Roles & Permissions",
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The uuid of the space to update",
+						"in": "path",
+						"name": "spaceUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateSpace"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share": {
+			"post": {
+				"operationId": "AddSpaceShareToUser",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Grant a user access to a space",
+				"tags": [
+					"Roles & Permissions",
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "spaceUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/AddSpaceShare"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share/{userUuid}": {
+			"delete": {
+				"operationId": "RevokeSpaceAccessForUser",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Remove a user's access to a space",
+				"tags": [
+					"Roles & Permissions",
+					"Spaces"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The uuid of the space's parent project",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The uuid of the space to update",
+						"in": "path",
+						"name": "spaceUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The uuid of the user to revoke access from",
+						"in": "path",
+						"name": "userUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/ssh/key-pairs": {
+			"post": {
+				"operationId": "createSshKeyPair",
+				"responses": {
+					"201": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSshKeyPairResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"SSH Keypairs"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/email/otp": {
+			"put": {
+				"operationId": "CreateEmailOneTimePasscode",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiEmailStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/email/status": {
+			"get": {
+				"operationId": "GetEmailVerificationStatus",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiEmailStatusResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the verification status for the current user's primary email",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the one-time passcode sent to the user's primary email",
+						"in": "query",
+						"name": "passcode",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/user/me/allowedOrganizations": {
+			"get": {
+				"operationId": "ListMyAvailableOrganizations",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/user/me/joinOrganization/{organizationUuid}": {
+			"post": {
+				"operationId": "JoinOrganization",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the uuid of the organization to join",
+						"in": "path",
+						"name": "organizationUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/user/me": {
+			"delete": {
+				"operationId": "DeleteMe",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiSuccessEmpty"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete user",
+				"tags": [
+					"My Account"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/projects/{projectUuid}/validate": {
+			"post": {
+				"operationId": "ValidateProject",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiJobScheduledResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the projectId for the validation",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"explores": {
+										"items": {},
+										"type": "array"
+									}
+								},
+								"type": "object",
+								"description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetLatestValidationResults",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiValidateResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get validation results for a project. This will return the results of the latest validation job.",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "the projectId for the validation",
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "boolean to know if this request is made from the settings page, for analytics",
+						"in": "query",
+						"name": "fromSettings",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					},
+					{
+						"description": "optional jobId to get results for a specific job, used on CLI",
+						"in": "query",
+						"name": "jobId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/projects/{projectUuid}/validate/{validationId}": {
+			"delete": {
+				"operationId": "DeleteValidationDismiss",
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiValidationDismissResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiErrorPayload"
+								}
+							}
+						}
+					}
+				},
+				"description": "Deletes a single validation error.",
+				"tags": [
+					"Projects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "projectUuid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the projectId for the validation",
+						"in": "path",
+						"name": "validationId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "/"
+		}
+	],
+	"tags": [
+		{
+			"name": "My Account",
+			"description": "These routes allow users to manage their own user account."
+		},
+		{
+			"name": "Organizations",
+			"description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
+		},
+		{
+			"name": "Projects",
+			"description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
+		},
+		{
+			"name": "Spaces",
+			"description": "Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins."
+		},
+		{
+			"name": "Roles & Permissions",
+			"description": "These routes allow users to manage roles and permissions for their organization.",
+			"externalDocs": {
+				"url": "https://docs.lightdash.com/references/roles"
+			}
+		}
+	]
 }

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1,6864 +1,6277 @@
 {
-	"components": {
-		"examples": {},
-		"headers": {},
-		"parameters": {},
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"ApiErrorPayload": {
-				"properties": {
-					"error": {
-						"properties": {
-							"data": {
-								"description": "Optional data containing details of the error"
-							},
-							"message": {
-								"type": "string",
-								"description": "A friendly message summarising the error"
-							},
-							"name": {
-								"type": "string",
-								"description": "Unique name for the type of error"
-							},
-							"statusCode": {
-								"type": "number",
-								"format": "integer",
-								"description": "HTTP status code"
-							}
-						},
-						"required": [
-							"name",
-							"statusCode"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"error"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"error",
-					"status"
-				],
-				"type": "object",
-				"description": "The Error object is returned from the api any time there is an error.\nThe message contains"
-			},
-			"ApiCsvUrlResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"status": {
-								"type": "string"
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"status",
-							"url"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_CreateDbtCloudIntegration.metricsJobId_": {
-				"properties": {
-					"metricsJobId": {
-						"type": "string",
-						"description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
-					}
-				},
-				"required": [
-					"metricsJobId"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DbtCloudIntegration": {
-				"$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
-				"description": "Configuration for a Lightdash integration with dbt Cloud"
-			},
-			"ApiDbtCloudIntegrationSettings": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/DbtCloudIntegration"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiDbtCloudSettingsDeleteSuccess": {
-				"properties": {
-					"results": {},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"DbtCloudMetric": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"timeGrains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"description": {
-						"type": "string"
-					},
-					"dimensions": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"name": {
-						"type": "string"
-					},
-					"uniqueId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"label",
-					"timeGrains",
-					"description",
-					"dimensions",
-					"name",
-					"uniqueId"
-				],
-				"type": "object"
-			},
-			"DbtCloudMetadataResponseMetrics": {
-				"properties": {
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/DbtCloudMetric"
-						},
-						"type": "array",
-						"description": "A list of dbt metric definitions from the dbt cloud metadata api"
-					}
-				},
-				"required": [
-					"metrics"
-				],
-				"type": "object",
-				"description": "Response from dbt cloud metadata api containing a list of metric definitions"
-			},
-			"ApiDbtCloudMetrics": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Group": {
-				"properties": {
-					"organizationUuid": {
-						"type": "string",
-						"description": "The UUID of the organization that the group belongs to"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time",
-						"description": "The time that the group was created"
-					},
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					},
-					"uuid": {
-						"type": "string",
-						"description": "The group's UUID"
-					}
-				},
-				"required": [
-					"organizationUuid",
-					"createdAt",
-					"name",
-					"uuid"
-				],
-				"type": "object"
-			},
-			"ApiGroupResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Group"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiSuccessEmpty": {
-				"properties": {
-					"results": {},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			},
-			"GroupMember": {
-				"properties": {
-					"lastName": {
-						"type": "string",
-						"description": "The user's last name"
-					},
-					"firstName": {
-						"type": "string",
-						"description": "The user's first name"
-					},
-					"email": {
-						"type": "string",
-						"description": "Primary email address for the user"
-					},
-					"userUuid": {
-						"type": "string",
-						"description": "Unique id for the user",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"lastName",
-					"firstName",
-					"email",
-					"userUuid"
-				],
-				"type": "object",
-				"description": "A summary for a Lightdash user within a group"
-			},
-			"ApiGroupMembersResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/GroupMember"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Group.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"UpdateGroup": {
-				"$ref": "#/components/schemas/Pick_Group.name_"
-			},
-			"Organization": {
-				"properties": {
-					"defaultProjectUuid": {
-						"type": "string",
-						"description": "The project a user sees when they first log in to the organization"
-					},
-					"needsProject": {
-						"type": "boolean",
-						"description": "The organization needs a project if it doesn't have at least one project."
-					},
-					"chartColors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The default color palette for all projects in the organization"
-					},
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"description": "The unique identifier of the organization",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid"
-				],
-				"type": "object",
-				"description": "Details of a user's Organization"
-			},
-			"ApiOrganization": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Organization"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Organization.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"CreateOrganization": {
-				"$ref": "#/components/schemas/Pick_Organization.name_"
-			},
-			"Partial_Omit_Organization.organizationUuid-or-needsProject__": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "The name of the organization"
-					},
-					"chartColors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The default color palette for all projects in the organization"
-					},
-					"defaultProjectUuid": {
-						"type": "string",
-						"description": "The project a user sees when they first log in to the organization"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"UpdateOrganization": {
-				"$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
-			},
-			"ProjectType": {
-				"enum": [
-					"DEFAULT",
-					"PREVIEW"
-				],
-				"type": "string"
-			},
-			"OrganizationProject": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/ProjectType"
-					},
-					"name": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string",
-						"description": "The unique identifier of the project",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"type",
-					"name",
-					"projectUuid"
-				],
-				"type": "object",
-				"description": "Summary of a project under an organization"
-			},
-			"ApiOrganizationProjects": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/OrganizationProject"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object",
-				"description": "List of projects in the current organization"
-			},
-			"OrganizationMemberRole": {
-				"enum": [
-					"member",
-					"viewer",
-					"interactive_viewer",
-					"editor",
-					"developer",
-					"admin"
-				],
-				"type": "string"
-			},
-			"OrganizationMemberProfile": {
-				"properties": {
-					"isInviteExpired": {
-						"type": "boolean",
-						"description": "Whether the user's invite to the organization has expired"
-					},
-					"isActive": {
-						"type": "boolean",
-						"description": "Whether the user has accepted their invite to the organization"
-					},
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole",
-						"description": "The role of the user in the organization"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"description": "Unique identifier for the organization the user is a member of"
-					},
-					"email": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"userUuid": {
-						"type": "string",
-						"description": "Unique identifier for the user",
-						"format": "uuid"
-					}
-				},
-				"required": [
-					"isActive",
-					"role",
-					"organizationUuid",
-					"email",
-					"lastName",
-					"firstName",
-					"userUuid"
-				],
-				"type": "object",
-				"description": "Profile for a user's membership in an organization"
-			},
-			"ApiOrganizationMemberProfiles": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/OrganizationMemberProfile"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiOrganizationMemberProfile": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/OrganizationMemberProfile"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"OrganizationMemberProfileUpdate": {
-				"properties": {
-					"role": {
-						"$ref": "#/components/schemas/OrganizationMemberRole"
-					}
-				},
-				"required": [
-					"role"
-				],
-				"type": "object"
-			},
-			"OrganizationMemberRole.EDITOR": {
-				"enum": [
-					"editor"
-				],
-				"type": "string"
-			},
-			"OrganizationMemberRole.INTERACTIVE_VIEWER": {
-				"enum": [
-					"interactive_viewer"
-				],
-				"type": "string"
-			},
-			"OrganizationMemberRole.VIEWER": {
-				"enum": [
-					"viewer"
-				],
-				"type": "string"
-			},
-			"OrganizationMemberRole.MEMBER": {
-				"enum": [
-					"member"
-				],
-				"type": "string"
-			},
-			"AllowedEmailDomainsRole": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/OrganizationMemberRole.EDITOR"
-					},
-					{
-						"$ref": "#/components/schemas/OrganizationMemberRole.INTERACTIVE_VIEWER"
-					},
-					{
-						"$ref": "#/components/schemas/OrganizationMemberRole.VIEWER"
-					},
-					{
-						"$ref": "#/components/schemas/OrganizationMemberRole.MEMBER"
-					}
-				]
-			},
-			"AllowedEmailDomains": {
-				"properties": {
-					"projectUuids": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"role": {
-						"$ref": "#/components/schemas/AllowedEmailDomainsRole"
-					},
-					"emailDomains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"projectUuids",
-					"role",
-					"emailDomains",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiOrganizationAllowedEmailDomains": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/AllowedEmailDomains"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
-				"properties": {
-					"emailDomains": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"role": {
-						"$ref": "#/components/schemas/AllowedEmailDomainsRole"
-					},
-					"projectUuids": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"emailDomains",
-					"role",
-					"projectUuids"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_AllowedEmailDomains.organizationUuid_": {
-				"$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"UpdateAllowedEmailDomains": {
-				"$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
-			},
-			"Pick_CreateGroup.name_": {
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "A friendly name for the group"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ApiGroupListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/Group"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.DASHBOARD": {
-				"enum": [
-					"dashboard"
-				],
-				"type": "string"
-			},
-			"UpdatedByUser": {
-				"properties": {
-					"userUuid": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"userUuid",
-					"firstName",
-					"lastName"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
-				"properties": {
-					"validationId": {
-						"type": "number",
-						"format": "double"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"error": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"validationId",
-					"createdAt",
-					"error"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ValidationSummary": {
-				"$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
-			},
-			"Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					},
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"validationErrors": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationSummary"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"name",
-					"uuid",
-					"updatedAt",
-					"spaceUuid",
-					"views",
-					"firstViewedAt",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewDashboardItem": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.CHART": {
-				"enum": [
-					"chart"
-				],
-				"type": "string"
-			},
-			"ChartKind": {
-				"enum": [
-					"line",
-					"horizontal_bar",
-					"vertical_bar",
-					"scatter",
-					"area",
-					"mixed",
-					"pie",
-					"table",
-					"big_number"
-				],
-				"type": "string"
-			},
-			"Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					},
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"validationErrors": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationSummary"
-						},
-						"type": "array"
-					},
-					"chartType": {
-						"$ref": "#/components/schemas/ChartKind"
-					}
-				},
-				"required": [
-					"name",
-					"uuid",
-					"updatedAt",
-					"spaceUuid",
-					"views",
-					"firstViewedAt",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewChartItem": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.CHART"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType.SPACE": {
-				"enum": [
-					"space"
-				],
-				"type": "string"
-			},
-			"Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"isPrivate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"pinnedListUuid",
-					"pinnedListOrder",
-					"isPrivate"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ResourceViewSpaceItem": {
-				"properties": {
-					"data": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
-							},
-							{
-								"properties": {
-									"chartCount": {
-										"type": "number",
-										"format": "double"
-									},
-									"dashboardCount": {
-										"type": "number",
-										"format": "double"
-									},
-									"accessListLength": {
-										"type": "number",
-										"format": "double"
-									},
-									"access": {
-										"items": {
-											"type": "string"
-										},
-										"type": "array"
-									}
-								},
-								"required": [
-									"chartCount",
-									"dashboardCount",
-									"accessListLength",
-									"access"
-								],
-								"type": "object"
-							}
-						]
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType.SPACE"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"PinnedItems": {
-				"items": {
-					"anyOf": [
-						{
-							"$ref": "#/components/schemas/ResourceViewDashboardItem"
-						},
-						{
-							"$ref": "#/components/schemas/ResourceViewChartItem"
-						},
-						{
-							"$ref": "#/components/schemas/ResourceViewSpaceItem"
-						}
-					]
-				},
-				"type": "array"
-			},
-			"ApiPinnedItems": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/PinnedItems"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ResourceViewItemType": {
-				"enum": [
-					"chart",
-					"dashboard",
-					"space"
-				],
-				"type": "string"
-			},
-			"Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
-				"properties": {
-					"uuid": {
-						"type": "string"
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					}
-				},
-				"required": [
-					"uuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"UpdatePinnedItemOrder": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ResourceViewItemType"
-					}
-				},
-				"required": [
-					"data",
-					"type"
-				],
-				"type": "object"
-			},
-			"DbtProjectType.DBT": {
-				"enum": [
-					"dbt"
-				],
-				"type": "string"
-			},
-			"DbtProjectEnvironmentVariable": {
-				"properties": {
-					"value": {
-						"type": "string"
-					},
-					"key": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"value",
-					"key"
-				],
-				"type": "object"
-			},
-			"DbtProjectType": {
-				"enum": [
-					"dbt",
-					"dbt_cloud_ide",
-					"github",
-					"gitlab",
-					"bitbucket",
-					"azure_devops",
-					"none"
-				],
-				"type": "string"
-			},
-			"DbtLocalProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.DBT"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"profiles_dir": {
-						"type": "string"
-					},
-					"project_dir": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.DBT_CLOUD_IDE": {
-				"enum": [
-					"dbt_cloud_ide"
-				],
-				"type": "string"
-			},
-			"DbtCloudIDEProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.DBT_CLOUD_IDE"
-					},
-					"api_key": {
-						"type": "string"
-					},
-					"account_id": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "number",
-								"format": "double"
-							}
-						]
-					},
-					"environment_id": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "number",
-								"format": "double"
-							}
-						]
-					},
-					"project_id": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "number",
-								"format": "double"
-							}
-						]
-					}
-				},
-				"required": [
-					"type",
-					"api_key",
-					"account_id",
-					"environment_id",
-					"project_id"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.GITHUB": {
-				"enum": [
-					"github"
-				],
-				"type": "string"
-			},
-			"DbtGithubProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.GITHUB"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"personal_access_token": {
-						"type": "string"
-					},
-					"repository": {
-						"type": "string"
-					},
-					"branch": {
-						"type": "string"
-					},
-					"project_sub_path": {
-						"type": "string"
-					},
-					"host_domain": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"personal_access_token",
-					"repository",
-					"branch",
-					"project_sub_path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.BITBUCKET": {
-				"enum": [
-					"bitbucket"
-				],
-				"type": "string"
-			},
-			"DbtBitBucketProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.BITBUCKET"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"username": {
-						"type": "string"
-					},
-					"personal_access_token": {
-						"type": "string"
-					},
-					"repository": {
-						"type": "string"
-					},
-					"branch": {
-						"type": "string"
-					},
-					"project_sub_path": {
-						"type": "string"
-					},
-					"host_domain": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"username",
-					"personal_access_token",
-					"repository",
-					"branch",
-					"project_sub_path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.GITLAB": {
-				"enum": [
-					"gitlab"
-				],
-				"type": "string"
-			},
-			"DbtGitlabProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.GITLAB"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"personal_access_token": {
-						"type": "string"
-					},
-					"repository": {
-						"type": "string"
-					},
-					"branch": {
-						"type": "string"
-					},
-					"project_sub_path": {
-						"type": "string"
-					},
-					"host_domain": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"personal_access_token",
-					"repository",
-					"branch",
-					"project_sub_path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.AZURE_DEVOPS": {
-				"enum": [
-					"azure_devops"
-				],
-				"type": "string"
-			},
-			"DbtAzureDevOpsProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.AZURE_DEVOPS"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"personal_access_token": {
-						"type": "string"
-					},
-					"organization": {
-						"type": "string"
-					},
-					"project": {
-						"type": "string"
-					},
-					"repository": {
-						"type": "string"
-					},
-					"branch": {
-						"type": "string"
-					},
-					"project_sub_path": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"personal_access_token",
-					"organization",
-					"project",
-					"repository",
-					"branch",
-					"project_sub_path"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectType.NONE": {
-				"enum": [
-					"none"
-				],
-				"type": "string"
-			},
-			"DbtNoneProjectConfig": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/DbtProjectType.NONE"
-					},
-					"target": {
-						"type": "string"
-					},
-					"environment": {
-						"items": {
-							"$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
-						},
-						"type": "array"
-					},
-					"hideRefreshButton": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"DbtProjectConfig": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/DbtLocalProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtCloudIDEProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtGithubProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtBitBucketProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtGitlabProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtAzureDevOpsProjectConfig"
-					},
-					{
-						"$ref": "#/components/schemas/DbtNoneProjectConfig"
-					}
-				]
-			},
-			"WarehouseTypes.SNOWFLAKE": {
-				"enum": [
-					"snowflake"
-				],
-				"type": "string"
-			},
-			"WeekDay": {
-				"enum": [
-					0,
-					1,
-					2,
-					3,
-					4,
-					5,
-					6
-				],
-				"type": "number"
-			},
-			"Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"role": {
-						"type": "string"
-					},
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
-					},
-					"account": {
-						"type": "string"
-					},
-					"database": {
-						"type": "string"
-					},
-					"warehouse": {
-						"type": "string"
-					},
-					"schema": {
-						"type": "string"
-					},
-					"threads": {
-						"type": "number",
-						"format": "double"
-					},
-					"clientSessionKeepAlive": {
-						"type": "boolean"
-					},
-					"queryTag": {
-						"type": "string"
-					},
-					"accessUrl": {
-						"type": "string"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"type",
-					"account",
-					"database",
-					"warehouse",
-					"schema"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"SnowflakeCredentials": {
-				"$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseTypes.REDSHIFT": {
-				"enum": [
-					"redshift"
-				],
-				"type": "string"
-			},
-			"Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
-					},
-					"schema": {
-						"type": "string"
-					},
-					"threads": {
-						"type": "number",
-						"format": "double"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					},
-					"useSshTunnel": {
-						"type": "boolean"
-					},
-					"sshTunnelHost": {
-						"type": "string"
-					},
-					"sshTunnelPort": {
-						"type": "number",
-						"format": "double"
-					},
-					"sshTunnelUser": {
-						"type": "string"
-					},
-					"sshTunnelPublicKey": {
-						"type": "string"
-					},
-					"host": {
-						"type": "string"
-					},
-					"port": {
-						"type": "number",
-						"format": "double"
-					},
-					"dbname": {
-						"type": "string"
-					},
-					"keepalivesIdle": {
-						"type": "number",
-						"format": "double"
-					},
-					"sslmode": {
-						"type": "string"
-					},
-					"ra3Node": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"type",
-					"schema",
-					"host",
-					"port",
-					"dbname"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"RedshiftCredentials": {
-				"$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseTypes.POSTGRES": {
-				"enum": [
-					"postgres"
-				],
-				"type": "string"
-			},
-			"Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"role": {
-						"type": "string"
-					},
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
-					},
-					"schema": {
-						"type": "string"
-					},
-					"threads": {
-						"type": "number",
-						"format": "double"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					},
-					"useSshTunnel": {
-						"type": "boolean"
-					},
-					"sshTunnelHost": {
-						"type": "string"
-					},
-					"sshTunnelPort": {
-						"type": "number",
-						"format": "double"
-					},
-					"sshTunnelUser": {
-						"type": "string"
-					},
-					"sshTunnelPublicKey": {
-						"type": "string"
-					},
-					"host": {
-						"type": "string"
-					},
-					"port": {
-						"type": "number",
-						"format": "double"
-					},
-					"dbname": {
-						"type": "string"
-					},
-					"keepalivesIdle": {
-						"type": "number",
-						"format": "double"
-					},
-					"sslmode": {
-						"type": "string"
-					},
-					"searchPath": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"schema",
-					"host",
-					"port",
-					"dbname"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"PostgresCredentials": {
-				"$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseTypes.BIGQUERY": {
-				"enum": [
-					"bigquery"
-				],
-				"type": "string"
-			},
-			"Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
-					},
-					"threads": {
-						"type": "number",
-						"format": "double"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					},
-					"project": {
-						"type": "string"
-					},
-					"dataset": {
-						"type": "string"
-					},
-					"timeoutSeconds": {
-						"type": "number",
-						"format": "double"
-					},
-					"priority": {
-						"type": "string",
-						"enum": [
-							"interactive",
-							"batch"
-						]
-					},
-					"retries": {
-						"type": "number",
-						"format": "double"
-					},
-					"location": {
-						"type": "string"
-					},
-					"maximumBytesBilled": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"type",
-					"project",
-					"dataset"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"BigqueryCredentials": {
-				"$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseTypes.DATABRICKS": {
-				"enum": [
-					"databricks"
-				],
-				"type": "string"
-			},
-			"Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
-					},
-					"database": {
-						"type": "string"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					},
-					"catalog": {
-						"type": "string"
-					},
-					"serverHostName": {
-						"type": "string"
-					},
-					"httpPath": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"database",
-					"serverHostName",
-					"httpPath"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"DatabricksCredentials": {
-				"$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseTypes.TRINO": {
-				"enum": [
-					"trino"
-				],
-				"type": "string"
-			},
-			"Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
-				"properties": {
-					"type": {
-						"$ref": "#/components/schemas/WarehouseTypes.TRINO"
-					},
-					"schema": {
-						"type": "string"
-					},
-					"startOfWeek": {
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/WeekDay"
-							}
-						],
-						"nullable": true
-					},
-					"host": {
-						"type": "string"
-					},
-					"port": {
-						"type": "number",
-						"format": "double"
-					},
-					"dbname": {
-						"type": "string"
-					},
-					"http_scheme": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"schema",
-					"host",
-					"port",
-					"dbname",
-					"http_scheme"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
-				"$ref": "#/components/schemas/Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"TrinoCredentials": {
-				"$ref": "#/components/schemas/Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_"
-			},
-			"WarehouseCredentials": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/SnowflakeCredentials"
-					},
-					{
-						"$ref": "#/components/schemas/RedshiftCredentials"
-					},
-					{
-						"$ref": "#/components/schemas/PostgresCredentials"
-					},
-					{
-						"$ref": "#/components/schemas/BigqueryCredentials"
-					},
-					{
-						"$ref": "#/components/schemas/DatabricksCredentials"
-					},
-					{
-						"$ref": "#/components/schemas/TrinoCredentials"
-					}
-				]
-			},
-			"Project": {
-				"properties": {
-					"copiedFromProjectUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string"
-					},
-					"warehouseConnection": {
-						"$ref": "#/components/schemas/WarehouseCredentials"
-					},
-					"dbtConnection": {
-						"$ref": "#/components/schemas/DbtProjectConfig"
-					},
-					"type": {
-						"$ref": "#/components/schemas/ProjectType"
-					},
-					"name": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"dbtConnection",
-					"type",
-					"name",
-					"projectUuid",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiProjectResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Project"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"spaceName": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"spaceUuid",
-					"pinnedListUuid",
-					"spaceName"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ChartType": {
-				"enum": [
-					"cartesian",
-					"table",
-					"big_number",
-					"pie"
-				],
-				"type": "string"
-			},
-			"ChartSummary": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
-					},
-					{
-						"properties": {
-							"chartType": {
-								"$ref": "#/components/schemas/ChartType"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"ApiChartSummaryListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ChartSummary"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"isPrivate": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"projectUuid",
-					"isPrivate"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"SpaceSummary": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
-					},
-					{
-						"properties": {
-							"access": {
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						},
-						"required": [
-							"access"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"ApiSpaceSummaryListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceSummary"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ProjectMemberRole": {
-				"enum": [
-					"viewer",
-					"interactive_viewer",
-					"editor",
-					"developer",
-					"admin"
-				],
-				"type": "string"
-			},
-			"ProjectMemberProfile": {
-				"properties": {
-					"lastName": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"email": {
-						"type": "string"
-					},
-					"role": {
-						"$ref": "#/components/schemas/ProjectMemberRole"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"userUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"lastName",
-					"firstName",
-					"email",
-					"role",
-					"projectUuid",
-					"userUuid"
-				],
-				"type": "object"
-			},
-			"ApiProjectAccessListResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ProjectMemberProfile"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"CreateProjectMember": {
-				"properties": {
-					"sendEmail": {
-						"type": "boolean"
-					},
-					"role": {
-						"$ref": "#/components/schemas/ProjectMemberRole"
-					},
-					"email": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"sendEmail",
-					"role",
-					"email"
-				],
-				"type": "object"
-			},
-			"UpdateProjectMember": {
-				"properties": {
-					"role": {
-						"$ref": "#/components/schemas/ProjectMemberRole"
-					}
-				},
-				"required": [
-					"role"
-				],
-				"type": "object"
-			},
-			"FieldId": {
-				"type": "string"
-			},
-			"FilterGroupResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"or": {
-								"items": {},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"or",
-							"id"
-						],
-						"type": "object"
-					},
-					{
-						"properties": {
-							"and": {
-								"items": {},
-								"type": "array"
-							},
-							"id": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"and",
-							"id"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Filters": {
-				"properties": {
-					"metrics": {
-						"$ref": "#/components/schemas/FilterGroupResponse"
-					},
-					"dimensions": {
-						"$ref": "#/components/schemas/FilterGroupResponse"
-					}
-				},
-				"type": "object"
-			},
-			"SortField": {
-				"properties": {
-					"descending": {
-						"type": "boolean"
-					},
-					"fieldId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"descending",
-					"fieldId"
-				],
-				"type": "object"
-			},
-			"TableCalculationFormatType": {
-				"enum": [
-					"default",
-					"percent",
-					"currency",
-					"number"
-				],
-				"type": "string"
-			},
-			"NumberSeparator": {
-				"enum": [
-					"default",
-					"commaPeriod",
-					"spacePeriod",
-					"periodComma",
-					"noSeparatorPeriod"
-				],
-				"type": "string"
-			},
-			"Compact": {
-				"enum": [
-					"thousands",
-					"millions",
-					"billions",
-					"trillions"
-				],
-				"type": "string"
-			},
-			"TableCalculationFormat": {
-				"properties": {
-					"suffix": {
-						"type": "string"
-					},
-					"prefix": {
-						"type": "string"
-					},
-					"compact": {
-						"$ref": "#/components/schemas/Compact"
-					},
-					"currency": {
-						"type": "string"
-					},
-					"separator": {
-						"$ref": "#/components/schemas/NumberSeparator"
-					},
-					"round": {
-						"type": "number",
-						"format": "double"
-					},
-					"type": {
-						"$ref": "#/components/schemas/TableCalculationFormatType"
-					}
-				},
-				"required": [
-					"type"
-				],
-				"type": "object"
-			},
-			"TableCalculation": {
-				"properties": {
-					"format": {
-						"$ref": "#/components/schemas/TableCalculationFormat"
-					},
-					"sql": {
-						"type": "string"
-					},
-					"displayName": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"index": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"sql",
-					"displayName",
-					"name"
-				],
-				"type": "object"
-			},
-			"MetricType": {
-				"enum": [
-					"percentile",
-					"average",
-					"count",
-					"count_distinct",
-					"sum",
-					"min",
-					"max",
-					"number",
-					"median",
-					"string",
-					"date",
-					"boolean"
-				],
-				"type": "string"
-			},
-			"CompactOrAlias": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/Compact"
-					},
-					{
-						"type": "string",
-						"enum": [
-							"K",
-							"thousand",
-							"M",
-							"million",
-							"B",
-							"billion",
-							"T",
-							"trillion"
-						]
-					}
-				]
-			},
-			"ConditionalOperator": {
-				"enum": [
-					"isNull",
-					"notNull",
-					"equals",
-					"notEquals",
-					"startsWith",
-					"endsWith",
-					"include",
-					"doesNotInclude",
-					"lessThan",
-					"lessThanOrEqual",
-					"greaterThan",
-					"greaterThanOrEqual",
-					"inThePast",
-					"inTheNext",
-					"inTheCurrent",
-					"inBetween"
-				],
-				"type": "string"
-			},
-			"MetricFilterRule": {
-				"properties": {
-					"values": {
-						"items": {},
-						"type": "array"
-					},
-					"operator": {
-						"$ref": "#/components/schemas/ConditionalOperator"
-					},
-					"id": {
-						"type": "string"
-					},
-					"target": {
-						"properties": {
-							"fieldRef": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"fieldRef"
-						],
-						"type": "object"
-					},
-					"settings": {}
-				},
-				"required": [
-					"operator",
-					"id",
-					"target"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"AdditionalMetric": {
-				"properties": {
-					"label": {
-						"type": "string"
-					},
-					"type": {
-						"$ref": "#/components/schemas/MetricType"
-					},
-					"description": {
-						"type": "string"
-					},
-					"sql": {
-						"type": "string"
-					},
-					"hidden": {
-						"type": "boolean"
-					},
-					"round": {
-						"type": "number",
-						"format": "double"
-					},
-					"compact": {
-						"$ref": "#/components/schemas/CompactOrAlias"
-					},
-					"format": {
-						"type": "string"
-					},
-					"table": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"index": {
-						"type": "number",
-						"format": "double"
-					},
-					"filters": {
-						"items": {
-							"$ref": "#/components/schemas/MetricFilterRule"
-						},
-						"type": "array"
-					},
-					"baseDimensionName": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string",
-						"nullable": true
-					}
-				},
-				"required": [
-					"type",
-					"sql",
-					"table",
-					"name"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"MetricQueryResponse": {
-				"properties": {
-					"additionalMetrics": {
-						"items": {
-							"$ref": "#/components/schemas/AdditionalMetric"
-						},
-						"type": "array"
-					},
-					"tableCalculations": {
-						"items": {
-							"$ref": "#/components/schemas/TableCalculation"
-						},
-						"type": "array"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sorts": {
-						"items": {
-							"$ref": "#/components/schemas/SortField"
-						},
-						"type": "array"
-					},
-					"filters": {
-						"$ref": "#/components/schemas/Filters"
-					},
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					},
-					"dimensions": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"tableCalculations",
-					"limit",
-					"sorts",
-					"filters",
-					"metrics",
-					"dimensions"
-				],
-				"type": "object"
-			},
-			"ApiRunQueryResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"rows": {
-								"items": {},
-								"type": "array"
-							},
-							"metricQuery": {
-								"$ref": "#/components/schemas/MetricQueryResponse"
-							}
-						},
-						"required": [
-							"rows",
-							"metricQuery"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"RunQueryRequest": {
-				"properties": {
-					"csvLimit": {
-						"type": "number",
-						"format": "double"
-					},
-					"additionalMetrics": {
-						"items": {
-							"$ref": "#/components/schemas/AdditionalMetric"
-						},
-						"type": "array"
-					},
-					"tableCalculations": {
-						"items": {
-							"$ref": "#/components/schemas/TableCalculation"
-						},
-						"type": "array"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sorts": {
-						"items": {
-							"$ref": "#/components/schemas/SortField"
-						},
-						"type": "array"
-					},
-					"filters": {
-						"properties": {
-							"metrics": {},
-							"dimensions": {}
-						},
-						"type": "object"
-					},
-					"metrics": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					},
-					"dimensions": {
-						"items": {
-							"$ref": "#/components/schemas/FieldId"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"tableCalculations",
-					"limit",
-					"sorts",
-					"filters",
-					"metrics",
-					"dimensions"
-				],
-				"type": "object"
-			},
-			"SchedulerFormat": {
-				"enum": [
-					"csv",
-					"image"
-				],
-				"type": "string"
-			},
-			"SchedulerCsvOptions": {
-				"properties": {
-					"limit": {
-						"anyOf": [
-							{
-								"type": "number",
-								"format": "double"
-							},
-							{
-								"type": "string",
-								"enum": [
-									"table",
-									"all"
-								]
-							}
-						]
-					},
-					"formatted": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"limit",
-					"formatted"
-				],
-				"type": "object"
-			},
-			"SchedulerImageOptions": {
-				"properties": {},
-				"type": "object"
-			},
-			"SchedulerOptions": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerCsvOptions"
-					},
-					{
-						"$ref": "#/components/schemas/SchedulerImageOptions"
-					}
-				]
-			},
-			"SchedulerBase": {
-				"properties": {
-					"options": {
-						"$ref": "#/components/schemas/SchedulerOptions"
-					},
-					"dashboardUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"savedChartUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"cron": {
-						"type": "string"
-					},
-					"format": {
-						"$ref": "#/components/schemas/SchedulerFormat"
-					},
-					"createdBy": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"name": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"options",
-					"dashboardUuid",
-					"savedChartUuid",
-					"cron",
-					"format",
-					"createdBy",
-					"updatedAt",
-					"createdAt",
-					"name",
-					"schedulerUuid"
-				],
-				"type": "object"
-			},
-			"ChartScheduler": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerBase"
-					},
-					{
-						"properties": {
-							"dashboardUuid": {
-								"type": "number",
-								"enum": [
-									null
-								],
-								"nullable": true
-							},
-							"savedChartUuid": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"dashboardUuid",
-							"savedChartUuid"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"DashboardScheduler": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/SchedulerBase"
-					},
-					{
-						"properties": {
-							"dashboardUuid": {
-								"type": "string"
-							},
-							"savedChartUuid": {
-								"type": "number",
-								"enum": [
-									null
-								],
-								"nullable": true
-							}
-						},
-						"required": [
-							"dashboardUuid",
-							"savedChartUuid"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Scheduler": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ChartScheduler"
-					},
-					{
-						"$ref": "#/components/schemas/DashboardScheduler"
-					}
-				]
-			},
-			"SchedulerSlackTarget": {
-				"properties": {
-					"channel": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"schedulerSlackTargetUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"channel",
-					"schedulerUuid",
-					"updatedAt",
-					"createdAt",
-					"schedulerSlackTargetUuid"
-				],
-				"type": "object"
-			},
-			"SchedulerEmailTarget": {
-				"properties": {
-					"recipient": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"schedulerEmailTargetUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"recipient",
-					"schedulerUuid",
-					"updatedAt",
-					"createdAt",
-					"schedulerEmailTargetUuid"
-				],
-				"type": "object"
-			},
-			"SchedulerAndTargets": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Scheduler"
-					},
-					{
-						"properties": {
-							"targets": {
-								"items": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/SchedulerSlackTarget"
-										},
-										{
-											"$ref": "#/components/schemas/SchedulerEmailTarget"
-										}
-									]
-								},
-								"type": "array"
-							}
-						},
-						"required": [
-							"targets"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"SchedulerJobStatus": {
-				"enum": [
-					"scheduled",
-					"started",
-					"completed",
-					"error"
-				],
-				"type": "string"
-			},
-			"Record_string.any_": {
-				"properties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"SchedulerLog": {
-				"properties": {
-					"details": {
-						"$ref": "#/components/schemas/Record_string.any_"
-					},
-					"targetType": {
-						"type": "string",
-						"enum": [
-							"email",
-							"slack"
-						]
-					},
-					"target": {
-						"type": "string"
-					},
-					"status": {
-						"$ref": "#/components/schemas/SchedulerJobStatus"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"scheduledTime": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"jobGroup": {
-						"type": "string"
-					},
-					"jobId": {
-						"type": "string"
-					},
-					"schedulerUuid": {
-						"type": "string"
-					},
-					"task": {
-						"type": "string",
-						"enum": [
-							"handleScheduledDelivery",
-							"sendEmailNotification",
-							"sendSlackNotification",
-							"downloadCsv",
-							"compileProject",
-							"testAndCompileProject",
-							"validateProject"
-						]
-					}
-				},
-				"required": [
-					"status",
-					"createdAt",
-					"scheduledTime",
-					"jobId",
-					"task"
-				],
-				"type": "object"
-			},
-			"SchedulerWithLogs": {
-				"properties": {
-					"logs": {
-						"items": {
-							"$ref": "#/components/schemas/SchedulerLog"
-						},
-						"type": "array"
-					},
-					"dashboards": {
-						"items": {
-							"properties": {
-								"dashboardUuid": {
-									"type": "string"
-								},
-								"name": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"dashboardUuid",
-								"name"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"charts": {
-						"items": {
-							"properties": {
-								"savedChartUuid": {
-									"type": "string"
-								},
-								"name": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"savedChartUuid",
-								"name"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"users": {
-						"items": {
-							"properties": {
-								"userUuid": {
-									"type": "string"
-								},
-								"lastName": {
-									"type": "string"
-								},
-								"firstName": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"userUuid",
-								"lastName",
-								"firstName"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"schedulers": {
-						"items": {
-							"$ref": "#/components/schemas/SchedulerAndTargets"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"logs",
-					"dashboards",
-					"charts",
-					"users",
-					"schedulers"
-				],
-				"type": "object"
-			},
-			"ApiSchedulerLogsResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/SchedulerWithLogs"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiSchedulerAndTargetsResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/SchedulerAndTargets"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ScheduledJobs": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"date": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"required": [
-					"id",
-					"date"
-				],
-				"type": "object"
-			},
-			"ApiScheduledJobsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ScheduledJobs"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiJobStatusResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"status": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"status"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ShareUrl": {
-				"properties": {
-					"host": {
-						"type": "string"
-					},
-					"url": {
-						"type": "string"
-					},
-					"shareUrl": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string",
-						"format": "uuid"
-					},
-					"createdByUserUuid": {
-						"type": "string",
-						"format": "uuid"
-					},
-					"params": {
-						"type": "string"
-					},
-					"path": {
-						"type": "string",
-						"description": "The URL path of the full URL"
-					},
-					"nanoid": {
-						"type": "string",
-						"description": "Unique shareable id"
-					}
-				},
-				"required": [
-					"params",
-					"path",
-					"nanoid"
-				],
-				"type": "object",
-				"description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
-			},
-			"ApiShareResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/ShareUrl"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_ShareUrl.path-or-params_": {
-				"properties": {
-					"path": {
-						"type": "string",
-						"description": "The URL path of the full URL"
-					},
-					"params": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"path",
-					"params"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"CreateShareUrl": {
-				"$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
-				"description": "Contains the detail of a full URL to generate a short URL id"
-			},
-			"SlackChannel": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"id"
-				],
-				"type": "object"
-			},
-			"ApiSlackChannelsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/SlackChannel"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					}
-				},
-				"required": [
-					"name",
-					"uuid",
-					"updatedAt",
-					"spaceUuid",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ViewStatistics": {
-				"properties": {
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"firstViewedAt",
-					"views"
-				],
-				"type": "object"
-			},
-			"SpaceQuery": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
-					},
-					{
-						"$ref": "#/components/schemas/ViewStatistics"
-					},
-					{
-						"properties": {
-							"validationErrors": {
-								"items": {
-									"$ref": "#/components/schemas/ValidationSummary"
-								},
-								"type": "array"
-							},
-							"chartType": {
-								"$ref": "#/components/schemas/ChartKind"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"updatedByUser": {
-						"$ref": "#/components/schemas/UpdatedByUser"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"views": {
-						"type": "number",
-						"format": "double"
-					},
-					"firstViewedAt": {
-						"anyOf": [
-							{
-								"type": "string",
-								"format": "date-time"
-							},
-							{
-								"type": "string"
-							}
-						],
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					}
-				},
-				"required": [
-					"name",
-					"organizationUuid",
-					"uuid",
-					"updatedAt",
-					"projectUuid",
-					"spaceUuid",
-					"views",
-					"firstViewedAt",
-					"pinnedListUuid",
-					"pinnedListOrder"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"DashboardBasicDetails": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"
-					},
-					{
-						"properties": {
-							"validationErrors": {
-								"items": {
-									"$ref": "#/components/schemas/ValidationSummary"
-								},
-								"type": "array"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"SpaceDashboard": {
-				"$ref": "#/components/schemas/DashboardBasicDetails"
-			},
-			"SpaceShare": {
-				"properties": {
-					"role": {
-						"$ref": "#/components/schemas/ProjectMemberRole"
-					},
-					"lastName": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"userUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"role",
-					"lastName",
-					"firstName",
-					"userUuid"
-				],
-				"type": "object"
-			},
-			"Space": {
-				"properties": {
-					"pinnedListOrder": {
-						"type": "number",
-						"format": "double",
-						"nullable": true
-					},
-					"pinnedListUuid": {
-						"type": "string",
-						"nullable": true
-					},
-					"access": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceShare"
-						},
-						"type": "array"
-					},
-					"dashboards": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceDashboard"
-						},
-						"type": "array"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"queries": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceQuery"
-						},
-						"type": "array"
-					},
-					"isPrivate": {
-						"type": "boolean"
-					},
-					"name": {
-						"type": "string"
-					},
-					"uuid": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"pinnedListOrder",
-					"pinnedListUuid",
-					"access",
-					"dashboards",
-					"projectUuid",
-					"queries",
-					"isPrivate",
-					"name",
-					"uuid",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiSpaceResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Space"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"CreateSpace": {
-				"properties": {
-					"access": {
-						"items": {
-							"$ref": "#/components/schemas/SpaceShare"
-						},
-						"type": "array"
-					},
-					"isPrivate": {
-						"type": "boolean"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name"
-				],
-				"type": "object"
-			},
-			"UpdateSpace": {
-				"properties": {
-					"isPrivate": {
-						"type": "boolean"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"isPrivate",
-					"name"
-				],
-				"type": "object"
-			},
-			"AddSpaceShare": {
-				"properties": {
-					"userUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"userUuid"
-				],
-				"type": "object"
-			},
-			"Pick_SshKeyPair.publicKey_": {
-				"properties": {
-					"publicKey": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"publicKey"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"ApiSshKeyPairResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"EmailOneTimePassword": {
-				"properties": {
-					"numberOfAttempts": {
-						"type": "number",
-						"format": "double",
-						"description": "Number of times the passcode has been attempted"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time",
-						"description": "Time that the passcode was created"
-					}
-				},
-				"required": [
-					"numberOfAttempts",
-					"createdAt"
-				],
-				"type": "object"
-			},
-			"EmailStatus": {
-				"properties": {
-					"otp": {
-						"$ref": "#/components/schemas/EmailOneTimePassword"
-					},
-					"isVerified": {
-						"type": "boolean"
-					},
-					"email": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"isVerified",
-					"email"
-				],
-				"type": "object"
-			},
-			"EmailOneTimePasswordExpiring": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/EmailOneTimePassword"
-					},
-					{
-						"properties": {
-							"isMaxAttempts": {
-								"type": "boolean"
-							},
-							"isExpired": {
-								"type": "boolean"
-							},
-							"expiresAt": {
-								"type": "string",
-								"format": "date-time"
-							}
-						},
-						"required": [
-							"isMaxAttempts",
-							"isExpired",
-							"expiresAt"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"EmailStatusExpiring": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/EmailStatus"
-					},
-					{
-						"properties": {
-							"otp": {
-								"$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
-								"description": "One time passcode information\nIf there is no active passcode, this will be undefined"
-							}
-						},
-						"type": "object"
-					}
-				],
-				"description": "Verification status of an email address"
-			},
-			"ApiEmailStatusResponse": {
-				"properties": {
-					"results": {
-						"$ref": "#/components/schemas/EmailStatusExpiring"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object",
-				"description": "Shows the current verification status of an email address"
-			},
-			"UserAllowedOrganization": {
-				"properties": {
-					"membersCount": {
-						"type": "number",
-						"format": "double"
-					},
-					"name": {
-						"type": "string"
-					},
-					"organizationUuid": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"membersCount",
-					"name",
-					"organizationUuid"
-				],
-				"type": "object"
-			},
-			"ApiUserAllowedOrganizationsResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/UserAllowedOrganization"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiJobScheduledResponse": {
-				"properties": {
-					"results": {
-						"properties": {
-							"jobId": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"jobId"
-						],
-						"type": "object"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ValidationErrorType": {
-				"enum": [
-					"chart",
-					"sorting",
-					"filter",
-					"metric",
-					"model",
-					"dimension"
-				],
-				"type": "string"
-			},
-			"ValidationSourceType": {
-				"enum": [
-					"chart",
-					"dashboard",
-					"table"
-				],
-				"type": "string"
-			},
-			"ValidationResponseBase": {
-				"properties": {
-					"source": {
-						"$ref": "#/components/schemas/ValidationSourceType"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"projectUuid": {
-						"type": "string"
-					},
-					"errorType": {
-						"$ref": "#/components/schemas/ValidationErrorType"
-					},
-					"error": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"validationId": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"projectUuid",
-					"errorType",
-					"error",
-					"name",
-					"createdAt",
-					"validationId"
-				],
-				"type": "object"
-			},
-			"ValidationErrorChartResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ValidationResponseBase"
-					},
-					{
-						"properties": {
-							"chartName": {
-								"type": "string"
-							},
-							"chartViews": {
-								"type": "number",
-								"format": "double"
-							},
-							"lastUpdatedAt": {
-								"type": "string",
-								"format": "date-time"
-							},
-							"lastUpdatedBy": {
-								"type": "string"
-							},
-							"fieldName": {
-								"type": "string"
-							},
-							"chartType": {
-								"$ref": "#/components/schemas/ChartKind"
-							},
-							"chartUuid": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"chartViews"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"ValidationErrorDashboardResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/ValidationResponseBase"
-					},
-					{
-						"properties": {
-							"dashboardViews": {
-								"type": "number",
-								"format": "double"
-							},
-							"lastUpdatedAt": {
-								"type": "string",
-								"format": "date-time"
-							},
-							"lastUpdatedBy": {
-								"type": "string"
-							},
-							"fieldName": {
-								"type": "string"
-							},
-							"chartName": {
-								"type": "string"
-							},
-							"dashboardUuid": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"dashboardViews"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
-				"properties": {
-					"projectUuid": {
-						"type": "string"
-					},
-					"spaceUuid": {
-						"type": "string"
-					},
-					"validationId": {
-						"type": "number",
-						"format": "double"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"error": {
-						"type": "string"
-					},
-					"errorType": {
-						"$ref": "#/components/schemas/ValidationErrorType"
-					},
-					"source": {
-						"$ref": "#/components/schemas/ValidationSourceType"
-					}
-				},
-				"required": [
-					"projectUuid",
-					"validationId",
-					"createdAt",
-					"error",
-					"errorType"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_ValidationResponseBase.name_": {
-				"$ref": "#/components/schemas/Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"ValidationErrorTableResponse": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Omit_ValidationResponseBase.name_"
-					},
-					{
-						"properties": {
-							"name": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				]
-			},
-			"ValidationResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ValidationErrorChartResponse"
-					},
-					{
-						"$ref": "#/components/schemas/ValidationErrorDashboardResponse"
-					},
-					{
-						"$ref": "#/components/schemas/ValidationErrorTableResponse"
-					}
-				]
-			},
-			"ApiValidateResponse": {
-				"properties": {
-					"results": {
-						"items": {
-							"$ref": "#/components/schemas/ValidationResponse"
-						},
-						"type": "array"
-					},
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"results",
-					"status"
-				],
-				"type": "object"
-			},
-			"ApiValidationDismissResponse": {
-				"properties": {
-					"status": {
-						"type": "string",
-						"enum": [
-							"ok"
-						],
-						"nullable": false
-					}
-				},
-				"required": [
-					"status"
-				],
-				"type": "object"
-			}
-		},
-		"securitySchemes": {
-			"session_cookie": {
-				"type": "apiKey",
-				"in": "cookie",
-				"name": "connect.sid"
-			},
-			"api_key": {
-				"type": "apiKey",
-				"in": "header",
-				"name": "Authorization",
-				"description": "Value should be 'ApiKey <your key>'"
-			}
-		}
-	},
-	"info": {
-		"title": "Lightdash API",
-		"version": "0.632.0",
-		"description": "Open API documentation for all public Lightdash API endpoints",
-		"license": {
-			"name": "MIT"
-		},
-		"contact": {
-			"name": "Lightdash Support",
-			"email": "support@lightdash.com",
-			"url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
-		}
-	},
-	"openapi": "3.0.0",
-	"paths": {
-		"/api/v1/csv/{jobId}": {
-			"get": {
-				"operationId": "getCsvUrl",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiCsvUrlResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a Csv",
-				"tags": [
-					"Exports"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the jobId for the CSV",
-						"in": "path",
-						"name": "jobId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
-			"get": {
-				"operationId": "getDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the current dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"post": {
-				"operationId": "updateDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update the dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "deleteDbtCloudIntegrationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove the dbt Cloud integration settings for a project",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
-			"get": {
-				"operationId": "getDbtCloudMetrics",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiDbtCloudMetrics"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/groups/{groupUuid}": {
-			"get": {
-				"operationId": "getGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get group details",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "unique id of the group",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "deleteGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"patch": {
-				"operationId": "updateGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateGroup"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/groups/{groupUuid}/members/{userUuid}": {
-			"put": {
-				"operationId": "addUserToGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Add a Lightdash user to a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to add the user to",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the UUID for the user to add to the group",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "removeUserFromGroup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove a user from a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to remove the user from",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the UUID for the user to remove from the group",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/groups/{groupUuid}/members": {
-			"get": {
-				"operationId": "getGroupMembers",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupMembersResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "View members of a group",
-				"tags": [
-					"User Groups"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the UUID for the group to view the members of",
-						"in": "path",
-						"name": "groupUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org": {
-			"get": {
-				"operationId": "GetMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganization"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			},
-			"put": {
-				"operationId": "CreateOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new organization settings",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateOrganization",
-								"description": "the new organization settings"
-							}
-						}
-					}
-				}
-			},
-			"patch": {
-				"operationId": "UpdateMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new organization settings",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateOrganization",
-								"description": "the new organization settings"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/{organizationUuid}": {
-			"delete": {
-				"operationId": "DeleteMyOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Deletes an organization and all users inside that organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the organization to delete",
-						"in": "path",
-						"name": "organizationUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org/projects": {
-			"get": {
-				"operationId": "ListOrganizationProjects",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationProjects"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets all projects of the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/org/users": {
-			"get": {
-				"operationId": "ListOrganizationMembers",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets all the members of the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/org/users/{userUuid}": {
-			"patch": {
-				"operationId": "UpdateOrganizationMember",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationMemberProfile"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Updates the membership profile for a user in the current user's organization",
-				"tags": [
-					"Roles & Permissions",
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the user to update",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new membership profile",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
-								"description": "the new membership profile"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/user/{userUuid}": {
-			"delete": {
-				"operationId": "DeleteOrganizationMember",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Deletes a user from the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the user to delete",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/org/allowedEmailDomains": {
-			"get": {
-				"operationId": "ListOrganizationEmailDomains",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets the allowed email domains for the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			},
-			"patch": {
-				"operationId": "UpdateOrganizationEmailDomains",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Updates the allowed email domains for the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new allowed email domains",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateAllowedEmailDomains",
-								"description": "the new allowed email domains"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/org/groups": {
-			"post": {
-				"operationId": "CreateGroupInOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Creates a new group in the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "the new group details",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/Pick_CreateGroup.name_",
-								"description": "the new group details"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "ListGroupsInOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiGroupListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Gets all the groups in the current user's organization",
-				"tags": [
-					"Organizations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
-			"get": {
-				"operationId": "getPinnedItems",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiPinnedItems"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get pinned items",
-				"tags": [
-					"Content"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "project uuid",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the list uuid for the pinned items",
-						"in": "path",
-						"name": "pinnedListUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
-			"patch": {
-				"operationId": "updatePinnedItemsOrder",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiPinnedItems"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update pinned items order",
-				"tags": [
-					"Content"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "project uuid",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the list uuid for the pinned items",
-						"in": "path",
-						"name": "pinnedListUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new order of the pinned items",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"items": {
-									"$ref": "#/components/schemas/UpdatePinnedItemOrder"
-								},
-								"type": "array",
-								"description": "the new order of the pinned items"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}": {
-			"get": {
-				"operationId": "GetProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiProjectResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a project of an organiztion",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/charts": {
-			"get": {
-				"operationId": "ListChartsInProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiChartSummaryListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List all charts in a project",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project to get charts for",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/spaces": {
-			"get": {
-				"operationId": "ListSpacesInProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List all spaces in a project",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project to get spaces for",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"post": {
-				"operationId": "CreateSpaceInProject",
-				"responses": {
-					"200": {
-						"description": "Created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSpaceResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new space inside a project",
-				"tags": [
-					"Roles & Permissions",
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateSpace"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/access": {
-			"get": {
-				"operationId": "GetProjectAccessList",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiProjectAccessListResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
-				"tags": [
-					"Roles & Permissions",
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"post": {
-				"operationId": "GrantProjectAccessToUser",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Grant a user access to a project",
-				"tags": [
-					"Roles & Permissions",
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateProjectMember"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/access/{userUuid}": {
-			"patch": {
-				"operationId": "UpdateProjectAccessForUser",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a user's access to a project",
-				"tags": [
-					"Roles & Permissions",
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateProjectMember"
-							}
-						}
-					}
-				}
-			},
-			"delete": {
-				"operationId": "RevokeProjectAccessForUser",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove a user's access to a project",
-				"tags": [
-					"Roles & Permissions",
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
-			"post": {
-				"operationId": "postRunUnderlyingDataQuery",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for underlying data results",
-				"tags": [
-					"Exploring"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "table name",
-						"in": "path",
-						"name": "exploreId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "metricQuery for the chart to run",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RunQueryRequest",
-								"description": "metricQuery for the chart to run"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
-			"post": {
-				"operationId": "postRunQuery",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for explore",
-				"tags": [
-					"Exploring"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "table name",
-						"in": "path",
-						"name": "exploreId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "metricQuery for the chart to run",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RunQueryRequest",
-								"description": "metricQuery for the chart to run"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/saved/{chartUuid}/results": {
-			"post": {
-				"operationId": "postChartResults",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiRunQueryResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Run a query for a chart",
-				"tags": [
-					"Charts"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "chartUuid for the chart to run",
-						"in": "path",
-						"name": "chartUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"filters": {
-										"$ref": "#/components/schemas/Filters"
-									}
-								},
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/schedulers/{projectUuid}/logs": {
-			"get": {
-				"operationId": "getSchedulerLogs",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerLogsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get scheduled logs",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/{schedulerUuid}": {
-			"get": {
-				"operationId": "getScheduler",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"patch": {
-				"operationId": "updateScheduler",
-				"responses": {
-					"201": {
-						"description": "Updated",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the new scheduler data",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"description": "the new scheduler data"
-							}
-						}
-					}
-				}
-			},
-			"delete": {
-				"operationId": "deleteScheduler",
-				"responses": {
-					"201": {
-						"description": "Deleted",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"results": {},
-										"status": {
-											"type": "string",
-											"enum": [
-												"ok"
-											],
-											"nullable": false
-										}
-									},
-									"required": [
-										"status"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete a scheduler",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to delete",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/{schedulerUuid}/jobs": {
-			"get": {
-				"operationId": "getScheduledJobs",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiScheduledJobsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get scheduled jobs",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the scheduler to update",
-						"in": "path",
-						"name": "schedulerUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/schedulers/job/{jobId}/status": {
-			"get": {
-				"operationId": "getSchedulerJobStatus",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiJobStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a generic job status\nThis method can be used when polling from the frontend",
-				"tags": [
-					"Schedulers"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the jobId for the status to check",
-						"in": "path",
-						"name": "jobId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/share/{nanoId}": {
-			"get": {
-				"operationId": "getShareUrl",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiShareResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get a share url from a short url id",
-				"tags": [
-					"Share links"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the short id for the share url",
-						"in": "path",
-						"name": "nanoId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/share": {
-			"post": {
-				"operationId": "CreateShareUrl",
-				"responses": {
-					"201": {
-						"description": "Created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiShareResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Given a full URL generates a short url id that can be used for sharing",
-				"tags": [
-					"Share links"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "a full URL used to generate a short url id",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CreateShareUrl",
-								"description": "a full URL used to generate a short url id"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/slack/channels": {
-			"get": {
-				"operationId": "getSlackChannels",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSlackChannelsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get slack channels",
-				"tags": [
-					"Integrations"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}": {
-			"get": {
-				"operationId": "GetSpace",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSpaceResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get details for a space in a project",
-				"tags": [
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The uuid of the space to get",
-						"in": "path",
-						"name": "spaceUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"delete": {
-				"operationId": "DeleteSpace",
-				"responses": {
-					"204": {
-						"description": "Deleted",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete a space from a project",
-				"tags": [
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The uuid of the space to delete",
-						"in": "path",
-						"name": "spaceUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			},
-			"patch": {
-				"operationId": "UpdateSpace",
-				"responses": {
-					"200": {
-						"description": "Updated",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSpaceResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update a space in a project",
-				"tags": [
-					"Roles & Permissions",
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The uuid of the space to update",
-						"in": "path",
-						"name": "spaceUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateSpace"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share": {
-			"post": {
-				"operationId": "AddSpaceShareToUser",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Grant a user access to a space",
-				"tags": [
-					"Roles & Permissions",
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "spaceUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/AddSpaceShare"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share/{userUuid}": {
-			"delete": {
-				"operationId": "RevokeSpaceAccessForUser",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Remove a user's access to a space",
-				"tags": [
-					"Roles & Permissions",
-					"Spaces"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "The uuid of the space's parent project",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The uuid of the space to update",
-						"in": "path",
-						"name": "spaceUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The uuid of the user to revoke access from",
-						"in": "path",
-						"name": "userUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/ssh/key-pairs": {
-			"post": {
-				"operationId": "createSshKeyPair",
-				"responses": {
-					"201": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSshKeyPairResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"SSH Keypairs"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/email/otp": {
-			"put": {
-				"operationId": "CreateEmailOneTimePasscode",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiEmailStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/email/status": {
-			"get": {
-				"operationId": "GetEmailVerificationStatus",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiEmailStatusResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get the verification status for the current user's primary email",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the one-time passcode sent to the user's primary email",
-						"in": "query",
-						"name": "passcode",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/user/me/allowedOrganizations": {
-			"get": {
-				"operationId": "ListMyAvailableOrganizations",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/user/me/joinOrganization/{organizationUuid}": {
-			"post": {
-				"operationId": "JoinOrganization",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the uuid of the organization to join",
-						"in": "path",
-						"name": "organizationUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/user/me": {
-			"delete": {
-				"operationId": "DeleteMe",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiSuccessEmpty"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete user",
-				"tags": [
-					"My Account"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/api/v1/projects/{projectUuid}/validate": {
-			"post": {
-				"operationId": "ValidateProject",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiJobScheduledResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the projectId for the validation",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"explores": {
-										"items": {},
-										"type": "array"
-									}
-								},
-								"type": "object",
-								"description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetLatestValidationResults",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiValidateResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get validation results for a project. This will return the results of the latest validation job.",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "the projectId for the validation",
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "boolean to know if this request is made from the settings page, for analytics",
-						"in": "query",
-						"name": "fromSettings",
-						"required": false,
-						"schema": {
-							"type": "boolean"
-						}
-					},
-					{
-						"description": "optional jobId to get results for a specific job, used on CLI",
-						"in": "query",
-						"name": "jobId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/api/v1/projects/{projectUuid}/validate/{validationId}": {
-			"delete": {
-				"operationId": "DeleteValidationDismiss",
-				"responses": {
-					"200": {
-						"description": "Success",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiValidationDismissResponse"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ApiErrorPayload"
-								}
-							}
-						}
-					}
-				},
-				"description": "Deletes a single validation error.",
-				"tags": [
-					"Projects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "projectUuid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "the projectId for the validation",
-						"in": "path",
-						"name": "validationId",
-						"required": true,
-						"schema": {
-							"format": "double",
-							"type": "number"
-						}
-					}
-				]
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "/"
-		}
-	],
-	"tags": [
-		{
-			"name": "My Account",
-			"description": "These routes allow users to manage their own user account."
-		},
-		{
-			"name": "Organizations",
-			"description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
-		},
-		{
-			"name": "Projects",
-			"description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
-		},
-		{
-			"name": "Spaces",
-			"description": "Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins."
-		},
-		{
-			"name": "Roles & Permissions",
-			"description": "These routes allow users to manage roles and permissions for their organization.",
-			"externalDocs": {
-				"url": "https://docs.lightdash.com/references/roles"
-			}
-		}
-	]
+    "components": {
+        "examples": {},
+        "headers": {},
+        "parameters": {},
+        "requestBodies": {},
+        "responses": {},
+        "schemas": {
+            "ApiErrorPayload": {
+                "properties": {
+                    "error": {
+                        "properties": {
+                            "data": {
+                                "description": "Optional data containing details of the error"
+                            },
+                            "message": {
+                                "type": "string",
+                                "description": "A friendly message summarising the error"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Unique name for the type of error"
+                            },
+                            "statusCode": {
+                                "type": "number",
+                                "format": "integer",
+                                "description": "HTTP status code"
+                            }
+                        },
+                        "required": ["name", "statusCode"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["error"],
+                        "nullable": false
+                    }
+                },
+                "required": ["error", "status"],
+                "type": "object",
+                "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
+            },
+            "ApiCsvUrlResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "status": {
+                                "type": "string"
+                            },
+                            "url": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["status", "url"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_CreateDbtCloudIntegration.metricsJobId_": {
+                "properties": {
+                    "metricsJobId": {
+                        "type": "string",
+                        "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
+                    }
+                },
+                "required": ["metricsJobId"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "DbtCloudIntegration": {
+                "$ref": "#/components/schemas/Pick_CreateDbtCloudIntegration.metricsJobId_",
+                "description": "Configuration for a Lightdash integration with dbt Cloud"
+            },
+            "ApiDbtCloudIntegrationSettings": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DbtCloudIntegration"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "ApiDbtCloudSettingsDeleteSuccess": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "DbtCloudMetric": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "timeGrains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uniqueId": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "label",
+                    "timeGrains",
+                    "description",
+                    "dimensions",
+                    "name",
+                    "uniqueId"
+                ],
+                "type": "object"
+            },
+            "DbtCloudMetadataResponseMetrics": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtCloudMetric"
+                        },
+                        "type": "array",
+                        "description": "A list of dbt metric definitions from the dbt cloud metadata api"
+                    }
+                },
+                "required": ["metrics"],
+                "type": "object",
+                "description": "Response from dbt cloud metadata api containing a list of metric definitions"
+            },
+            "ApiDbtCloudMetrics": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DbtCloudMetadataResponseMetrics"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Group": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "The UUID of the organization that the group belongs to"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The time that the group was created"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    },
+                    "uuid": {
+                        "type": "string",
+                        "description": "The group's UUID"
+                    }
+                },
+                "required": ["organizationUuid", "createdAt", "name", "uuid"],
+                "type": "object"
+            },
+            "ApiGroupResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Group"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSuccessEmpty": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "GroupMember": {
+                "properties": {
+                    "lastName": {
+                        "type": "string",
+                        "description": "The user's last name"
+                    },
+                    "firstName": {
+                        "type": "string",
+                        "description": "The user's first name"
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "Primary email address for the user"
+                    },
+                    "userUuid": {
+                        "type": "string",
+                        "description": "Unique id for the user",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["lastName", "firstName", "email", "userUuid"],
+                "type": "object",
+                "description": "A summary for a Lightdash user within a group"
+            },
+            "ApiGroupMembersResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/GroupMember"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Group.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdateGroup": {
+                "$ref": "#/components/schemas/Pick_Group.name_"
+            },
+            "Organization": {
+                "properties": {
+                    "defaultProjectUuid": {
+                        "type": "string",
+                        "description": "The project a user sees when they first log in to the organization"
+                    },
+                    "needsProject": {
+                        "type": "boolean",
+                        "description": "The organization needs a project if it doesn't have at least one project."
+                    },
+                    "chartColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "The default color palette for all projects in the organization"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "The unique identifier of the organization",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["name", "organizationUuid"],
+                "type": "object",
+                "description": "Details of a user's Organization"
+            },
+            "ApiOrganization": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Organization"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Organization.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateOrganization": {
+                "$ref": "#/components/schemas/Pick_Organization.name_"
+            },
+            "Partial_Omit_Organization.organizationUuid-or-needsProject__": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    },
+                    "chartColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "The default color palette for all projects in the organization"
+                    },
+                    "defaultProjectUuid": {
+                        "type": "string",
+                        "description": "The project a user sees when they first log in to the organization"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpdateOrganization": {
+                "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
+            },
+            "ProjectType": {
+                "enum": ["DEFAULT", "PREVIEW"],
+                "type": "string"
+            },
+            "OrganizationProject": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/ProjectType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string",
+                        "description": "The unique identifier of the project",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["type", "name", "projectUuid"],
+                "type": "object",
+                "description": "Summary of a project under an organization"
+            },
+            "ApiOrganizationProjects": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationProject"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "List of projects in the current organization"
+            },
+            "OrganizationMemberRole": {
+                "enum": [
+                    "member",
+                    "viewer",
+                    "interactive_viewer",
+                    "editor",
+                    "developer",
+                    "admin"
+                ],
+                "type": "string"
+            },
+            "OrganizationMemberProfile": {
+                "properties": {
+                    "isInviteExpired": {
+                        "type": "boolean",
+                        "description": "Whether the user's invite to the organization has expired"
+                    },
+                    "isActive": {
+                        "type": "boolean",
+                        "description": "Whether the user has accepted their invite to the organization"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole",
+                        "description": "The role of the user in the organization"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the organization the user is a member of"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the user",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "isActive",
+                    "role",
+                    "organizationUuid",
+                    "email",
+                    "lastName",
+                    "firstName",
+                    "userUuid"
+                ],
+                "type": "object",
+                "description": "Profile for a user's membership in an organization"
+            },
+            "ApiOrganizationMemberProfiles": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationMemberProfile"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiOrganizationMemberProfile": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/OrganizationMemberProfile"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "OrganizationMemberProfileUpdate": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/OrganizationMemberRole"
+                    }
+                },
+                "required": ["role"],
+                "type": "object"
+            },
+            "OrganizationMemberRole.EDITOR": {
+                "enum": ["editor"],
+                "type": "string"
+            },
+            "OrganizationMemberRole.INTERACTIVE_VIEWER": {
+                "enum": ["interactive_viewer"],
+                "type": "string"
+            },
+            "OrganizationMemberRole.VIEWER": {
+                "enum": ["viewer"],
+                "type": "string"
+            },
+            "OrganizationMemberRole.MEMBER": {
+                "enum": ["member"],
+                "type": "string"
+            },
+            "AllowedEmailDomainsRole": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/OrganizationMemberRole.EDITOR"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationMemberRole.INTERACTIVE_VIEWER"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationMemberRole.VIEWER"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationMemberRole.MEMBER"
+                    }
+                ]
+            },
+            "AllowedEmailDomains": {
+                "properties": {
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/AllowedEmailDomainsRole"
+                    },
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "projectUuids",
+                    "role",
+                    "emailDomains",
+                    "organizationUuid"
+                ],
+                "type": "object"
+            },
+            "ApiOrganizationAllowedEmailDomains": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AllowedEmailDomains"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
+                "properties": {
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/AllowedEmailDomainsRole"
+                    },
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["emailDomains", "role", "projectUuids"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_AllowedEmailDomains.organizationUuid_": {
+                "$ref": "#/components/schemas/Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "UpdateAllowedEmailDomains": {
+                "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
+            },
+            "Pick_CreateGroup.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "A friendly name for the group"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiGroupListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Group"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ResourceViewItemType.DASHBOARD": {
+                "enum": ["dashboard"],
+                "type": "string"
+            },
+            "UpdatedByUser": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["userUuid", "firstName", "lastName"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+                "properties": {
+                    "validationId": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "error": {
+                        "type": "string"
+                    }
+                },
+                "required": ["validationId", "createdAt", "error"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ValidationSummary": {
+                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
+            },
+            "Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "validationErrors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name",
+                    "uuid",
+                    "updatedAt",
+                    "spaceUuid",
+                    "views",
+                    "firstViewedAt",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewDashboardItem": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "ResourceViewItemType.CHART": {
+                "enum": ["chart"],
+                "type": "string"
+            },
+            "ChartKind": {
+                "enum": [
+                    "line",
+                    "horizontal_bar",
+                    "vertical_bar",
+                    "scatter",
+                    "area",
+                    "mixed",
+                    "pie",
+                    "table",
+                    "big_number"
+                ],
+                "type": "string"
+            },
+            "Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "validationErrors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationSummary"
+                        },
+                        "type": "array"
+                    },
+                    "chartType": {
+                        "$ref": "#/components/schemas/ChartKind"
+                    }
+                },
+                "required": [
+                    "name",
+                    "uuid",
+                    "updatedAt",
+                    "spaceUuid",
+                    "views",
+                    "firstViewedAt",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewChartItem": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.CHART"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "ResourceViewItemType.SPACE": {
+                "enum": ["space"],
+                "type": "string"
+            },
+            "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder",
+                    "isPrivate"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ResourceViewSpaceItem": {
+                "properties": {
+                    "data": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_"
+                            },
+                            {
+                                "properties": {
+                                    "chartCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "dashboardCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "accessListLength": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "access": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "chartCount",
+                                    "dashboardCount",
+                                    "accessListLength",
+                                    "access"
+                                ],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "PinnedItems": {
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/components/schemas/ResourceViewDashboardItem"
+                        },
+                        {
+                            "$ref": "#/components/schemas/ResourceViewChartItem"
+                        },
+                        {
+                            "$ref": "#/components/schemas/ResourceViewSpaceItem"
+                        }
+                    ]
+                },
+                "type": "array"
+            },
+            "ApiPinnedItems": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/PinnedItems"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ResourceViewItemType": {
+                "enum": ["chart", "dashboard", "space"],
+                "type": "string"
+            },
+            "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+                "properties": {
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    }
+                },
+                "required": ["uuid", "pinnedListOrder"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdatePinnedItemOrder": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
+            "DbtProjectType.DBT": {
+                "enum": ["dbt"],
+                "type": "string"
+            },
+            "DbtProjectEnvironmentVariable": {
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value", "key"],
+                "type": "object"
+            },
+            "DbtProjectType": {
+                "enum": [
+                    "dbt",
+                    "dbt_cloud_ide",
+                    "github",
+                    "gitlab",
+                    "bitbucket",
+                    "azure_devops",
+                    "none"
+                ],
+                "type": "string"
+            },
+            "DbtLocalProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.DBT"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "profiles_dir": {
+                        "type": "string"
+                    },
+                    "project_dir": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.DBT_CLOUD_IDE": {
+                "enum": ["dbt_cloud_ide"],
+                "type": "string"
+            },
+            "DbtCloudIDEProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.DBT_CLOUD_IDE"
+                    },
+                    "api_key": {
+                        "type": "string"
+                    },
+                    "account_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
+                    },
+                    "environment_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
+                    },
+                    "project_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "type",
+                    "api_key",
+                    "account_id",
+                    "environment_id",
+                    "project_id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.GITHUB": {
+                "enum": ["github"],
+                "type": "string"
+            },
+            "DbtGithubProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.GITHUB"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "personal_access_token": {
+                        "type": "string"
+                    },
+                    "repository": {
+                        "type": "string"
+                    },
+                    "branch": {
+                        "type": "string"
+                    },
+                    "project_sub_path": {
+                        "type": "string"
+                    },
+                    "host_domain": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type",
+                    "personal_access_token",
+                    "repository",
+                    "branch",
+                    "project_sub_path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.BITBUCKET": {
+                "enum": ["bitbucket"],
+                "type": "string"
+            },
+            "DbtBitBucketProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.BITBUCKET"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "personal_access_token": {
+                        "type": "string"
+                    },
+                    "repository": {
+                        "type": "string"
+                    },
+                    "branch": {
+                        "type": "string"
+                    },
+                    "project_sub_path": {
+                        "type": "string"
+                    },
+                    "host_domain": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type",
+                    "username",
+                    "personal_access_token",
+                    "repository",
+                    "branch",
+                    "project_sub_path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.GITLAB": {
+                "enum": ["gitlab"],
+                "type": "string"
+            },
+            "DbtGitlabProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.GITLAB"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "personal_access_token": {
+                        "type": "string"
+                    },
+                    "repository": {
+                        "type": "string"
+                    },
+                    "branch": {
+                        "type": "string"
+                    },
+                    "project_sub_path": {
+                        "type": "string"
+                    },
+                    "host_domain": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type",
+                    "personal_access_token",
+                    "repository",
+                    "branch",
+                    "project_sub_path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.AZURE_DEVOPS": {
+                "enum": ["azure_devops"],
+                "type": "string"
+            },
+            "DbtAzureDevOpsProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.AZURE_DEVOPS"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "personal_access_token": {
+                        "type": "string"
+                    },
+                    "organization": {
+                        "type": "string"
+                    },
+                    "project": {
+                        "type": "string"
+                    },
+                    "repository": {
+                        "type": "string"
+                    },
+                    "branch": {
+                        "type": "string"
+                    },
+                    "project_sub_path": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type",
+                    "personal_access_token",
+                    "organization",
+                    "project",
+                    "repository",
+                    "branch",
+                    "project_sub_path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectType.NONE": {
+                "enum": ["none"],
+                "type": "string"
+            },
+            "DbtNoneProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.NONE"
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "items": {
+                            "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"
+                        },
+                        "type": "array"
+                    },
+                    "hideRefreshButton": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["type"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "DbtProjectConfig": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/DbtLocalProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtCloudIDEProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtGithubProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtBitBucketProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtGitlabProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtAzureDevOpsProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtNoneProjectConfig"
+                    }
+                ]
+            },
+            "WarehouseTypes.SNOWFLAKE": {
+                "enum": ["snowflake"],
+                "type": "string"
+            },
+            "WeekDay": {
+                "enum": [0, 1, 2, 3, 4, 5, 6],
+                "type": "number"
+            },
+            "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "role": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
+                    },
+                    "account": {
+                        "type": "string"
+                    },
+                    "database": {
+                        "type": "string"
+                    },
+                    "warehouse": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "clientSessionKeepAlive": {
+                        "type": "boolean"
+                    },
+                    "queryTag": {
+                        "type": "string"
+                    },
+                    "accessUrl": {
+                        "type": "string"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "type",
+                    "account",
+                    "database",
+                    "warehouse",
+                    "schema"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "SnowflakeCredentials": {
+                "$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseTypes.REDSHIFT": {
+                "enum": ["redshift"],
+                "type": "string"
+            },
+            "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "useSshTunnel": {
+                        "type": "boolean"
+                    },
+                    "sshTunnelHost": {
+                        "type": "string"
+                    },
+                    "sshTunnelPort": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sshTunnelUser": {
+                        "type": "string"
+                    },
+                    "sshTunnelPublicKey": {
+                        "type": "string"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "port": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "dbname": {
+                        "type": "string"
+                    },
+                    "keepalivesIdle": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sslmode": {
+                        "type": "string"
+                    },
+                    "ra3Node": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["type", "schema", "host", "port", "dbname"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "RedshiftCredentials": {
+                "$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseTypes.POSTGRES": {
+                "enum": ["postgres"],
+                "type": "string"
+            },
+            "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "role": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "useSshTunnel": {
+                        "type": "boolean"
+                    },
+                    "sshTunnelHost": {
+                        "type": "string"
+                    },
+                    "sshTunnelPort": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sshTunnelUser": {
+                        "type": "string"
+                    },
+                    "sshTunnelPublicKey": {
+                        "type": "string"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "port": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "dbname": {
+                        "type": "string"
+                    },
+                    "keepalivesIdle": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sslmode": {
+                        "type": "string"
+                    },
+                    "searchPath": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type", "schema", "host", "port", "dbname"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "PostgresCredentials": {
+                "$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseTypes.BIGQUERY": {
+                "enum": ["bigquery"],
+                "type": "string"
+            },
+            "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "project": {
+                        "type": "string"
+                    },
+                    "dataset": {
+                        "type": "string"
+                    },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "priority": {
+                        "type": "string",
+                        "enum": ["interactive", "batch"]
+                    },
+                    "retries": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "maximumBytesBilled": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["type", "project", "dataset"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "BigqueryCredentials": {
+                "$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseTypes.DATABRICKS": {
+                "enum": ["databricks"],
+                "type": "string"
+            },
+            "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
+                    },
+                    "database": {
+                        "type": "string"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "catalog": {
+                        "type": "string"
+                    },
+                    "serverHostName": {
+                        "type": "string"
+                    },
+                    "httpPath": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type", "database", "serverHostName", "httpPath"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "DatabricksCredentials": {
+                "$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseTypes.TRINO": {
+                "enum": ["trino"],
+                "type": "string"
+            },
+            "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.TRINO"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "port": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "dbname": {
+                        "type": "string"
+                    },
+                    "http_scheme": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type",
+                    "schema",
+                    "host",
+                    "port",
+                    "dbname",
+                    "http_scheme"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_": {
+                "$ref": "#/components/schemas/Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "TrinoCredentials": {
+                "$ref": "#/components/schemas/Omit_CreateTrinoCredentials.SensitiveCredentialsFieldNames_"
+            },
+            "WarehouseCredentials": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/SnowflakeCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RedshiftCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/PostgresCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/BigqueryCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DatabricksCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TrinoCredentials"
+                    }
+                ]
+            },
+            "Project": {
+                "properties": {
+                    "copiedFromProjectUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string"
+                    },
+                    "warehouseConnection": {
+                        "$ref": "#/components/schemas/WarehouseCredentials"
+                    },
+                    "dbtConnection": {
+                        "$ref": "#/components/schemas/DbtProjectConfig"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ProjectType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "dbtConnection",
+                    "type",
+                    "name",
+                    "projectUuid",
+                    "organizationUuid"
+                ],
+                "type": "object"
+            },
+            "ApiProjectResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Project"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "spaceUuid",
+                    "pinnedListUuid",
+                    "spaceName"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ChartType": {
+                "enum": ["cartesian", "table", "big_number", "pie"],
+                "type": "string"
+            },
+            "ChartSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid_"
+                    },
+                    {
+                        "properties": {
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartType"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiChartSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ChartSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "isPrivate"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "SpaceSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+                    },
+                    {
+                        "properties": {
+                            "access": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["access"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSpaceSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ProjectMemberRole": {
+                "enum": [
+                    "viewer",
+                    "interactive_viewer",
+                    "editor",
+                    "developer",
+                    "admin"
+                ],
+                "type": "string"
+            },
+            "ProjectMemberProfile": {
+                "properties": {
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/ProjectMemberRole"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "lastName",
+                    "firstName",
+                    "email",
+                    "role",
+                    "projectUuid",
+                    "userUuid"
+                ],
+                "type": "object"
+            },
+            "ApiProjectAccessListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProjectMemberProfile"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "CreateProjectMember": {
+                "properties": {
+                    "sendEmail": {
+                        "type": "boolean"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/ProjectMemberRole"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": ["sendEmail", "role", "email"],
+                "type": "object"
+            },
+            "UpdateProjectMember": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/ProjectMemberRole"
+                    }
+                },
+                "required": ["role"],
+                "type": "object"
+            },
+            "FieldId": {
+                "type": "string"
+            },
+            "FilterGroupResponse": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "or": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "id": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["or", "id"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "and": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "id": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["and", "id"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Filters": {
+                "properties": {
+                    "metrics": {
+                        "$ref": "#/components/schemas/FilterGroupResponse"
+                    },
+                    "dimensions": {
+                        "$ref": "#/components/schemas/FilterGroupResponse"
+                    }
+                },
+                "type": "object"
+            },
+            "SortField": {
+                "properties": {
+                    "descending": {
+                        "type": "boolean"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    }
+                },
+                "required": ["descending", "fieldId"],
+                "type": "object"
+            },
+            "TableCalculationFormatType": {
+                "enum": ["default", "percent", "currency", "number"],
+                "type": "string"
+            },
+            "NumberSeparator": {
+                "enum": [
+                    "default",
+                    "commaPeriod",
+                    "spacePeriod",
+                    "periodComma",
+                    "noSeparatorPeriod"
+                ],
+                "type": "string"
+            },
+            "Compact": {
+                "enum": ["thousands", "millions", "billions", "trillions"],
+                "type": "string"
+            },
+            "TableCalculationFormat": {
+                "properties": {
+                    "suffix": {
+                        "type": "string"
+                    },
+                    "prefix": {
+                        "type": "string"
+                    },
+                    "compact": {
+                        "$ref": "#/components/schemas/Compact"
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "separator": {
+                        "$ref": "#/components/schemas/NumberSeparator"
+                    },
+                    "round": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/TableCalculationFormatType"
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
+            "TableCalculation": {
+                "properties": {
+                    "format": {
+                        "$ref": "#/components/schemas/TableCalculationFormat"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "index": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["sql", "displayName", "name"],
+                "type": "object"
+            },
+            "MetricType": {
+                "enum": [
+                    "percentile",
+                    "average",
+                    "count",
+                    "count_distinct",
+                    "sum",
+                    "min",
+                    "max",
+                    "number",
+                    "median",
+                    "string",
+                    "date",
+                    "boolean"
+                ],
+                "type": "string"
+            },
+            "CompactOrAlias": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/Compact"
+                    },
+                    {
+                        "type": "string",
+                        "enum": [
+                            "K",
+                            "thousand",
+                            "M",
+                            "million",
+                            "B",
+                            "billion",
+                            "T",
+                            "trillion"
+                        ]
+                    }
+                ]
+            },
+            "ConditionalOperator": {
+                "enum": [
+                    "isNull",
+                    "notNull",
+                    "equals",
+                    "notEquals",
+                    "startsWith",
+                    "endsWith",
+                    "include",
+                    "doesNotInclude",
+                    "lessThan",
+                    "lessThanOrEqual",
+                    "greaterThan",
+                    "greaterThanOrEqual",
+                    "inThePast",
+                    "inTheNext",
+                    "inTheCurrent",
+                    "inBetween"
+                ],
+                "type": "string"
+            },
+            "MetricFilterRule": {
+                "properties": {
+                    "values": {
+                        "items": {},
+                        "type": "array"
+                    },
+                    "operator": {
+                        "$ref": "#/components/schemas/ConditionalOperator"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "target": {
+                        "properties": {
+                            "fieldRef": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["fieldRef"],
+                        "type": "object"
+                    },
+                    "settings": {}
+                },
+                "required": ["operator", "id", "target"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "AdditionalMetric": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/MetricType"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "hidden": {
+                        "type": "boolean"
+                    },
+                    "round": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "compact": {
+                        "$ref": "#/components/schemas/CompactOrAlias"
+                    },
+                    "format": {
+                        "type": "string"
+                    },
+                    "table": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "index": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "filters": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricFilterRule"
+                        },
+                        "type": "array"
+                    },
+                    "baseDimensionName": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["type", "sql", "table", "name"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "MetricQueryResponse": {
+                "properties": {
+                    "additionalMetrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/AdditionalMetric"
+                        },
+                        "type": "array"
+                    },
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/TableCalculation"
+                        },
+                        "type": "array"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sorts": {
+                        "items": {
+                            "$ref": "#/components/schemas/SortField"
+                        },
+                        "type": "array"
+                    },
+                    "filters": {
+                        "$ref": "#/components/schemas/Filters"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "tableCalculations",
+                    "limit",
+                    "sorts",
+                    "filters",
+                    "metrics",
+                    "dimensions"
+                ],
+                "type": "object"
+            },
+            "ApiRunQueryResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "rows": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "metricQuery": {
+                                "$ref": "#/components/schemas/MetricQueryResponse"
+                            }
+                        },
+                        "required": ["rows", "metricQuery"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RunQueryRequest": {
+                "properties": {
+                    "csvLimit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "additionalMetrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/AdditionalMetric"
+                        },
+                        "type": "array"
+                    },
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/TableCalculation"
+                        },
+                        "type": "array"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sorts": {
+                        "items": {
+                            "$ref": "#/components/schemas/SortField"
+                        },
+                        "type": "array"
+                    },
+                    "filters": {
+                        "properties": {
+                            "metrics": {},
+                            "dimensions": {}
+                        },
+                        "type": "object"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldId"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "tableCalculations",
+                    "limit",
+                    "sorts",
+                    "filters",
+                    "metrics",
+                    "dimensions"
+                ],
+                "type": "object"
+            },
+            "SchedulerFormat": {
+                "enum": ["csv", "image"],
+                "type": "string"
+            },
+            "SchedulerCsvOptions": {
+                "properties": {
+                    "limit": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            {
+                                "type": "string",
+                                "enum": ["table", "all"]
+                            }
+                        ]
+                    },
+                    "formatted": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["limit", "formatted"],
+                "type": "object"
+            },
+            "SchedulerImageOptions": {
+                "properties": {},
+                "type": "object"
+            },
+            "SchedulerOptions": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerCsvOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerImageOptions"
+                    }
+                ]
+            },
+            "SchedulerBase": {
+                "properties": {
+                    "options": {
+                        "$ref": "#/components/schemas/SchedulerOptions"
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedChartUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cron": {
+                        "type": "string"
+                    },
+                    "format": {
+                        "$ref": "#/components/schemas/SchedulerFormat"
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "options",
+                    "dashboardUuid",
+                    "savedChartUuid",
+                    "cron",
+                    "format",
+                    "createdBy",
+                    "updatedAt",
+                    "createdAt",
+                    "name",
+                    "schedulerUuid"
+                ],
+                "type": "object"
+            },
+            "ChartScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedChartUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "DashboardScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "string"
+                            },
+                            "savedChartUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            }
+                        },
+                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Scheduler": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ChartScheduler"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardScheduler"
+                    }
+                ]
+            },
+            "SchedulerSlackTarget": {
+                "properties": {
+                    "channel": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerSlackTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "channel",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerSlackTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerEmailTarget": {
+                "properties": {
+                    "recipient": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerEmailTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "recipient",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerEmailTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerAndTargets": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Scheduler"
+                    },
+                    {
+                        "properties": {
+                            "targets": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["targets"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "SchedulerJobStatus": {
+                "enum": ["scheduled", "started", "completed", "error"],
+                "type": "string"
+            },
+            "Record_string.any_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "SchedulerLog": {
+                "properties": {
+                    "details": {
+                        "$ref": "#/components/schemas/Record_string.any_"
+                    },
+                    "targetType": {
+                        "type": "string",
+                        "enum": ["email", "slack"]
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/SchedulerJobStatus"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "scheduledTime": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "jobGroup": {
+                        "type": "string"
+                    },
+                    "jobId": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "task": {
+                        "type": "string",
+                        "enum": [
+                            "handleScheduledDelivery",
+                            "sendEmailNotification",
+                            "sendSlackNotification",
+                            "downloadCsv",
+                            "compileProject",
+                            "testAndCompileProject",
+                            "validateProject"
+                        ]
+                    }
+                },
+                "required": [
+                    "status",
+                    "createdAt",
+                    "scheduledTime",
+                    "jobId",
+                    "task"
+                ],
+                "type": "object"
+            },
+            "SchedulerWithLogs": {
+                "properties": {
+                    "logs": {
+                        "items": {
+                            "$ref": "#/components/schemas/SchedulerLog"
+                        },
+                        "type": "array"
+                    },
+                    "dashboards": {
+                        "items": {
+                            "properties": {
+                                "dashboardUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["dashboardUuid", "name"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "charts": {
+                        "items": {
+                            "properties": {
+                                "savedChartUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["savedChartUuid", "name"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "users": {
+                        "items": {
+                            "properties": {
+                                "userUuid": {
+                                    "type": "string"
+                                },
+                                "lastName": {
+                                    "type": "string"
+                                },
+                                "firstName": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["userUuid", "lastName", "firstName"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "schedulers": {
+                        "items": {
+                            "$ref": "#/components/schemas/SchedulerAndTargets"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "logs",
+                    "dashboards",
+                    "charts",
+                    "users",
+                    "schedulers"
+                ],
+                "type": "object"
+            },
+            "ApiSchedulerLogsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SchedulerWithLogs"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSchedulerAndTargetsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SchedulerAndTargets"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ScheduledJobs": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": ["id", "date"],
+                "type": "object"
+            },
+            "ApiScheduledJobsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScheduledJobs"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiJobStatusResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "status": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["status"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ShareUrl": {
+                "properties": {
+                    "host": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "shareUrl": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "params": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "The URL path of the full URL"
+                    },
+                    "nanoid": {
+                        "type": "string",
+                        "description": "Unique shareable id"
+                    }
+                },
+                "required": ["params", "path", "nanoid"],
+                "type": "object",
+                "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
+            },
+            "ApiShareResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ShareUrl"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_ShareUrl.path-or-params_": {
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The URL path of the full URL"
+                    },
+                    "params": {
+                        "type": "string"
+                    }
+                },
+                "required": ["path", "params"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateShareUrl": {
+                "$ref": "#/components/schemas/Pick_ShareUrl.path-or-params_",
+                "description": "Contains the detail of a full URL to generate a short URL id"
+            },
+            "SlackChannel": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "id"],
+                "type": "object"
+            },
+            "ApiSlackChannelsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/SlackChannel"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "name",
+                    "uuid",
+                    "updatedAt",
+                    "spaceUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ViewStatistics": {
+                "properties": {
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["firstViewedAt", "views"],
+                "type": "object"
+            },
+            "SpaceQuery": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ViewStatistics"
+                    },
+                    {
+                        "properties": {
+                            "validationErrors": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationSummary"
+                                },
+                                "type": "array"
+                            },
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartKind"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "updatedAt",
+                    "projectUuid",
+                    "spaceUuid",
+                    "views",
+                    "firstViewedAt",
+                    "pinnedListUuid",
+                    "pinnedListOrder"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "DashboardBasicDetails": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_"
+                    },
+                    {
+                        "properties": {
+                            "validationErrors": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationSummary"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "SpaceDashboard": {
+                "$ref": "#/components/schemas/DashboardBasicDetails"
+            },
+            "SpaceShare": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/ProjectMemberRole"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["role", "lastName", "firstName", "userUuid"],
+                "type": "object"
+            },
+            "Space": {
+                "properties": {
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "access": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceShare"
+                        },
+                        "type": "array"
+                    },
+                    "dashboards": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceDashboard"
+                        },
+                        "type": "array"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "queries": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceQuery"
+                        },
+                        "type": "array"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "pinnedListOrder",
+                    "pinnedListUuid",
+                    "access",
+                    "dashboards",
+                    "projectUuid",
+                    "queries",
+                    "isPrivate",
+                    "name",
+                    "uuid",
+                    "organizationUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSpaceResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Space"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "CreateSpace": {
+                "properties": {
+                    "access": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceShare"
+                        },
+                        "type": "array"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"],
+                "type": "object"
+            },
+            "UpdateSpace": {
+                "properties": {
+                    "isPrivate": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["isPrivate", "name"],
+                "type": "object"
+            },
+            "AddSpaceShare": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["userUuid"],
+                "type": "object"
+            },
+            "Pick_SshKeyPair.publicKey_": {
+                "properties": {
+                    "publicKey": {
+                        "type": "string"
+                    }
+                },
+                "required": ["publicKey"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiSshKeyPairResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Pick_SshKeyPair.publicKey_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "EmailOneTimePassword": {
+                "properties": {
+                    "numberOfAttempts": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Number of times the passcode has been attempted"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time that the passcode was created"
+                    }
+                },
+                "required": ["numberOfAttempts", "createdAt"],
+                "type": "object"
+            },
+            "EmailStatus": {
+                "properties": {
+                    "otp": {
+                        "$ref": "#/components/schemas/EmailOneTimePassword"
+                    },
+                    "isVerified": {
+                        "type": "boolean"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": ["isVerified", "email"],
+                "type": "object"
+            },
+            "EmailOneTimePasswordExpiring": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/EmailOneTimePassword"
+                    },
+                    {
+                        "properties": {
+                            "isMaxAttempts": {
+                                "type": "boolean"
+                            },
+                            "isExpired": {
+                                "type": "boolean"
+                            },
+                            "expiresAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "EmailStatusExpiring": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/EmailStatus"
+                    },
+                    {
+                        "properties": {
+                            "otp": {
+                                "$ref": "#/components/schemas/EmailOneTimePasswordExpiring",
+                                "description": "One time passcode information\nIf there is no active passcode, this will be undefined"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ],
+                "description": "Verification status of an email address"
+            },
+            "ApiEmailStatusResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/EmailStatusExpiring"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "Shows the current verification status of an email address"
+            },
+            "UserAllowedOrganization": {
+                "properties": {
+                    "membersCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["membersCount", "name", "organizationUuid"],
+                "type": "object"
+            },
+            "ApiUserAllowedOrganizationsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/UserAllowedOrganization"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiJobScheduledResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "jobId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["jobId"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ValidationErrorType": {
+                "enum": [
+                    "chart",
+                    "sorting",
+                    "filter",
+                    "metric",
+                    "model",
+                    "dimension"
+                ],
+                "type": "string"
+            },
+            "ValidationSourceType": {
+                "enum": ["chart", "dashboard", "table"],
+                "type": "string"
+            },
+            "ValidationResponseBase": {
+                "properties": {
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "errorType": {
+                        "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "validationId": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "projectUuid",
+                    "errorType",
+                    "error",
+                    "name",
+                    "createdAt",
+                    "validationId"
+                ],
+                "type": "object"
+            },
+            "ValidationErrorChartResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationResponseBase"
+                    },
+                    {
+                        "properties": {
+                            "chartName": {
+                                "type": "string"
+                            },
+                            "chartViews": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "lastUpdatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "lastUpdatedBy": {
+                                "type": "string"
+                            },
+                            "fieldName": {
+                                "type": "string"
+                            },
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartKind"
+                            },
+                            "chartUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["chartViews"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ValidationErrorDashboardResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationResponseBase"
+                    },
+                    {
+                        "properties": {
+                            "dashboardViews": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "lastUpdatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "lastUpdatedBy": {
+                                "type": "string"
+                            },
+                            "fieldName": {
+                                "type": "string"
+                            },
+                            "chartName": {
+                                "type": "string"
+                            },
+                            "dashboardUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["dashboardViews"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__": {
+                "properties": {
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "validationId": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "errorType": {
+                        "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
+                    }
+                },
+                "required": [
+                    "projectUuid",
+                    "validationId",
+                    "createdAt",
+                    "error",
+                    "errorType"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_ValidationResponseBase.name_": {
+                "$ref": "#/components/schemas/Pick_ValidationResponseBase.Exclude_keyofValidationResponseBase.name__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "ValidationErrorTableResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Omit_ValidationResponseBase.name_"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ValidationResponse": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorChartResponse"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorDashboardResponse"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ValidationErrorTableResponse"
+                    }
+                ]
+            },
+            "ApiValidateResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationResponse"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiValidationDismissResponse": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            }
+        },
+        "securitySchemes": {
+            "session_cookie": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "connect.sid"
+            },
+            "api_key": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "Authorization",
+                "description": "Value should be 'ApiKey <your key>'"
+            }
+        }
+    },
+    "info": {
+        "title": "Lightdash API",
+        "version": "0.632.0",
+        "description": "Open API documentation for all public Lightdash API endpoints",
+        "license": {
+            "name": "MIT"
+        },
+        "contact": {
+            "name": "Lightdash Support",
+            "email": "support@lightdash.com",
+            "url": "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
+        }
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/api/v1/csv/{jobId}": {
+            "get": {
+                "operationId": "getCsvUrl",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCsvUrlResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a Csv",
+                "tags": ["Exports"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the jobId for the CSV",
+                        "in": "path",
+                        "name": "jobId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/settings": {
+            "get": {
+                "operationId": "getDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the current dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "updateDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudIntegrationSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "deleteDbtCloudIntegrationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudSettingsDeleteSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove the dbt Cloud integration settings for a project",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/integrations/dbt-cloud/metrics": {
+            "get": {
+                "operationId": "getDbtCloudMetrics",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDbtCloudMetrics"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a list of dbt metric definitions from the dbt Cloud metadata api.\nThe metrics are taken from the metadata from a single dbt Cloud job configured\nwith the dbt Cloud integration settings for the project.",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/groups/{groupUuid}": {
+            "get": {
+                "operationId": "getGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get group details",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "unique id of the group",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "deleteGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateGroup"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/groups/{groupUuid}/members/{userUuid}": {
+            "put": {
+                "operationId": "addUserToGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add a Lightdash user to a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to add the user to",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the UUID for the user to add to the group",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "removeUserFromGroup",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove a user from a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to remove the user from",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the UUID for the user to remove from the group",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/groups/{groupUuid}/members": {
+            "get": {
+                "operationId": "getGroupMembers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupMembersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "View members of a group",
+                "tags": ["User Groups"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the UUID for the group to view the members of",
+                        "in": "path",
+                        "name": "groupUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org": {
+            "get": {
+                "operationId": "GetMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganization"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "CreateOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new organization settings",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateOrganization",
+                                "description": "the new organization settings"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "UpdateMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new organization settings",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateOrganization",
+                                "description": "the new organization settings"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/{organizationUuid}": {
+            "delete": {
+                "operationId": "DeleteMyOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Deletes an organization and all users inside that organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the organization to delete",
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/projects": {
+            "get": {
+                "operationId": "ListOrganizationProjects",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationProjects"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all projects of the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/users": {
+            "get": {
+                "operationId": "ListOrganizationMembers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfiles"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all the members of the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/users/{userUuid}": {
+            "patch": {
+                "operationId": "UpdateOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Updates the membership profile for a user in the current user's organization",
+                "tags": ["Roles & Permissions", "Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user to update",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new membership profile",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationMemberProfileUpdate",
+                                "description": "the new membership profile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/user/{userUuid}": {
+            "delete": {
+                "operationId": "DeleteOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Deletes a user from the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user to delete",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/allowedEmailDomains": {
+            "get": {
+                "operationId": "ListOrganizationEmailDomains",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets the allowed email domains for the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "patch": {
+                "operationId": "UpdateOrganizationEmailDomains",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationAllowedEmailDomains"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Updates the allowed email domains for the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new allowed email domains",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAllowedEmailDomains",
+                                "description": "the new allowed email domains"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/groups": {
+            "post": {
+                "operationId": "CreateGroupInOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates a new group in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the new group details",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pick_CreateGroup.name_",
+                                "description": "the new group details"
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "operationId": "ListGroupsInOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets all the groups in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {
+            "get": {
+                "operationId": "getPinnedItems",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPinnedItems"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get pinned items",
+                "tags": ["Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "project uuid",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the list uuid for the pinned items",
+                        "in": "path",
+                        "name": "pinnedListUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items/order": {
+            "patch": {
+                "operationId": "updatePinnedItemsOrder",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPinnedItems"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update pinned items order",
+                "tags": ["Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "project uuid",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the list uuid for the pinned items",
+                        "in": "path",
+                        "name": "pinnedListUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new order of the pinned items",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "items": {
+                                    "$ref": "#/components/schemas/UpdatePinnedItemOrder"
+                                },
+                                "type": "array",
+                                "description": "the new order of the pinned items"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}": {
+            "get": {
+                "operationId": "GetProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a project of an organiztion",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/charts": {
+            "get": {
+                "operationId": "ListChartsInProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List all charts in a project",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to get charts for",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces": {
+            "get": {
+                "operationId": "ListSpacesInProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List all spaces in a project",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to get spaces for",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "CreateSpaceInProject",
+                "responses": {
+                    "200": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a new space inside a project",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateSpace"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/access": {
+            "get": {
+                "operationId": "GetProjectAccessList",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectAccessListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
+                "tags": ["Roles & Permissions", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "GrantProjectAccessToUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Grant a user access to a project",
+                "tags": ["Roles & Permissions", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateProjectMember"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/access/{userUuid}": {
+            "patch": {
+                "operationId": "UpdateProjectAccessForUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a user's access to a project",
+                "tags": ["Roles & Permissions", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProjectMember"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "RevokeProjectAccessForUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove a user's access to a project",
+                "tags": ["Roles & Permissions", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
+            "post": {
+                "operationId": "postRunUnderlyingDataQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for underlying data results",
+                "tags": ["Exploring"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "table name",
+                        "in": "path",
+                        "name": "exploreId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "metricQuery for the chart to run",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunQueryRequest",
+                                "description": "metricQuery for the chart to run"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
+            "post": {
+                "operationId": "postRunQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for explore",
+                "tags": ["Exploring"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "table name",
+                        "in": "path",
+                        "name": "exploreId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "metricQuery for the chart to run",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunQueryRequest",
+                                "description": "metricQuery for the chart to run"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/saved/{chartUuid}/results": {
+            "post": {
+                "operationId": "postChartResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a query for a chart",
+                "tags": ["Charts"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "chartUuid for the chart to run",
+                        "in": "path",
+                        "name": "chartUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "filters": {
+                                        "$ref": "#/components/schemas/Filters"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/schedulers/{projectUuid}/logs": {
+            "get": {
+                "operationId": "getSchedulerLogs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerLogsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get scheduled logs",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/{schedulerUuid}": {
+            "get": {
+                "operationId": "getScheduler",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateScheduler",
+                "responses": {
+                    "201": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new scheduler data",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "the new scheduler data"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteScheduler",
+                "responses": {
+                    "201": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {},
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a scheduler",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to delete",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/{schedulerUuid}/jobs": {
+            "get": {
+                "operationId": "getScheduledJobs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiScheduledJobsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get scheduled jobs",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the scheduler to update",
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/schedulers/job/{jobId}/status": {
+            "get": {
+                "operationId": "getSchedulerJobStatus",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a generic job status\nThis method can be used when polling from the frontend",
+                "tags": ["Schedulers"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the jobId for the status to check",
+                        "in": "path",
+                        "name": "jobId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/share/{nanoId}": {
+            "get": {
+                "operationId": "getShareUrl",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiShareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a share url from a short url id",
+                "tags": ["Share links"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the short id for the share url",
+                        "in": "path",
+                        "name": "nanoId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/share": {
+            "post": {
+                "operationId": "CreateShareUrl",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiShareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Given a full URL generates a short url id that can be used for sharing",
+                "tags": ["Share links"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "a full URL used to generate a short url id",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateShareUrl",
+                                "description": "a full URL used to generate a short url id"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/slack/channels": {
+            "get": {
+                "operationId": "getSlackChannels",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSlackChannelsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get slack channels",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}": {
+            "get": {
+                "operationId": "GetSpace",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get details for a space in a project",
+                "tags": ["Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to get",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "DeleteSpace",
+                "responses": {
+                    "204": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a space from a project",
+                "tags": ["Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to delete",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "UpdateSpace",
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a space in a project",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to update",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateSpace"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share": {
+            "post": {
+                "operationId": "AddSpaceShareToUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Grant a user access to a space",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddSpaceShare"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/share/{userUuid}": {
+            "delete": {
+                "operationId": "RevokeSpaceAccessForUser",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove a user's access to a space",
+                "tags": ["Roles & Permissions", "Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to update",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the user to revoke access from",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/ssh/key-pairs": {
+            "post": {
+                "operationId": "createSshKeyPair",
+                "responses": {
+                    "201": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSshKeyPairResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["SSH Keypairs"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/email/otp": {
+            "put": {
+                "operationId": "CreateEmailOneTimePasscode",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/email/status": {
+            "get": {
+                "operationId": "GetEmailVerificationStatus",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiEmailStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the verification status for the current user's primary email",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the one-time passcode sent to the user's primary email",
+                        "in": "query",
+                        "name": "passcode",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/user/me/allowedOrganizations": {
+            "get": {
+                "operationId": "ListMyAvailableOrganizations",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserAllowedOrganizationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/user/me/joinOrganization/{organizationUuid}": {
+            "post": {
+                "operationId": "JoinOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the organization to join",
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/user/me": {
+            "delete": {
+                "operationId": "DeleteMe",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete user",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/projects/{projectUuid}/validate": {
+            "post": {
+                "operationId": "ValidateProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the projectId for the validation",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "explores": {
+                                        "items": {},
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object",
+                                "description": "the compiled explores to validate against an existing project, this is used in the CLI to validate a project without creating a preview"
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "operationId": "GetLatestValidationResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiValidateResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get validation results for a project. This will return the results of the latest validation job.",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the projectId for the validation",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "boolean to know if this request is made from the settings page, for analytics",
+                        "in": "query",
+                        "name": "fromSettings",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "optional jobId to get results for a specific job, used on CLI",
+                        "in": "query",
+                        "name": "jobId",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/validate/{validationId}": {
+            "delete": {
+                "operationId": "DeleteValidationDismiss",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiValidationDismissResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Deletes a single validation error.",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the projectId for the validation",
+                        "in": "path",
+                        "name": "validationId",
+                        "required": true,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "tags": [
+        {
+            "name": "My Account",
+            "description": "These routes allow users to manage their own user account."
+        },
+        {
+            "name": "Organizations",
+            "description": "Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users."
+        },
+        {
+            "name": "Projects",
+            "description": "Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly."
+        },
+        {
+            "name": "Spaces",
+            "description": "Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins."
+        },
+        {
+            "name": "Roles & Permissions",
+            "description": "These routes allow users to manage roles and permissions for their organization.",
+            "externalDocs": {
+                "url": "https://docs.lightdash.com/references/roles"
+            }
+        }
+    ]
 }

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -25,6 +25,9 @@ export class OrganizationModel {
             organizationUuid: data.organization_uuid,
             name: data.organization_name,
             chartColors: data.chart_colors,
+            defaultProjectUuid: data.default_project_uuid
+                ? data.default_project_uuid
+                : undefined,
         };
     }
 
@@ -64,6 +67,7 @@ export class OrganizationModel {
             .update({
                 organization_name: data.name,
                 chart_colors: data.chartColors,
+                default_project_uuid: data.defaultProjectUuid,
             })
             .returning('*');
         return OrganizationModel.mapDBObjectToOrganization(org);

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -3,7 +3,6 @@ import {
     AllowedEmailDomains,
     CreateGroup,
     CreateOrganization,
-    CreateProject,
     ForbiddenError,
     Group,
     isUserWithOrg,
@@ -125,7 +124,10 @@ export class OrganizationService {
                         : 'self-hosted',
                 organizationId: organizationUuid,
                 organizationName: org.name,
+                defaultProjectUuid: org.defaultProjectUuid,
                 defaultColourPaletteUpdated: data.chartColors !== undefined,
+                defaultProjectUuidUpdated:
+                    data.defaultProjectUuid !== undefined,
             },
         });
     }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -414,6 +414,9 @@ export class UserService {
                             : 'self-hosted',
                     organizationId: user.organizationUuid,
                     organizationName,
+                    defaultProjectUuid: undefined,
+                    defaultColourPaletteUpdated: false,
+                    defaultProjectUuidUpdated: false,
                 },
             });
             if (enableEmailDomainAccess && user.email) {

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -23,6 +23,10 @@ export type Organization = {
      * The organization needs a project if it doesn't have at least one project.
      */
     needsProject?: boolean;
+    /**
+     * The project a user sees when they first log in to the organization
+     */
+    defaultProjectUuid?: string;
 };
 
 export type CreateOrganization = Pick<Organization, 'name'>;

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -1,0 +1,70 @@
+import { ProjectType } from '@lightdash/common';
+import { Button, Select, Stack } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import React, { FC, useEffect } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
+import { useProjects } from '../../../hooks/useProjects';
+
+const DefaultProjectPanel: FC = () => {
+    const { isLoading: isOrganizationLoading, data } = useOrganization();
+    const { isLoading: isLoadingProjects, data: projects = [] } = useProjects();
+    const {
+        isLoading: isOrganizationUpdateLoading,
+        mutate: updateOrganization,
+    } = useOrganizationUpdateMutation();
+
+    const isLoading =
+        isOrganizationUpdateLoading ||
+        isOrganizationLoading ||
+        isLoadingProjects;
+    const form = useForm({
+        initialValues: {
+            defaultProjectUuid: undefined as string | undefined,
+        },
+    });
+
+    const { setFieldValue } = form;
+
+    useEffect(() => {
+        if (data) {
+            setFieldValue('defaultProjectUuid', data?.defaultProjectUuid);
+        }
+    }, [data, data?.defaultProjectUuid, setFieldValue]);
+
+    const handleOnSubmit = form.onSubmit(({ defaultProjectUuid }) => {
+        updateOrganization({ defaultProjectUuid: defaultProjectUuid });
+    });
+
+    return (
+        <form onSubmit={handleOnSubmit}>
+            <Stack>
+                <Select
+                    label="Project name"
+                    data={projects
+                        .filter(({ type }) => type !== ProjectType.PREVIEW)
+                        .map((project) => ({
+                            value: project.projectUuid,
+                            label: project.name,
+                        }))}
+                    disabled={isLoading}
+                    required
+                    placeholder="No project selected"
+                    dropdownPosition="bottom"
+                    {...form.getInputProps('defaultProjectUuid')}
+                />
+                <Button
+                    display="block"
+                    ml="auto"
+                    type="submit"
+                    disabled={isLoading}
+                    loading={isLoading}
+                >
+                    Update
+                </Button>
+            </Stack>
+        </form>
+    );
+};
+
+export default DefaultProjectPanel;

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
     QueryClient,
     useMutation,
@@ -39,9 +40,10 @@ export const useUpdateActiveProjectMutation = () => {
             Promise.resolve(
                 localStorage.setItem(LAST_PROJECT_KEY, projectUuid),
             ),
-        onSuccess: () => {
+        onSuccess: async () => {
             clearProjectCache(queryClient);
-            queryClient.invalidateQueries(['validations']);
+            await queryClient.invalidateQueries(['validations']);
+            await queryClient.invalidateQueries(['activeProject']);
         },
     });
 };
@@ -63,22 +65,44 @@ export const useActiveProjectUuid = () => {
         useDefaultProject();
     const { data: lastProjectUuid, isLoading: isLoadingLastProject } =
         useActiveProject();
+    const { mutate } = useUpdateActiveProjectMutation();
 
-    if (isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject) {
+    const isLoading =
+        isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject;
+
+    const paramProject = projects?.find(
+        (project) => project.projectUuid === params.projectUuid,
+    );
+
+    const lastProject = projects?.find(
+        (project) => project.projectUuid === lastProjectUuid,
+    );
+
+    useEffect(() => {
+        const newValue =
+            paramProject?.projectUuid || defaultProject?.projectUuid;
+        if (!isLoading && !lastProject && newValue) {
+            mutate(newValue);
+        }
+    }, [
+        isLoading,
+        defaultProject?.projectUuid,
+        lastProject,
+        mutate,
+        paramProject?.projectUuid,
+    ]);
+
+    if (isLoading) {
         return {
             isLoading: true,
             activeProjectUuid: undefined,
         };
     }
 
-    const lastProject = projects?.find(
-        (project) => project.projectUuid === lastProjectUuid,
-    );
-
     return {
         isLoading: false,
         activeProjectUuid:
-            params.projectUuid ||
+            paramProject?.projectUuid ||
             lastProject?.projectUuid ||
             defaultProject?.projectUuid,
     };

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -6,6 +6,7 @@ import {
     UseQueryOptions,
 } from 'react-query';
 import { lightdashApi } from '../api';
+import { useOrganization } from './organization/useOrganization';
 import useToaster from './toaster/useToaster';
 
 const getProjectsQuery = async () =>
@@ -25,16 +26,24 @@ export const useProjects = (
     });
 };
 
-export const useDefaultProject = () => {
-    const query = useProjects();
+export const useDefaultProject = (): {
+    isLoading: boolean;
+    data: OrganizationProject | undefined;
+} => {
+    const { isLoading: isOrganizationLoading, data: org } = useOrganization();
+    const { isLoading: isLoadingProjects, data: projects = [] } = useProjects();
 
-    const defaultProject = query.data?.find(
+    const defaultProject = projects?.find(
+        (project) => project.projectUuid === org?.defaultProjectUuid,
+    );
+
+    const fallbackProject = projects?.find(
         ({ type }) => type === ProjectType.DEFAULT,
     );
 
     return {
-        ...query,
-        data: defaultProject || query.data?.[0],
+        isLoading: isOrganizationLoading || isLoadingProjects,
+        data: defaultProject || fallbackProject || projects?.[0],
     };
 };
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -30,6 +30,7 @@ import PageSpinner from '../components/PageSpinner';
 import AccessTokensPanel from '../components/UserSettings/AccessTokensPanel';
 import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel';
 import AppearancePanel from '../components/UserSettings/AppearancePanel';
+import DefaultProjectPanel from '../components/UserSettings/DefaultProjectPanel';
 import { DeleteOrganizationPanel } from '../components/UserSettings/DeleteOrganizationPanel';
 import { Description } from '../components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
@@ -372,6 +373,19 @@ const Settings: FC = () => {
                                     </Description>
                                 </div>
                                 <AllowedDomainsPanel />
+                            </SettingsGridCard>
+
+                            <SettingsGridCard>
+                                <div>
+                                    <Title order={4}>Default Project</Title>
+                                    <Description>
+                                        If a user has access to this project,
+                                        this is the project they will see when
+                                        they first log in to Lightdash for the
+                                        first time.
+                                    </Description>
+                                </div>
+                                <DefaultProjectPanel />
                             </SettingsGridCard>
 
                             {user.ability?.can('delete', 'Organization') && (

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -379,10 +379,11 @@ const Settings: FC = () => {
                                 <div>
                                     <Title order={4}>Default Project</Title>
                                     <Description>
-                                        If a user has access to this project,
-                                        this is the project they will see when
-                                        they first log in to Lightdash for the
-                                        first time.
+                                        This is the project users will see when
+                                        they log in for the first time or from a
+                                        new device. If a user does not have
+                                        access, they will see their next
+                                        accessible project.
                                     </Description>
                                 </div>
                                 <DefaultProjectPanel />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5869 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Acceptance criteria:

- [x] There is a section to set a default project in the organization settings page - it is a project picker.
- [x] When a user first joins the org, they open Lightdash in the default project
- [x] The default project is used when the user first logs in, afterwards, we use the same project logic as we have now (i.e. the last project you were looking at is opened again)
- [x] If a user doesn't have access to the default project, then they open Lightdash to the project that was created _**first**_ out of the projects they have access to
- [x] By default, the default project is not selected and the empty state says "No project selected"

### Docs

- [x] Update the roles and permissions doc here to include information about the `default project`


Default state:

<img width="1610" alt="Captura de ecrã 2023-06-23, às 10 14 59" src="https://github.com/lightdash/lightdash/assets/9117144/b37dde91-512c-4c36-afde-2f3bed5e5965">


Setting default project + new users joining:

https://github.com/lightdash/lightdash/assets/9117144/21f16486-0e96-4042-aedd-797a8f9436fd

