### PR TITLE
Feat save chart metadata

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -19,6 +19,9 @@ export type DbSavedChart = {
     name: string;
     created_at: Date;
     description: string | undefined;
+    last_version_chart_kind: ChartType;
+    last_version_updated_at: Date;
+    last_version_updated_by_user_uuid: string | undefined;
 };
 
 export type SavedChartTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20230711080805_last_chart_metadata.ts
+++ b/packages/backend/src/database/migrations/20230711080805_last_chart_metadata.ts
@@ -1,0 +1,30 @@
+import { ChartKind } from '@lightdash/common';
+import { Knex } from 'knex';
+
+const chartTable = 'saved_queries';
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(chartTable, (table) => {
+        table
+            .string('last_version_chart_kind')
+            .defaultTo(ChartKind.VERTICAL_BAR);
+        table
+            .timestamp('last_version_updated_at', { useTz: false })
+            .defaultTo(knex.fn.now());
+        table
+            .uuid('last_version_updated_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(chartTable, (table) => {
+        table.dropColumns(
+            'last_version_chart_kind',
+            'last_version_updated_at',
+            'last_version_updated_by_user_uuid',
+        );
+    });
+}

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -5,6 +5,7 @@ import {
     CreateSavedChart,
     CreateSavedChartVersion,
     DBFieldTypes,
+    getChartType,
     NotFoundError,
     SavedChart,
     SessionUser,
@@ -280,7 +281,19 @@ export class SavedChartModel {
                 ...data,
                 updatedByUser: user,
             });
+
+            await trx('saved_queries')
+                .update({
+                    last_version_chart_kind: getChartType(
+                        data.chartConfig.type,
+                        data.chartConfig.config,
+                    ),
+                    last_version_updated_at: new Date(),
+                    last_version_updated_by_user_uuid: user.userUuid,
+                })
+                .where('saved_query_uuid', savedChartUuid);
         });
+
         return this.get(savedChartUuid);
     }
 

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -425,7 +425,7 @@ export class SpaceModel {
                 'saved_queries_versions.updated_by_user_uuid',
                 'users.user_uuid',
             )
