### PR TITLE
fix: only set url params with pristine state

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -56,14 +56,17 @@ export const useExplorerRoute = () => {
 
     // Update url params based on pristine state
     useEffect(() => {
-        history.replace(
-            getExplorerUrlFromCreateSavedChartVersion(pathParams.projectUuid, {
-                ...unsavedChartVersion,
-                metricQuery:
-                    queryResultsData?.metricQuery ??
-                    unsavedChartVersion.metricQuery,
-            }),
-        );
+        if (queryResultsData?.metricQuery) {
+            history.replace(
+                getExplorerUrlFromCreateSavedChartVersion(
+                    pathParams.projectUuid,
+                    {
+                        ...unsavedChartVersion,
+                        metricQuery: queryResultsData.metricQuery,
+                    },
+                ),
+            );
+        }
     }, [
         queryResultsData,
         history,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -24,6 +24,7 @@ import produce from 'immer';
 import cloneDeep from 'lodash-es/cloneDeep';
 import isEqual from 'lodash-es/isEqual';
 import { FC, useCallback, useEffect, useMemo, useReducer } from 'react';
+import { useHistory } from 'react-router-dom';
 import { createContext, useContextSelector } from 'use-context-selector';
 import useDefaultSortField from '../hooks/useDefaultSortField';
 import { useQueryResults } from '../hooks/useQueryResults';
@@ -1235,7 +1236,7 @@ export const ExplorerProvider: FC<{
         });
         resetQueryResults();
     }, [resetQueryResults]);
-
+    const history = useHistory();
     const clearQuery = useCallback(async () => {
         dispatch({
             type: ActionType.RESET,
@@ -1248,7 +1249,11 @@ export const ExplorerProvider: FC<{
             },
         });
         resetQueryResults();
-    }, [resetQueryResults, unsavedChartVersion.tableName]);
+        // clear state in url params
+        history.replace({
+            search: '',
+        });
+    }, [history, resetQueryResults, unsavedChartVersion.tableName]);
 
     const defaultSort = useDefaultSortField(unsavedChartVersion);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- only update explore url params where there is a pristine state ( aka: when a use runs a query )
- clear the url params when user hits `command + option + k` 
