### PR TITLE
fix: tooltip appear to the right of table name

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -72,6 +72,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             withinPortal: true,
                             disabled: !data.tables[data.baseTable].description,
                             label: data.tables[data.baseTable].description,
+							position: 'right',
                         },
                     },
                 ]}

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -72,7 +72,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             withinPortal: true,
                             disabled: !data.tables[data.baseTable].description,
                             label: data.tables[data.baseTable].description,
-							position: 'right',
+                            position: 'right',
                         },
                     },
                 ]}


### PR DESCRIPTION
Closes: #6065 

### Description:
Tooltips apprear to the right of table name

### Screen Shots:
![image](https://github.com/lightdash/lightdash/assets/55316723/e7d52b06-e3d5-4f6e-9019-439cf2b086cd)