### PR TITLE
fix: reduce retry and get org id from param when validating 

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -590,7 +590,7 @@ export class ValidationService {
         fromSettings = false,
         jobId?: string,
     ): Promise<ValidationResponse[]> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = user;
 
         if (
             user.ability.cannot(

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -36,6 +36,7 @@ export const useValidation = (
     return useQuery<ValidationResponse[], ApiError>({
         queryKey: ['validation', fromSettings],
         queryFn: () => getValidation(projectUuid, fromSettings),
+        retry: (_, error) => error.error.statusCode !== 403,
         onSuccess: (data) => {
             if (data.length === 0) return;
             const latestValidationTimestamp = data[0].createdAt.toString();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

We were seeing too many `403` logs when users were on any page where there's a nav bar. The nav bar would get validation results (`GET` /validate), which would then retrieve the results **if** the user could manage `validation` - only admins and developers. If they didn't have the ability to do so, it would throw a 403. However, this endpoint is retried 3 times, which is unnecessary. 
Only retry the hook if it's !== 403

Also, we were pulling the project from memory when checking if the user could manage validation of a project. We can achieve the same by just getting the `user.organizationUuid` from the `get` args. 
