### PR TITLE
fix: correct color picker z index issue

### DIFF
--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -14,7 +14,12 @@ const BigNumberConfigPanel: React.FC = () => {
     const disabled = !selectedField;
 
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+        <Popover
+            {...COLLAPSABLE_CARD_POPOVER_PROPS}
+            disabled={disabled}
+            zIndex={15}
+            closeOnClickOutside={false}
+        >
             <Popover.Target>
                 <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
                     Configure

--- a/packages/frontend/src/components/ChartConfigPanel/Series/Series.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/Series.styles.ts
@@ -140,25 +140,6 @@ export const SeriesExtraSelect = styled(HTMLSelect)`
     }
 `;
 
-export const ColorButton = styled.button`
-    height: 2.143em;
-    width: 2.143em;
-    cursor: pointer;
-    border: none;
-    background-color: transparent;
-
-    box-sizing: border-box;
-    box-shadow: 0 0 0 0 rgb(19 124 189 / 0%), 0 0 0 0 rgb(19 124 189 / 0%),
-        inset 0 0 0 1px rgb(16 22 26 / 15%), inset 0 1px 1px rgb(16 22 26 / 20%);
-    border-radius: 0.214em;
-    padding: 0.286em;
-`;
-
-export const ColorButtonInner = styled.div`
-    height: 100%;
-    width: 100%;
-`;
-
 export const SeriesDivider = styled.hr`
     height: 0.071em;
     width: 100%;

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
@@ -45,8 +45,16 @@ const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
             </Popover.Target>
             <Popover.Dropdown>
                 <BlockPicker
+                    triangle="hide"
                     color={color}
                     colors={colors}
+                    styles={{
+                        default: {
+                            card: {
+                                boxShadow: 'none',
+                            },
+                        },
+                    }}
                     onChange={(result: ColorResult) => {
                         onChange(result.hex);
                     }}

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
@@ -1,12 +1,10 @@
-import { Colors, Icon } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
 import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
+import { ActionIcon, Center, Popover } from '@mantine/core';
+import { IconDropletFilled } from '@tabler/icons-react';
 import { FC } from 'react';
 import { BlockPicker, ColorResult } from 'react-color';
-import { useToggle } from 'react-use';
-
 import { useOrganization } from '../../../hooks/organization/useOrganization';
-import { ColorButton, ColorButtonInner } from './Series.styles';
+import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
     color?: string;
@@ -14,14 +12,38 @@ type Props = {
 };
 
 const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
-    const [isOpen, toggle] = useToggle(false);
     const { data } = useOrganization();
 
     const colors = data?.chartColors || ECHARTS_DEFAULT_COLORS;
     return (
-        <Popover2
-            isOpen={isOpen}
-            content={
+        <Popover
+            closeOnClickOutside
+            width={200}
+            position="bottom"
+            withArrow
+            shadow="md"
+        >
+            <Popover.Target>
+                <ActionIcon
+                    bg={color}
+                    sx={{
+                        ':hover': {
+                            backgroundColor: color,
+                        },
+                    }}
+                >
+                    <Center>
+                        {!color && (
+                            <MantineIcon
+                                size={16}
+                                color="gray.5"
+                                icon={IconDropletFilled}
+                            />
+                        )}
+                    </Center>
+                </ActionIcon>
+            </Popover.Target>
+            <Popover.Dropdown>
                 <BlockPicker
                     color={color}
                     colors={colors}
@@ -29,26 +51,8 @@ const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
                         onChange(result.hex);
                     }}
                 />
-            }
-            position="bottom"
-            hasBackdrop
-            backdropProps={{
-                onClick: (e) => {
-                    e.stopPropagation();
-                    toggle(false);
-                },
-            }}
-        >
-            <ColorButton onClick={toggle}>
-                <ColorButtonInner
-                    style={{
-                        backgroundColor: color,
-                    }}
-                >
-                    {!color && <Icon icon="tint" color={Colors.GRAY3} />}
-                </ColorButtonInner>
-            </ColorButton>
-        </Popover2>
+            </Popover.Dropdown>
+        </Popover>
     );
 };
 

--- a/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/Series/SeriesColorPicker.tsx
@@ -18,10 +18,10 @@ const SeriesColorPicker: FC<Props> = ({ color, onChange }) => {
     return (
         <Popover
             closeOnClickOutside
-            width={200}
+            width="auto"
             position="bottom"
             withArrow
-            shadow="md"
+            shadow="sm"
         >
             <Popover.Target>
                 <ActionIcon

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -17,6 +17,7 @@ const ChartConfigPanel: React.FC = () => {
             disabled={disabled}
             // TODO: remove once blueprint migration is complete
             zIndex={15}
+            closeOnClickOutside={false}
         >
             <Popover.Target>
                 <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -12,7 +12,12 @@ const ChartConfigPanel: React.FC = () => {
     const disabled = !eChartsOptions;
 
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+        <Popover
+            {...COLLAPSABLE_CARD_POPOVER_PROPS}
+            disabled={disabled}
+            // TODO: remove once blueprint migration is complete
+            zIndex={15}
+        >
             <Popover.Target>
                 <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
                     Configure

--- a/packages/frontend/src/components/PieChartConfig/index.tsx
+++ b/packages/frontend/src/components/PieChartConfig/index.tsx
@@ -8,7 +8,12 @@ import PieLayoutConfig from './PieChartLayoutConfig';
 
 const PieChartConfig: React.FC = () => {
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS}>
+        <Popover
+            {...COLLAPSABLE_CARD_POPOVER_PROPS}
+            // TODO: remove once blueprint migration is complete
+            zIndex={15}
+            closeOnClickOutside={false}
+        >
             <Popover.Target>
                 <Button {...COLLAPSABLE_CARD_BUTTON_PROPS}>Configure</Button>
             </Popover.Target>

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -15,7 +15,13 @@ const TableConfigPanel: React.FC = () => {
     const disabled = !resultsData;
 
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+        <Popover
+            {...COLLAPSABLE_CARD_POPOVER_PROPS}
+            disabled={disabled}
+            // TODO: remove once blueprint migration is complete
+            zIndex={15}
+            closeOnClickOutside={false}
+        >
             <Popover.Target>
                 <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
                     Configure


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Fix z-index issue with chart config panels where any component that renders a popover or a dropdown gets displayed behind the panel. 

Disable `closeOnClickOutside` to avoid closing the config panel when selecting an item. 
NOTE: this means that when users click on other `tabs` like `Export as` the current tab doesn't close automatically. But that can be done separately because it doesn't block functionality. 
