### PR TITLE
feat: display item description popover on renderFilterItem

### DIFF
--- a/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
@@ -4,10 +4,41 @@ import {
     Field,
     getItemId,
     getItemLabelWithoutTableName,
+    isField,
     TableCalculation,
 } from '@lightdash/common';
+import { Tooltip } from '@mantine/core';
+import { forwardRef, ReactNode } from 'react';
 import FieldIcon from './FieldIcon';
 import FieldLabel from './FieldLabel';
+
+const FilterItem = forwardRef<
+    HTMLDivElement,
+    {
+        item: Field | TableCalculation;
+        active: boolean;
+        disabled: boolean;
+        text: ReactNode;
+        handleFocus: (() => void) | undefined;
+        handleClick: React.MouseEventHandler<HTMLElement>;
+    }
+>(({ item, active, disabled, handleClick, handleFocus, text }, ref) => {
+    return (
+        <div ref={ref}>
+            <MenuItem2
+                key={getItemId(item)}
+                roleStructure="listoption"
+                shouldDismissPopover={false}
+                active={active}
+                disabled={disabled}
+                icon={<FieldIcon item={item} />}
+                onClick={handleClick}
+                onFocus={handleFocus}
+                text={text}
+            />
+        </div>
+    );
+});
 
 export const renderFilterItem: ItemRenderer<Field | TableCalculation> = (
     item,
@@ -17,17 +48,20 @@ export const renderFilterItem: ItemRenderer<Field | TableCalculation> = (
         return null;
     }
     return (
-        <MenuItem2
-            key={getItemId(item)}
-            roleStructure="listoption"
-            shouldDismissPopover={false}
-            active={modifiers.active}
-            disabled={modifiers.disabled}
-            icon={<FieldIcon item={item} />}
-            text={<FieldLabel item={item} />}
-            onClick={handleClick}
-            onFocus={handleFocus}
-        />
+        <Tooltip
+            withinPortal
+            label={isField(item) ? item.description : ''}
+            disabled={!isField(item) || (isField(item) && !item.description)}
+        >
+            <FilterItem
+                item={item}
+                active={modifiers.active}
+                disabled={modifiers.disabled}
+                text={<FieldLabel item={item} />}
+                handleClick={handleClick}
+                handleFocus={handleFocus}
+            />
+        </Tooltip>
     );
 };
 
@@ -38,16 +72,19 @@ export const renderFilterItemWithoutTableName: ItemRenderer<
         return null;
     }
     return (
-        <MenuItem2
-            key={getItemId(item)}
-            roleStructure="listoption"
-            shouldDismissPopover={false}
-            active={modifiers.active}
-            disabled={modifiers.disabled}
-            icon={<FieldIcon item={item} />}
-            text={getItemLabelWithoutTableName(item)}
-            onClick={handleClick}
-            onFocus={handleFocus}
-        />
+        <Tooltip
+            label={isField(item) ? item.description : ''}
+            withinPortal
+            disabled={!isField(item) || (isField(item) && !item.description)}
+        >
+            <FilterItem
+                item={item}
+                active={modifiers.active}
+                disabled={modifiers.disabled}
+                text={getItemLabelWithoutTableName(item)}
+                handleClick={handleClick}
+                handleFocus={handleFocus}
+            />
+        </Tooltip>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5977

### Description:

Add `Tooltip` of description on hover of fields in `FieldAutocomplete`
ForwardRef to `MenuItem2`: https://mantine.dev/core/tooltip/#custom-components-with-tooltip


Screenrecording: 

https://github.com/lightdash/lightdash/assets/7611706/35c29ef8-043a-449f-8c29-79bccd301b3b