-            .leftJoin(
+            /* .leftJoin(
                 PinnedChartTableName,
                 `${PinnedChartTableName}.saved_chart_uuid`,
                 `${SavedChartsTableName}.saved_query_uuid`,
@@ -434,7 +434,7 @@ export class SpaceModel {
                 PinnedListTableName,
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.pinned_list_uuid`,
-            )
+            ) */
             .select<
                 {
                     saved_query_uuid: string;
@@ -467,7 +467,8 @@ export class SpaceModel {
                     `(SELECT ${AnalyticsChartViewsTableName}.timestamp FROM ${AnalyticsChartViewsTableName} WHERE ${AnalyticsChartViewsTableName}.chart_uuid = saved_queries.saved_query_uuid ORDER BY ${AnalyticsChartViewsTableName}.timestamp ASC LIMIT 1) as first_viewed_at`,
                 ),
                 `saved_queries_versions.chart_config`,
-                `saved_queries_versions.chart_type`,
+                // `saved_queries_versions.chart_type`,
+                `saved_queries.chart_type`,
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.order`,
                 this.database.raw(`

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1,5 +1,6 @@
 import {
     ChartConfig,
+    ChartKind,
     ChartType,
     getChartType,
     NotFoundError,
@@ -419,13 +420,18 @@ export class SpaceModel {
                 'saved_queries_versions',
                 `saved_queries.saved_query_id`,
                 `saved_queries_versions.saved_query_id`,
-            )
+            ) // TODO remove
             .leftJoin(
                 'users',
                 'saved_queries_versions.updated_by_user_uuid',
                 'users.user_uuid',
-            )
+            ) // TODO remove
             /* .leftJoin(
+                'users',
+                'saved_queries.last_version_updated_by_user_uuid',
+                'users.user_uuid',
+            ) */ // TODO add
+            .leftJoin(
                 PinnedChartTableName,
                 `${PinnedChartTableName}.saved_chart_uuid`,
                 `${SavedChartsTableName}.saved_query_uuid`,
@@ -434,7 +440,7 @@ export class SpaceModel {
                 PinnedListTableName,
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.pinned_list_uuid`,
-            ) */
+            )
             .select<
                 {
                     saved_query_uuid: string;
@@ -446,8 +452,9 @@ export class SpaceModel {
                     last_name: string;
                     views: string;
                     first_viewed_at: Date | null;
-                    chart_config: ChartConfig['config'];
-                    chart_type: ChartType;
+                    chart_config: ChartConfig['config']; // TODO remove
+                    chart_type: ChartType; // TODO remove
+                    // chart_kind: ChartKind; //TODO add
                     pinned_list_uuid: string;
                     order: number;
                     validation_errors: DbValidationTable[];
@@ -456,7 +463,8 @@ export class SpaceModel {
                 `saved_queries.saved_query_uuid`,
                 `saved_queries.name`,
                 `saved_queries.description`,
-                `saved_queries_versions.created_at`,
+                `saved_queries_versions.created_at`, // TODO remove
+                // `saved_queries.last_version_updated_at as created_at`,  // TODO add
                 `users.user_uuid`,
                 `users.first_name`,
                 `users.last_name`,
@@ -466,9 +474,9 @@ export class SpaceModel {
                 this.database.raw(
                     `(SELECT ${AnalyticsChartViewsTableName}.timestamp FROM ${AnalyticsChartViewsTableName} WHERE ${AnalyticsChartViewsTableName}.chart_uuid = saved_queries.saved_query_uuid ORDER BY ${AnalyticsChartViewsTableName}.timestamp ASC LIMIT 1) as first_viewed_at`,
                 ),
-                `saved_queries_versions.chart_config`,
-                // `saved_queries_versions.chart_type`,
-                `saved_queries.chart_type`,
+                `saved_queries_versions.chart_config`, // TODO remove
+                `saved_queries_versions.chart_type`, // TODO remove
+                // `saved_queries.last_version_chart_kind as chart_kind`, // TODO add
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.order`,
                 this.database.raw(`
@@ -483,14 +491,18 @@ export class SpaceModel {
             ])
             .orderBy([
                 {
-                    column: `saved_queries_versions.saved_query_id`,
+                    column: `saved_queries_versions.saved_query_id`, // TODO remove
+                    // column: `saved_queries.saved_query_uuid`, // TODO add
                 },
                 {
-                    column: `saved_queries_versions.created_at`,
+                    column: `saved_queries_versions.created_at`, // TODO remove
+                    //  column: `saved_queries.last_version_updated_at`, //TODO add
                     order: 'desc',
                 },
             ])
-            .distinctOn(`saved_queries_versions.saved_query_id`)
+            .distinctOn(`saved_queries_versions.saved_query_id`) // TODO remove
+            // .distinctOn(`saved_queries.saved_query_uuid`) // TODO add
+
             .where(`${SpaceTableName}.space_uuid`, spaceUuid);
 
         return savedQueries.map((savedQuery) => ({
@@ -509,7 +521,8 @@ export class SpaceModel {
             chartType: getChartType(
                 savedQuery.chart_type,
                 savedQuery.chart_config,
-            ),
+            ), // TODO remove
+            // chartType: savedQuery.chart_kind,// TODO add
             pinnedListUuid: savedQuery.pinned_list_uuid,
             pinnedListOrder: savedQuery.order,
             validationErrors: savedQuery.validation_errors.map(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #6117

### Description:
- [x] In the chart table, we should add the columns: 
>    - `last_version_chart_kind`: ChartKind | null
>    - `last_version_updated_at`: Date
>    - `last_version_updated_by_user_uuid`: reference to user table | null
- [x] Update those columns on chart update
- [ ] Remove `saved_queries_versions` joins and use new columns.

We are not going to remove the joins at the moment, because the fields are not populated. 

We'll be doing this on a later review (follow all TODOs) 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


Right now 


![Screenshot from 2023-07-11 12-42-13](https://github.com/lightdash/lightdash/assets/1983672/9eedbec1-9fb9-4491-a2d5-91ad900cd7a8)


With empty state


![Screenshot from 2023-07-11 12-36-50](https://github.com/lightdash/lightdash/assets/1983672/d14b8762-f1e0-4323-8d09-1ec06a690b2d)

After updating 1 chart: 

![Screenshot from 2023-07-11 12-37-14](https://github.com/lightdash/lightdash/assets/1983672/8af4fd94-782b-414c-9dde-951fcc5dd74b)
