### PR TITLE
style: move mantine modals up to match blueprint's

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -124,7 +124,6 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                     <Title order={4}>Add saved charts</Title>
                 </Flex>
             }
-            centered
             withCloseButton
         >
             <Stack spacing="md">

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -184,7 +184,6 @@ export const CustomMetricModal = () => {
     return item ? (
         <Modal
             size="xl"
-            centered
             zIndex={15}
             onClick={(e) => e.stopPropagation()}
             opened={isOpen}

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -196,7 +196,6 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                     <Title order={4}> Add chart to dashboard</Title>
                 </Group>
             }
-            centered
             withCloseButton
         >
             <Stack spacing="md" mih="100%">

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
@@ -80,7 +80,6 @@ export const CreateTokenModal: FC<{
     return (
         <Modal
             size="lg"
-            centered
             opened
             onClose={() => {
                 onBackClick();

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -89,7 +89,6 @@ export const TokensTable = () => {
             </Paper>
 
             <Modal
-                centered
                 opened={!!tokenToDelete}
                 onClose={() => !isDeleting && setTokenToDelete(undefined)}
                 title={

--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
@@ -38,7 +38,6 @@ export const OrganizationDeleteModal: FC<
     return (
         <Modal
             size="md"
-            centered
             opened={opened}
             title={
                 <Group spacing="xs">

--- a/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -46,7 +46,6 @@ export const ProjectDeleteModal: FC<
     return (
         <Modal
             size="md"
-            centered
             opened={opened}
             title={
                 <Group spacing="xs">

--- a/packages/frontend/src/components/UserSettings/InvitesModal/index.tsx
+++ b/packages/frontend/src/components/UserSettings/InvitesModal/index.tsx
@@ -60,7 +60,6 @@ const InvitesModal: FC<{
                     <Title order={4}>Add user</Title>
                 </Group>
             }
-            yOffset="15vw"
             size="lg"
         >
             <TrackPage

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -191,7 +191,6 @@ const UserListItem: FC<{
                                         <Title order={4}>Delete user</Title>
                                     </Group>
                                 }
-                                centered
                             >
                                 <Text pb="md">
                                     Are you sure you want to delete this user ?

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -133,6 +133,14 @@ export const getMantineThemeOverride = (overrides?: {
             }),
         },
 
+        Modal: {
+            defaultProps: {
+                // FIXME: This makes the mantine modals line up exactly with the Blueprint ones.
+                // It could be made a less-magic number once we migrate
+                yOffset: 140,
+            },
+        },
+
         ...overrides?.components,
     },
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6082 

### Description:

Defaults the Mantine modals' y-position to match the Blueprint ones. Removes centering from the Mantine modals. 
