### PR TITLE
fix: stop info icon from wrapping on resource list

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -186,7 +186,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                 )}
 
                                 <Stack spacing={2}>
-                                    <Group spacing="xs">
+                                    <Group spacing="xs" noWrap>
                                         <Text
                                             fw={600}
                                             lineClamp={1}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6203 

### Description:

Stops the info icon from wrapping when resource names are too long
