### PR TITLE
chore: skip blueprint action for external PRs

### DIFF
--- a/.github/workflows/count-blueprint.yml
+++ b/.github/workflows/count-blueprint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/count-blueprint.yml
+++ b/.github/workflows/count-blueprint.yml
@@ -11,12 +11,13 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
-        run: yarn 
+        run: yarn
       - name: Count blueprint imports
         run: |
           EOF="$(openssl rand -hex 8)"


### PR DESCRIPTION
This github action always fails for external PRs since it doesnt have access to `secrets.CI_GITHUB_TOKEN` 