### PR TITLE
feat: allow admins to list all private spaces

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -8,7 +8,6 @@ import {
     CreateProjectMember,
     UpdateProjectMember,
 } from '@lightdash/common';
-import { Query } from '@tsoa/runtime';
 import express from 'express';
 import {
     Body,
@@ -79,7 +78,6 @@ export class ProjectController extends Controller {
      * List all spaces in a project
      * @param projectUuid The uuid of the project to get spaces for
      * @param req express request
-     * @param includePrivateSpaces Whether to include all organization private spaces
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -88,16 +86,11 @@ export class ProjectController extends Controller {
     async getSpacesInProject(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-        @Query() includePrivateSpaces?: boolean,
     ): Promise<ApiSpaceSummaryListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getSpaces(
-                req.user!,
-                projectUuid,
-                includePrivateSpaces,
-            ),
+            results: await projectService.getSpaces(req.user!, projectUuid),
         };
     }
 

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -8,6 +8,7 @@ import {
     CreateProjectMember,
     UpdateProjectMember,
 } from '@lightdash/common';
+import { Query } from '@tsoa/runtime';
 import express from 'express';
 import {
     Body,
@@ -78,6 +79,7 @@ export class ProjectController extends Controller {
      * List all spaces in a project
      * @param projectUuid The uuid of the project to get spaces for
      * @param req express request
+     * @param includePrivateSpaces Whether to include all organization private spaces
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -86,11 +88,16 @@ export class ProjectController extends Controller {
     async getSpacesInProject(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() includePrivateSpaces?: boolean,
     ): Promise<ApiSpaceSummaryListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getSpaces(req.user!, projectUuid),
+            results: await projectService.getSpaces(
+                req.user!,
+                projectUuid,
+                includePrivateSpaces,
+            ),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1641,7 +1641,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -1651,6 +1651,22 @@ const models: TsoaRoute.Models = {
                     organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     projectUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     isPrivate: { dataType: 'boolean', required: true },
                 },
                 validators: {},
@@ -1663,11 +1679,13 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dashboardCount: { dataType: 'double', required: true },
+                        chartCount: { dataType: 'double', required: true },
                         access: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -1932,6 +1950,7 @@ const models: TsoaRoute.Models = {
             'greaterThan',
             'greaterThanOrEqual',
             'inThePast',
+            'notInThePast',
             'inTheNext',
             'inTheCurrent',
             'inBetween',
@@ -4427,6 +4446,11 @@ export function RegisterRoutes(app: express.Router) {
                     name: 'req',
                     required: true,
                     dataType: 'object',
+                },
+                includePrivateSpaces: {
+                    in: 'query',
+                    name: 'includePrivateSpaces',
+                    dataType: 'boolean',
                 },
             };
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1641,7 +1641,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
         {
             dataType: 'refAlias',
             type: {
@@ -1651,22 +1651,6 @@ const models: TsoaRoute.Models = {
                     organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     projectUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
                     isPrivate: { dataType: 'boolean', required: true },
                 },
                 validators: {},
@@ -1679,13 +1663,11 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        dashboardCount: { dataType: 'double', required: true },
-                        chartCount: { dataType: 'double', required: true },
                         access: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -4446,11 +4428,6 @@ export function RegisterRoutes(app: express.Router) {
                     name: 'req',
                     required: true,
                     dataType: 'object',
-                },
-                includePrivateSpaces: {
-                    in: 'query',
-                    name: 'includePrivateSpaces',
-                    dataType: 'boolean',
                 },
             };
 

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1892,7 +1892,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -1906,15 +1906,6 @@
                     "projectUuid": {
                         "type": "string"
                     },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
                     "isPrivate": {
                         "type": "boolean"
                     }
@@ -1924,8 +1915,6 @@
                     "organizationUuid",
                     "uuid",
                     "projectUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder",
                     "isPrivate"
                 ],
                 "type": "object",
@@ -1934,18 +1923,10 @@
             "SpaceSummary": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
                     },
                     {
                         "properties": {
-                            "dashboardCount": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "chartCount": {
-                                "type": "number",
-                                "format": "double"
-                            },
                             "access": {
                                 "items": {
                                     "type": "string"
@@ -1953,7 +1934,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["dashboardCount", "chartCount", "access"],
+                        "required": ["access"],
                         "type": "object"
                     }
                 ]
@@ -4859,15 +4840,6 @@
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Whether to include all organization private spaces",
-                        "in": "query",
-                        "name": "includePrivateSpaces",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1892,7 +1892,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -1906,6 +1906,15 @@
                     "projectUuid": {
                         "type": "string"
                     },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     }
@@ -1915,6 +1924,8 @@
                     "organizationUuid",
                     "uuid",
                     "projectUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder",
                     "isPrivate"
                 ],
                 "type": "object",
@@ -1923,10 +1934,18 @@
             "SpaceSummary": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_"
                     },
                     {
                         "properties": {
+                            "dashboardCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "chartCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "access": {
                                 "items": {
                                     "type": "string"
@@ -1934,7 +1953,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["access"],
+                        "required": ["dashboardCount", "chartCount", "access"],
                         "type": "object"
                     }
                 ]
@@ -2214,6 +2233,7 @@
                     "greaterThan",
                     "greaterThanOrEqual",
                     "inThePast",
+                    "notInThePast",
                     "inTheNext",
                     "inTheCurrent",
                     "inBetween"
@@ -3675,7 +3695,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.640.1",
+        "version": "0.651.2",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -4839,6 +4859,15 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Whether to include all organization private spaces",
+                        "in": "query",
+                        "name": "includePrivateSpaces",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1986,7 +1986,6 @@ export class ProjectService {
     async getSpaces(
         user: SessionUser,
         projectUuid: string,
-        includePrivateSpaces = false,
     ): Promise<SpaceSummary[]> {
         const { organizationUuid } = await this.projectModel.get(projectUuid);
         if (
@@ -2000,7 +1999,7 @@ export class ProjectService {
 
         const spaces = await this.spaceModel.find({ projectUuid });
         const allowedSpaces = spaces.filter((space) =>
-            hasSpaceAccess(user, space, includePrivateSpaces),
+            hasSpaceAccess(user, space, true),
         );
         return allowedSpaces;
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1986,6 +1986,7 @@ export class ProjectService {
     async getSpaces(
         user: SessionUser,
         projectUuid: string,
+        includePrivateSpaces = false,
     ): Promise<SpaceSummary[]> {
         const { organizationUuid } = await this.projectModel.get(projectUuid);
         if (
@@ -1998,12 +1999,9 @@ export class ProjectService {
         }
 
         const spaces = await this.spaceModel.find({ projectUuid });
-        const allowedSpaces = spaces.filter(
-            (space) =>
-                space.projectUuid === projectUuid &&
-                (!space.isPrivate || space.access.includes(user.userUuid)),
+        const allowedSpaces = spaces.filter((space) =>
+            hasSpaceAccess(user, space, includePrivateSpaces),
         );
-
         return allowedSpaces;
     }
 

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -1,7 +1,7 @@
 import assertUnreachable from '../utils/assertUnreachable';
 import { DashboardBasicDetails } from './dashboard';
 import { SpaceQuery } from './savedCharts';
-import { Space } from './space';
+import { Space, SpaceSummary } from './space';
 
 export enum ResourceViewItemType {
     CHART = 'chart',
@@ -111,7 +111,7 @@ export const wrapResourceView = (
     resources.map((resource) => wrapResource(resource, type));
 
 export const spaceToResourceViewItem = (
-    space: Space,
+    space: SpaceSummary,
 ): ResourceViewSpaceItem['data'] => ({
     organizationUuid: space.organizationUuid,
     projectUuid: space.projectUuid,
@@ -121,7 +121,7 @@ export const spaceToResourceViewItem = (
     pinnedListUuid: space.pinnedListUuid,
     pinnedListOrder: space.pinnedListOrder,
     accessListLength: space.access.length,
-    dashboardCount: space.dashboards.length,
-    chartCount: space.queries.length,
-    access: space.access.map((access) => access.userUuid),
+    dashboardCount: space.dashboardCount,
+    chartCount: space.chartCount,
+    access: space.access,
 });

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -17,9 +17,17 @@ export type Space = {
 
 export type SpaceSummary = Pick<
     Space,
-    'organizationUuid' | 'projectUuid' | 'uuid' | 'name' | 'isPrivate'
+    | 'organizationUuid'
+    | 'projectUuid'
+    | 'uuid'
+    | 'name'
+    | 'isPrivate'
+    | 'pinnedListUuid'
+    | 'pinnedListOrder'
 > & {
     access: string[];
+    chartCount: number;
+    dashboardCount: number;
 };
 
 export type CreateSpace = {

--- a/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
@@ -312,7 +312,7 @@ describe('Lightdash API tests for an project admin accessing other private space
         });
     });
 
-    it('Should not list private spaces', () => {
+    it('Should list private spaces', () => {
         cy.request({
             url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             failOnStatusCode: false,
@@ -321,7 +321,7 @@ describe('Lightdash API tests for an project admin accessing other private space
             const privateSpace = resp.body.results.find(
                 (space) => space.name === 'private space',
             );
-            expect(privateSpace).to.eq(undefined);
+            expect(privateSpace).to.not.eq(undefined);
         });
     });
 

--- a/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
@@ -348,7 +348,7 @@ describe('Lightdash API tests for an project admin accessing other private space
             ).to.eq(undefined);
         });
     });
-    it('Should not list private spaces', () => {
+    it('Should list private spaces', () => {
         cy.request({
             url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             failOnStatusCode: false,
@@ -357,7 +357,7 @@ describe('Lightdash API tests for an project admin accessing other private space
             const privateSpace = resp.body.results.find(
                 (space) => space.name === 'private space',
             );
-            expect(privateSpace).to.eq(undefined);
+            expect(privateSpace).to.not.eq(undefined);
         });
     });
 

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -66,6 +66,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     );
     const { data: spaces, isLoading: isLoadingSpaces } = useSpaceSummaries(
         projectUuid,
+        false,
         {
             onSuccess: (data) => {
                 if (data.length === 0) {

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -46,6 +46,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
 
     const { data: spaces, isLoading: isLoadingSpaces } = useSpaceSummaries(
         projectUuid,
+        false,
         {
             onSuccess: (data) => {
                 if (data.length > 0) {

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -49,6 +49,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
 
     const { data: spaces, isLoading: isLoadingSpaces } = useSpaceSummaries(
         projectUuid,
+        false,
         {
             onSuccess: (data) => {
                 if (data.length > 0) {

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -21,7 +21,7 @@ const getSpaces = async (projectUuid: string) =>
         body: undefined,
     });
 
-export const useSpaces = (
+const useSpaces = (
     projectUuid: string,
     queryOptions?: UseQueryOptions<Space[], ApiError>,
 ) => {
@@ -32,9 +32,12 @@ export const useSpaces = (
     );
 };
 
-const getSpaceSummaries = async (projectUuid: string) => {
+const getSpaceSummaries = async (
+    projectUuid: string,
+    includePrivateSpaces: boolean,
+) => {
     return lightdashApi<SpaceSummary[]>({
-        url: `/projects/${projectUuid}/spaces`,
+        url: `/projects/${projectUuid}/spaces?includePrivateSpaces=${includePrivateSpaces}`,
         method: 'GET',
         body: undefined,
     });
@@ -42,11 +45,12 @@ const getSpaceSummaries = async (projectUuid: string) => {
 
 export const useSpaceSummaries = (
     projectUuid: string,
+    includePrivateSpaces: boolean = false,
     queryOptions?: UseQueryOptions<SpaceSummary[], ApiError>,
 ) => {
     return useQuery<SpaceSummary[], ApiError>(
-        ['projects', projectUuid, 'spaces'],
-        () => getSpaceSummaries(projectUuid),
+        ['projects', projectUuid, 'spaces', includePrivateSpaces],
+        () => getSpaceSummaries(projectUuid, includePrivateSpaces),
         { ...queryOptions },
     );
 };

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -5,10 +5,12 @@ import {
     spaceToResourceViewItem,
     wrapResourceView,
 } from '@lightdash/common';
-import { Button, Group, Stack } from '@mantine/core';
+import { Button, Group, Stack, Switch } from '@mantine/core';
+import { useToggle } from '@mantine/hooks';
 import { IconFolders, IconPlus } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { Can } from '../components/common/Authorization';
 import LoadingState from '../components/common/LoadingState';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -20,15 +22,18 @@ import SpaceActionModal, {
 } from '../components/common/SpaceActionModal';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useProject } from '../hooks/useProject';
-import { useSpaces } from '../hooks/useSpaces';
+import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 import { PinnedItemsProvider } from '../providers/PinnedItemsProvider';
 
 const Spaces: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
-    const { data: spaces = [], isLoading: spaceIsLoading } =
-        useSpaces(projectUuid);
+    const [includePrivateSpaces, setIncludePrivateSpaces] = useToggle();
+    const { data: spaces = [], isLoading: spaceIsLoading } = useSpaceSummaries(
+        projectUuid,
+        includePrivateSpaces,
+    );
     const project = useProject(projectUuid);
     const isLoading = spaceIsLoading || project.isLoading;
 
@@ -97,6 +102,24 @@ const Spaces: FC = () => {
                         )}
                         headerProps={{
                             title: 'Spaces',
+                            action: (
+                                <Can
+                                    I="manage"
+                                    this={subject('Project', {
+                                        organizationUuid:
+                                            user.data?.organizationUuid,
+                                        projectUuid: projectUuid,
+                                    })}
+                                >
+                                    <Switch
+                                        label="Include all private spaces"
+                                        checked={includePrivateSpaces}
+                                        onChange={() =>
+                                            setIncludePrivateSpaces()
+                                        }
+                                    />
+                                </Can>
+                            ),
                         }}
                         emptyStateProps={{
                             icon: <IconFolders size={30} />,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/6038<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- stop using `spaces-and-content` endpoint since it queries all dashboards and charts
- update chart summary endpoint to have all the necessary information
- allow users that can manage projects to see all private spaces

https://github.com/lightdash/lightdash/assets/9117144/4b659fb0-7fa1-4767-acfa-9be915989885
