### PR TITLE
fix: revert of mantine config panels

### DIFF
--- a/packages/e2e/cypress/e2e/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/downloadCsv.cy.ts
@@ -193,8 +193,9 @@ describe('Download CSV on Explore', () => {
             cy.get('button').contains('Bar chart').click();
             cy.get('[role="menuitem"]').contains('Table').click();
 
-            cy.findByText('Export CSV').click();
-            cy.get('.bp4-popover2').contains('button', 'Export CSV').click();
+            // find by role and text
+            cy.contains('button', 'Export CSV').click();
+            cy.findByRole('dialog').contains('button', 'Export CSV').click();
 
             cy.wait('@apiDownloadCsv').then((interception) => {
                 expect(interception?.response?.statusCode).to.eq(200);

--- a/packages/frontend/src/components/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -15,12 +15,10 @@ import {
     ComparisonFormatTypes,
     getItemId,
 } from '@lightdash/common';
+import { Box } from '@mantine/core';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
-import React, { useState } from 'react';
-import {
-    InputWrapper,
-    Wrapper,
-} from '../ChartConfigPanel/ChartConfigPanel.styles';
+import { useState } from 'react';
+import { InputWrapper } from '../ChartConfigPanel/ChartConfigPanel.styles';
 import FieldAutoComplete from '../common/Filters/FieldAutoComplete';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 
@@ -59,7 +57,7 @@ const BigNumberConfigTabs = () => {
     } = useVisualizationContext();
     const [tab, setTab] = useState<string | number>('layout');
     return (
-        <Wrapper>
+        <Box w={320}>
             <Tabs
                 onChange={setTab}
                 selectedTabId={tab}
@@ -233,7 +231,7 @@ const BigNumberConfigTabs = () => {
                     }
                 />
             </Tabs>
-        </Wrapper>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/BigNumberConfig/index.tsx
+++ b/packages/frontend/src/components/BigNumberConfig/index.tsx
@@ -1,6 +1,9 @@
-import { Button } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
-import React, { useState } from 'react';
+import { Button, Popover } from '@mantine/core';
+import React from 'react';
+import {
+    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_POPOVER_PROPS,
+} from '../common/CollapsableCard';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import BigNumberConfigTabs from './BigNumberConfigTabs';
 
@@ -8,25 +11,20 @@ const BigNumberConfigPanel: React.FC = () => {
     const {
         bigNumberConfig: { selectedField },
     } = useVisualizationContext();
-    const [isOpen, setIsOpen] = useState(false);
     const disabled = !selectedField;
 
     return (
-        <Popover2
-            disabled={disabled}
-            content={<BigNumberConfigTabs />}
-            interactionKind="click"
-            isOpen={isOpen}
-            onInteraction={setIsOpen}
-            position="bottom"
-        >
-            <Button
-                minimal
-                rightIcon="caret-down"
-                text="Configure"
-                disabled={disabled}
-            />
-        </Popover2>
+        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+            <Popover.Target>
+                <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
+                    Configure
+                </Button>
+            </Popover.Target>
+
+            <Popover.Dropdown>
+                <BigNumberConfigTabs />
+            </Popover.Dropdown>
+        </Popover>
     );
 };
 

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigPanel.styles.ts
@@ -19,14 +19,6 @@ export const InputWrapper = styled(FormGroup)`
     }
 `;
 
-export const Wrapper = styled.div`
-    max-width: 28.571em;
-    max-height: 35em;
-    overflow: auto;
-    width: 25em;
-    padding: 1.429em 1.429em 2.143em;
-`;
-
 export const GridLabel = styled.span`
     font-size: 14px;
     line-height: 1.286em;

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -19,6 +19,7 @@ import {
     Metric,
     TableCalculation,
 } from '@lightdash/common';
+import { Box } from '@mantine/core';
 import { FC, useCallback, useState } from 'react';
 import { useToggle } from 'react-use';
 import { useTracking } from '../../providers/TrackingProvider';
@@ -31,7 +32,6 @@ import {
     MinMaxContainer,
     MinMaxInput,
     MinMaxWrapper,
-    Wrapper,
 } from './ChartConfigPanel.styles';
 import FieldLayoutOptions from './FieldLayoutOptions';
 import GridPanel from './Grid';
@@ -181,7 +181,7 @@ const ChartConfigTabs: FC = () => {
     );
 
     return (
-        <Wrapper>
+        <Box w={320}>
             <Tabs
                 onChange={setTab}
                 selectedTabId={tab}
@@ -375,7 +375,7 @@ const ChartConfigTabs: FC = () => {
                 />
                 <Tab id="grid" title="Margins" panel={<GridPanel />} />
             </Tabs>
-        </Wrapper>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/ChartConfigTabs.tsx
@@ -181,7 +181,7 @@ const ChartConfigTabs: FC = () => {
     );
 
     return (
-        <Box w={320}>
+        <Box w={320} p="sm">
             <Tabs
                 onChange={setTab}
                 selectedTabId={tab}

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -1,10 +1,8 @@
-import { Button, Popover } from '@mantine/core';
+import { Popover2 } from '@blueprintjs/popover2';
+import { Button } from '@mantine/core';
 import React from 'react';
 import useEcharts from '../../hooks/echarts/useEcharts';
-import {
-    COLLAPSABLE_CARD_BUTTON_PROPS,
-    COLLAPSABLE_CARD_POPOVER_PROPS,
-} from '../common/CollapsableCard';
+import { COLLAPSABLE_CARD_BUTTON_PROPS } from '../common/CollapsableCard';
 import ChartConfigTabs from './ChartConfigTabs';
 
 const ChartConfigPanel: React.FC = () => {
@@ -12,17 +10,15 @@ const ChartConfigPanel: React.FC = () => {
     const disabled = !eChartsOptions;
 
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
-            <Popover.Target>
-                <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
-                    Configure
-                </Button>
-            </Popover.Target>
-
-            <Popover.Dropdown>
-                <ChartConfigTabs />
-            </Popover.Dropdown>
-        </Popover>
+        <Popover2
+            disabled={disabled}
+            position="bottom"
+            content={<ChartConfigTabs />}
+        >
+            <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
+                Configure
+            </Button>
+        </Popover2>
     );
 };
 

--- a/packages/frontend/src/components/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/ChartConfigPanel/index.tsx
@@ -1,7 +1,10 @@
-import { Button } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
+import { Button, Popover } from '@mantine/core';
 import React from 'react';
 import useEcharts from '../../hooks/echarts/useEcharts';
+import {
+    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_POPOVER_PROPS,
+} from '../common/CollapsableCard';
 import ChartConfigTabs from './ChartConfigTabs';
 
 const ChartConfigPanel: React.FC = () => {
@@ -9,19 +12,17 @@ const ChartConfigPanel: React.FC = () => {
     const disabled = !eChartsOptions;
 
     return (
-        <Popover2
-            content={<ChartConfigTabs />}
-            interactionKind="click"
-            position="bottom"
-            disabled={disabled}
-        >
-            <Button
-                minimal
-                rightIcon="caret-down"
-                text="Configure"
-                disabled={disabled}
-            />
-        </Popover2>
+        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+            <Popover.Target>
+                <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
+                    Configure
+                </Button>
+            </Popover.Target>
+
+            <Popover.Dropdown>
+                <ChartConfigTabs />
+            </Popover.Dropdown>
+        </Popover>
     );
 };
 

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -1,12 +1,10 @@
 import {
-    Button,
+    Button as BlueprintButton,
     Divider,
     FormGroup,
     HTMLSelect,
     Intent,
-    PopoverPosition,
 } from '@blueprintjs/core';
-import { Classes, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     ApiScheduledDownloadCsv,
@@ -18,9 +16,14 @@ import EChartsReact from 'echarts-for-react';
 import JsPDF from 'jspdf';
 import React, { memo, RefObject, useCallback, useState } from 'react';
 
+import { Button, Popover } from '@mantine/core';
 import useEcharts from '../hooks/echarts/useEcharts';
 import { useApp } from '../providers/AppProvider';
 import { Can } from './common/Authorization';
+import {
+    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_POPOVER_PROPS,
+} from './common/CollapsableCard';
 import ExportCSV from './ExportCSV';
 import { useVisualizationContext } from './LightdashVisualization/VisualizationProvider';
 
@@ -187,7 +190,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
             </FormGroup>
             <Divider />
             {!isTable && (
-                <Button
+                <BlueprintButton
                     style={{ alignSelf: 'flex-end' }}
                     intent={Intent.PRIMARY}
                     icon="cloud-download"
@@ -219,7 +222,6 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             resultsData,
         } = useVisualizationContext();
         const eChartsOptions = useEcharts();
-        const [isOpen, setIsOpen] = useState(false);
         const disabled =
             (chartType === ChartType.TABLE &&
                 resultsData?.rows &&
@@ -229,6 +231,7 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             (chartType === ChartType.CARTESIAN && !eChartsOptions);
 
         const { user } = useApp();
+
         return chartType === ChartType.TABLE && getCsvLink ? (
             <Can
                 I="manage"
@@ -237,11 +240,22 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                     projectUuid,
                 })}
             >
-                <Popover2
-                    lazy
-                    position={PopoverPosition.BOTTOM_LEFT}
-                    popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-                    content={
+                <Popover
+                    {...COLLAPSABLE_CARD_POPOVER_PROPS}
+                    disabled={disabled}
+                    position="bottom-end"
+                    arrowOffset={12}
+                >
+                    <Popover.Target>
+                        <Button
+                            {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                            disabled={disabled}
+                        >
+                            Export CSV
+                        </Button>
+                    </Popover.Target>
+
+                    <Popover.Dropdown>
                         <ExportCSV
                             getCsvLink={async (
                                 limit: number | null,
@@ -259,33 +273,31 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             }
                             rows={resultsData?.rows}
                         />
-                    }
-                >
-                    <Button text="Export CSV" rightIcon="caret-down" minimal />
-                </Popover2>
+                    </Popover.Dropdown>
+                </Popover>
             </Can>
         ) : chartType === ChartType.TABLE && !getCsvLink ? null : (
-            <Popover2
-                lazy
-                content={
+            <Popover
+                {...COLLAPSABLE_CARD_POPOVER_PROPS}
+                disabled={disabled}
+                position="bottom-end"
+            >
+                <Popover.Target>
+                    <Button
+                        {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                        disabled={disabled}
+                    >
+                        Export as
+                    </Button>
+                </Popover.Target>
+
+                <Popover.Dropdown>
                     <ChartDownloadOptions
                         chartRef={chartRef}
                         chartType={chartType}
                     />
-                }
-                popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-                isOpen={isOpen}
-                onInteraction={setIsOpen}
-                position={PopoverPosition.BOTTOM_LEFT}
-                disabled={disabled}
-            >
-                <Button
-                    minimal
-                    rightIcon="caret-down"
-                    text="Export as"
-                    disabled={disabled}
-                />
-            </Popover2>
+                </Popover.Dropdown>
+            </Popover>
         );
     },
 );

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,11 +1,10 @@
-import { Button, Colors, Menu } from '@blueprintjs/core';
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import {
     assertUnreachable,
     CartesianSeriesType,
     ChartType,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
+import { Button, Menu } from '@mantine/core';
 import {
     IconChartArea,
     IconChartAreaLine,
@@ -16,7 +15,12 @@ import {
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
-import { FC, memo, useMemo, useState } from 'react';
+import { FC, memo, useMemo } from 'react';
+import {
+    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_POPOVER_PROPS,
+} from '../../common/CollapsableCard';
+import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 
 const VisualizationCardOptions: FC = memo(() => {
@@ -32,7 +36,6 @@ const VisualizationCardOptions: FC = memo(() => {
     const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
     const cartesianType = cartesianConfig.dirtyChartType;
     const cartesianFlipAxis = cartesianConfig.dirtyLayout?.flipAxes;
-    const [isOpen, setIsOpen] = useState<boolean>(false);
     const isChartTypeTheSameForAllSeries: boolean =
         !isSeriesWithMixedChartTypes(
             cartesianConfig.dirtyEchartsConfig?.series,
@@ -47,14 +50,7 @@ const VisualizationCardOptions: FC = memo(() => {
                 if (!isChartTypeTheSameForAllSeries) {
                     return {
                         text: 'Mixed',
-                        icon: (
-                            <IconChartAreaLine
-                                size={20}
-                                color={
-                                    disabled ? Colors.LIGHT_GRAY1 : Colors.GRAY1
-                                }
-                            />
-                        ),
+                        icon: <MantineIcon icon={IconChartAreaLine} />,
                     };
                 }
                 switch (cartesianType) {
@@ -63,31 +59,13 @@ const VisualizationCardOptions: FC = memo(() => {
 
                         return {
                             text: 'Area chart',
-                            icon: (
-                                <IconChartArea
-                                    size={20}
-                                    color={
-                                        disabled
-                                            ? Colors.LIGHT_GRAY1
-                                            : Colors.GRAY1
-                                    }
-                                />
-                            ),
+                            icon: <MantineIcon icon={IconChartArea} />,
                         };
                     case CartesianSeriesType.LINE:
                         setStacking(false);
                         return {
                             text: 'Line chart',
-                            icon: (
-                                <IconChartLine
-                                    size={20}
-                                    color={
-                                        disabled
-                                            ? Colors.LIGHT_GRAY1
-                                            : Colors.GRAY1
-                                    }
-                                />
-                            ),
+                            icon: <MantineIcon icon={IconChartLine} />,
                         };
 
                     case CartesianSeriesType.BAR:
@@ -95,45 +73,22 @@ const VisualizationCardOptions: FC = memo(() => {
                             ? {
                                   text: 'Horizontal bar chart',
                                   icon: (
-                                      <IconChartBar
-                                          size={20}
+                                      <MantineIcon
+                                          icon={IconChartBar}
                                           style={{ rotate: '90deg' }}
-                                          color={
-                                              disabled
-                                                  ? Colors.LIGHT_GRAY1
-                                                  : Colors.GRAY1
-                                          }
                                       />
                                   ),
                               }
                             : {
                                   text: 'Bar chart',
-                                  icon: (
-                                      <IconChartBar
-                                          size={20}
-                                          color={
-                                              disabled
-                                                  ? Colors.LIGHT_GRAY1
-                                                  : Colors.GRAY1
-                                          }
-                                      />
-                                  ),
+                                  icon: <MantineIcon icon={IconChartBar} />,
                               };
                     case CartesianSeriesType.SCATTER:
                         setStacking(false);
 
                         return {
                             text: 'Scatter chart',
-                            icon: (
-                                <IconChartDots
-                                    size={20}
-                                    color={
-                                        disabled
-                                            ? Colors.LIGHT_GRAY1
-                                            : Colors.GRAY1
-                                    }
-                                />
-                            ),
+                            icon: <MantineIcon icon={IconChartDots} />,
                         };
                     default:
                         return assertUnreachable(
@@ -145,32 +100,17 @@ const VisualizationCardOptions: FC = memo(() => {
             case ChartType.TABLE:
                 return {
                     text: 'Table',
-                    icon: (
-                        <IconTable
-                            size={20}
-                            color={disabled ? Colors.LIGHT_GRAY1 : Colors.GRAY1}
-                        />
-                    ),
+                    icon: <MantineIcon icon={IconTable} />,
                 };
             case ChartType.BIG_NUMBER:
                 return {
                     text: 'Big value',
-                    icon: (
-                        <IconSquareNumber1
-                            size={20}
-                            color={disabled ? Colors.LIGHT_GRAY1 : Colors.GRAY1}
-                        />
-                    ),
+                    icon: <MantineIcon icon={IconSquareNumber1} />,
                 };
             case ChartType.PIE:
                 return {
                     text: 'Pie chart',
-                    icon: (
-                        <IconChartPie
-                            size={20}
-                            color={disabled ? Colors.LIGHT_GRAY1 : Colors.GRAY1}
-                        />
-                    ),
+                    icon: <MantineIcon icon={IconChartPie} />,
                 };
             default: {
                 return assertUnreachable(
@@ -185,178 +125,183 @@ const VisualizationCardOptions: FC = memo(() => {
         cartesianType,
         chartType,
         setStacking,
-        disabled,
     ]);
 
     return (
-        <Popover2
-            content={
-                <Menu>
-                    <MenuItem2
-                        active={
-                            isChartTypeTheSameForAllSeries &&
-                            chartType === ChartType.CARTESIAN &&
-                            cartesianType === CartesianSeriesType.BAR &&
-                            !cartesianFlipAxis
-                        }
-                        icon={<IconChartBar size={20} color={Colors.GRAY1} />}
-                        onClick={() => {
-                            setChartType(ChartType.CARTESIAN);
-                            cartesianConfig.setType(
-                                CartesianSeriesType.BAR,
-                                false,
-                                false,
-                            );
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Bar chart"
-                    />
-
-                    <MenuItem2
-                        active={
-                            isChartTypeTheSameForAllSeries &&
-                            chartType === ChartType.CARTESIAN &&
-                            cartesianType === CartesianSeriesType.BAR &&
-                            cartesianFlipAxis
-                        }
-                        icon={
-                            <IconChartBar
-                                size={20}
-                                style={{ rotate: '90deg' }}
-                                color={Colors.GRAY1}
-                            />
-                        }
-                        onClick={() => {
-                            setChartType(ChartType.CARTESIAN);
-                            cartesianConfig.setType(
-                                CartesianSeriesType.BAR,
-                                true,
-                                false,
-                            );
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Horizontal bar chart"
-                    />
-
-                    <MenuItem2
-                        active={
-                            isChartTypeTheSameForAllSeries &&
-                            chartType === ChartType.CARTESIAN &&
-                            cartesianType === CartesianSeriesType.LINE
-                        }
-                        icon={<IconChartLine size={20} color={Colors.GRAY1} />}
-                        onClick={() => {
-                            setChartType(ChartType.CARTESIAN);
-                            cartesianConfig.setType(
-                                CartesianSeriesType.LINE,
-                                false,
-                                false,
-                            );
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Line chart"
-                    />
-
-                    <MenuItem2
-                        active={
-                            isChartTypeTheSameForAllSeries &&
-                            chartType === ChartType.CARTESIAN &&
-                            cartesianType === CartesianSeriesType.AREA
-                        }
-                        icon={<IconChartArea size={20} color={Colors.GRAY1} />}
-                        onClick={() => {
-                            setChartType(ChartType.CARTESIAN);
-                            cartesianConfig.setType(
-                                CartesianSeriesType.LINE,
-                                false,
-                                true,
-                            );
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Area chart"
-                    />
-
-                    <MenuItem2
-                        active={
-                            isChartTypeTheSameForAllSeries &&
-                            chartType === ChartType.CARTESIAN &&
-                            cartesianType === CartesianSeriesType.SCATTER
-                        }
-                        icon={<IconChartDots size={20} color={Colors.GRAY1} />}
-                        onClick={() => {
-                            setChartType(ChartType.CARTESIAN);
-                            cartesianConfig.setType(
-                                CartesianSeriesType.SCATTER,
-                                false,
-                                false,
-                            );
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Scatter chart"
-                    />
-
-                    {localStorage.getItem('enablePieCharts') === 'true' && (
-                        <MenuItem2
-                            active={chartType === ChartType.PIE}
-                            icon={
-                                <IconChartPie size={20} color={Colors.GRAY1} />
-                            }
-                            onClick={() => {
-                                setChartType(ChartType.PIE);
-                                setPivotDimensions(undefined);
-                                setIsOpen(false);
-                            }}
-                            disabled={disabled}
-                            text="Pie chart"
-                        />
-                    )}
-
-                    <MenuItem2
-                        active={chartType === ChartType.TABLE}
-                        icon={<IconTable size={20} color={Colors.GRAY1} />}
-                        onClick={() => {
-                            setChartType(ChartType.TABLE);
-                            setPivotDimensions(undefined);
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Table"
-                    />
-
-                    <MenuItem2
-                        active={chartType === ChartType.BIG_NUMBER}
-                        icon={
-                            <IconSquareNumber1 size={20} color={Colors.GRAY1} />
-                        }
-                        onClick={() => {
-                            setChartType(ChartType.BIG_NUMBER);
-                            setPivotDimensions(undefined);
-                            setIsOpen(false);
-                        }}
-                        disabled={disabled}
-                        text="Big value"
-                    />
-                </Menu>
-            }
-            interactionKind="click"
-            isOpen={isOpen}
-            onInteraction={setIsOpen}
-            position="bottom"
+        <Menu
+            {...COLLAPSABLE_CARD_POPOVER_PROPS}
+            closeOnItemClick
             disabled={disabled}
         >
-            <Button
-                minimal
-                icon={selectedChartType.icon}
-                rightIcon="caret-down"
-                text={selectedChartType.text}
-                disabled={disabled}
-            />
-        </Popover2>
+            <Menu.Target>
+                <Button
+                    {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                    disabled={disabled}
+                    leftIcon={selectedChartType.icon}
+                >
+                    {selectedChartType.text}
+                </Button>
+            </Menu.Target>
+
+            <Menu.Dropdown>
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isChartTypeTheSameForAllSeries &&
+                        chartType === ChartType.CARTESIAN &&
+                        cartesianType === CartesianSeriesType.BAR &&
+                        !cartesianFlipAxis
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconChartBar} />}
+                    onClick={() => {
+                        setChartType(ChartType.CARTESIAN);
+                        cartesianConfig.setType(
+                            CartesianSeriesType.BAR,
+                            false,
+                            false,
+                        );
+                    }}
+                >
+                    Bar chart
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isChartTypeTheSameForAllSeries &&
+                        chartType === ChartType.CARTESIAN &&
+                        cartesianType === CartesianSeriesType.BAR &&
+                        cartesianFlipAxis
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={
+                        <MantineIcon
+                            icon={IconChartBar}
+                            style={{ rotate: '90deg' }}
+                        />
+                    }
+                    onClick={() => {
+                        setChartType(ChartType.CARTESIAN);
+                        cartesianConfig.setType(
+                            CartesianSeriesType.BAR,
+                            true,
+                            false,
+                        );
+                    }}
+                >
+                    Horizontal bar chart
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isChartTypeTheSameForAllSeries &&
+                        chartType === ChartType.CARTESIAN &&
+                        cartesianType === CartesianSeriesType.LINE
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconChartLine} />}
+                    onClick={() => {
+                        setChartType(ChartType.CARTESIAN);
+                        cartesianConfig.setType(
+                            CartesianSeriesType.LINE,
+                            false,
+                            false,
+                        );
+                    }}
+                >
+                    Line chart
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isChartTypeTheSameForAllSeries &&
+                        chartType === ChartType.CARTESIAN &&
+                        cartesianType === CartesianSeriesType.AREA
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconChartArea} />}
+                    onClick={() => {
+                        setChartType(ChartType.CARTESIAN);
+                        cartesianConfig.setType(
+                            CartesianSeriesType.LINE,
+                            false,
+                            true,
+                        );
+                    }}
+                >
+                    Area chart
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isChartTypeTheSameForAllSeries &&
+                        chartType === ChartType.CARTESIAN &&
+                        cartesianType === CartesianSeriesType.SCATTER
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconChartDots} />}
+                    onClick={() => {
+                        setChartType(ChartType.CARTESIAN);
+                        cartesianConfig.setType(
+                            CartesianSeriesType.SCATTER,
+                            false,
+                            false,
+                        );
+                    }}
+                >
+                    Scatter chart
+                </Menu.Item>
+
+                {localStorage.getItem('enablePieCharts') === 'true' && (
+                    <Menu.Item
+                        disabled={disabled}
+                        color={chartType === ChartType.PIE ? 'blue' : undefined}
+                        icon={<MantineIcon icon={IconChartPie} />}
+                        onClick={() => {
+                            setChartType(ChartType.PIE);
+                            setPivotDimensions(undefined);
+                        }}
+                    >
+                        Pie chart
+                    </Menu.Item>
+                )}
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={chartType === ChartType.TABLE ? 'blue' : undefined}
+                    icon={<MantineIcon icon={IconTable} />}
+                    onClick={() => {
+                        setChartType(ChartType.TABLE);
+                        setPivotDimensions(undefined);
+                    }}
+                >
+                    Table
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        chartType === ChartType.BIG_NUMBER ? 'blue' : undefined
+                    }
+                    icon={<MantineIcon icon={IconSquareNumber1} />}
+                    onClick={() => {
+                        setChartType(ChartType.BIG_NUMBER);
+                        setPivotDimensions(undefined);
+                    }}
+                >
+                    Big value
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
     );
 });
 

--- a/packages/frontend/src/components/TableConfigPanel/TableConfig.styles.ts
+++ b/packages/frontend/src/components/TableConfigPanel/TableConfig.styles.ts
@@ -1,15 +1,5 @@
-import { Button, Colors, FormGroup } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
 import styled from 'styled-components';
-
-export const ConfigWrapper = styled(FormGroup)`
-    width: 320px;
-    & label.bp4-label {
-        display: inline-flex;
-        gap: 0.214em;
-        color: ${Colors.DARK_GRAY1};
-        font-weight: 600;
-    }
-`;
 
 export const AddPivotButton = styled(Button)`
     margin-bottom: 0.286em;

--- a/packages/frontend/src/components/TableConfigPanel/TableConfig.styles.ts
+++ b/packages/frontend/src/components/TableConfigPanel/TableConfig.styles.ts
@@ -2,10 +2,7 @@ import { Button, Colors, FormGroup } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const ConfigWrapper = styled(FormGroup)`
-    max-width: 28.571em;
-    width: 25em;
-    padding: 1.429em 1.429em;
-    margin: 0;
+    width: 320px;
     & label.bp4-label {
         display: inline-flex;
         gap: 0.214em;

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -1,29 +1,34 @@
-import { Tab, Tabs } from '@blueprintjs/core';
-import { Button, Popover } from '@mantine/core';
+import { Colors, Tab, Tabs } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
+import { Box, Button } from '@mantine/core';
 import React from 'react';
-import {
-    COLLAPSABLE_CARD_BUTTON_PROPS,
-    COLLAPSABLE_CARD_POPOVER_PROPS,
-} from '../common/CollapsableCard';
+import { COLLAPSABLE_CARD_BUTTON_PROPS } from '../common/CollapsableCard';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
-import { ConfigWrapper } from './TableConfig.styles';
 
 const TableConfigPanel: React.FC = () => {
     const { resultsData } = useVisualizationContext();
     const disabled = !resultsData;
 
     return (
-        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
-            <Popover.Target>
-                <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
-                    Configure
-                </Button>
-            </Popover.Target>
-
-            <Popover.Dropdown>
-                <ConfigWrapper>
+        <Popover2
+            disabled={disabled}
+            position="bottom"
+            content={
+                <Box
+                    w={320}
+                    p="sm"
+                    sx={{
+                        // FIXME: remove after Blueprint migration is complete
+                        'label.bp4-label': {
+                            display: 'inline-flex',
+                            gap: '0.214em',
+                            color: Colors.DARK_GRAY1,
+                            fontWeight: 600,
+                        },
+                    }}
+                >
                     <Tabs>
                         <Tab
                             id="general"
@@ -36,9 +41,13 @@ const TableConfigPanel: React.FC = () => {
                             panel={<ConditionalFormattingList />}
                         />
                     </Tabs>
-                </ConfigWrapper>
-            </Popover.Dropdown>
-        </Popover>
+                </Box>
+            }
+        >
+            <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
+                Configure
+            </Button>
+        </Popover2>
     );
 };
 

--- a/packages/frontend/src/components/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/TableConfigPanel/index.tsx
@@ -1,22 +1,28 @@
-import { Button, Tab, Tabs } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
-import React, { useState } from 'react';
-
+import { Tab, Tabs } from '@blueprintjs/core';
+import { Button, Popover } from '@mantine/core';
+import React from 'react';
+import {
+    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_POPOVER_PROPS,
+} from '../common/CollapsableCard';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
 import { ConfigWrapper } from './TableConfig.styles';
 
 const TableConfigPanel: React.FC = () => {
-    const [isOpen, setIsOpen] = useState(false);
-
     const { resultsData } = useVisualizationContext();
     const disabled = !resultsData;
 
     return (
-        <Popover2
-            disabled={disabled}
-            content={
+        <Popover {...COLLAPSABLE_CARD_POPOVER_PROPS} disabled={disabled}>
+            <Popover.Target>
+                <Button {...COLLAPSABLE_CARD_BUTTON_PROPS} disabled={disabled}>
+                    Configure
+                </Button>
+            </Popover.Target>
+
+            <Popover.Dropdown>
                 <ConfigWrapper>
                     <Tabs>
                         <Tab
@@ -31,19 +37,8 @@ const TableConfigPanel: React.FC = () => {
                         />
                     </Tabs>
                 </ConfigWrapper>
-            }
-            interactionKind="click"
-            isOpen={isOpen}
-            onInteraction={setIsOpen}
-            position="bottom"
-        >
-            <Button
-                minimal
-                rightIcon="caret-down"
-                text="Configure"
-                disabled={disabled}
-            />
-        </Popover2>
+            </Popover.Dropdown>
+        </Popover>
     );
 };
 


### PR DESCRIPTION
- reverts reverted mantine migration changes
- reverts back to popover2 (from mantine to blueprint popover) for table config and chart config

skip revert and only review this commit: https://github.com/lightdash/lightdash/pull/6067/commits/26e91a45c8adac8660a0573100c404b7c8dbdacb