### PR TITLE
fix: make chart dropdown searchable when adding to dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -177,6 +177,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                         defaultValue={[]}
                         placeholder="Search..."
                         required
+                        searchable
                         withinPortal
                         itemComponent={MultiSelectItem}
                         {...form.getInputProps('savedChartsUuids')}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6056 

### Description:

add `searchable` prop.

Screen recording


https://github.com/lightdash/lightdash/assets/7611706/4a7ec38d-412c-47c4-94dd-8f9cdfbc405f



