### PR TITLE
feat: remove duplicated job scheduler

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -447,6 +447,17 @@ export class SchedulerModel {
             SchedulerModel.parseSchedulerLog,
         );
 
+        const sortedLogs = schedulerLogs.sort(SchedulerModel.sortLogs);
+        const uniqueLogs = sortedLogs.reduce<SchedulerLog[]>((acc, log) => {
+            if (
+                acc.some(
+                    (l) => l.jobGroup === log.jobGroup && l.task === log.task,
+                )
+            ) {
+                return acc;
+            }
+            return [...acc, log];
+        }, []);
         const users = await this.database(UserTableName)
             .select('first_name', 'last_name', 'user_uuid')
             .whereIn('user_uuid', userUuids);
@@ -472,7 +483,7 @@ export class SchedulerModel {
                 name: d.name,
                 dashboardUuid: d.dashboard_uuid,
             })),
-            logs: schedulerLogs.sort(SchedulerModel.sortLogs),
+            logs: uniqueLogs,
         };
     }
 

--- a/packages/frontend/src/components/SchedulersView/LogsView.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsView.tsx
@@ -1,4 +1,4 @@
-import { SchedulerWithLogs } from '@lightdash/common';
+import { SchedulerLog, SchedulerWithLogs } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -70,11 +70,21 @@ const Logs: FC<LogsProps> = ({
         [openedUuids],
     );
 
-    const groupedLogs = useMemo(
-        () => Object.entries(groupBy(logs, 'jobGroup')),
-        [logs],
-    );
-
+    const groupedLogs = useMemo(() => {
+        // Get only last log per job
+        // Logs should already by sorted by status and time
+        const uniqueLogs = logs.reduce<SchedulerLog[]>((acc, log) => {
+            if (
+                acc.some(
+                    (l) => l.jobGroup === log.jobGroup && l.task === log.task,
+                )
+            ) {
+                return acc;
+            }
+            return [...acc, log];
+        }, []);
+        return Object.entries(groupBy(uniqueLogs, 'jobGroup'));
+    }, [logs]);
     const columns = useMemo<Column[]>(() => {
         return [
             {
@@ -195,6 +205,7 @@ const Logs: FC<LogsProps> = ({
                     );
                 },
             },
+
             {
                 id: 'deliveryScheduled',
                 label: 'Delivery scheduled',

--- a/packages/frontend/src/components/SchedulersView/LogsView.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsView.tsx
@@ -1,4 +1,4 @@
-import { SchedulerLog, SchedulerWithLogs } from '@lightdash/common';
+import { SchedulerWithLogs } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -70,21 +70,11 @@ const Logs: FC<LogsProps> = ({
         [openedUuids],
     );
 
-    const groupedLogs = useMemo(() => {
-        // Get only last log per job
-        // Logs should already by sorted by status and time
-        const uniqueLogs = logs.reduce<SchedulerLog[]>((acc, log) => {
-            if (
-                acc.some(
-                    (l) => l.jobGroup === log.jobGroup && l.task === log.task,
-                )
-            ) {
-                return acc;
-            }
-            return [...acc, log];
-        }, []);
-        return Object.entries(groupBy(uniqueLogs, 'jobGroup'));
-    }, [logs]);
+    const groupedLogs = useMemo(
+        () => Object.entries(groupBy(logs, 'jobGroup')),
+        [logs],
+    );
+
     const columns = useMemo<Column[]>(() => {
         return [
             {
@@ -205,7 +195,6 @@ const Logs: FC<LogsProps> = ({
                     );
                 },
             },
-
             {
                 id: 'deliveryScheduled',
                 label: 'Delivery scheduled',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6070

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before:

![Screenshot from 2023-07-06 11-33-02](https://github.com/lightdash/lightdash/assets/1983672/22078f1b-40dd-4d7c-b6be-f56f75e4013f)

After:

![Screenshot from 2023-07-06 11-33-19](https://github.com/lightdash/lightdash/assets/1983672/6ff13577-f310-4f69-aa77-df2b3bf39702)

About the missaligned issue: 

This is happening because we use collapsible groups inside a cell , this means we can't align the job name with the timestamps. 

However, I was not able to replicate this locally, (see screenshots) 

A solution would be to incrase the job name size to avoid text on  2 lines , or use ellipsis... but we can do this on a separate PR. 
