### PR TITLE
feat: pie charts value formatting options

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -67,9 +67,11 @@ export type PieChart = {
     metricId?: string;
     isDonut?: boolean;
     valueLabel?: PieChartValueLabel;
-    showLegend?: boolean;
+    showValue?: boolean;
+    showPercentage?: boolean;
     groupLabelOverrides?: Record<string, string>;
     groupColorOverrides?: Record<string, string>;
+    showLegend?: boolean;
 };
 
 export type PieChartConfig = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -62,7 +62,7 @@ export const PieChartValueLabels = {
 
 export type PieChartValueLabel = keyof typeof PieChartValueLabels;
 
-export type PieChartLabelOptions = {
+export type PieChartValueOptions = {
     valueLabel: PieChartValueLabel;
     showValue: boolean;
     showPercentage: boolean;
@@ -72,12 +72,12 @@ export type PieChart = {
     groupFieldIds?: string[];
     metricId?: string;
     isDonut?: boolean;
-    valueLabel?: PieChartLabelOptions['valueLabel'];
-    showValue?: PieChartLabelOptions['showValue'];
-    showPercentage?: PieChartLabelOptions['showPercentage'];
+    valueLabel?: PieChartValueOptions['valueLabel'];
+    showValue?: PieChartValueOptions['showValue'];
+    showPercentage?: PieChartValueOptions['showPercentage'];
     groupLabelOverrides?: Record<string, string>;
     groupColorOverrides?: Record<string, string>;
-    groupLabelOptionOverrides?: Record<string, PieChartLabelOptions>;
+    groupValueOptionOverrides?: Record<string, PieChartValueOptions>;
     showLegend?: boolean;
 };
 

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -77,7 +77,7 @@ export type PieChart = {
     showPercentage?: PieChartValueOptions['showPercentage'];
     groupLabelOverrides?: Record<string, string>;
     groupColorOverrides?: Record<string, string>;
-    groupValueOptionOverrides?: Record<string, PieChartValueOptions>;
+    groupValueOptionOverrides?: Record<string, Partial<PieChartValueOptions>>;
     showLegend?: boolean;
 };
 

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -62,15 +62,22 @@ export const PieChartValueLabels = {
 
 export type PieChartValueLabel = keyof typeof PieChartValueLabels;
 
+export type PieChartLabelOptions = {
+    valueLabel: PieChartValueLabel;
+    showValue: boolean;
+    showPercentage: boolean;
+};
+
 export type PieChart = {
     groupFieldIds?: string[];
     metricId?: string;
     isDonut?: boolean;
-    valueLabel?: PieChartValueLabel;
-    showValue?: boolean;
-    showPercentage?: boolean;
+    valueLabel?: PieChartLabelOptions['valueLabel'];
+    showValue?: PieChartLabelOptions['showValue'];
+    showPercentage?: PieChartLabelOptions['showPercentage'];
     groupLabelOverrides?: Record<string, string>;
     groupColorOverrides?: Record<string, string>;
+    groupLabelOptionOverrides?: Record<string, PieChartLabelOptions>;
     showLegend?: boolean;
 };
 

--- a/packages/frontend/src/components/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartLayoutConfig.tsx
@@ -17,7 +17,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
-import React, { forwardRef, useMemo } from 'react';
+import React, { forwardRef } from 'react';
 import FieldIcon from '../common/Filters/FieldIcon';
 import FieldLabel, { fieldLabelText } from '../common/Filters/FieldLabel';
 import MantineIcon from '../common/MantineIcon';
@@ -56,16 +56,12 @@ const PieChartLayoutConfig: React.FC = () => {
             groupChange,
             groupRemove,
 
+            selectedMetric,
+
             isDonut,
             toggleDonut,
         },
     } = useVisualizationContext();
-
-    const selectedMetric = useMemo(() => {
-        return allNumericMetrics.find((m) =>
-            isField(m) ? fieldId(m) === metricId : m.name === metricId,
-        );
-    }, [allNumericMetrics, metricId]);
 
     return (
         <Stack>

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -116,7 +116,15 @@ const GroupItem: FC<GroupItemProps> = ({
                 <Input.Wrapper>
                     <Popover shadow="md" withArrow>
                         <Popover.Target>
-                            <ColorSwatch color={color} />
+                            <ColorSwatch
+                                size={24}
+                                color={color}
+                                sx={{
+                                    cursor: 'pointer',
+                                    transition: 'opacity 100ms ease',
+                                    '&:hover': { opacity: 0.8 },
+                                }}
+                            />
                         </Popover.Target>
 
                         <Popover.Dropdown p="xs">
@@ -163,10 +171,9 @@ const GroupItem: FC<GroupItemProps> = ({
                     }}
                 />
 
-                <ActionIcon>
+                <ActionIcon onClick={toggle} size="sm">
                     <MantineIcon
                         icon={opened ? IconChevronUp : IconChevronDown}
-                        onClick={toggle}
                     />
                 </ActionIcon>
             </Group>
@@ -222,7 +229,7 @@ const PieChartSeriesConfig: FC = () => {
             {groupLabels.length === 0 ? null : (
                 <Stack
                     spacing="xs"
-                    bg="gray.1"
+                    bg="gray.0"
                     p="sm"
                     sx={(theme) => ({ borderRadius: theme.radius.sm })}
                 >

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Checkbox,
     Collapse,
     ColorPicker,
     ColorSwatch,
@@ -13,7 +14,6 @@ import {
     Popover,
     Select,
     Stack,
-    Switch,
     TextInput,
     Tooltip,
 } from '@mantine/core';
@@ -27,9 +27,9 @@ import { useVisualizationContext } from '../LightdashVisualization/Visualization
 type ValueOptionsProps = {
     inputLabel: string;
 
-    defaultValueLabel?: PieChartValueLabel;
-    defaultShowValue?: boolean;
-    defaultShowPercentage?: boolean;
+    isValueLabelOverriden?: boolean;
+    isShowValueOverriden?: boolean;
+    isShowPercentageOverriden?: boolean;
 
     valueLabel: PieChartValueLabel;
     showValue: boolean;
@@ -43,13 +43,13 @@ type ValueOptionsProps = {
 const ValueOptions: FC<ValueOptionsProps> = ({
     inputLabel,
 
-    defaultShowPercentage,
-    defaultShowValue,
-    defaultValueLabel,
+    isValueLabelOverriden = false,
+    isShowValueOverriden = false,
+    isShowPercentageOverriden = false,
 
-    valueLabel = defaultValueLabel,
-    showValue = defaultShowValue,
-    showPercentage = defaultShowPercentage,
+    valueLabel,
+    showValue,
+    showPercentage,
 
     onValueLabelChange,
     onToggleShowValue,
@@ -58,10 +58,14 @@ const ValueOptions: FC<ValueOptionsProps> = ({
     <>
         <Select
             label={inputLabel}
-            value={valueLabel}
-            data={Object.entries(PieChartValueLabels).map(([value, label]) => ({
+            value={isValueLabelOverriden ? 'mixed' : valueLabel}
+            data={[
+                ...(isValueLabelOverriden ? [['mixed', 'Mixed']] : []),
+                ...Object.entries(PieChartValueLabels),
+            ].map(([value, label]) => ({
                 value,
                 label,
+                disabled: value === 'mixed',
             }))}
             onChange={(newValueLabel: PieChartValueLabel) => {
                 onValueLabelChange(newValueLabel);
@@ -74,8 +78,9 @@ const ValueOptions: FC<ValueOptionsProps> = ({
             label={`Enable ${inputLabel} to configure this option`}
         >
             <div>
-                <Switch
+                <Checkbox
                     disabled={valueLabel === 'hidden'}
+                    indeterminate={isShowValueOverriden}
                     checked={showValue}
                     onChange={(newValue) =>
                         onToggleShowValue(newValue.currentTarget.checked)
@@ -91,8 +96,9 @@ const ValueOptions: FC<ValueOptionsProps> = ({
             label={`Enable ${inputLabel} to configure this option`}
         >
             <div>
-                <Switch
+                <Checkbox
                     disabled={valueLabel === 'hidden'}
+                    indeterminate={isShowPercentageOverriden}
                     checked={showPercentage}
                     onChange={(newValue) =>
                         onToggleShowPercentage(newValue.currentTarget.checked)
@@ -107,10 +113,6 @@ const ValueOptions: FC<ValueOptionsProps> = ({
 type GroupItemProps = {
     defaultColor: string;
     defaultLabel: string;
-
-    defaultValueLabel: PieChartValueLabel;
-    defaultShowValue: boolean;
-    defaultShowPercentage: boolean;
 
     swatches: string[];
 
@@ -132,10 +134,6 @@ type GroupItemProps = {
 const GroupItem: FC<GroupItemProps> = ({
     defaultLabel,
     defaultColor,
-
-    defaultValueLabel,
-    defaultShowValue,
-    defaultShowPercentage,
 
     swatches,
 
@@ -227,9 +225,6 @@ const GroupItem: FC<GroupItemProps> = ({
             <Collapse in={opened}>
                 <Stack pb="md" px="xxl">
                     <ValueOptions
-                        defaultValueLabel={defaultValueLabel}
-                        defaultShowValue={defaultShowValue}
-                        defaultShowPercentage={defaultShowPercentage}
                         inputLabel="Value label"
                         valueLabel={valueLabel}
                         onValueLabelChange={(newValue) =>
@@ -266,6 +261,9 @@ const PieChartSeriesConfig: FC = () => {
             toggleShowValue,
             showPercentage,
             toggleShowPercentage,
+            isValueLabelOverriden,
+            isShowValueOverriden,
+            isShowPercentageOverriden,
             groupLabels,
             groupLabelOverrides,
             groupLabelChange,
@@ -281,6 +279,9 @@ const PieChartSeriesConfig: FC = () => {
         <Stack>
             <ValueOptions
                 inputLabel="Value label"
+                isValueLabelOverriden={isValueLabelOverriden}
+                isShowValueOverriden={isShowValueOverriden}
+                isShowPercentageOverriden={isShowPercentageOverriden}
                 valueLabel={valueLabel}
                 onValueLabelChange={valueLabelChange}
                 showValue={showValue}
@@ -302,12 +303,20 @@ const PieChartSeriesConfig: FC = () => {
                             swatches={defaultColors}
                             defaultColor={groupColorDefaults[groupLabel]}
                             defaultLabel={groupLabel}
-                            defaultValueLabel={valueLabel}
-                            defaultShowValue={showValue}
-                            defaultShowPercentage={showPercentage}
                             color={groupColorOverrides[groupLabel]}
                             label={groupLabelOverrides[groupLabel]}
-                            {...groupValueOptionOverrides[groupLabel]}
+                            valueLabel={
+                                groupValueOptionOverrides[groupLabel]
+                                    ?.valueLabel ?? valueLabel
+                            }
+                            showValue={
+                                groupValueOptionOverrides[groupLabel]
+                                    ?.showValue ?? showValue
+                            }
+                            showPercentage={
+                                groupValueOptionOverrides[groupLabel]
+                                    ?.showPercentage ?? showPercentage
+                            }
                             onLabelChange={groupLabelChange}
                             onColorChange={groupColorChange}
                             onValueOptionsChange={groupValueOptionChange}

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -26,19 +26,31 @@ import { useVisualizationContext } from '../LightdashVisualization/Visualization
 
 type ValueOptionsProps = {
     inputLabel: string;
+
+    defaultValueLabel?: PieChartValueLabel;
+    defaultShowValue?: boolean;
+    defaultShowPercentage?: boolean;
+
     valueLabel: PieChartValueLabel;
-    onValueLabelChange: (newValueLabel: PieChartValueLabel) => void;
     showValue: boolean;
-    onToggleShowValue: (newValue: boolean) => void;
     showPercentage: boolean;
+
+    onValueLabelChange: (newValueLabel: PieChartValueLabel) => void;
+    onToggleShowValue: (newValue: boolean) => void;
     onToggleShowPercentage: (newValue: boolean) => void;
 };
 
 const ValueOptions: FC<ValueOptionsProps> = ({
     inputLabel,
-    valueLabel,
-    showValue,
-    showPercentage,
+
+    defaultShowPercentage,
+    defaultShowValue,
+    defaultValueLabel,
+
+    valueLabel = defaultValueLabel,
+    showValue = defaultShowValue,
+    showPercentage = defaultShowPercentage,
+
     onValueLabelChange,
     onToggleShowValue,
     onToggleShowPercentage,
@@ -93,10 +105,16 @@ const ValueOptions: FC<ValueOptionsProps> = ({
 );
 
 type GroupItemProps = {
-    swatches: string[];
     defaultColor: string;
-    color: string;
     defaultLabel: string;
+
+    defaultValueLabel: PieChartValueLabel;
+    defaultShowValue: boolean;
+    defaultShowPercentage: boolean;
+
+    swatches: string[];
+
+    color: string;
     label: string;
 
     valueLabel: PieChartValueLabel;
@@ -109,10 +127,16 @@ type GroupItemProps = {
 };
 
 const GroupItem: FC<GroupItemProps> = ({
-    swatches,
     defaultLabel,
-    label,
     defaultColor: _defaultColor,
+
+    defaultValueLabel,
+    defaultShowValue,
+    defaultShowPercentage,
+
+    swatches,
+
+    label,
     color,
 
     valueLabel,
@@ -197,6 +221,9 @@ const GroupItem: FC<GroupItemProps> = ({
             <Collapse in={opened}>
                 <Stack pb="md" px="xxl">
                     <ValueOptions
+                        defaultValueLabel={defaultValueLabel}
+                        defaultShowValue={defaultShowValue}
+                        defaultShowPercentage={defaultShowPercentage}
                         inputLabel="Value label"
                         valueLabel={valueLabel}
                         onValueLabelChange={(newValue) =>
@@ -270,8 +297,11 @@ const PieChartSeriesConfig: FC = () => {
                                 key={groupLabel}
                                 swatches={defaultColors}
                                 defaultColor={groupColorDefaults[groupLabel]}
-                                color={color}
                                 defaultLabel={groupLabel}
+                                defaultValueLabel={valueLabel}
+                                defaultShowValue={showValue}
+                                defaultShowPercentage={showPercentage}
+                                color={color}
                                 label={groupLabelOverrides[groupLabel] ?? ''}
                                 {...valueOptions}
                                 onLabelChange={(newLabel) => {

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -25,8 +25,6 @@ import MantineIcon from '../common/MantineIcon';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 
 type ValueOptionsProps = {
-    inputLabel: string;
-
     isValueLabelOverriden?: boolean;
     isShowValueOverriden?: boolean;
     isShowPercentageOverriden?: boolean;
@@ -41,8 +39,6 @@ type ValueOptionsProps = {
 };
 
 const ValueOptions: FC<ValueOptionsProps> = ({
-    inputLabel,
-
     isValueLabelOverriden = false,
     isShowValueOverriden = false,
     isShowPercentageOverriden = false,
@@ -57,7 +53,7 @@ const ValueOptions: FC<ValueOptionsProps> = ({
 }) => (
     <>
         <Select
-            label={inputLabel}
+            label="Value label"
             value={isValueLabelOverriden ? 'mixed' : valueLabel}
             data={[
                 ...(isValueLabelOverriden ? [['mixed', 'Mixed']] : []),
@@ -75,7 +71,7 @@ const ValueOptions: FC<ValueOptionsProps> = ({
         <Tooltip
             position="top-start"
             disabled={valueLabel !== 'hidden'}
-            label={`Enable ${inputLabel} to configure this option`}
+            label="Enable Value label to configure this option"
         >
             <div>
                 <Checkbox
@@ -93,7 +89,7 @@ const ValueOptions: FC<ValueOptionsProps> = ({
         <Tooltip
             position="top-start"
             disabled={valueLabel !== 'hidden'}
-            label={`Enable ${inputLabel} to configure this option`}
+            label="Enable Value label to configure this option"
         >
             <div>
                 <Checkbox
@@ -215,17 +211,18 @@ const GroupItem: FC<GroupItemProps> = ({
                     }}
                 />
 
-                <ActionIcon onClick={toggle} size="sm">
-                    <MantineIcon
-                        icon={opened ? IconChevronUp : IconChevronDown}
-                    />
-                </ActionIcon>
+                <Tooltip label="Override value label options">
+                    <ActionIcon onClick={toggle} size="sm">
+                        <MantineIcon
+                            icon={opened ? IconChevronUp : IconChevronDown}
+                        />
+                    </ActionIcon>
+                </Tooltip>
             </Group>
 
             <Collapse in={opened}>
-                <Stack pb="md" px="xxl">
+                <Stack pb="md" px="xxl" spacing="sm">
                     <ValueOptions
-                        inputLabel="Value label"
                         valueLabel={valueLabel}
                         onValueLabelChange={(newValue) =>
                             onValueOptionsChange(defaultLabel, {
@@ -278,7 +275,6 @@ const PieChartSeriesConfig: FC = () => {
     return (
         <Stack>
             <ValueOptions
-                inputLabel="Value label"
                 isValueLabelOverriden={isValueLabelOverriden}
                 isShowValueOverriden={isShowValueOverriden}
                 isShowPercentageOverriden={isShowPercentageOverriden}

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -7,7 +7,9 @@ import {
     Popover,
     Select,
     Stack,
+    Switch,
     TextInput,
+    Tooltip,
 } from '@mantine/core';
 import { IconHash } from '@tabler/icons-react';
 import React from 'react';
@@ -21,6 +23,10 @@ const PieChartSeriesConfig: React.FC = () => {
             defaultColors,
             valueLabel,
             valueLabelChange,
+            showValue,
+            toggleShowValue,
+            showPercentage,
+            toggleShowPercentage,
             groupLabels,
             groupLabelOverrides,
             groupLabelChange,
@@ -45,6 +51,36 @@ const PieChartSeriesConfig: React.FC = () => {
                     valueLabelChange(newValueLabel);
                 }}
             />
+
+            <Tooltip
+                position="top-start"
+                disabled={valueLabel !== 'hidden'}
+                label="Enable value labels to configure this option"
+            >
+                <div>
+                    <Switch
+                        disabled={valueLabel === 'hidden'}
+                        checked={showValue}
+                        onChange={toggleShowValue}
+                        label="Show value"
+                    />
+                </div>
+            </Tooltip>
+
+            <Tooltip
+                position="top-start"
+                disabled={valueLabel !== 'hidden'}
+                label="Enable value labels to configure this option"
+            >
+                <div>
+                    <Switch
+                        disabled={valueLabel === 'hidden'}
+                        checked={showPercentage}
+                        onChange={toggleShowPercentage}
+                        label="Show percentage"
+                    />
+                </div>
+            </Tooltip>
 
             {groupLabels.length === 0 ? null : (
                 <Stack

--- a/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/PieChartConfig/PieChartSeriesConfig.tsx
@@ -42,61 +42,55 @@ const ValueOptions: FC<ValueOptionsProps> = ({
     onValueLabelChange,
     onToggleShowValue,
     onToggleShowPercentage,
-}) => {
-    return (
-        <>
-            <Select
-                label={inputLabel}
-                value={valueLabel}
-                data={Object.entries(PieChartValueLabels).map(
-                    ([value, label]) => ({
-                        value,
-                        label,
-                    }),
-                )}
-                onChange={(newValueLabel: PieChartValueLabel) => {
-                    onValueLabelChange(newValueLabel);
-                }}
-            />
+}) => (
+    <>
+        <Select
+            label={inputLabel}
+            value={valueLabel}
+            data={Object.entries(PieChartValueLabels).map(([value, label]) => ({
+                value,
+                label,
+            }))}
+            onChange={(newValueLabel: PieChartValueLabel) => {
+                onValueLabelChange(newValueLabel);
+            }}
+        />
 
-            <Tooltip
-                position="top-start"
-                disabled={valueLabel !== 'hidden'}
-                label="Enable value labels to configure this option"
-            >
-                <div>
-                    <Switch
-                        disabled={valueLabel === 'hidden'}
-                        checked={showValue}
-                        onChange={(newValue) =>
-                            onToggleShowValue(newValue.currentTarget.checked)
-                        }
-                        label="Show value"
-                    />
-                </div>
-            </Tooltip>
+        <Tooltip
+            position="top-start"
+            disabled={valueLabel !== 'hidden'}
+            label={`Enable ${inputLabel} to configure this option`}
+        >
+            <div>
+                <Switch
+                    disabled={valueLabel === 'hidden'}
+                    checked={showValue}
+                    onChange={(newValue) =>
+                        onToggleShowValue(newValue.currentTarget.checked)
+                    }
+                    label="Show value"
+                />
+            </div>
+        </Tooltip>
 
-            <Tooltip
-                position="top-start"
-                disabled={valueLabel !== 'hidden'}
-                label="Enable value labels to configure this option"
-            >
-                <div>
-                    <Switch
-                        disabled={valueLabel === 'hidden'}
-                        checked={showPercentage}
-                        onChange={(newValue) =>
-                            onToggleShowPercentage(
-                                newValue.currentTarget.checked,
-                            )
-                        }
-                        label="Show percentage"
-                    />
-                </div>
-            </Tooltip>
-        </>
-    );
-};
+        <Tooltip
+            position="top-start"
+            disabled={valueLabel !== 'hidden'}
+            label={`Enable ${inputLabel} to configure this option`}
+        >
+            <div>
+                <Switch
+                    disabled={valueLabel === 'hidden'}
+                    checked={showPercentage}
+                    onChange={(newValue) =>
+                        onToggleShowPercentage(newValue.currentTarget.checked)
+                    }
+                    label="Show percentage"
+                />
+            </div>
+        </Tooltip>
+    </>
+);
 
 type GroupItemProps = {
     swatches: string[];

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -1,5 +1,25 @@
+import { PieChartValueOptions } from '@lightdash/common';
 import { useMemo } from 'react';
 import { useVisualizationContext } from '../../components/LightdashVisualization/VisualizationProvider';
+
+const getLabelOptions = ({
+    valueLabel,
+    showValue,
+    showPercentage,
+}: Partial<PieChartValueOptions>) => {
+    return {
+        show: valueLabel !== 'hidden',
+        position: valueLabel,
+        formatter:
+            valueLabel !== 'hidden' && showValue && showPercentage
+                ? '{d}% - {c}'
+                : showValue
+                ? '{c}'
+                : showPercentage
+                ? '{d}%'
+                : undefined,
+    };
+};
 
 const useEchartsPieConfig = () => {
     const context = useVisualizationContext();
@@ -15,6 +35,7 @@ const useEchartsPieConfig = () => {
                 showPercentage,
                 groupLabelOverrides,
                 groupColorOverrides,
+                groupValueOptionOverrides,
                 showLegend,
             },
         },
@@ -58,6 +79,9 @@ const useEchartsPieConfig = () => {
                             groupColorOverrides?.[name] ??
                             groupColorDefaults?.[name],
                     },
+                    label: groupValueOptionOverrides?.[name]
+                        ? getLabelOptions(groupValueOptionOverrides[name])
+                        : undefined,
                 };
             });
     }, [
@@ -66,6 +90,7 @@ const useEchartsPieConfig = () => {
         resultsData,
         groupLabelOverrides,
         groupColorOverrides,
+        groupValueOptionOverrides,
         groupColorDefaults,
     ]);
 
@@ -91,20 +116,11 @@ const useEchartsPieConfig = () => {
                             : showLegend
                             ? ['50%', '52%']
                             : ['50%', '50%'],
-                    label: {
-                        show: valueLabel !== 'hidden',
-                        position: valueLabel,
-                        formatter:
-                            valueLabel !== 'hidden' &&
-                            showValue &&
-                            showPercentage
-                                ? '{d}% - {c}'
-                                : showValue
-                                ? '{c}'
-                                : showPercentage
-                                ? '{d}%'
-                                : undefined,
-                    },
+                    label: getLabelOptions({
+                        valueLabel,
+                        showValue,
+                        showPercentage,
+                    }),
                     data,
                 },
             ],

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -8,11 +8,11 @@ const getLabelOptions = ({
     showPercentage,
 }: Partial<PieChartValueOptions>) => {
     return {
-        show: valueLabel !== 'hidden',
+        show: valueLabel !== 'hidden' && (showValue || showPercentage),
         position: valueLabel,
         formatter:
             valueLabel !== 'hidden' && showValue && showPercentage
-                ? '{d}% - {c}'
+                ? '{c} - {d}%'
                 : showValue
                 ? '{c}'
                 : showPercentage
@@ -79,15 +79,26 @@ const useEchartsPieConfig = () => {
                             groupColorOverrides?.[name] ??
                             groupColorDefaults?.[name],
                     },
-                    label: groupValueOptionOverrides?.[name]
-                        ? getLabelOptions(groupValueOptionOverrides[name])
-                        : undefined,
+                    label: getLabelOptions({
+                        valueLabel:
+                            groupValueOptionOverrides?.[name]?.valueLabel ??
+                            valueLabel,
+                        showValue:
+                            groupValueOptionOverrides?.[name]?.showValue ??
+                            showValue,
+                        showPercentage:
+                            groupValueOptionOverrides?.[name]?.showPercentage ??
+                            showPercentage,
+                    }),
                 };
             });
     }, [
+        resultsData,
         groupFieldIds,
         metricId,
-        resultsData,
+        showPercentage,
+        showValue,
+        valueLabel,
         groupLabelOverrides,
         groupColorOverrides,
         groupValueOptionOverrides,
@@ -116,16 +127,11 @@ const useEchartsPieConfig = () => {
                             : showLegend
                             ? ['50%', '52%']
                             : ['50%', '50%'],
-                    label: getLabelOptions({
-                        valueLabel,
-                        showValue,
-                        showPercentage,
-                    }),
                     data,
                 },
             ],
         }),
-        [data, isDonut, valueLabel, showLegend, showValue, showPercentage],
+        [data, isDonut, valueLabel, showLegend],
     );
 
     if (!explore || !data || data.length === 0) {

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -95,7 +95,9 @@ const useEchartsPieConfig = () => {
                         show: valueLabel !== 'hidden',
                         position: valueLabel,
                         formatter:
-                            showValue && showPercentage
+                            valueLabel !== 'hidden' &&
+                            showValue &&
+                            showPercentage
                                 ? '{d}% - {c}'
                                 : showValue
                                 ? '{c}'

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -12,7 +12,7 @@ const getLabelOptions = ({
         position: valueLabel,
         formatter:
             valueLabel !== 'hidden' && showValue && showPercentage
-                ? '{c} - {d}%'
+                ? '{d}% - {c}'
                 : showValue
                 ? '{c}'
                 : showPercentage
@@ -71,6 +71,18 @@ const useEchartsPieConfig = () => {
         )
             .sort((a, b) => b[1] - a[1])
             .map(([name, value]) => {
+                const labelOptions = getLabelOptions({
+                    valueLabel:
+                        groupValueOptionOverrides?.[name]?.valueLabel ??
+                        valueLabel,
+                    showValue:
+                        groupValueOptionOverrides?.[name]?.showValue ??
+                        showValue,
+                    showPercentage:
+                        groupValueOptionOverrides?.[name]?.showPercentage ??
+                        showPercentage,
+                });
+
                 return {
                     name: groupLabelOverrides?.[name] ?? name,
                     value,
@@ -79,17 +91,8 @@ const useEchartsPieConfig = () => {
                             groupColorOverrides?.[name] ??
                             groupColorDefaults?.[name],
                     },
-                    label: getLabelOptions({
-                        valueLabel:
-                            groupValueOptionOverrides?.[name]?.valueLabel ??
-                            valueLabel,
-                        showValue:
-                            groupValueOptionOverrides?.[name]?.showValue ??
-                            showValue,
-                        showPercentage:
-                            groupValueOptionOverrides?.[name]?.showPercentage ??
-                            showPercentage,
-                    }),
+                    label: labelOptions,
+                    tooltip: { ...labelOptions, position: undefined },
                 };
             });
     }, [
@@ -116,13 +119,14 @@ const useEchartsPieConfig = () => {
                 left: 'center',
                 type: 'scroll',
             },
-
             series: [
                 {
                     type: 'pie',
                     radius: isDonut ? ['30%', '70%'] : '70%',
                     center:
-                        showLegend && valueLabel === 'outside'
+                        showLegend &&
+                        valueLabel === 'outside' &&
+                        (showValue || showPercentage)
                             ? ['50%', '55%']
                             : showLegend
                             ? ['50%', '52%']
@@ -131,7 +135,7 @@ const useEchartsPieConfig = () => {
                 },
             ],
         }),
-        [data, isDonut, valueLabel, showLegend],
+        [data, isDonut, valueLabel, showValue, showPercentage, showLegend],
     );
 
     if (!explore || !data || data.length === 0) {

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -7,8 +7,10 @@ const getLabelOptions = ({
     showValue,
     showPercentage,
 }: Partial<PieChartValueOptions>) => {
-    return {
-        show: valueLabel !== 'hidden' && (showValue || showPercentage),
+    const show = valueLabel !== 'hidden' && (showValue || showPercentage);
+
+    const labelConfig = {
+        show,
         position: valueLabel,
         formatter:
             valueLabel !== 'hidden' && showValue && showPercentage
@@ -18,6 +20,12 @@ const getLabelOptions = ({
                 : showPercentage
                 ? '{d}%'
                 : undefined,
+    };
+
+    return {
+        label: labelConfig,
+        labelLine: { show: show && valueLabel === 'outside' },
+        tooltip: { ...labelConfig, position: undefined },
     };
 };
 
@@ -91,8 +99,7 @@ const useEchartsPieConfig = () => {
                             groupColorOverrides?.[name] ??
                             groupColorDefaults?.[name],
                     },
-                    label: labelOptions,
-                    tooltip: { ...labelOptions, position: undefined },
+                    ...labelOptions,
                 };
             });
     }, [

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -11,9 +11,11 @@ const useEchartsPieConfig = () => {
                 metricId,
                 isDonut,
                 valueLabel,
-                showLegend,
+                showValue,
+                showPercentage,
                 groupLabelOverrides,
                 groupColorOverrides,
+                showLegend,
             },
         },
         explore,
@@ -92,13 +94,20 @@ const useEchartsPieConfig = () => {
                     label: {
                         show: valueLabel !== 'hidden',
                         position: valueLabel,
-                        formatter: '{b}\n {d}%',
+                        formatter:
+                            showValue && showPercentage
+                                ? '{d}% - {c}'
+                                : showValue
+                                ? '{c}'
+                                : showPercentage
+                                ? '{d}%'
+                                : undefined,
                     },
                     data,
                 },
             ],
         }),
-        [data, isDonut, valueLabel, showLegend],
+        [data, isDonut, valueLabel, showLegend, showValue, showPercentage],
     );
 
     if (!explore || !data || data.length === 0) {

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -39,6 +39,11 @@ type PieChartConfig = {
     valueLabel: PieChartValueLabel;
     valueLabelChange: (valueLabel: PieChartValueLabel) => void;
 
+    showValue: boolean;
+    toggleShowValue: () => void;
+    showPercentage: boolean;
+    toggleShowPercentage: () => void;
+
     defaultColors: string[];
 
     groupLabels: string[];
@@ -77,6 +82,14 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const [valueLabel, setValueLabel] = useState<PieChartValueLabel>(
         pieChartConfig?.valueLabel ?? 'hidden',
+    );
+
+    const [showValue, setShowValue] = useState<boolean>(
+        pieChartConfig?.showValue ?? false,
+    );
+
+    const [showPercentage, setShowPercentage] = useState<boolean>(
+        pieChartConfig?.showPercentage ?? false,
     );
 
     const [groupLabelOverrides, setGroupLabelOverrides] = useState(
@@ -148,6 +161,14 @@ const usePieChartConfig: PieChartConfigFn = (
 
         setMetricId(allNumericMetricIds[0] ?? null);
     }, [isLoading, allNumericMetricIds, metricId, pieChartConfig?.metricId]);
+
+    const handleValueLabelChange = useCallback((value) => {
+        if (value === 'hidden') {
+            setShowValue(false);
+            setShowPercentage(false);
+        }
+        setValueLabel(value);
+    }, []);
 
     const handleGroupChange = useCallback((prevValue, newValue) => {
         setGroupFieldIds((prev) => {
@@ -223,7 +244,8 @@ const usePieChartConfig: PieChartConfigFn = (
             groupFieldIds,
             metricId: metricId ?? undefined,
             valueLabel,
-            showLegend,
+            showValue,
+            showPercentage,
             groupLabelOverrides: pick(
                 debouncedGroupLabelOverrides,
                 groupLabels,
@@ -233,17 +255,20 @@ const usePieChartConfig: PieChartConfigFn = (
                 (color, label) =>
                     isHexCodeColor(color) ? color : groupColorDefaults[label],
             ),
+            showLegend,
         }),
         [
             isDonut,
             groupFieldIds,
             metricId,
             valueLabel,
-            showLegend,
+            showValue,
+            showPercentage,
             groupLabels,
             debouncedGroupLabelOverrides,
             groupColorDefaults,
             debouncedGroupColorOverrides,
+            showLegend,
         ],
     );
 
@@ -263,7 +288,12 @@ const usePieChartConfig: PieChartConfigFn = (
             toggleDonut: () => setIsDonut((prev) => !prev),
 
             valueLabel,
-            valueLabelChange: setValueLabel,
+            valueLabelChange: handleValueLabelChange,
+
+            showValue,
+            toggleShowValue: () => setShowValue((prev) => !prev),
+            showPercentage,
+            toggleShowPercentage: () => setShowPercentage((prev) => !prev),
 
             defaultColors,
 
@@ -290,6 +320,10 @@ const usePieChartConfig: PieChartConfigFn = (
             isDonut,
 
             valueLabel,
+            handleValueLabelChange,
+
+            showValue,
+            showPercentage,
 
             defaultColors,
 

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -10,7 +10,7 @@ import {
     isMetric,
     Metric,
     PieChart,
-    PieChartLabelOptions,
+    PieChartValueOptions,
     TableCalculation,
 } from '@lightdash/common';
 import { useDebouncedValue } from '@mantine/hooks';
@@ -36,12 +36,12 @@ type PieChartConfig = {
     isDonut: boolean;
     toggleDonut: () => void;
 
-    valueLabel: PieChartLabelOptions['valueLabel'];
-    valueLabelChange: (valueLabel: PieChartLabelOptions['valueLabel']) => void;
+    valueLabel: PieChartValueOptions['valueLabel'];
+    valueLabelChange: (valueLabel: PieChartValueOptions['valueLabel']) => void;
 
-    showValue: PieChartLabelOptions['showValue'];
+    showValue: PieChartValueOptions['showValue'];
     toggleShowValue: () => void;
-    showPercentage: PieChartLabelOptions['showPercentage'];
+    showPercentage: PieChartValueOptions['showPercentage'];
     toggleShowPercentage: () => void;
 
     defaultColors: string[];
@@ -52,7 +52,11 @@ type PieChartConfig = {
     groupColorOverrides: Record<string, string>;
     groupColorDefaults: Record<string, string>;
     groupColorChange: (prevValue: any, newValue: any) => void;
-    groupLabelOptionOverrides: Record<string, PieChartLabelOptions>;
+    groupValueOptionOverrides: Record<string, PieChartValueOptions>;
+    groupValueOptionChange: (
+        label: string,
+        value: Partial<PieChartValueOptions>,
+    ) => void;
 
     showLegend: boolean;
     toggleShowLegend: () => void;
@@ -109,8 +113,8 @@ const usePieChartConfig: PieChartConfigFn = (
         500,
     );
 
-    const [groupLabelOptionOverrides, setGroupLabelOptionOverrides] = useState(
-        pieChartConfig?.groupLabelOptionOverrides ?? {},
+    const [groupValueOptionOverrides, setGroupValueOptionOverrides] = useState(
+        pieChartConfig?.groupValueOptionOverrides ?? {},
     );
 
     const [showLegend, setShowLegend] = useState(
@@ -213,9 +217,9 @@ const usePieChartConfig: PieChartConfigFn = (
         });
     }, []);
 
-    const handleGroupLabelOptionChange = useCallback(
-        (label: string, value: Partial<PieChartLabelOptions>) => {
-            setGroupLabelOptionOverrides((prev) => {
+    const handleGroupValueOptionChange = useCallback(
+        (label: string, value: Partial<PieChartValueOptions>) => {
+            setGroupValueOptionOverrides((prev) => {
                 return { ...prev, [label]: { ...prev[label], ...value } };
             });
         },
@@ -314,8 +318,8 @@ const usePieChartConfig: PieChartConfigFn = (
             groupColorOverrides,
             groupColorDefaults,
             groupColorChange: handleGroupColorChange,
-            groupLabelOptionOverrides,
-            groupLabelOptionChange: handleGroupLabelOptionChange,
+            groupValueOptionOverrides,
+            groupValueOptionChange: handleGroupValueOptionChange,
 
             showLegend,
             toggleShowLegend: () => setShowLegend((prev) => !prev),
@@ -345,8 +349,8 @@ const usePieChartConfig: PieChartConfigFn = (
             groupColorOverrides,
             groupColorDefaults,
             handleGroupColorChange,
-            groupLabelOptionOverrides,
-            handleGroupLabelOptionChange,
+            groupValueOptionOverrides,
+            handleGroupValueOptionChange,
 
             showLegend,
         ],

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -79,6 +79,10 @@ const usePieChartConfig: PieChartConfigFn = (
 ) => {
     const { data } = useOrganization();
 
+    const [groupFieldIds, setGroupFieldIds] = useState(
+        pieChartConfig?.groupFieldIds ?? [],
+    );
+
     const [metricId, setMetricId] = useState(pieChartConfig?.metricId ?? null);
 
     const [isDonut, setIsDonut] = useState(pieChartConfig?.isDonut ?? true);
@@ -138,10 +142,6 @@ const usePieChartConfig: PieChartConfigFn = (
         [allNumericMetrics],
     );
 
-    const [groupFieldIds, setGroupFieldIds] = useState<string[]>(
-        pieChartConfig?.groupFieldIds ?? [],
-    );
-
     const isLoading = !explore || !resultsData;
 
     useEffect(() => {
@@ -169,22 +169,17 @@ const usePieChartConfig: PieChartConfigFn = (
         setMetricId(allNumericMetricIds[0] ?? null);
     }, [isLoading, allNumericMetricIds, metricId, pieChartConfig?.metricId]);
 
-    const handleValueLabelChange = useCallback((value) => {
-        if (value === 'hidden') {
-            setShowValue(false);
-            setShowPercentage(false);
-        }
-        setValueLabel(value);
-    }, []);
-
-    const handleGroupChange = useCallback((prevValue, newValue) => {
-        setGroupFieldIds((prev) => {
-            const newSet = new Set(prev);
-            newSet.delete(prevValue);
-            newSet.add(newValue);
-            return [...newSet.values()];
-        });
-    }, []);
+    const handleGroupChange = useCallback(
+        (prevValue: string, newValue: string) => {
+            setGroupFieldIds((prev) => {
+                const newSet = new Set(prev);
+                newSet.delete(prevValue);
+                newSet.add(newValue);
+                return [...newSet.values()];
+            });
+        },
+        [],
+    );
 
     const handleGroupAdd = useCallback(() => {
         setGroupFieldIds((prev) => {
@@ -197,7 +192,7 @@ const usePieChartConfig: PieChartConfigFn = (
         });
     }, [dimensionIds]);
 
-    const handleRemoveGroup = useCallback((dimensionId) => {
+    const handleRemoveGroup = useCallback((dimensionId: string) => {
         setGroupFieldIds((prev) => {
             const newSet = new Set(prev);
             newSet.delete(dimensionId);
@@ -205,15 +200,15 @@ const usePieChartConfig: PieChartConfigFn = (
         });
     }, []);
 
-    const handleGroupLabelChange = useCallback((key, value) => {
-        setGroupLabelOverrides((prev) => {
-            return { ...prev, [key]: value === '' ? undefined : value };
+    const handleGroupLabelChange = useCallback((key: string, value: string) => {
+        setGroupLabelOverrides(({ [key]: _, ...rest }) => {
+            return value === '' ? rest : { ...rest, [key]: value };
         });
     }, []);
 
-    const handleGroupColorChange = useCallback((key, value) => {
-        setGroupColorOverrides((prev) => {
-            return { ...prev, [key]: value === '' ? undefined : value };
+    const handleGroupColorChange = useCallback((key: string, value: string) => {
+        setGroupColorOverrides(({ [key]: _, ...rest }) => {
+            return value === '' ? rest : { ...rest, [key]: value };
         });
     }, []);
 
@@ -304,7 +299,7 @@ const usePieChartConfig: PieChartConfigFn = (
             toggleDonut: () => setIsDonut((prev) => !prev),
 
             valueLabel,
-            valueLabelChange: handleValueLabelChange,
+            valueLabelChange: setValueLabel,
             showValue,
             toggleShowValue: () => setShowValue((prev) => !prev),
             showPercentage,
@@ -337,7 +332,7 @@ const usePieChartConfig: PieChartConfigFn = (
             isDonut,
 
             valueLabel,
-            handleValueLabelChange,
+            setValueLabel,
             showValue,
             showPercentage,
 

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -14,8 +14,9 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { useDebouncedValue } from '@mantine/hooks';
+import isEmpty from 'lodash-es/isEmpty';
 import isEqual from 'lodash-es/isEqual';
-import mapValues from 'lodash-es/mapValues';
+import omitBy from 'lodash-es/omitBy';
 import pick from 'lodash-es/pick';
 import uniq from 'lodash-es/uniq';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -261,10 +262,13 @@ const usePieChartConfig: PieChartConfigFn = (
                 debouncedGroupLabelOverrides,
                 groupLabels,
             ),
-            groupColorOverrides: mapValues(
+            groupColorOverrides: omitBy(
                 pick(debouncedGroupColorOverrides, groupLabels),
-                (color, label) =>
-                    isHexCodeColor(color) ? color : groupColorDefaults[label],
+                isHexCodeColor,
+            ),
+            groupValueOptionOverrides: omitBy(
+                pick(groupValueOptionOverrides, groupLabels),
+                isEmpty,
             ),
             showLegend,
         }),
@@ -277,8 +281,8 @@ const usePieChartConfig: PieChartConfigFn = (
             showPercentage,
             groupLabels,
             debouncedGroupLabelOverrides,
-            groupColorDefaults,
             debouncedGroupColorOverrides,
+            groupValueOptionOverrides,
             showLegend,
         ],
     );

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -10,7 +10,7 @@ import {
     isMetric,
     Metric,
     PieChart,
-    PieChartValueLabel,
+    PieChartLabelOptions,
     TableCalculation,
 } from '@lightdash/common';
 import { useDebouncedValue } from '@mantine/hooks';
@@ -36,12 +36,12 @@ type PieChartConfig = {
     isDonut: boolean;
     toggleDonut: () => void;
 
-    valueLabel: PieChartValueLabel;
-    valueLabelChange: (valueLabel: PieChartValueLabel) => void;
+    valueLabel: PieChartLabelOptions['valueLabel'];
+    valueLabelChange: (valueLabel: PieChartLabelOptions['valueLabel']) => void;
 
-    showValue: boolean;
+    showValue: PieChartLabelOptions['showValue'];
     toggleShowValue: () => void;
-    showPercentage: boolean;
+    showPercentage: PieChartLabelOptions['showPercentage'];
     toggleShowPercentage: () => void;
 
     defaultColors: string[];
@@ -52,6 +52,7 @@ type PieChartConfig = {
     groupColorOverrides: Record<string, string>;
     groupColorDefaults: Record<string, string>;
     groupColorChange: (prevValue: any, newValue: any) => void;
+    groupLabelOptionOverrides: Record<string, PieChartLabelOptions>;
 
     showLegend: boolean;
     toggleShowLegend: () => void;
@@ -76,19 +77,17 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const [metricId, setMetricId] = useState(pieChartConfig?.metricId ?? null);
 
-    const [isDonut, setIsDonut] = useState<boolean>(
-        pieChartConfig?.isDonut ?? true,
-    );
+    const [isDonut, setIsDonut] = useState(pieChartConfig?.isDonut ?? true);
 
-    const [valueLabel, setValueLabel] = useState<PieChartValueLabel>(
+    const [valueLabel, setValueLabel] = useState(
         pieChartConfig?.valueLabel ?? 'hidden',
     );
 
-    const [showValue, setShowValue] = useState<boolean>(
+    const [showValue, setShowValue] = useState(
         pieChartConfig?.showValue ?? false,
     );
 
-    const [showPercentage, setShowPercentage] = useState<boolean>(
+    const [showPercentage, setShowPercentage] = useState(
         pieChartConfig?.showPercentage ?? false,
     );
 
@@ -110,7 +109,11 @@ const usePieChartConfig: PieChartConfigFn = (
         500,
     );
 
-    const [showLegend, setShowLegend] = useState<boolean>(
+    const [groupLabelOptionOverrides, setGroupLabelOptionOverrides] = useState(
+        pieChartConfig?.groupLabelOptionOverrides ?? {},
+    );
+
+    const [showLegend, setShowLegend] = useState(
         pieChartConfig?.showLegend ?? true,
     );
 
@@ -210,6 +213,15 @@ const usePieChartConfig: PieChartConfigFn = (
         });
     }, []);
 
+    const handleGroupLabelOptionChange = useCallback(
+        (label: string, value: Partial<PieChartLabelOptions>) => {
+            setGroupLabelOptionOverrides((prev) => {
+                return { ...prev, [label]: { ...prev[label], ...value } };
+            });
+        },
+        [],
+    );
+
     const groupLabels = useMemo(() => {
         if (
             !resultsData ||
@@ -289,7 +301,6 @@ const usePieChartConfig: PieChartConfigFn = (
 
             valueLabel,
             valueLabelChange: handleValueLabelChange,
-
             showValue,
             toggleShowValue: () => setShowValue((prev) => !prev),
             showPercentage,
@@ -303,6 +314,8 @@ const usePieChartConfig: PieChartConfigFn = (
             groupColorOverrides,
             groupColorDefaults,
             groupColorChange: handleGroupColorChange,
+            groupLabelOptionOverrides,
+            groupLabelOptionChange: handleGroupLabelOptionChange,
 
             showLegend,
             toggleShowLegend: () => setShowLegend((prev) => !prev),
@@ -321,7 +334,6 @@ const usePieChartConfig: PieChartConfigFn = (
 
             valueLabel,
             handleValueLabelChange,
-
             showValue,
             showPercentage,
 
@@ -333,6 +345,8 @@ const usePieChartConfig: PieChartConfigFn = (
             groupColorOverrides,
             groupColorDefaults,
             handleGroupColorChange,
+            groupLabelOptionOverrides,
+            handleGroupLabelOptionChange,
 
             showLegend,
         ],

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -33,6 +33,7 @@ type PieChartConfig = {
     groupRemove: (dimensionId: any) => void;
 
     metricId: string | null;
+    selectedMetric: Metric | AdditionalMetric | TableCalculation | undefined;
     metricChange: (metricId: string | null) => void;
 
     isDonut: boolean;
@@ -143,6 +144,12 @@ const usePieChartConfig: PieChartConfigFn = (
             ),
         [allNumericMetrics],
     );
+
+    const selectedMetric = useMemo(() => {
+        return allNumericMetrics.find((m) =>
+            isField(m) ? fieldId(m) === metricId : m.name === metricId,
+        );
+    }, [allNumericMetrics, metricId]);
 
     const isLoading = !explore || !resultsData;
 
@@ -297,6 +304,7 @@ const usePieChartConfig: PieChartConfigFn = (
             groupChange: handleGroupChange,
             groupRemove: handleRemoveGroup,
 
+            selectedMetric,
             metricId,
             metricChange: setMetricId,
 
@@ -332,6 +340,7 @@ const usePieChartConfig: PieChartConfigFn = (
             handleGroupChange,
             handleRemoveGroup,
 
+            selectedMetric,
             metricId,
 
             isDonut,

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -16,6 +16,7 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import isEmpty from 'lodash-es/isEmpty';
 import isEqual from 'lodash-es/isEqual';
+import mapValues from 'lodash-es/mapValues';
 import omitBy from 'lodash-es/omitBy';
 import pick from 'lodash-es/pick';
 import pickBy from 'lodash-es/pickBy';
@@ -41,11 +42,14 @@ type PieChartConfig = {
 
     valueLabel: PieChartValueOptions['valueLabel'];
     valueLabelChange: (valueLabel: PieChartValueOptions['valueLabel']) => void;
-
     showValue: PieChartValueOptions['showValue'];
     toggleShowValue: () => void;
     showPercentage: PieChartValueOptions['showPercentage'];
     toggleShowPercentage: () => void;
+
+    isValueLabelOverriden: boolean;
+    isShowValueOverriden: boolean;
+    isShowPercentageOverriden: boolean;
 
     defaultColors: string[];
 
@@ -55,7 +59,7 @@ type PieChartConfig = {
     groupColorOverrides: Record<string, string>;
     groupColorDefaults: Record<string, string>;
     groupColorChange: (prevValue: any, newValue: any) => void;
-    groupValueOptionOverrides: Record<string, PieChartValueOptions>;
+    groupValueOptionOverrides: Record<string, Partial<PieChartValueOptions>>;
     groupValueOptionChange: (
         label: string,
         value: Partial<PieChartValueOptions>,
@@ -209,6 +213,33 @@ const usePieChartConfig: PieChartConfigFn = (
         });
     }, []);
 
+    const handleValueLabelChange = useCallback(
+        (newValueLabel: PieChartValueOptions['valueLabel']) => {
+            setValueLabel(newValueLabel);
+
+            setGroupValueOptionOverrides((prev) =>
+                mapValues(prev, ({ valueLabel: _, ...rest }) => ({ ...rest })),
+            );
+        },
+        [],
+    );
+
+    const handleToggleShowValue = useCallback(() => {
+        setShowValue((prev) => !prev);
+
+        setGroupValueOptionOverrides((prev) =>
+            mapValues(prev, ({ showValue: _, ...rest }) => ({ ...rest })),
+        );
+    }, []);
+
+    const handleToggleShowPercentage = useCallback(() => {
+        setShowPercentage((prev) => !prev);
+
+        setGroupValueOptionOverrides((prev) =>
+            mapValues(prev, ({ showPercentage: _, ...rest }) => ({ ...rest })),
+        );
+    }, []);
+
     const handleGroupLabelChange = useCallback((key: string, value: string) => {
         setGroupLabelOverrides(({ [key]: _, ...rest }) => {
             return value === '' ? rest : { ...rest, [key]: value };
@@ -257,6 +288,24 @@ const usePieChartConfig: PieChartConfigFn = (
             ]),
         );
     }, [groupLabels, defaultColors]);
+
+    const isValueLabelOverriden = useMemo(() => {
+        return Object.values(groupValueOptionOverrides).some(
+            (value) => value.valueLabel !== undefined,
+        );
+    }, [groupValueOptionOverrides]);
+
+    const isShowValueOverriden = useMemo(() => {
+        return Object.values(groupValueOptionOverrides).some(
+            (value) => value.showValue !== undefined,
+        );
+    }, [groupValueOptionOverrides]);
+
+    const isShowPercentageOverriden = useMemo(() => {
+        return Object.values(groupValueOptionOverrides).some(
+            (value) => value.showPercentage !== undefined,
+        );
+    }, [groupValueOptionOverrides]);
 
     const validPieChartConfig: PieChart = useMemo(
         () => ({
@@ -312,11 +361,15 @@ const usePieChartConfig: PieChartConfigFn = (
             toggleDonut: () => setIsDonut((prev) => !prev),
 
             valueLabel,
-            valueLabelChange: setValueLabel,
+            valueLabelChange: handleValueLabelChange,
             showValue,
-            toggleShowValue: () => setShowValue((prev) => !prev),
+            toggleShowValue: handleToggleShowValue,
             showPercentage,
-            toggleShowPercentage: () => setShowPercentage((prev) => !prev),
+            toggleShowPercentage: handleToggleShowPercentage,
+
+            isValueLabelOverriden,
+            isShowValueOverriden,
+            isShowPercentageOverriden,
 
             defaultColors,
 
@@ -346,9 +399,15 @@ const usePieChartConfig: PieChartConfigFn = (
             isDonut,
 
             valueLabel,
-            setValueLabel,
+            handleValueLabelChange,
             showValue,
+            handleToggleShowValue,
             showPercentage,
+            handleToggleShowPercentage,
+
+            isValueLabelOverriden,
+            isShowValueOverriden,
+            isShowPercentageOverriden,
 
             defaultColors,
 

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -18,6 +18,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import isEqual from 'lodash-es/isEqual';
 import omitBy from 'lodash-es/omitBy';
 import pick from 'lodash-es/pick';
+import pickBy from 'lodash-es/pickBy';
 import uniq from 'lodash-es/uniq';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isHexCodeColor } from '../utils/colorUtils';
@@ -97,7 +98,7 @@ const usePieChartConfig: PieChartConfigFn = (
     );
 
     const [showPercentage, setShowPercentage] = useState(
-        pieChartConfig?.showPercentage ?? false,
+        pieChartConfig?.showPercentage ?? true,
     );
 
     const [groupLabelOverrides, setGroupLabelOverrides] = useState(
@@ -262,7 +263,7 @@ const usePieChartConfig: PieChartConfigFn = (
                 debouncedGroupLabelOverrides,
                 groupLabels,
             ),
-            groupColorOverrides: omitBy(
+            groupColorOverrides: pickBy(
                 pick(debouncedGroupColorOverrides, groupLabels),
                 isHexCodeColor,
             ),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6007

### Description:

⚠️ ⚠️ ⚠️  TESTING VIDEO WITH UI QUESTION: https://cln.sh/r1zJRgK4

- [x] If you turn on the value labels, there is the option to have the value labels show as value or % of total or both
- [x] you only see these options if you have selected to show value labels
- [x] If you select **both** then the two values appear like `xx % - yy` where `yy` is the value and `xx` is the `%` of total


items left:
- [x] sync tooltips with value label config
- [x] fix echarts line bug (when switching between display option between outside<>inside)
- [x] format values based on metric formatting options

<img width="750" alt="CleanShot 2023-07-07 at 20 08 13@2x" src="https://github.com/lightdash/lightdash/assets/962095/ea412ee6-bd5f-4a25-9652-4f9d0791579c">

<img width="899" alt="CleanShot 2023-07-07 at 20 07 08@2x" src="https://github.com/lightdash/lightdash/assets/962095/0594faf4-1ba8-43c8-992f-f6bb60a2a882">
