### PR TITLE
style: make modal larger and remove dashboard name from title

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     Button,
+    Flex,
     Group,
     Modal,
     MultiSelect,
@@ -105,27 +106,23 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
         onClose();
     });
 
-    const dashboardTitleName = dashboard?.name
-        ? `"${dashboard.name}"`
-        : 'dashboard';
-
     if (!savedCharts || !dashboardTiles || isLoading) return null;
 
     return (
         <Modal
+            size="lg"
             opened={true}
             onClose={onClose}
             title={
-                <Group spacing="xs">
+                <Flex align="center" gap="xs">
                     <MantineIcon
                         icon={IconChartAreaLine}
                         size="lg"
                         color="blue.8"
                     />
-                    <Title order={4}>
-                        Add saved charts to {dashboardTitleName}
-                    </Title>
-                </Group>
+
+                    <Title order={4}>Add saved charts</Title>
+                </Flex>
             }
             centered
             withCloseButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6073

### Description:

* make modal bigger
* remove dashboard name from modal title to avoid verbosity

before
<img width="1327" alt="Screenshot 2023-06-28 at 15 33 17" src="https://github.com/lightdash/lightdash/assets/7611706/d6d14b06-6066-49bf-801b-4ed9427f4334">

after
<img width="1384" alt="Screenshot 2023-06-28 at 15 32 36" src="https://github.com/lightdash/lightdash/assets/7611706/eeb182c2-bd02-42f1-bde3-54b44ea4f4bf">

