### PR TITLE
chore: remove 500 timeout from api e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/api/api.cy.ts
+++ b/packages/e2e/cypress/e2e/api/api.cy.ts
@@ -275,7 +275,6 @@ describe('Lightdash API forbidden tests', () => {
         endpoints.forEach((endpoint) => {
             cy.request({
                 url: `${apiUrl}${endpoint}`,
-                timeout: 500,
                 failOnStatusCode: false,
             }).then((resp) => {
                 expect(resp.status).to.eq(403);
@@ -382,7 +381,6 @@ describe('Lightdash API forbidden tests', () => {
                 endpoints.forEach((endpoint) => {
                     cy.request({
                         url: `${apiUrl}${endpoint}`,
-                        timeout: 500,
                         failOnStatusCode: false,
                     }).then((resp) => {
                         expect(resp.status).to.eq(403);

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -45,7 +45,6 @@ describe('Lightdash API organization permission tests', () => {
         endpoints.forEach((endpoint) => {
             cy.request({
                 url: `${apiUrl}${endpoint}`,
-                timeout: 500,
                 failOnStatusCode: false,
             }).then((resp) => {
                 expect(resp.status).to.eq(403);
@@ -149,7 +148,6 @@ describe('Lightdash API organization permission tests', () => {
                 endpoints.forEach((endpoint) => {
                     cy.request({
                         url: `${apiUrl}${endpoint}`,
-                        timeout: 500,
                         failOnStatusCode: false,
                     }).then((resp) => {
                         expect(resp.status).to.eq(403);

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -809,7 +809,6 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
     it('Should get forbidden error (403) from GET Scheduler logs', () => {
         cy.request({
             url: `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
-            timeout: 500,
             failOnStatusCode: false,
         }).then((resp) => {
             expect(resp.status).to.eq(403);
@@ -1010,7 +1009,6 @@ describe('Lightdash API tests for member user with viewer project permissions', 
     it('Should get forbidden error (403) from GET Scheduler logs', () => {
         cy.request({
             url: `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
-            timeout: 500,
             failOnStatusCode: false,
         }).then((resp) => {
             expect(resp.status).to.eq(403);
@@ -1313,7 +1311,6 @@ describe('Lightdash API tests for member user with NO project permissions', () =
         endpoints.forEach((endpoint) => {
             cy.request({
                 url: `${apiUrl}${endpoint}`,
-                timeout: 500,
                 failOnStatusCode: false,
             }).then((resp) => {
                 expect(resp.status).to.eq(403);


### PR DESCRIPTION
Reduce/remove flakiness from api tests. 
Since we started e2e test parallelisation the server is taking more than 500 ms to respond to some requests.