### PR TITLE
fix: preview content where charts have custom metrics

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -940,7 +940,7 @@ export class ProjectModel {
 
             const copyChartVersionContent = async (
                 table: string,
-                fieldId: string,
+                excludedFields: string[],
             ) => {
                 const content = await trx(table)
                     .whereIn('saved_queries_version_id', chartVersionIds)
@@ -959,7 +959,9 @@ export class ProjectModel {
                                             m.id === d.saved_queries_version_id,
                                     )?.newId,
                             };
-                            delete createContent[fieldId];
+                            excludedFields.forEach((fieldId) => {
+                                delete createContent[fieldId];
+                            });
                             return createContent;
                         }),
                     )
@@ -970,19 +972,17 @@ export class ProjectModel {
 
             await copyChartVersionContent(
                 'saved_queries_version_table_calculations',
-                'saved_queries_version_table_calculation_id',
+                ['saved_queries_version_table_calculation_id'],
             );
-            await copyChartVersionContent(
-                'saved_queries_version_sorts',
+            await copyChartVersionContent('saved_queries_version_sorts', [
                 'saved_queries_version_sort_id',
-            );
-            await copyChartVersionContent(
-                'saved_queries_version_fields',
+            ]);
+            await copyChartVersionContent('saved_queries_version_fields', [
                 'saved_queries_version_field_id',
-            );
+            ]);
             await copyChartVersionContent(
                 'saved_queries_version_additional_metrics',
-                'saved_queries_version_additional_metric_id',
+                ['saved_queries_version_additional_metric_id', 'uuid'],
             );
 
             const dashboards = await trx('dashboards')


### PR DESCRIPTION
### Description:

If the project content uses custom metrics, none of the content is copied to the preview project.
It errors because the custom metric table has a unique column `uuid` and we are copying its value to the preview.


![Captura de ecrã 2023-06-29, às 14 36 24](https://github.com/lightdash/lightdash/assets/9117144/84cbdf89-2f82-4e1f-9584-963bd2c8b548)

