### PR TITLE
chore: pin plugin to last working version

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -38,7 +38,7 @@ jobs:
             @semantic-release/git@10
             @semantic-release/github@8
             @amanda-mitchell/semantic-release-npm-multiple@2.17.0
-            @google/semantic-release-replace-plugin@1
+            @google/semantic-release-replace-plugin@1.2.0
       - name: Reset alpha branch upon release
         if: |
           steps.semantic.outputs.new_release_published == 'true' &&


### PR DESCRIPTION
Pin the plugin to the last working version.

Open issue: https://github.com/jpoehnelt/semantic-release-replace-plugin/issues/221
