### PR TITLE
chore: dont update user email in e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/settings/profile.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/profile.cy.ts
@@ -18,13 +18,12 @@ describe('Settings - Profile', () => {
         });
     });
 
-    it('Should change name and email', () => {
+    it('should update user names', () => {
         cy.visit('/');
         cy.findByTestId('user-avatar').click();
         cy.findByRole('menuitem', { name: 'User settings' }).click();
         cy.get('[data-cy="first-name-input"]').clear().type('Kevin');
         cy.get('[data-cy="last-name-input"]').clear().type('Space');
-        cy.get('[data-cy="email-input"]').clear().type('kspace@lightdash.com');
         cy.get('[data-cy="update-profile-settings"]').click();
         cy.findByText('Success! User details were updated.').should(
             'be.visible',


### PR DESCRIPTION
Changing the email had an impact on other e2e tests that run in parallel. 