### PR TITLE
feat: Add an API to get an organization member

### DIFF
--- a/examples/api/organization-members.http
+++ b/examples/api/organization-members.http
@@ -1,0 +1,26 @@
+### Login
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+### Get all members
+GET http://localhost:8080/api/v1/org/users
+
+### Get a member by uuid
+GET http://localhost:8080/api/v1/org/users/b264d83a-9000-426a-85ec-3f9c20f368ce
+
+### Get a member by email address
+GET http://localhost:8080/api/v1/org/users/emails/demo@lightdash.com
+
+### Get a member that doesn't exist
+GET http://localhost:8080/api/v1/org/users/emails/notexists
+
+### Get a member that doesn't exist
+GET http://localhost:8080/api/v1/org/users/notexists
+
+### Get a member from another org
+GET http://localhost:8080/api/v1/org/users/57cd4548-cbe3-42b3-aa13-97821713e307

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -10,6 +10,7 @@ import {
     ApiSuccessEmpty,
     CreateGroup,
     CreateOrganization,
+    OrganizationMemberProfileGet,
     OrganizationMemberProfileUpdate,
     UpdateAllowedEmailDomains,
     UpdateOrganization,
@@ -172,6 +173,41 @@ export class OrganizationController extends Controller {
             status: 'ok',
             results: await organizationService.getUsers(req.user!),
         };
+    }
+
+    /**
+     * Get the membership profile for a user in the current user's organization
+     * @param req express request
+     * @param body the userUuid or email of the user to get. Either userUuid or email must be provided.
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/user')
+    @OperationId('ListOrganizationMembers')
+    async getOrganizationMemberByEmail(
+        @Request() req: express.Request,
+        @Body() body: OrganizationMemberProfileGet,
+    ): Promise<ApiOrganizationMemberProfile> {
+        if (body.userUuid) {
+            this.setStatus(200);
+            return {
+                status: 'ok',
+                results: await organizationService.getMember(
+                    req.user!,
+                    body.userUuid,
+                ),
+            };
+        }
+        if (body.email) {
+            this.setStatus(200);
+            return {
+                status: 'ok',
+                results: await organizationService.getMemberByEmail(
+                    req.user!,
+                    body.email,
+                ),
+            };
+        }
+        throw new Error('Must provide either userUuid or email');
     }
 
     /**

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -183,7 +183,7 @@ export class OrganizationController extends Controller {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Post('/user')
     @OperationId('ListOrganizationMembers')
-    async getOrganizationMemberByEmail(
+    async getOrganizationMember(
         @Request() req: express.Request,
         @Body() body: OrganizationMemberProfileGet,
     ): Promise<ApiOrganizationMemberProfile> {

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -10,7 +10,6 @@ import {
     ApiSuccessEmpty,
     CreateGroup,
     CreateOrganization,
-    OrganizationMemberProfileGet,
     OrganizationMemberProfileUpdate,
     UpdateAllowedEmailDomains,
     UpdateOrganization,
@@ -176,38 +175,47 @@ export class OrganizationController extends Controller {
     }
 
     /**
-     * Get the membership profile for a user in the current user's organization
+     * Get the member profile for a user in the current user's organization by email
      * @param req express request
-     * @param body the userUuid or email of the user to get. Either userUuid or email must be provided.
+     * @param primary email of the user
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @Post('/user')
-    @OperationId('GetOrganizationMember')
-    async getOrganizationMember(
+    @Get('/users/emails/{email}')
+    @OperationId('GetOrganizationMemberByEmail')
+    async getOrganizationMemberByEmail(
         @Request() req: express.Request,
-        @Body() body: OrganizationMemberProfileGet,
+        @Path() email: string,
     ): Promise<ApiOrganizationMemberProfile> {
-        if (body.userUuid) {
-            this.setStatus(200);
-            return {
-                status: 'ok',
-                results: await organizationService.getMember(
-                    req.user!,
-                    body.userUuid,
-                ),
-            };
-        }
-        if (body.email) {
-            this.setStatus(200);
-            return {
-                status: 'ok',
-                results: await organizationService.getMemberByEmail(
-                    req.user!,
-                    body.email,
-                ),
-            };
-        }
-        throw new Error('Must provide either userUuid or email');
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await organizationService.getMemberByPrimaryEmail(
+                req.user!,
+                email,
+            ),
+        };
+    }
+
+    /**
+     * Get the member profile for a user in the current user's organization by uuid
+     * @param req express request
+     * @param userUuid the uuid of the user
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/users/{userUuid}')
+    @OperationId('GetOrganizationMemberByUuid')
+    async getOrganizationMemberByUuid(
+        @Request() req: express.Request,
+        @Path() userUuid: string,
+    ): Promise<ApiOrganizationMemberProfile> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await organizationService.getMemberByUuid(
+                req.user!,
+                userUuid,
+            ),
+        };
     }
 
     /**

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -13,6 +13,7 @@ import {
     OrganizationMemberProfileUpdate,
     UpdateAllowedEmailDomains,
     UpdateOrganization,
+    UUID,
 } from '@lightdash/common';
 import express from 'express';
 import {
@@ -206,7 +207,7 @@ export class OrganizationController extends Controller {
     @OperationId('GetOrganizationMemberByUuid')
     async getOrganizationMemberByUuid(
         @Request() req: express.Request,
-        @Path() userUuid: string,
+        @Path() userUuid: UUID,
     ): Promise<ApiOrganizationMemberProfile> {
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -182,7 +182,7 @@ export class OrganizationController extends Controller {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Post('/user')
-    @OperationId('ListOrganizationMembers')
+    @OperationId('GetOrganizationMember')
     async getOrganizationMember(
         @Request() req: express.Request,
         @Body() body: OrganizationMemberProfileGet,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -436,6 +436,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UUID: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'string',
+            validators: {
+                pattern: {
+                    value: '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}',
+                },
+            },
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationMemberProfileUpdate: {
         dataType: 'refAlias',
         type: {
@@ -481,14 +493,51 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ProjectMemberRole.EDITOR': {
+        dataType: 'refEnum',
+        enums: ['editor'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ProjectMemberRole.INTERACTIVE_VIEWER': {
+        dataType: 'refEnum',
+        enums: ['interactive_viewer'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ProjectMemberRole.VIEWER': {
+        dataType: 'refEnum',
+        enums: ['viewer'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AllowedEmailDomainProjectsRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ProjectMemberRole.EDITOR' },
+                { ref: 'ProjectMemberRole.INTERACTIVE_VIEWER' },
+                { ref: 'ProjectMemberRole.VIEWER' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AllowedEmailDomains: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                projectUuids: {
+                projects: {
                     dataType: 'array',
-                    array: { dataType: 'string' },
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            role: {
+                                ref: 'AllowedEmailDomainProjectsRole',
+                                required: true,
+                            },
+                            projectUuid: { dataType: 'string', required: true },
+                        },
+                    },
                     required: true,
                 },
                 role: { ref: 'AllowedEmailDomainsRole', required: true },
@@ -527,9 +576,21 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     role: { ref: 'AllowedEmailDomainsRole', required: true },
-                    projectUuids: {
+                    projects: {
                         dataType: 'array',
-                        array: { dataType: 'string' },
+                        array: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                role: {
+                                    ref: 'AllowedEmailDomainProjectsRole',
+                                    required: true,
+                                },
+                                projectUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
                         required: true,
                     },
                 },
@@ -1592,7 +1653,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -1602,6 +1663,22 @@ const models: TsoaRoute.Models = {
                     organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     projectUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     isPrivate: { dataType: 'boolean', required: true },
                 },
                 validators: {},
@@ -1614,11 +1691,13 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dashboardCount: { dataType: 'double', required: true },
+                        chartCount: { dataType: 'double', required: true },
                         access: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -1883,6 +1962,7 @@ const models: TsoaRoute.Models = {
             'greaterThan',
             'greaterThanOrEqual',
             'inThePast',
+            'notInThePast',
             'inTheNext',
             'inTheCurrent',
             'inBetween',
@@ -3952,7 +4032,7 @@ export function RegisterRoutes(app: express.Router) {
                     in: 'path',
                     name: 'userUuid',
                     required: true,
-                    dataType: 'string',
+                    ref: 'UUID',
                 },
             };
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -436,6 +436,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OrganizationMemberProfileGet: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                email: { dataType: 'string' },
+                userUuid: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationMemberProfileUpdate: {
         dataType: 'refAlias',
         type: {
@@ -1641,7 +1653,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -1651,6 +1663,22 @@ const models: TsoaRoute.Models = {
                     organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     projectUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     isPrivate: { dataType: 'boolean', required: true },
                 },
                 validators: {},
@@ -1663,11 +1691,13 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dashboardCount: { dataType: 'double', required: true },
+                        chartCount: { dataType: 'double', required: true },
                         access: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -3923,6 +3953,52 @@ export function RegisterRoutes(app: express.Router) {
                 const controller = new OrganizationController();
 
                 const promise = controller.getOrganizationMembers.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/org/user',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationMember,
+        ),
+
+        function OrganizationController_getOrganizationMember(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'OrganizationMemberProfileGet',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new OrganizationController();
+
+                const promise = controller.getOrganizationMember.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -436,18 +436,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OrganizationMemberProfileGet: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                email: { dataType: 'string' },
-                userUuid: { dataType: 'string' },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationMemberProfileUpdate: {
         dataType: 'refAlias',
         type: {
@@ -493,51 +481,14 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ProjectMemberRole.EDITOR': {
-        dataType: 'refEnum',
-        enums: ['editor'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ProjectMemberRole.INTERACTIVE_VIEWER': {
-        dataType: 'refEnum',
-        enums: ['interactive_viewer'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ProjectMemberRole.VIEWER': {
-        dataType: 'refEnum',
-        enums: ['viewer'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AllowedEmailDomainProjectsRole: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ProjectMemberRole.EDITOR' },
-                { ref: 'ProjectMemberRole.INTERACTIVE_VIEWER' },
-                { ref: 'ProjectMemberRole.VIEWER' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AllowedEmailDomains: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                projects: {
+                projectUuids: {
                     dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            role: {
-                                ref: 'AllowedEmailDomainProjectsRole',
-                                required: true,
-                            },
-                            projectUuid: { dataType: 'string', required: true },
-                        },
-                    },
+                    array: { dataType: 'string' },
                     required: true,
                 },
                 role: { ref: 'AllowedEmailDomainsRole', required: true },
@@ -576,21 +527,9 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     role: { ref: 'AllowedEmailDomainsRole', required: true },
-                    projects: {
+                    projectUuids: {
                         dataType: 'array',
-                        array: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                role: {
-                                    ref: 'AllowedEmailDomainProjectsRole',
-                                    required: true,
-                                },
-                                projectUuid: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                            },
-                        },
+                        array: { dataType: 'string' },
                         required: true,
                     },
                 },
@@ -1653,7 +1592,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_':
         {
             dataType: 'refAlias',
             type: {
@@ -1663,22 +1602,6 @@ const models: TsoaRoute.Models = {
                     organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     projectUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
                     isPrivate: { dataType: 'boolean', required: true },
                 },
                 validators: {},
@@ -1691,13 +1614,11 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        dashboardCount: { dataType: 'double', required: true },
-                        chartCount: { dataType: 'double', required: true },
                         access: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -1962,7 +1883,6 @@ const models: TsoaRoute.Models = {
             'greaterThan',
             'greaterThanOrEqual',
             'inThePast',
-            'notInThePast',
             'inTheNext',
             'inTheCurrent',
             'inBetween',
@@ -3963,14 +3883,14 @@ export function RegisterRoutes(app: express.Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/org/user',
+    app.get(
+        '/api/v1/org/users/emails/:email',
         ...fetchMiddlewares<RequestHandler>(OrganizationController),
         ...fetchMiddlewares<RequestHandler>(
-            OrganizationController.prototype.getOrganizationMember,
+            OrganizationController.prototype.getOrganizationMemberByEmail,
         ),
 
-        function OrganizationController_getOrganizationMember(
+        function OrganizationController_getOrganizationMemberByEmail(
             request: any,
             response: any,
             next: any,
@@ -3982,11 +3902,11 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'object',
                 },
-                body: {
-                    in: 'body',
-                    name: 'body',
+                email: {
+                    in: 'path',
+                    name: 'email',
                     required: true,
-                    ref: 'OrganizationMemberProfileGet',
+                    dataType: 'string',
                 },
             };
 
@@ -3998,7 +3918,53 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new OrganizationController();
 
-                const promise = controller.getOrganizationMember.apply(
+                const promise = controller.getOrganizationMemberByEmail.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/org/users/:userUuid',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getOrganizationMemberByUuid,
+        ),
+
+        function OrganizationController_getOrganizationMemberByUuid(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                userUuid: {
+                    in: 'path',
+                    name: 'userUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new OrganizationController();
+
+                const promise = controller.getOrganizationMemberByUuid.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -483,17 +483,6 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "OrganizationMemberProfileGet": {
-                "properties": {
-                    "email": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "OrganizationMemberProfileUpdate": {
                 "properties": {
                     "role": {
@@ -535,45 +524,11 @@
                     }
                 ]
             },
-            "ProjectMemberRole.EDITOR": {
-                "enum": ["editor"],
-                "type": "string"
-            },
-            "ProjectMemberRole.INTERACTIVE_VIEWER": {
-                "enum": ["interactive_viewer"],
-                "type": "string"
-            },
-            "ProjectMemberRole.VIEWER": {
-                "enum": ["viewer"],
-                "type": "string"
-            },
-            "AllowedEmailDomainProjectsRole": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ProjectMemberRole.EDITOR"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ProjectMemberRole.INTERACTIVE_VIEWER"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ProjectMemberRole.VIEWER"
-                    }
-                ]
-            },
             "AllowedEmailDomains": {
                 "properties": {
-                    "projects": {
+                    "projectUuids": {
                         "items": {
-                            "properties": {
-                                "role": {
-                                    "$ref": "#/components/schemas/AllowedEmailDomainProjectsRole"
-                                },
-                                "projectUuid": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["role", "projectUuid"],
-                            "type": "object"
+                            "type": "string"
                         },
                         "type": "array"
                     },
@@ -591,7 +546,7 @@
                     }
                 },
                 "required": [
-                    "projects",
+                    "projectUuids",
                     "role",
                     "emailDomains",
                     "organizationUuid"
@@ -623,23 +578,14 @@
                     "role": {
                         "$ref": "#/components/schemas/AllowedEmailDomainsRole"
                     },
-                    "projects": {
+                    "projectUuids": {
                         "items": {
-                            "properties": {
-                                "role": {
-                                    "$ref": "#/components/schemas/AllowedEmailDomainProjectsRole"
-                                },
-                                "projectUuid": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["role", "projectUuid"],
-                            "type": "object"
+                            "type": "string"
                         },
                         "type": "array"
                     }
                 },
-                "required": ["emailDomains", "role", "projects"],
+                "required": ["emailDomains", "role", "projectUuids"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -1903,7 +1849,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -1917,15 +1863,6 @@
                     "projectUuid": {
                         "type": "string"
                     },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
                     "isPrivate": {
                         "type": "boolean"
                     }
@@ -1935,8 +1872,6 @@
                     "organizationUuid",
                     "uuid",
                     "projectUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder",
                     "isPrivate"
                 ],
                 "type": "object",
@@ -1945,18 +1880,10 @@
             "SpaceSummary": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
                     },
                     {
                         "properties": {
-                            "dashboardCount": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "chartCount": {
-                                "type": "number",
-                                "format": "double"
-                            },
                             "access": {
                                 "items": {
                                     "type": "string"
@@ -1964,7 +1891,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["dashboardCount", "chartCount", "access"],
+                        "required": ["access"],
                         "type": "object"
                     }
                 ]
@@ -2244,7 +2171,6 @@
                     "greaterThan",
                     "greaterThanOrEqual",
                     "inThePast",
-                    "notInThePast",
                     "inTheNext",
                     "inTheCurrent",
                     "inBetween"
@@ -4400,9 +4326,9 @@
                 "parameters": []
             }
         },
-        "/api/v1/org/user": {
-            "post": {
-                "operationId": "GetOrganizationMember",
+        "/api/v1/org/users/emails/{email}": {
+            "get": {
+                "operationId": "GetOrganizationMemberByEmail",
                 "responses": {
                     "200": {
                         "description": "Ok",
@@ -4425,25 +4351,61 @@
                         }
                     }
                 },
-                "description": "Get the membership profile for a user in the current user's organization",
+                "description": "Get the member profile for a user in the current user's organization by email",
                 "tags": ["Organizations"],
                 "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "the userUuid or email of the user to get. Either userUuid or email must be provided.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OrganizationMemberProfileGet",
-                                "description": "the userUuid or email of the user to get. Either userUuid or email must be provided."
-                            }
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "email",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
-                }
+                ]
             }
         },
         "/api/v1/org/users/{userUuid}": {
+            "get": {
+                "operationId": "GetOrganizationMemberByUuid",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the member profile for a user in the current user's organization by uuid",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
             "patch": {
                 "operationId": "UpdateOrganizationMember",
                 "responses": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -483,6 +483,17 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "OrganizationMemberProfileGet": {
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "OrganizationMemberProfileUpdate": {
                 "properties": {
                     "role": {
@@ -1892,7 +1903,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -1906,6 +1917,15 @@
                     "projectUuid": {
                         "type": "string"
                     },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     }
@@ -1915,6 +1935,8 @@
                     "organizationUuid",
                     "uuid",
                     "projectUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder",
                     "isPrivate"
                 ],
                 "type": "object",
@@ -1923,10 +1945,18 @@
             "SpaceSummary": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_"
                     },
                     {
                         "properties": {
+                            "dashboardCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "chartCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "access": {
                                 "items": {
                                     "type": "string"
@@ -1934,7 +1964,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["access"],
+                        "required": ["dashboardCount", "chartCount", "access"],
                         "type": "object"
                     }
                 ]
@@ -3676,7 +3706,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.651.2",
+        "version": "0.661.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -4368,6 +4398,49 @@
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/org/user": {
+            "post": {
+                "operationId": "ListOrganizationMembers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationMemberProfile"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the membership profile for a user in the current user's organization",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "the userUuid or email of the user to get. Either userUuid or email must be provided.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationMemberProfileGet",
+                                "description": "the userUuid or email of the user to get. Either userUuid or email must be provided."
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/org/users/{userUuid}": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4402,7 +4402,7 @@
         },
         "/api/v1/org/user": {
             "post": {
-                "operationId": "ListOrganizationMembers",
+                "operationId": "GetOrganizationMember",
                 "responses": {
                     "200": {
                         "description": "Ok",

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -483,6 +483,12 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "UUID": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Stringified UUIDv4.\nSee [RFC 4112](https://tools.ietf.org/html/rfc4122)",
+                "pattern": "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
+            },
             "OrganizationMemberProfileUpdate": {
                 "properties": {
                     "role": {
@@ -524,11 +530,45 @@
                     }
                 ]
             },
+            "ProjectMemberRole.EDITOR": {
+                "enum": ["editor"],
+                "type": "string"
+            },
+            "ProjectMemberRole.INTERACTIVE_VIEWER": {
+                "enum": ["interactive_viewer"],
+                "type": "string"
+            },
+            "ProjectMemberRole.VIEWER": {
+                "enum": ["viewer"],
+                "type": "string"
+            },
+            "AllowedEmailDomainProjectsRole": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ProjectMemberRole.EDITOR"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ProjectMemberRole.INTERACTIVE_VIEWER"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ProjectMemberRole.VIEWER"
+                    }
+                ]
+            },
             "AllowedEmailDomains": {
                 "properties": {
-                    "projectUuids": {
+                    "projects": {
                         "items": {
-                            "type": "string"
+                            "properties": {
+                                "role": {
+                                    "$ref": "#/components/schemas/AllowedEmailDomainProjectsRole"
+                                },
+                                "projectUuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["role", "projectUuid"],
+                            "type": "object"
                         },
                         "type": "array"
                     },
@@ -546,7 +586,7 @@
                     }
                 },
                 "required": [
-                    "projectUuids",
+                    "projects",
                     "role",
                     "emailDomains",
                     "organizationUuid"
@@ -578,14 +618,23 @@
                     "role": {
                         "$ref": "#/components/schemas/AllowedEmailDomainsRole"
                     },
-                    "projectUuids": {
+                    "projects": {
                         "items": {
-                            "type": "string"
+                            "properties": {
+                                "role": {
+                                    "$ref": "#/components/schemas/AllowedEmailDomainProjectsRole"
+                                },
+                                "projectUuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["role", "projectUuid"],
+                            "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": ["emailDomains", "role", "projectUuids"],
+                "required": ["emailDomains", "role", "projects"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -1849,7 +1898,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -1863,6 +1912,15 @@
                     "projectUuid": {
                         "type": "string"
                     },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     }
@@ -1872,6 +1930,8 @@
                     "organizationUuid",
                     "uuid",
                     "projectUuid",
+                    "pinnedListUuid",
+                    "pinnedListOrder",
                     "isPrivate"
                 ],
                 "type": "object",
@@ -1880,10 +1940,18 @@
             "SpaceSummary": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder_"
                     },
                     {
                         "properties": {
+                            "dashboardCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "chartCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "access": {
                                 "items": {
                                     "type": "string"
@@ -1891,7 +1959,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["access"],
+                        "required": ["dashboardCount", "chartCount", "access"],
                         "type": "object"
                     }
                 ]
@@ -2171,6 +2239,7 @@
                     "greaterThan",
                     "greaterThanOrEqual",
                     "inThePast",
+                    "notInThePast",
                     "inTheNext",
                     "inTheCurrent",
                     "inBetween"
@@ -4401,7 +4470,7 @@
                         "name": "userUuid",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/UUID"
                         }
                     }
                 ]

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -103,6 +103,21 @@ export class OrganizationMemberProfileModel {
         return member && OrganizationMemberProfileModel.parseRow(member);
     }
 
+    async findOrganizationMemberByEmail(
+        organizationUuid: string,
+        email: string,
+    ): Promise<OrganizationMemberProfile | undefined> {
+        const [member] = await this.queryBuilder()
+            .where(`${EmailTableName}.email`, email)
+            .andWhere(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .select<DbOrganizationMemberProfile[]>(SelectColumns);
+
+        return member && OrganizationMemberProfileModel.parseRow(member);
+    }
+
     async getOrganizationMembers(
         organizationUuid: string,
     ): Promise<OrganizationMemberProfile[]> {
@@ -136,10 +151,27 @@ export class OrganizationMemberProfileModel {
         ).insert<DbOrganizationMembershipIn>(membershipIn);
     };
 
-    async getOrganizationMember(organizationUuid: string, userUuid: string) {
+    async getOrganizationMember(
+        organizationUuid: string,
+        userUuid: string,
+    ): Promise<OrganizationMemberProfile> {
         const member = await this.findOrganizationMember(
             organizationUuid,
             userUuid,
+        );
+        if (member) {
+            return member;
+        }
+        throw new NotFoundError('No matching member found in organization');
+    }
+
+    async getOrganizationMemberByEmail(
+        organizationUuid: string,
+        email: string,
+    ): Promise<OrganizationMemberProfile> {
+        const member = await this.findOrganizationMemberByEmail(
+            organizationUuid,
+            email,
         );
         if (member) {
             return member;

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -151,7 +151,7 @@ export class OrganizationMemberProfileModel {
         ).insert<DbOrganizationMembershipIn>(membershipIn);
     };
 
-    async getOrganizationMember(
+    async getOrganizationMemberByUuid(
         organizationUuid: string,
         userUuid: string,
     ): Promise<OrganizationMemberProfile> {
@@ -165,7 +165,7 @@ export class OrganizationMemberProfileModel {
         return member;
     }
 
-    async getOrganizationMemberByEmail(
+    async getOrganizationMemberByPrimaryEmail(
         organizationUuid: string,
         email: string,
     ): Promise<OrganizationMemberProfile> {
@@ -205,6 +205,6 @@ export class OrganizationMemberProfileModel {
                 sqlParams,
             );
         }
-        return this.getOrganizationMember(organizationUuid, userUuid);
+        return this.getOrganizationMemberByUuid(organizationUuid, userUuid);
     }
 }

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -159,10 +159,10 @@ export class OrganizationMemberProfileModel {
             organizationUuid,
             userUuid,
         );
-        if (member) {
-            return member;
+        if (!member) {
+            throw new NotFoundError('No matching member found in organization');
         }
-        throw new NotFoundError('No matching member found in organization');
+        return member;
     }
 
     async getOrganizationMemberByEmail(
@@ -173,10 +173,10 @@ export class OrganizationMemberProfileModel {
             organizationUuid,
             email,
         );
-        if (member) {
-            return member;
+        if (!member) {
+            throw new NotFoundError('No matching member found in organization');
         }
-        throw new NotFoundError('No matching member found in organization');
+        return member;
     }
 
     async updateOrganizationMember(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -243,41 +243,57 @@ export class OrganizationService {
         });
     }
 
-    async getMember(
+    async getMemberByUuid(
         user: SessionUser,
-        member_uuid: string,
+        memberUuid: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
-        if (user.ability.cannot('view', 'OrganizationMemberProfile')) {
+        if (
+            organizationUuid === undefined ||
+            user.ability.cannot('view', 'OrganizationMemberProfile')
+        ) {
             throw new ForbiddenError();
         }
-        if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
-        }
         const member =
-            await this.organizationMemberProfileModel.getOrganizationMember(
+            await this.organizationMemberProfileModel.getOrganizationMemberByUuid(
                 organizationUuid,
-                member_uuid,
+                memberUuid,
             );
+        if (
+            user.ability.cannot(
+                'view',
+                subject('OrganizationMemberProfile', member),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         return member;
     }
 
-    async getMemberByEmail(
+    async getMemberByPrimaryEmail(
         user: SessionUser,
         email: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
-        if (user.ability.cannot('view', 'OrganizationMemberProfile')) {
+        if (
+            organizationUuid === undefined ||
+            user.ability.cannot('view', 'OrganizationMemberProfile')
+        ) {
             throw new ForbiddenError();
         }
-        if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
-        }
         const member =
-            await this.organizationMemberProfileModel.getOrganizationMemberByEmail(
+            await this.organizationMemberProfileModel.getOrganizationMemberByPrimaryEmail(
                 organizationUuid,
                 email,
             );
+        if (
+            user.ability.cannot(
+                'view',
+                subject('OrganizationMemberProfile', member),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         return member;
     }
 

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -243,6 +243,44 @@ export class OrganizationService {
         });
     }
 
+    async getMember(
+        user: SessionUser,
+        member_uuid: string,
+    ): Promise<OrganizationMemberProfile> {
+        const { organizationUuid } = user;
+        if (user.ability.cannot('view', 'OrganizationMemberProfile')) {
+            throw new ForbiddenError();
+        }
+        if (organizationUuid === undefined) {
+            throw new NotExistsError('Organization not found');
+        }
+        const member =
+            await this.organizationMemberProfileModel.getOrganizationMember(
+                organizationUuid,
+                member_uuid,
+            );
+        return member;
+    }
+
+    async getMemberByEmail(
+        user: SessionUser,
+        email: string,
+    ): Promise<OrganizationMemberProfile> {
+        const { organizationUuid } = user;
+        if (user.ability.cannot('view', 'OrganizationMemberProfile')) {
+            throw new ForbiddenError();
+        }
+        if (organizationUuid === undefined) {
+            throw new NotExistsError('Organization not found');
+        }
+        const member =
+            await this.organizationMemberProfileModel.getOrganizationMemberByEmail(
+                organizationUuid,
+                email,
+            );
+        return member;
+    }
+
     async updateMember(
         authenticatedUser: SessionUser,
         memberUserUuid: string,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -96,6 +96,7 @@ export * from './types/api/errors';
 export * from './types/api/integrations';
 export * from './types/api/share';
 export * from './types/api/success';
+export * from './types/api/uuid';
 export * from './types/conditionalFormatting';
 export * from './types/conditionalRule';
 export * from './types/csv';

--- a/packages/common/src/types/api/uuid.ts
+++ b/packages/common/src/types/api/uuid.ts
@@ -1,0 +1,7 @@
+/**
+ * Stringified UUIDv4.
+ * See [RFC 4112](https://tools.ietf.org/html/rfc4122)
+ * @pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}
+ * @format uuid
+ */
+export type UUID = string;

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -37,11 +37,6 @@ export type OrganizationMemberProfile = {
     isInviteExpired?: boolean;
 };
 
