### PR TITLE
chore: skip e2e action on main branch

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,7 @@ jobs:
   prepare-preview:
     # Only trigger for correct environment and status
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     outputs:
       url: ${{ steps.deployment-url.outputs.url }}
     steps:


### PR DESCRIPTION

Avoid check error in `main` commits
<img width="1180" alt="Screenshot 2023-07-07 at 16 24 41" src="https://github.com/lightdash/lightdash/assets/9117144/3433b789-e37e-4db9-bd70-af4583128523">

