### PR TITLE
fix: add hasGrouping to filters in explore

### DIFF
--- a/packages/e2e/cypress/e2e/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/dates.cy.ts
@@ -253,7 +253,7 @@ describe('Date tests', () => {
         cy.findAllByText('Loading chart').should('have.length', 0);
         // Filter by year
         cy.contains('Add filter').click();
-        cy.contains('Customers Created year').click();
+        cy.contains('Created year').click();
 
         cy.get('.bp4-numeric-input input').clear().type('2017');
         cy.get('.bp4-numeric-input input').should('have.value', '2017');
@@ -270,7 +270,7 @@ describe('Date tests', () => {
 
         // Filter by month
         cy.contains('Add filter').click();
-        cy.contains('Customers Created month').click();
+        cy.contains('Created month').click();
 
         cy.get('.bp4-numeric-input input').clear().type('2017');
         cy.get('.bp4-numeric-input input').should('have.value', '2017');
@@ -298,7 +298,8 @@ describe('Date tests', () => {
         cy.findAllByText('Loading chart').should('have.length', 0);
         // Filter by day
         cy.contains('Add filter').click();
-        cy.contains('Customers Created day').click();
+        cy.findByPlaceholderText('Search field...').type('created day');
+        cy.contains('Created day').click();
 
         cy.get('.bp4-date-input input').should('have.value', todayDate);
         cy.get('.bp4-code').contains(

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -205,6 +205,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                             fields={fields}
                             onChange={addFieldRule}
                             onClosed={toggleFieldInput}
+                            hasGrouping
                         />
                         <Button
                             minimal


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Add `hasGrouping` to filters in explore

Screen recordings

before

https://github.com/lightdash/lightdash/assets/7611706/3ab2abeb-56c8-4a70-b039-bec13acd5061


after

https://github.com/lightdash/lightdash/assets/7611706/24500be2-0097-4ffc-bc20-5e25fa2a28b6

