### PR TITLE
remove centered

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -51,6 +51,7 @@ type DbDashboardTileChart = {
     dashboard_tile_uuid: string;
     saved_chart_id: number;
     hide_title?: boolean;
+    title: string | null;
 };
 
 export type DashboardTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20230710081637_dashboard_tile_charts_title.ts
+++ b/packages/backend/src/database/migrations/20230710081637_dashboard_tile_charts_title.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const DashboardTileChartsTable = 'dashboard_tile_charts';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardTileChartsTable, (tableBuilder) => {
+        tableBuilder.string('title').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardTileChartsTable, (tableBuilder) => {
+        tableBuilder.dropColumns('title');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -152,6 +152,7 @@ export class DashboardModel {
                                 insertedTile.dashboard_tile_uuid,
                             saved_chart_id: savedChart.saved_query_id,
                             hide_title: tile.properties.hideTitle,
+                            title: tile.properties.title,
                         });
                     }
                     break;
@@ -482,6 +483,7 @@ export class DashboardModel {
                 `${SavedChartsTableName}.saved_query_uuid`,
                 this.database.raw(
                     `COALESCE(
+                        ${DashboardTileChartTableName}.title,
                         ${SavedChartsTableName}.name,
                         ${DashboardTileLoomsTableName}.title,
                         ${DashboardTileMarkdownsTableName}.title

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -41,7 +41,7 @@ export type DashboardLoomTileProperties = {
 export type DashboardChartTileProperties = {
     type: DashboardTileTypes.SAVED_CHART;
     properties: {
-        title: string | null;
+        title: string;
         hideTitle?: boolean;
         savedChartUuid: string | null;
     };

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -172,6 +172,7 @@ const ValidDashboardChartTile: FC<{
 const ValidDashboardChartTileMinimal: FC<{
     tileUuid: string;
     isTitleHidden?: boolean;
+    title: string;
     data: SavedChart;
 }> = ({ tileUuid, data, isTitleHidden = false }) => {
     const { data: resultData, isLoading } = useChartResults(
@@ -223,7 +224,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const {
         tile: {
             uuid: tileUuid,
-            properties: { savedChartUuid, hideTitle },
+            properties: { savedChartUuid, hideTitle, title },
         },
         isEditMode,
     } = props;
@@ -427,7 +428,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                         </Tooltip2>
                     )
                 }
-                title={savedQueryWithDashboardFilters?.name || ''}
+                title={title || savedQueryWithDashboardFilters?.name || ''}
                 titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
                 description={savedQueryWithDashboardFilters?.description}
                 isLoading={isLoading || isLoadingExplore}
@@ -661,7 +662,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
     const {
         tile: {
             uuid: tileUuid,
-            properties: { savedChartUuid, hideTitle },
+            properties: { savedChartUuid, hideTitle, title },
         },
     } = props;
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -683,6 +684,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     tileUuid={tileUuid}
                     isTitleHidden={hideTitle}
                     data={data}
+                    title={title}
                 />
             ) : (
                 <InvalidDashboardChartTile />

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -10,6 +10,7 @@ import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import { Tooltip } from '@mantine/core';
 import { useHover, useToggle } from '@mantine/hooks';
 import React, { ReactNode, useState } from 'react';
+import TileUpdateChartTitle from '../TileForms/TileUpdateChartTitle';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
 import {
     ButtonsWrapper,
@@ -29,7 +30,7 @@ type Props<T> = {
     isLoading?: boolean;
     extraMenuItems?: React.ReactNode;
     onDelete: (tile: T) => void;
-    onEdit: (tile: T) => void;
+    onReplaceChart: (tile: T) => void;
     children?: ReactNode;
     extraHeaderElement?: React.ReactNode;
 };
@@ -42,12 +43,14 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     isLoading,
     extraMenuItems,
     onDelete,
-    onEdit,
+    onReplaceChart,
     children,
     extraHeaderElement,
     titleHref,
 }: Props<T>) => {
-    const [isEditing, setIsEditing] = useState(false);
+    const [isReplacingChart, setIsReplacingChart] = useState(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+
     const [isHovering, setIsHovering] = useState(false);
     const { hovered: containerHovered, ref: containerRef } = useHover();
     const { hovered: titleHovered, ref: titleRef } =
@@ -115,9 +118,18 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                     <>
                                                         <MenuItem2
                                                             icon="edit"
-                                                            text="Edit tile content"
+                                                            text="Edit title"
                                                             onClick={() =>
-                                                                setIsEditing(
+                                                                setIsEditingTitle(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        />
+                                                        <MenuItem2
+                                                            icon="exchange"
+                                                            text="Replace chart in tile"
+                                                            onClick={() =>
+                                                                setIsReplacingChart(
                                                                     true,
                                                                 )
                                                             }
@@ -136,15 +148,17 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                                         : 'Hide'
                                                                 } title`}
                                                                 onClick={() =>
-                                                                    onEdit({
-                                                                        ...tile,
-                                                                        properties:
-                                                                            {
-                                                                                ...tile.properties,
-                                                                                hideTitle:
-                                                                                    !hideTitle,
-                                                                            },
-                                                                    })
+                                                                    onReplaceChart(
+                                                                        {
+                                                                            ...tile,
+                                                                            properties:
+                                                                                {
+                                                                                    ...tile.properties,
+                                                                                    hideTitle:
+                                                                                        !hideTitle,
+                                                                                },
+                                                                        },
+                                                                    )
                                                                 }
                                                             />
                                                         )}