-export type OrganizationMemberProfileGet = {
-    userUuid?: string;
-    email?: string;
-};
-
 export type OrganizationMemberProfileUpdate = {
     role: OrganizationMemberRole;
 };

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -37,6 +37,11 @@ export type OrganizationMemberProfile = {
     isInviteExpired?: boolean;
 };
 
+export type OrganizationMemberProfileGet = {
+    userUuid?: string;
+    email?: string;
+};
+
 export type OrganizationMemberProfileUpdate = {
     role: OrganizationMemberRole;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/5914

**Update @owlas**

You can now test with:

```
### Login
POST http://localhost:8080/api/v1/login
Content-Type: application/json

{
    "email": "demo@lightdash.com",
    "password": "demo_password!"
}

### Get all members
GET http://localhost:8080/api/v1/org/users

### Get a member by uuid
GET http://localhost:8080/api/v1/org/users/b264d83a-9000-426a-85ec-3f9c20f368ce

### Get a member by email address
GET http://localhost:8080/api/v1/org/users/emails/demo@lightdash.com

### Get a member that doesn't exist
GET http://localhost:8080/api/v1/org/users/emails/notexists

### Get a member that doesn't exist
GET http://localhost:8080/api/v1/org/users/notexists

### Get a member from another org
GET http://localhost:8080/api/v1/org/users/57cd4548-cbe3-42b3-aa13-97821713e307
```

### Description:
I would like to add an API to get a member's profile. Although we already have the API to get all members of an organization, it wouldn't be efficient if we want to get just one.

In my opinion, there are two use cases to get an user. First, we want to get an user by the UUID of an user. Second, we want to get an user by email.

We consider if we implement a terraform provider for Lightdash. We may want to get a user by the UUID, if we create a terraform data source. Meanwhile, we may want to get an user by the email, if we create a terraform resource. That's why the API I implemented supports either of UUID and email.

```terraform
data "lightdash_organization_member" "sample_member" {
  uuid = "xxxxx-xxxx-xxxx"
}

resource "lightdash_organization_member" "sample_member_02" {
  email = "sample-member-02@test.com"
  role = ...
}
```