### PR TITLE
fix: prevent dashboard request when uuid is empty

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -81,7 +81,7 @@ export const useDashboardQuery = (
     return useQuery<Dashboard, ApiError>({
         queryKey: ['saved_dashboard_query', id],
         queryFn: () => getDashboard(id || ''),
-        enabled: id !== undefined,
+        enabled: !!id,
         retry: false,
         onError: (result) => setErrorResponse(result),
         ...useQueryOptions,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

After a user creates a chart and clicks `Add to dashboard` there is an edge case that triggers an error message, even though there is no real impact to the user experience.

![image (3)](https://github.com/lightdash/lightdash/assets/9117144/eb587bf4-0a98-453a-837c-7a0a90823f51)


This is because we are trying to request a dashboard without a uuid. ( last request )

<img width="863" alt="Captura de ecrã 2023-06-29, às 10 26 56" src="https://github.com/lightdash/lightdash/assets/9117144/38fde380-b9e1-4ca7-9525-afaefbc767f3">



