### PR TITLE
fix: dont override custom metric when creating a chart from another c…

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -81,6 +81,8 @@ import {
     ProjectTableName,
 } from '../database/entities/projects';
 import {
+    SavedChartAdditionalMetricTable,
+    SavedChartAdditionalMetricTableName,
     SavedChartsTableName,
     SavedChartVersionFieldsTable,
     SavedChartVersionFieldsTableName,
@@ -162,6 +164,7 @@ declare module 'knex/types/tables' {
         [SavedChartVersionFieldsTableName]: SavedChartVersionFieldsTable;
         [SavedChartVersionSortsTableName]: SavedChartVersionSortsTable;
         [SavedQueryTableCalculationTableName]: SavedQueryTableCalculationTable;
+        [SavedChartAdditionalMetricTableName]: SavedChartAdditionalMetricTable;
         [SpaceTableName]: SpaceTable;
         [DashboardsTableName]: DashboardTable;
         [DashboardVersionsTableName]: DashboardVersionTable;

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -134,14 +134,19 @@ export type DbSavedChartAdditionalMetric = {
     saved_queries_version_id: number;
     filters: MetricFilterRule[] | null; // JSONB
     base_dimension_name: string | null;
-    uuid: string | null;
+    uuid: string;
 };
 export type DbSavedChartAdditionalMetricInsert = Omit<
     DbSavedChartAdditionalMetric,
-    'saved_queries_version_additional_metric_id' | 'filters'
+    'saved_queries_version_additional_metric_id' | 'filters' | 'uuid'
 > & {
     filters: string | null;
 };
+
+export type SavedChartAdditionalMetricTable = Knex.CompositeTableType<
+    DbSavedChartAdditionalMetric,
+    DbSavedChartAdditionalMetricInsert
+>;
 
 export type DBFilteredAdditionalMetrics = Pick<
     DbSavedChartAdditionalMetric,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -25,7 +25,6 @@ import {
     CreateDbSavedChartVersionField,
     CreateDbSavedChartVersionSort,
     DBFilteredAdditionalMetrics,
-    DbSavedChartAdditionalMetric,
     DbSavedChartAdditionalMetricInsert,
     DbSavedChartTableCalculationInsert,
     SavedChartAdditionalMetricTableName,
@@ -95,8 +94,6 @@ const createSavedChartVersionAdditionalMetrics = async (
 ) => {
     const results = await trx(SavedChartAdditionalMetricTableName)
         .insert(data)
-        .onConflict('uuid')
-        .merge()
         .returning('*');
     return results[0];
 };
@@ -204,7 +201,6 @@ const createSavedChartVersion = async (
                             : null,
                     base_dimension_name:
                         additionalMetric.baseDimensionName ?? null,
-                    uuid: additionalMetric.uuid ?? null,
                 }),
             );
         });
@@ -441,27 +437,28 @@ export class SavedChartModel {
                     savedQuery.saved_queries_version_id,
                 );
 
-            const additionalMetricsRows: DbSavedChartAdditionalMetric[] =
-                await this.database(SavedChartAdditionalMetricTableName)
-                    .select([
-                        'table',
-                        'name',
-                        'type',
-                        'label',
-                        'description',
-                        'sql',
-                        'hidden',
-                        'round',
-                        'format',
-                        'filters',
-                        'base_dimension_name',
-                        'uuid',
-                        'compact',
-                    ])
-                    .where(
-                        'saved_queries_version_id',
-                        savedQuery.saved_queries_version_id,
-                    );
+            const additionalMetricsRows = await this.database(
+                SavedChartAdditionalMetricTableName,
+            )
+                .select([
+                    'table',
+                    'name',
+                    'type',
+                    'label',
+                    'description',
+                    'sql',
+                    'hidden',
+                    'round',
+                    'format',
+                    'filters',
+                    'base_dimension_name',
+                    'uuid',
+                    'compact',
+                ])
+                .where(
+                    'saved_queries_version_id',
+                    savedQuery.saved_queries_version_id,
+                );
 
             // Filters out "null" fields
             const additionalMetricsFiltered: DBFilteredAdditionalMetrics[] =


### PR DESCRIPTION
…hart


### Description:

Bug where a custom metric is removed when creating a chart from an existing chart

Replication steps:
- create chart with custom metric
- open saved chart 
- click "explore from here"
- save a new chart
- open initial chart
- see that custom metric is not there anymore

https://github.com/lightdash/lightdash/assets/9117144/2c72fb3f-fd1e-40ce-9f4a-dccd8c8cd8c1


Fix:

https://github.com/lightdash/lightdash/assets/9117144/c4178736-7bc4-4c30-8a0e-46da7bee1f35

