### PR TITLE
feat: Migrate hotkeys hooks to mantine

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,6 +1,7 @@
-import { Classes, HotkeyConfig, KeyCombo, useHotkeys } from '@blueprintjs/core';
+import { Classes } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import { memo, useCallback, useMemo } from 'react';
+import { useHotkeys } from '@mantine/hooks';
+import { memo, useCallback } from 'react';
 import { useExplorerContext } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
@@ -20,45 +21,28 @@ export const RefreshButton = memo(() => {
         (context) => context.hasUnfetchedChanges,
     );
 
+    const canRunQuery = !isLoading && isValidQuery && hasUnfetchedChanges;
+
     const { track } = useTracking();
 
     const onClick = useCallback(() => {
-        fetchResults();
-        track({ name: EventName.RUN_QUERY_BUTTON_CLICKED });
-    }, [fetchResults, track]);
+        if (canRunQuery) {
+            fetchResults();
+            track({ name: EventName.RUN_QUERY_BUTTON_CLICKED });
+        }
+    }, [fetchResults, track, canRunQuery]);
 
-    const isButtonDisabled = isLoading || !isValidQuery || !hasUnfetchedChanges;
-
-    const hotkeys = useMemo<HotkeyConfig[]>(
-        () => [
-            {
-                combo: 'mod+enter',
-                group: 'Explorer',
-                label: 'Run query',
-                allowInInput: true,
-                onKeyDown: onClick,
-                global: true,
-                preventDefault: true,
-                stopPropagation: true,
-                disabled: isButtonDisabled,
-            },
-        ],
-        [onClick, isButtonDisabled],
-    );
-
-    useHotkeys(hotkeys);
+    useHotkeys([['mod + enter', onClick, { preventDefault: true }]]);
 
     return (
         <Tooltip2
             content={
-                !hasUnfetchedChanges ? (
-                    'You need to make some changes before running a query'
-                ) : (
-                    <KeyCombo combo="mod+enter" />
-                )
+                !hasUnfetchedChanges
+                    ? 'You need to make some changes before running a query'
+                    : ''
             }
             position="bottom"
-            disabled={isLoading || !isValidQuery}
+            disabled={canRunQuery}
         >
             <BigButton
                 style={{ width: 150 }}
@@ -66,8 +50,8 @@ export const RefreshButton = memo(() => {
                 intent="primary"
                 loading={isLoading}
                 // disabled button captures hover events
-                onClick={isButtonDisabled ? undefined : onClick}
-                className={isButtonDisabled ? Classes.DISABLED : undefined}
+                onClick={onClick}
+                className={!canRunQuery ? Classes.DISABLED : undefined}
             >
                 Run query
             </BigButton>

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -42,7 +42,7 @@ export const RefreshButton = memo(() => {
                     : ''
             }
             position="bottom"
-            disabled={!hasUnfetchedChanges}
+            disabled={hasUnfetchedChanges}
         >
             <BigButton
                 style={{ width: 150 }}

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import { Classes } from '@blueprintjs/core';
+import { Classes, KeyCombo } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { useHotkeys } from '@mantine/hooks';
 import { memo, useCallback } from 'react';
@@ -37,12 +37,14 @@ export const RefreshButton = memo(() => {
     return (
         <Tooltip2
             content={
-                !hasUnfetchedChanges
-                    ? 'You need to make some changes before running a query'
-                    : ''
+                !hasUnfetchedChanges ? (
+                    'You need to make some changes before running a query'
+                ) : (
+                    <KeyCombo combo="mod+enter" />
+                )
             }
             position="bottom"
-            disabled={hasUnfetchedChanges}
+            disabled={isLoading || !isValidQuery}
         >
             <BigButton
                 style={{ width: 150 }}

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -42,7 +42,7 @@ export const RefreshButton = memo(() => {
                     : ''
             }
             position="bottom"
-            disabled={canRunQuery}
+            disabled={!hasUnfetchedChanges}
         >
             <BigButton
                 style={{ width: 150 }}

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -1,5 +1,5 @@
-import { HotkeyConfig, useHotkeys } from '@blueprintjs/core';
 import { ConditionalFormattingConfig, ResultRow } from '@lightdash/common';
+import { useHotkeys } from '@mantine/hooks';
 import {
     Cell,
     ColumnOrderState,
@@ -16,7 +16,6 @@ import React, {
     useCallback,
     useContext,
     useEffect,
-    useMemo,
     useState,
 } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -182,35 +181,23 @@ export const TableProvider: FC<Props> = ({
 
     const [copyingCellId, setCopyingCellId] = useState<string>();
 
-    const hotkeys = useMemo<HotkeyConfig[]>(
-        () => [
-            {
-                label: 'Copy value from the select cell',
-                combo: 'mod+c',
-                global: true,
-                disabled: !selectedCell,
-                onKeyDown: () => {
-                    if (!selectedCell) return;
+    const onCopyCell = () => {
+        if (!selectedCell) return;
 
-                    const value = (selectedCell.getValue() as ResultRow[0])
-                        .value;
+        const value = (selectedCell.getValue() as ResultRow[0]).value;
 
-                    copy(value.formatted);
+        copy(value.formatted);
 
-                    showToastSuccess({ title: 'Copied to clipboard!' });
+        showToastSuccess({ title: 'Copied to clipboard!' });
 
-                    setCopyingCellId((cellId) => {
-                        if (cellId) return;
-                        setTimeout(() => setCopyingCellId(undefined), 300);
-                        return selectedCell.id;
-                    });
-                },
-            },
-        ],
-        [selectedCell, showToastSuccess],
-    );
+        setCopyingCellId((cellId) => {
+            if (cellId) return;
+            setTimeout(() => setCopyingCellId(undefined), 300);
+            return selectedCell.id;
+        });
+    };
 
-    const { handleKeyDown } = useHotkeys(hotkeys);
+    useHotkeys([['mod + c', onCopyCell]]);
 
     return (
         <Context.Provider
@@ -219,7 +206,7 @@ export const TableProvider: FC<Props> = ({
                 selectedCell,
                 onSelectCell: handleDebouncedCellSelect,
                 copyingCellId: copyingCellId,
-                onCopyCell: handleKeyDown,
+                onCopyCell,
                 ...rest,
             }}
         >

--- a/packages/frontend/src/providers/BlueprintProvider.tsx
+++ b/packages/frontend/src/providers/BlueprintProvider.tsx
@@ -8,12 +8,7 @@ import '@blueprintjs/select/lib/css/blueprint-select.css';
 // below is a cleaner version of the above
 import './../styles/blueprint-core.css';
 
-import {
-    Colors,
-    Dialog,
-    FocusStyleManager,
-    HotkeysProvider,
-} from '@blueprintjs/core';
+import { Colors, Dialog, FocusStyleManager } from '@blueprintjs/core';
 import { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
@@ -81,9 +76,7 @@ export const BlueprintProvider: FC = ({ children }) => {
     return (
         <>
             <GlobalBlueprintStyles />
-            <HotkeysProvider>
-                <>{children}</>
-            </HotkeysProvider>
+            {children}
         </>
     );
 };


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 --> https://github.com/lightdash/lightdash/issues/6024

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- Migrate `useHotkeys` hook to mantine

**Note to reviewers: 
               - I haven't checked on non-mac system, can take a look if it fails on windows**


