### PR TITLE
docs: add branch prefix explanation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -226,8 +226,8 @@ docs: add page about metrics
 style: add more space 
 ```
 
-Note that **feat** and **fix** are typically used for changes that will provide value to the end-user
-and, so they trigger a release (version update). If you are making a change to docs, styles, or some 
+Note that **feat** and **fix** are typically used for changes that will provide value to the end-user 
+so they trigger a release (version update). If you are making a change to docs, styles, or some 
 other part of the system, please use the appropriate tag to avoid the extra overhead.
 
 You can see all

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -223,7 +223,12 @@ E.g:
 feat: add table calculations
 fix: remove infinite loop during login
 docs: add page about metrics
+style: add more space 
 ```
+
+Note that **feat** and **fix** are typically used for changes that will provide value to the end-user
+and, so they trigger a release (version update). If you are making a change to docs, styles, or some 
+other part of the system, please use the appropriate tag to avoid the extra overhead.
 
 You can see all
 the [supported types here](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json).


### PR DESCRIPTION

### Description:

Adds more information to the contributing doc about PR tags. I could have used this info 😄 . 

Note that I did not open a ticket for this since it is very small and docs-only. But I can if we think that's better. 
