### PR TITLE
fix: target dbt 1.5.2

### DIFF
--- a/.github/workflows/cli-test-1.5.yml
+++ b/.github/workflows/cli-test-1.5.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7.x'
-      - run: pip install dbt-postgres==1.5
+      - run: pip install dbt-postgres~=1.5.0
 
       ## DBT run
       - name: Run DBT

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -48,7 +48,6 @@ describe('DbtCliClient', () => {
     });
     it('should get manifest with success', async () => {
         execaMock.mockImplementationOnce(cliMockImplementation.success);
-
         jest.spyOn(fs, 'readFile').mockImplementationOnce(
             async () => dbtProjectYml,
         );

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -48,6 +48,7 @@ describe('DbtCliClient', () => {
     });
     it('should get manifest with success', async () => {
         execaMock.mockImplementationOnce(cliMockImplementation.success);
+
         jest.spyOn(fs, 'readFile').mockImplementationOnce(
             async () => dbtProjectYml,
         );

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -14,7 +14,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import execa from 'execa';
-import * as fs from 'fs/promises';
+import { existsSync, promises as fs } from 'fs';
 import yaml, { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 import path from 'path';
 import Logger from '../logging/logger';
@@ -258,9 +258,17 @@ export class DbtCliClient implements DbtClient {
         version: DbtManifestVersion,
         filename: string,
     ): Promise<any> {
+        // There was a bug between dbt>=1.5.0 and <1.5.2 where the manifest was not being generated in the dir when using project-dir
+        // https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.2
+        // https://github.com/dbt-labs/dbt-core/issues/7819
         const targetDir = await this._getTargetDirectory();
+
+        const pathVersion150 = path.join('.', targetDir, filename);
+        if (version === DbtManifestVersion.V9 && existsSync(pathVersion150))
+            return DbtCliClient.loadDbtFile(pathVersion150);
+
         const fullPath = path.join(
-            version === DbtManifestVersion.V9 ? '.' : this.dbtProjectDirectory,
+            this.dbtProjectDirectory,
             targetDir,
             filename,
         );

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -1,5 +1,4 @@
 import {
-    assertUnreachable,
     DbtError,
     DbtLog,
     DbtManifestVersion,
@@ -14,7 +13,6 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import execa from 'execa';
-import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
 import yaml, { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 import path from 'path';
@@ -259,14 +257,8 @@ export class DbtCliClient implements DbtClient {
         version: DbtManifestVersion,
         filename: string,
     ): Promise<any> {
-        // There was a bug between dbt>=1.5.0 and <1.5.2 where the manifest was not being generated in the dir when using project-dir
-        // https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.2
-        // https://github.com/dbt-labs/dbt-core/issues/7819
         const targetDir = await this._getTargetDirectory();
 
-        const pathVersion150 = path.join('.', targetDir, filename);
-        if (version === DbtManifestVersion.V9 && existsSync(pathVersion150))
-            return DbtCliClient.loadDbtFile(pathVersion150);
         const fullPath = path.join(
             this.dbtProjectDirectory,
             targetDir,

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -14,7 +14,8 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import execa from 'execa';
-import { existsSync, promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import * as fs from 'fs/promises';
 import yaml, { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 import path from 'path';
 import Logger from '../logging/logger';
@@ -266,7 +267,6 @@ export class DbtCliClient implements DbtClient {
         const pathVersion150 = path.join('.', targetDir, filename);
         if (version === DbtManifestVersion.V9 && existsSync(pathVersion150))
             return DbtCliClient.loadDbtFile(pathVersion150);
-
         const fullPath = path.join(
             this.dbtProjectDirectory,
             targetDir,

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,5 +1,5 @@
 import { DbtManifest, DbtManifestVersion } from '@lightdash/common';
-import { existsSync, promises as fs } from 'fs';
+import { promises as fs } from 'fs';
 import * as path from 'path';
 import globalState from '../globalState';
 import { getDbtVersion } from '../handlers/dbt/getDbtVersion';
@@ -14,17 +14,8 @@ export const getDbtManifest = async (): Promise<DbtManifestVersion> => {
     return DbtManifestVersion.V7;
 };
 
-export const getManifestPath = async (targetDir: string): Promise<string> => {
-    const version = await getDbtVersion();
-    // There was a bug between dbt>=1.5.0 and <1.5.2 where the manifest was not being generated in the dir when using project-dir
-    // https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.2
-    // https://github.com/dbt-labs/dbt-core/issues/7819
-    const pathVersion150 = path.join('./target', 'manifest.json');
-    if (version.startsWith('1.5.') && existsSync(pathVersion150))
-        return pathVersion150;
-
-    return path.join(targetDir, 'manifest.json');
-};
+export const getManifestPath = async (targetDir: string): Promise<string> =>
+    path.join(targetDir, 'manifest.json');
 
 export const loadManifest = async ({
     targetDir,

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,5 +1,5 @@
 import { DbtManifest, DbtManifestVersion } from '@lightdash/common';
-import { promises as fs } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import * as path from 'path';
 import globalState from '../globalState';
 import { getDbtVersion } from '../handlers/dbt/getDbtVersion';
@@ -16,8 +16,13 @@ export const getDbtManifest = async (): Promise<DbtManifestVersion> => {
 
 export const getManifestPath = async (targetDir: string): Promise<string> => {
     const version = await getDbtVersion();
-    if (version.startsWith('1.5.'))
-        return path.join('./target', 'manifest.json');
+    // There was a bug between dbt>=1.5.0 and <1.5.2 where the manifest was not being generated in the dir when using project-dir
+    // https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.2
+    // https://github.com/dbt-labs/dbt-core/issues/7819
+    const pathVersion150 = path.join('./target', 'manifest.json');
+    if (version.startsWith('1.5.') && existsSync(pathVersion150))
+        return pathVersion150;
+
     return path.join(targetDir, 'manifest.json');
 };
 

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -45,7 +45,7 @@ export const compile = async (options: CompileHandlerOptions) => {
     if (!isSupportedDbtVersion(dbtVersion)) {
         if (process.env.CI === 'true') {
             console.error(
-                `Your dbt version ${dbtVersion} does not match our supported versions (1.3.0 - 1.4.*), this could cause problems on compile or validation.`,
+                `Your dbt version ${dbtVersion} does not match our supported versions (1.3.0 - 1.5.*), this could cause problems on compile or validation.`,
             );
         } else {
             const answers = await inquirer.prompt([
@@ -53,7 +53,7 @@ export const compile = async (options: CompileHandlerOptions) => {
                     type: 'confirm',
                     name: 'isConfirm',
                     message: `${styles.warning(
-                        `Your dbt version ${dbtVersion} does not match our supported version (1.3.0 - 1.4.*), this could cause problems on compile or validation.`,
+                        `Your dbt version ${dbtVersion} does not match our supported version (1.3.0 - 1.5.*), this could cause problems on compile or validation.`,
                     )}\nDo you still want to continue?`,
                 },
             ]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/6104


   There was a bug between dbt>=1.5.0 and <1.5.2 where the manifest was not being generated in the dir when using project-dir 
   https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.2
   https://github.com/dbt-labs/dbt-core/issues/7819

This is affecting both the CLi and backend, where a user can use 1.5.0 and get the bug, or use 1.5.2 where the bug is no more

On cloud, we install on docker ~1.5.0 which always gets the last minor version available (1.5.2 right now) 

![image](https://github.com/lightdash/lightdash/assets/1983672/9522d4a3-caf9-408b-a3e2-737cede3a816)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2023-07-04 09-33-45](https://github.com/lightdash/lightdash/assets/1983672/729ec9be-83db-4dc4-bc7b-9bf7da308f77)

<!-- Even better add a screenshot / gif / loom -->

![image](https://github.com/lightdash/lightdash/assets/1983672/67ef7224-d24b-49cf-935d-482220439abb)


Backend with 1.5.0

![Screenshot from 2023-07-04 09-38-36](https://github.com/lightdash/lightdash/assets/1983672/b4b32585-dadd-4218-b192-ea646c082970)


Backend with 1.5.2

![image](https://github.com/lightdash/lightdash/assets/1983672/7b0929c0-19fa-4293-bb21-16fa6dbd4011)
