### PR TITLE
fix: make dashboard link to open in new tab for saved charts

### DIFF
--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -1,6 +1,5 @@
 import { Anchor, List, Text } from '@mantine/core';
 import { FC } from 'react';
-import { Link } from 'react-router-dom';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
 
 type Props = {
@@ -25,8 +24,8 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
                     {relatedDashboards.map(({ uuid, name }) => (
                         <List.Item key={uuid}>
                             <Anchor
-                                component={Link}
-                                to={`/projects/${projectUuid}/dashboards/${uuid}/view`}
+                                href={`${window.location.origin}/projects/${projectUuid}/dashboards/${uuid}/view/`}
+                                target="_blank"
                             >
                                 {name}
                             </Anchor>

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -28,7 +28,7 @@ export const ResourceInfoPopup: FC<Props> = ({
             <HoverCard.Target>
                 <MantineIcon icon={IconInfoCircle} color="gray.6" />
             </HoverCard.Target>
-            <HoverCard.Dropdown maw={300} onClick={(e) => e.preventDefault()}>
+            <HoverCard.Dropdown maw={300}>
                 <div>
                     {description && (
                         <>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6188 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Make link to open in new tab
<!-- Even better add a screenshot / gif / loom -->
