### PR TITLE
fix: land on charts if dashboards are empty (#5931)

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -59,11 +59,12 @@ export enum ResourceViewType {
 interface ResourceViewProps extends ResourceViewCommonProps {
     listProps?: ResourceViewListCommonProps;
     gridProps?: ResourceViewGridCommonProps;
+    defaultActiveTab?: string;
 }
 
 const ResourceView: React.FC<ResourceViewProps> = ({
     view = ResourceViewType.LIST,
-    items,
+    items: allItems,
     maxItems,
     tabs,
     gridProps = {},
@@ -71,6 +72,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
     headerProps = {},
     emptyStateProps = {},
     hasReorder = false,
+    defaultActiveTab,
 }) => {
     const theme = useMantineTheme();
     const tableTabStyles = useTableTabStyles();
@@ -79,8 +81,6 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         type: ResourceViewItemAction.CLOSE,
     });
 
-    const [activeTabId, setActiveTabId] = useState(tabs?.[0]?.id);
-
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {
             setAction(newAction);
@@ -88,23 +88,28 @@ const ResourceView: React.FC<ResourceViewProps> = ({
         [],
     );
 
-    const slicedSortedItems = useMemo(() => {
-        let sortedItems = items;
+    const itemsByTabs = useMemo(() => {
+        return new Map(
+            tabs?.map((tab) => [
+                tab.id,
+                allItems
+                    .filter(tab.filter ?? (() => true))
+                    .sort(tab.sort ?? (() => 0))
+                    .slice(0, maxItems),
+            ]),
+        );
+    }, [tabs, allItems, maxItems]);
 
-        const activeTab = tabs?.find((tab) => tab.id === activeTabId);
-        if (activeTab && activeTab.sort) {
-            sortedItems = items.sort(activeTab.sort);
-        }
-
-        if (activeTab && activeTab.filter) {
-            sortedItems = sortedItems.filter(activeTab.filter);
-        }
-
-        return maxItems ? sortedItems.slice(0, maxItems) : sortedItems;
-    }, [items, activeTabId, maxItems, tabs]);
+    const [activeTabId, setActiveTabId] = useState(
+        defaultActiveTab ??
+            [...itemsByTabs.entries()].find(
+                ([_tabId, items]) => items.length > 0,
+            )?.[0] ??
+            tabs?.[0]?.id,
+    );
 
     const sortProps =
-        tabs && tabs?.length > 0 && items.length > 1
+        tabs && tabs?.length > 0 && allItems.length > 1
             ? {
                   enableSorting: false,
                   enableMultiSort: false,
@@ -116,7 +121,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                   defaultSort: listProps.defaultSort,
               };
 
-    const hasTabs = tabs && tabs.length > 0 && items.length > 0;
+    const hasTabs = tabs && tabs.length > 0 && allItems.length > 0;
     const hasHeader = headerProps && (headerProps.title || headerProps.action);
 
     if (hasTabs && headerProps.title) {
@@ -124,6 +129,9 @@ const ResourceView: React.FC<ResourceViewProps> = ({
             'Cannot have both tabs and a header title. Please use one or the other.',
         );
     }
+
+    const items =
+        hasTabs && activeTabId ? itemsByTabs.get(activeTabId) ?? [] : allItems;
 
     return (
         <>
@@ -201,11 +209,11 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                     </>
                 ) : null}
 
-                {slicedSortedItems.length === 0 ? (
+                {items.length === 0 ? (
                     <ResourceEmptyState {...emptyStateProps} />
                 ) : view === ResourceViewType.LIST ? (
                     <ResourceViewList
-                        items={slicedSortedItems}
+                        items={items}
                         {...sortProps}
                         defaultColumnVisibility={
                             listProps.defaultColumnVisibility
@@ -214,7 +222,7 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                     />
                 ) : view === ResourceViewType.GRID ? (
                     <ResourceViewGrid
-                        items={slicedSortedItems}
+                        items={items}
                         groups={gridProps.groups}
                         onAction={handleAction}
                         hasReorder={hasReorder}


### PR DESCRIPTION
### Description:

Re-introduces the reverted commit: https://github.com/lightdash/lightdash/commit/bcaf4b7fcc26ec374cb454382998c466e668d4bd

That was previously reverted on: 
https://github.com/lightdash/lightdash/commit/bcaf4b7fcc26ec374cb454382998c466e668d4bd
