### PR TITLE
chore: cache yarn in github actions

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -68,9 +68,21 @@ jobs:
           PGUSER: postgres
           PGDATABASE: postgres
           SEED_SCHEMA: jaffle-${{strategy.job-index}}
-      ## Install packages and lightdash cli from source
-      - name: Install packages/common modules
-        run: yarn workspace @lightdash/common install
+      # Install packages
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      # Build packages
       - name: Build packages/common module
         run: yarn common-build
       - name: Build packages/warehouses module

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -69,18 +69,11 @@ jobs:
           PGDATABASE: postgres
           SEED_SCHEMA: jaffle-${{strategy.job-index}}
       # Install packages
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '18'
+          cache: 'yarn'
       - name: Install packages
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       # Build packages
       - name: Build packages/common module

--- a/.github/workflows/count-blueprint.yml
+++ b/.github/workflows/count-blueprint.yml
@@ -16,8 +16,21 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v2
-      - name: Install deps
-        run: yarn
+      # Install packages
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      # Count Blueprint & Mantine imports
       - name: Count blueprint imports
         run: |
           EOF="$(openssl rand -hex 8)"

--- a/.github/workflows/count-blueprint.yml
+++ b/.github/workflows/count-blueprint.yml
@@ -17,18 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Install packages
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '18'
+          cache: 'yarn'
       - name: Install packages
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       # Count Blueprint & Mantine imports
       - name: Count blueprint imports

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,18 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       # Install packages
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '18'
+          cache: 'yarn'
       - name: Install packages
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       # Build packages
       - name: Build packages/common module
@@ -111,23 +104,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       # Install packages
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '18'
+          cache: 'yarn'
       - name: Install packages
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       # Build packages
-      - name: Install packages
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
       - name: Build packages/common module
         run: yarn common-build
       # Prepare bigquery credentials for Cypress

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       # Install packages
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:
@@ -118,6 +121,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       # Build packages
       - name: Install packages
         if: steps.yarn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,13 +33,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install and build Common package
-      - name: Install packages/common modules
-        run: yarn workspace @lightdash/common install
+      # Install packages
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      # Build packages
       - name: Build packages/common module
         run: yarn common-build
-      # Install NPM dependencies, cache them correctly
-      # and run all Cypress tests
+      # Prepare bigquery credentials for Cypress
       - name: create-json
         id: create-json
         uses: jsdaniell/create-json@1.1.2
@@ -47,6 +58,7 @@ jobs:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
           dir: "./packages/e2e/cypress/fixtures/"
+      # Run E2E tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
@@ -98,13 +110,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install and build Common package
-      - name: Install packages/common modules
-        run: yarn workspace @lightdash/common install
+      # Install packages
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      # Build packages
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - name: Build packages/common module
         run: yarn common-build
-      # Install NPM dependencies, cache them correctly
-      # and run all Cypress tests
+      # Prepare bigquery credentials for Cypress
       - name: create-json
         id: create-json
         uses: jsdaniell/create-json@1.1.2
@@ -112,6 +132,7 @@ jobs:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
           dir: "./packages/e2e/cypress/fixtures/"
+      # Run E2E tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: '16'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build-published-packages
       - name: Semantic Release

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -13,16 +13,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install modules
-      run: yarn
-      
+    - uses: actions/checkout@v3
+    # Install packages
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+    - uses: actions/cache@v3
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: Install packages
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile
+
     - name: Lint all packages
       run: yarn lint
     - name: Check formatting all packages
       run: yarn format
     - name: Check for unused exports
-      run: yarn workspace frontend unused-exports 
+      run: yarn workspace frontend unused-exports
 
     - name: Build common
       run: yarn common-build

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -15,18 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     # Install packages
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v3
-      id: yarn-cache
+    - uses: actions/setup-node@v3
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        node-version: '18'
+        cache: 'yarn'
     - name: Install packages
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile
 
     - name: Lint all packages


### PR DESCRIPTION
Changes:
- cache yarn dependencies
- use `--frozen-lockfile` option 

This should reduce the time of most of github actions since we install all our dependencies multiple times.

Note: 
Still getting a few `cache not found` and I'm not sure why. Would still merge it and keep checking it during the next week.