### PR TITLE
feat: add chart type icon when adding to dashboard

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -615,19 +615,24 @@ export class SavedChartModel {
     }
 
     private getChartSummaryQuery() {
-        return this.database('saved_queries')
+        return this.database(SavedChartsTableName)
             .select({
-                uuid: 'saved_queries.saved_query_uuid',
-                name: 'saved_queries.name',
-                description: 'saved_queries.description',
+                uuid: `${SavedChartsTableName}.saved_query_uuid`,
+                name: `${SavedChartsTableName}.name`,
+                description: `${SavedChartsTableName}.description`,
                 spaceUuid: 'spaces.space_uuid',
                 spaceName: 'spaces.name',
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
                 pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
                 chartType: 'last_saved_query_version.chart_type',
+                chartConfig: 'last_saved_query_version.chart_config',
             })
-            .leftJoin('spaces', 'saved_queries.space_id', 'spaces.space_id')
+            .leftJoin(
+                'spaces',
+                `${SavedChartsTableName}.space_id`,
+                'spaces.space_id',
+            )
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
             .leftJoin(
                 OrganizationTableName,
@@ -639,7 +644,7 @@ export class SavedChartModel {
                     .distinctOn('saved_query_id')
                     .orderBy('saved_query_id')
                     .orderBy('created_at', 'desc')
-                    .select('chart_type', 'saved_query_id')
+                    .select('chart_type', 'chart_config', 'saved_query_id')
                     .as('last_saved_query_version'),
                 `saved_queries.saved_query_id`,
                 'last_saved_query_version.saved_query_id',

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -458,7 +458,10 @@ export type ChartSummary = Pick<
     | 'projectUuid'
     | 'organizationUuid'
     | 'pinnedListUuid'
-> & { chartType?: ChartType | undefined };
+> & {
+    chartType?: ChartType | undefined;
+    chartConfig?: ChartConfig['config'] | undefined;
+};
 
 export type ApiChartSummaryListResponse = {
     status: 'ok';

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -107,7 +107,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                     group: spaceName,
                     disabled: alreadyAddedChart !== undefined,
                     description: alreadyAddedChart
-                        ? 'This chart has been already added to this dashboard'
+                        ? 'This chart has already been added to this dashboard'
                         : undefined,
                     ...(chartConfig &&
                         chartType && {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -60,9 +60,11 @@ const MultiSelectItem = forwardRef<HTMLDivElement, ItemProps>(
                         position="top-start"
                     >
                         <Flex align="center" gap="sm">
-                            <Box opacity={disabled ? 0.5 : 1}>
-                                {getChartIcon(chartType)}
-                            </Box>
+                            {chartType && (
+                                <Box opacity={disabled ? 0.5 : 1}>
+                                    {getChartIcon(chartType)}
+                                </Box>
+                            )}
 
                             <Text>{label}</Text>
                         </Flex>

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -6,6 +6,7 @@ import {
     getChartType,
 } from '@lightdash/common';
 import {
+    Box,
     Button,
     Flex,
     Group,
@@ -18,14 +19,14 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconChartAreaLine, IconCircleCheck } from '@tabler/icons-react';
+import { IconChartAreaLine } from '@tabler/icons-react';
 import { FC, forwardRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
 import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import MantineIcon from '../../common/MantineIcon';
-import { getChartIcon, ResourceIndicator } from '../../common/ResourceIcon';
+import { getChartIcon } from '../../common/ResourceIcon';
 
 type Props = {
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
@@ -59,23 +60,9 @@ const MultiSelectItem = forwardRef<HTMLDivElement, ItemProps>(
                         position="top-start"
                     >
                         <Flex align="center" gap="sm">
-                            <ResourceIndicator
-                                indicatorProps={{
-                                    disabled: !disabled,
-                                    position: 'top-start',
-                                    size: 8,
-                                    inline: true,
-                                }}
-                                iconProps={{
-                                    icon: IconCircleCheck,
-                                    fill: 'green',
-                                    color: 'white',
-                                }}
-                                tooltipProps={{ disabled: true }}
-                                tooltipLabel={undefined}
-                            >
+                            <Box opacity={disabled ? 0.5 : 1}>
                                 {getChartIcon(chartType)}
-                            </ResourceIndicator>
+                            </Box>
 
                             <Text>{label}</Text>
                         </Flex>

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -158,11 +158,19 @@ export const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
 export const ResourceIndicator: FC<
     {
         children: ReactNode;
-        tooltipLabel: ReactNode;
+        tooltipLabel?: ReactNode;
         iconProps: MantineIconProps;
         tooltipProps: Partial<TooltipProps>;
+        indicatorProps?: Partial<IndicatorProps>;
     } & Pick<IndicatorProps, 'disabled'>
-> = ({ disabled, tooltipLabel, iconProps, tooltipProps, children }) => {
+> = ({
+    disabled,
+    tooltipLabel,
+    iconProps,
+    tooltipProps,
+    indicatorProps = {},
+    children,
+}) => {
     // NOTE: Control the Tooltip visibility manually to allow hovering on Label.
     const [opened, setOpened] = useState(false);
     const [isHovering, setIsHovering] = useState(false);
@@ -203,12 +211,14 @@ export const ResourceIndicator: FC<
                     {...tooltipProps}
                     sx={{ pointerEvents: 'auto' }}
                     label={
-                        <div
-                            onMouseEnter={handleLabelMouseEnter}
-                            onMouseLeave={handleLabelMouseLeave}
-                        >
-                            {tooltipLabel}
-                        </div>
+                        tooltipLabel && (
+                            <div
+                                onMouseEnter={handleLabelMouseEnter}
+                                onMouseLeave={handleLabelMouseLeave}
+                            >
+                                {tooltipLabel}
+                            </div>
+                        )
                     }
                     opened={opened || isHovering}
                 >
@@ -219,6 +229,7 @@ export const ResourceIndicator: FC<
                     />
                 </Tooltip>
             }
+            {...indicatorProps}
         >
             {children}
         </Indicator>

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -158,19 +158,11 @@ export const ResourceTypeIcon: FC<ResourceTypeIconProps> = ({ type }) => {
 export const ResourceIndicator: FC<
     {
         children: ReactNode;
-        tooltipLabel?: ReactNode;
+        tooltipLabel: ReactNode;
         iconProps: MantineIconProps;
         tooltipProps: Partial<TooltipProps>;
-        indicatorProps?: Partial<IndicatorProps>;
     } & Pick<IndicatorProps, 'disabled'>
-> = ({
-    disabled,
-    tooltipLabel,
-    iconProps,
-    tooltipProps,
-    indicatorProps = {},
-    children,
-}) => {
+> = ({ disabled, tooltipLabel, iconProps, tooltipProps, children }) => {
     // NOTE: Control the Tooltip visibility manually to allow hovering on Label.
     const [opened, setOpened] = useState(false);
     const [isHovering, setIsHovering] = useState(false);
@@ -211,14 +203,12 @@ export const ResourceIndicator: FC<
                     {...tooltipProps}
                     sx={{ pointerEvents: 'auto' }}
                     label={
-                        tooltipLabel && (
-                            <div
-                                onMouseEnter={handleLabelMouseEnter}
-                                onMouseLeave={handleLabelMouseLeave}
-                            >
-                                {tooltipLabel}
-                            </div>
-                        )
+                        <div
+                            onMouseEnter={handleLabelMouseEnter}
+                            onMouseLeave={handleLabelMouseLeave}
+                        >
+                            {tooltipLabel}
+                        </div>
                     }
                     opened={opened || isHovering}
                 >
@@ -229,7 +219,6 @@ export const ResourceIndicator: FC<
                     />
                 </Tooltip>
             }
-            {...indicatorProps}
         >
             {children}
         </Indicator>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5767 

### Description:

Make modal bigger;
Get chart `config` from chart summaries so that we get the chart kind to render the icon
Grey out icon if chart is already in dashboard. 


https://github.com/lightdash/lightdash/assets/7611706/5a663aab-e6e7-4351-ac3b-5d29067d82c9



