### PR TITLE
feat: rename admin spaces tab. Add tooltip.

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -13,6 +13,7 @@ import {
 import { IconInfoCircle } from '@tabler/icons-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTableTabStyles } from '../../../hooks/styles/useTableTabStyles';
+import MantineIcon from '../MantineIcon';
 import ResourceActionHandlers, {
     ResourceViewItemAction,
     ResourceViewItemActionState,
@@ -31,6 +32,7 @@ type TabType = {
     id: string;
     name?: string;
     icon?: JSX.Element;
+    infoTooltipText?: string;
     sort?: (a: ResourceViewItem, b: ResourceViewItem) => number;
     filter?: (item: ResourceViewItem) => boolean;
 };
@@ -153,6 +155,25 @@ const ResourceView: React.FC<ResourceViewProps> = ({
                                                 key={tab.id}
                                                 icon={tab.icon}
                                                 value={tab.id}
+                                                rightSection={
+                                                    !!tab.infoTooltipText ? (
+                                                        <Tooltip
+                                                            label={
+                                                                tab.infoTooltipText
+                                                            }
+                                                            disabled={
+                                                                !tab.infoTooltipText
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconInfoCircle
+                                                                }
+                                                                color="gray.6"
+                                                            />
+                                                        </Tooltip>
+                                                    ) : null
+                                                }
                                             >
                                                 {tab.name ? (
                                                     <Text

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -122,7 +122,9 @@ const Spaces: FC = () => {
                                       },
                                       {
                                           id: 'all',
-                                          name: 'All spaces',
+                                          name: 'Admin Content View',
+                                          infoTooltipText:
+                                              'View all public and private spaces in your organization',
                                       },
                                   ]
                                 : []


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6170 

### Description:

Change the name of the Admin all spaces tab and add a tooltip. Note that I had to add the ability to add info-tooltips to tabs.

### Acceptance criteria

- [ ] `All Spaces ` tab should change to `Admin Content View`
- [ ] Add an info icon and tooltip next to it which reads `View all public and private spaces in your organization`
- [ ] This should only affect Admins 
