### PR TITLE
fix: exit process when makeWorkerUtils fails

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -70,8 +70,8 @@ export class SchedulerClient {
                 .migrate()
                 .then(() => utils)
                 .catch((e: any) => {
-                    Logger.warn('Error migrating graphile worker', e);
-                    return utils;
+                    Logger.error('Error migrating graphile worker', e);
+                    process.exit(1);
                 }),
         );
     }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -65,15 +65,12 @@ export class SchedulerClient {
         this.schedulerModel = schedulerModel;
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
-        }).then((utils) =>
-            utils
-                .migrate()
-                .then(() => utils)
-                .catch((e: any) => {
-                    Logger.error('Error migrating graphile worker', e);
-                    process.exit(1);
-                }),
-        );
+        })
+            .then((utils) => utils)
+            .catch((e: any) => {
+                Logger.error('Error migrating graphile worker', e);
+                process.exit(1);
+            });
     }
 
     async getScheduledJobs(schedulerUuid: string): Promise<ScheduledJobs[]> {


### PR DESCRIPTION
### Summary

- Remove double migration (`makeWorkerUtils` already runs migrations [see source](https://github.com/graphile/worker/blob/4d05832a1712f456d92001514c9474da73b56901/src/lib.ts#L223) we don't need an extra call).
- Crash if migrations fail

### Explanation

`makeWorkerUtils` tries to run migrations before creating the graphile utils client. This can error for a couple of reasons:

- if multiple workers try to run migrations some, none, or all can fail
- if the database connection isn't ready it'll fail 

The problem is that the current code will cache the rejected promise on `this.graphileUtils` so the scheduler will never work but also will never exit (meaning no restarts in k8s or docker etc.). 

After this change if we can't start the migrations we catch the error, log it out, and exit the scheduler process. In a kubernetes environment with a `restartPolicy` this means that the container will be restarted.

### Example from Lightdash Cloud infra

A pod with 2 containers;
- sql proxy to connect to postgres
- scheduler

If the scheduler starts before the sql proxy (it happens), then the scheduler becomes unhealthy and remains unhealthy even when the sql proxy is live. 

However with this change, the scheduler would be restarted repeatedly until the sql proxy is ready and it'll finally connect and become healthy. 

