### PR TITLE
revert: echarts show tooltip only on hovered lines/bars (#6195)

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1414,7 +1414,7 @@ const useEcharts = (validCartesianConfigLegend?: LegendValues) => {
             tooltip: {
                 show: true,
                 confine: true,
-                trigger: 'item',
+                trigger: 'axis',
                 axisPointer: {
                     type: 'shadow',
                     label: { show: true },


### PR DESCRIPTION
This reverts commit 6cf9580d47a8ce8b8d41d764b88d9957fa7db920.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