@@ -181,12 +195,28 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
                     <TileUpdateModal
                         className="non-draggable"
-                        isOpen={isEditing}
+                        isOpen={isReplacingChart}
                         tile={tile}
-                        onClose={() => setIsEditing(false)}
+                        onClose={() => setIsReplacingChart(false)}
                         onConfirm={(data) => {
-                            onEdit(data);
-                            setIsEditing(false);
+                            onReplaceChart(data);
+                            setIsReplacingChart(false);
+                        }}
+                    />
+
+                    <TileUpdateChartTitle
+                        isOpen={isEditingTitle}
+                        title={title}
+                        onClose={() => setIsEditingTitle(false)}
+                        onConfirm={(newTitle) => {
+                            onReplaceChart({
+                                ...tile,
+                                properties: {
+                                    ...tile.properties,
+                                    title: newTitle,
+                                },
+                            });
+                            setIsEditingTitle(false);
                         }}
                     />
                 </>

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateChartTitle.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateChartTitle.tsx
@@ -1,0 +1,52 @@
+import { Button, Modal, Stack, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+
+interface TileUpdateModalProps {
+    title: string;
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (title: string) => void;
+}
+
+const TileUpdateModal = ({
+    title,
+    isOpen,
+    onClose,
+    onConfirm,
+}: TileUpdateModalProps) => {
+    const form = useForm({
+        initialValues: {
+            title,
+        },
+    });
+
+    const handleOnSubmit = form.onSubmit(({ title: newTitle }) => {
+        onConfirm(newTitle);
+        onClose();
+    });
+    return (
+        <Modal
+            size="lg"
+            opened={isOpen}
+            className="non-draggable"
+            onClose={onClose}
+            title="Edit chart title"
+        >
+            <form onSubmit={handleOnSubmit}>
+                <Stack spacing="md">
+                    <TextInput
+                        label="Chart title"
+                        placeholder={title}
+                        required
+                        {...form.getInputProps('title')}
+                    />
+                    <Button type="submit" ml="auto">
+                        Update title
+                    </Button>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};
+
+export default TileUpdateModal;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -463,7 +463,7 @@ const Dashboard: FC = () => {
                                         isEditMode={isEditMode}
                                         tile={tile}
                                         onDelete={handleDeleteTile}
-                                        onEdit={handleEditTiles}
+                                        onReplaceChart={handleEditTiles}
                                     />
                                 </TrackSection>
                             </div>

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -58,7 +58,7 @@ const MinimalDashboard: FC = () => {
                                 tile={tile}
                                 isEditMode={false}
                                 onDelete={() => {}}
-                                onEdit={() => {}}
+                                onReplaceChart={() => {}}
                             />
                         ) : tile.type === DashboardTileTypes.MARKDOWN ? (
                             <MarkdownTile
@@ -66,7 +66,7 @@ const MinimalDashboard: FC = () => {
                                 tile={tile}
                                 isEditMode={false}
                                 onDelete={() => {}}
-                                onEdit={() => {}}
+                                onReplaceChart={() => {}}
                             />
                         ) : tile.type === DashboardTileTypes.LOOM ? (
                             <LoomTile
@@ -74,7 +74,7 @@ const MinimalDashboard: FC = () => {
                                 tile={tile}
                                 isEditMode={false}
                                 onDelete={() => {}}
-                                onEdit={() => {}}
+                                onReplaceChart={() => {}}
                             />
                         ) : (
                             assertUnreachable(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #2708

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Acceptance criteria

Miro sketch: https://miro.com/app/board/uXjVM5_vIl0=/?share_link_id=339879375259

- [ ] I'm able to rename a chart title using the three-dot-menu on a chart when I'm in `edit` mode on a dashboard. There is an option which is `Edit title`
- [ ] Rename the `edit tile content` option to say `replace chart in tile` and update the icon to use a "replace" type icon
- [ ] If I rename a chart in a dashboard, when I search for the chart in search, it will appear in search using the original chart title.
