### PR TITLE
fix: pivot table align totals to right

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -435,6 +435,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                   key={`index-total-${rowIndex}-${colIndex}`}
                                                   value={value}
                                                   withValue={!!value.formatted}
+                                                  withAlignRight
                                                   withBolderFont
                                                   withGrayBackground
                                               >
@@ -513,6 +514,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                         value={value}
                                         component="th"
                                         withValue={!!value.formatted}
+                                        withAlignRight
                                         withBolderFont
                                         withGrayBackground
                                     >


### PR DESCRIPTION
Closes: 🤷 

### Description:

<img width="1088" alt="CleanShot 2023-06-27 at 16 53 12@2x" src="https://github.com/lightdash/lightdash/assets/962095/b32099ef-831c-481a-bc96-d7be0487b1d5">
<img width="577" alt="CleanShot 2023-06-27 at 16 53 19@2x" src="https://github.com/lightdash/lightdash/assets/962095/e0bd4cf6-6cba-4419-92ee-de280c1f20c9">
