### PR TITLE
feat: add description tooltip to table names when adding filters

### DIFF
--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -48,6 +48,9 @@ export const getItemLabel = (item: Field | TableCalculation) =>
     isField(item) ? `${item.tableLabel} ${item.label}` : item.displayName;
 
 export const getItemTableName = (item: Field | TableCalculation) =>
+    isField(item) ? `${item.table}` : item.displayName;
+
+export const getItemTableLabel = (item: Field | TableCalculation) =>
     isField(item) ? `${item.tableLabel}` : item.displayName;
 
 export const getItemLabelWithoutTableName = (item: Field | TableCalculation) =>

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -47,12 +47,6 @@ export const getItemId = (item: Field | AdditionalMetric | TableCalculation) =>
 export const getItemLabel = (item: Field | TableCalculation) =>
     isField(item) ? `${item.tableLabel} ${item.label}` : item.displayName;
 
-export const getItemTableName = (item: Field | TableCalculation) =>
-    isField(item) ? `${item.table}` : item.displayName;
-
-export const getItemTableLabel = (item: Field | TableCalculation) =>
-    isField(item) ? `${item.tableLabel}` : item.displayName;
-
 export const getItemLabelWithoutTableName = (item: Field | TableCalculation) =>
     isField(item) ? `${item.label}` : item.displayName;
 

--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -108,18 +108,12 @@ const FieldAutoComplete = <T extends Field | TableCalculation>({
                 }
                 {...(hasGrouping && {
                     itemListRenderer: (itemListRendererProps) => {
-                        if (hasGrouping) {
-                            const tables =
-                                exploresData?.map((explore) => ({
-                                    description: explore.description,
-                                    name: explore.name,
-                                })) ?? [];
-                            return renderFilterList(
-                                itemListRendererProps,
-                                tables,
-                            );
-                        }
-                        return null;
+                        const tables =
+                            exploresData?.map((explore) => ({
+                                description: explore.description,
+                                name: explore.name,
+                            })) ?? [];
+                        return renderFilterList(itemListRendererProps, tables);
                     },
                 })}
                 activeItem={activeField}

--- a/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterItem.tsx
@@ -4,41 +4,10 @@ import {
     Field,
     getItemId,
     getItemLabelWithoutTableName,
-    isField,
     TableCalculation,
 } from '@lightdash/common';
-import { Tooltip } from '@mantine/core';
-import { forwardRef, ReactNode } from 'react';
 import FieldIcon from './FieldIcon';
 import FieldLabel from './FieldLabel';
-
-const FilterItem = forwardRef<
-    HTMLDivElement,
-    {
-        item: Field | TableCalculation;
-        active: boolean;
-        disabled: boolean;
-        text: ReactNode;
-        handleFocus: (() => void) | undefined;
-        handleClick: React.MouseEventHandler<HTMLElement>;
-    }
->(({ item, active, disabled, handleClick, handleFocus, text }, ref) => {
-    return (
-        <div ref={ref}>
-            <MenuItem2
-                key={getItemId(item)}
-                roleStructure="listoption"
-                shouldDismissPopover={false}
-                active={active}
-                disabled={disabled}
-                icon={<FieldIcon item={item} />}
-                onClick={handleClick}
-                onFocus={handleFocus}
-                text={text}
-            />
-        </div>
-    );
-});
 
 export const renderFilterItem: ItemRenderer<Field | TableCalculation> = (
     item,
@@ -48,20 +17,17 @@ export const renderFilterItem: ItemRenderer<Field | TableCalculation> = (
         return null;
     }
     return (
-        <Tooltip
-            withinPortal
-            label={isField(item) ? item.description : ''}
-            disabled={!isField(item) || (isField(item) && !item.description)}
-        >
-            <FilterItem
-                item={item}
-                active={modifiers.active}
-                disabled={modifiers.disabled}
-                text={<FieldLabel item={item} />}
-                handleClick={handleClick}
-                handleFocus={handleFocus}
-            />
-        </Tooltip>
+        <MenuItem2
+            key={getItemId(item)}
+            roleStructure="listoption"
+            shouldDismissPopover={false}
+            active={modifiers.active}
+            disabled={modifiers.disabled}
+            icon={<FieldIcon item={item} />}
+            text={<FieldLabel item={item} />}
+            onClick={handleClick}
+            onFocus={handleFocus}
+        />
     );
 };
 
@@ -72,19 +38,16 @@ export const renderFilterItemWithoutTableName: ItemRenderer<
         return null;
     }
     return (
-        <Tooltip
-            label={isField(item) ? item.description : ''}
-            withinPortal
-            disabled={!isField(item) || (isField(item) && !item.description)}
-        >
-            <FilterItem
-                item={item}
-                active={modifiers.active}
-                disabled={modifiers.disabled}
-                text={getItemLabelWithoutTableName(item)}
-                handleClick={handleClick}
-                handleFocus={handleFocus}
-            />
-        </Tooltip>
+        <MenuItem2
+            key={getItemId(item)}
+            roleStructure="listoption"
+            shouldDismissPopover={false}
+            active={modifiers.active}
+            disabled={modifiers.disabled}
+            icon={<FieldIcon item={item} />}
+            text={getItemLabelWithoutTableName(item)}
+            onClick={handleClick}
+            onFocus={handleFocus}
+        />
     );
 };

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -2,8 +2,7 @@ import { Colors, Divider, Menu } from '@blueprintjs/core';
 import { ItemListRendererProps } from '@blueprintjs/select';
 import {
     Field,
-    getItemTableLabel,
-    getItemTableName,
+    isField,
     SummaryExplore,
     TableCalculation,
 } from '@lightdash/common';
@@ -59,6 +58,9 @@ const StickyMenuDivider = forwardRef<HTMLLIElement, StickyMenuDividerProps>(
     ),
 );
 
+const getItemGroupLabel = (item: Field | TableCalculation) =>
+    isField(item) ? item.tableLabel : item.displayName;
+
 const renderFilterList = <T extends Field | TableCalculation>(
     itemListRendererProps: ItemListRendererProps<T>,
     tables: Pick<SummaryExplore, 'name' | 'description'>[],
@@ -71,10 +73,12 @@ const renderFilterList = <T extends Field | TableCalculation>(
                 items: typeof items;
             }[]
         >((acc, item) => {
-            const table = tables.find((t) => t.name === getItemTableName(item));
+            const table = isField(item)
+                ? tables.find((t) => t.name === item.table)
+                : undefined;
 
             const group = {
-                name: getItemTableLabel(item),
+                name: getItemGroupLabel(item),
                 description: table?.description,
             };
 

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -1,9 +1,15 @@
 import { Colors, Divider, Menu } from '@blueprintjs/core';
 import { ItemListRendererProps } from '@blueprintjs/select';
-import { Field, getItemTableName, TableCalculation } from '@lightdash/common';
-import { Group, Text } from '@mantine/core';
+import {
+    Field,
+    getItemTableLabel,
+    getItemTableName,
+    SummaryExplore,
+    TableCalculation,
+} from '@lightdash/common';
+import { Group, Text, Tooltip } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
-import React, { FC } from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import MantineIcon from '../MantineIcon';
 
@@ -39,9 +45,9 @@ type StickyMenuDividerProps = {
     title: string;
 };
 
-const StickyMenuDivider: FC<StickyMenuDividerProps> = ({ index, title }) => {
-    return (
-        <MenuDivider $isFirst={index === 0}>
+const StickyMenuDivider = forwardRef<HTMLLIElement, StickyMenuDividerProps>(
+    ({ index, title }, ref) => (
+        <MenuDivider $isFirst={index === 0} ref={ref}>
             {index !== 0 && <StyledDivider />}
             <Group spacing="xs">
                 <MantineIcon icon={IconTable} color="gray.6" size="lg" />
@@ -50,39 +56,56 @@ const StickyMenuDivider: FC<StickyMenuDividerProps> = ({ index, title }) => {
                 </Text>
             </Group>
         </MenuDivider>
-    );
-};
+    ),
+);
 
-const renderFilterList = <T extends Field | TableCalculation>({
-    items,
-    itemsParentRef,
-    renderItem,
-}: ItemListRendererProps<T>) => {
+const renderFilterList = <T extends Field | TableCalculation>(
+    itemListRendererProps: ItemListRendererProps<T>,
+    tables: Pick<SummaryExplore, 'name' | 'description'>[],
+) => {
+    const { items, itemsParentRef, renderItem } = itemListRendererProps;
     const getGroupedItems = (filteredItems: typeof items) => {
-        return filteredItems.reduce<{ group: string; items: typeof items }[]>(
-            (acc, item) => {
-                const group = getItemTableName(item);
+        return filteredItems.reduce<
+            {
+                group: typeof tables[0];
+                items: typeof items;
+            }[]
+        >((acc, item) => {
+            const table = tables.find((t) => t.name === getItemTableName(item));
 
-                const lastGroup = acc[acc.length - 1];
-                if (lastGroup && lastGroup.group === group) {
-                    lastGroup.items.push(item);
-                } else {
-                    acc.push({ group, items: [item] });
-                }
-                return acc;
-            },
-            [],
-        );
+            const group = {
+                name: getItemTableLabel(item),
+                description: table?.description ?? '',
+            };
+
+            const lastGroup = acc[acc.length - 1];
+            if (lastGroup && lastGroup.group.name === group.name) {
+                lastGroup.items.push(item);
+            } else {
+                acc.push({ group, items: [item] });
+            }
+            return acc;
+        }, []);
     };
 
     return (
         <Menu role="listbox" ulRef={itemsParentRef}>
             {getGroupedItems(items).map((groupedItem, index) => (
                 <React.Fragment key={index}>
-                    <StickyMenuDivider
-                        index={index}
-                        title={groupedItem.group}
-                    />
+                    <Tooltip
+                        offset={-2}
+                        maw={300}
+                        multiline
+                        position="bottom"
+                        withinPortal
+                        label={groupedItem.group.description}
+                        disabled={!groupedItem.group.description}
+                    >
+                        <StickyMenuDivider
+                            index={index}
+                            title={groupedItem.group.name}
+                        />
+                    </Tooltip>
 
                     {groupedItem.items.map((item, itemIndex) =>
                         renderItem(item, index + itemIndex),

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -75,7 +75,7 @@ const renderFilterList = <T extends Field | TableCalculation>(
 
             const group = {
                 name: getItemTableLabel(item),
-                description: table?.description ?? '',
+                description: table?.description,
             };
 
             const lastGroup = acc[acc.length - 1];

--- a/packages/frontend/src/components/common/Filters/renderFilterList.tsx
+++ b/packages/frontend/src/components/common/Filters/renderFilterList.tsx
@@ -59,7 +59,7 @@ const StickyMenuDivider = forwardRef<HTMLLIElement, StickyMenuDividerProps>(
 );
 
 const getItemGroupLabel = (item: Field | TableCalculation) =>
-    isField(item) ? item.tableLabel : item.displayName;
+    isField(item) ? item.tableLabel : 'Table Calculations';
 
 const renderFilterList = <T extends Field | TableCalculation>(
     itemListRendererProps: ItemListRendererProps<T>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5977

### Description:

- Removes show tooltip on hover of field (in pr #6077) - so changes to `renderFilterItem` are what's reverted
- Instead, adds tooltip on hover of table name (if there's a `description`)
- Changed a util name and added another one to get the `name` and `tableLabel` for a `field`.


screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/d6bcd774-428a-45c6-8603-09be8029097a

