### PR TITLE
feat: use tsoa for sql query api

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -4,6 +4,7 @@ import {
     ApiProjectAccessListResponse,
     ApiProjectResponse,
     ApiSpaceSummaryListResponse,
+    ApiSqlQueryResults,
     ApiSuccessEmpty,
     CreateProjectMember,
     UpdateProjectMember,
@@ -200,6 +201,37 @@ export class ProjectController extends Controller {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Run a raw sql query against the project's warehouse connection
+     * @param projectUuid The uuid of the project to run the query against
+     * @param body The query to run
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/sqlQuery')
+    @OperationId('RunSqlQuery')
+    @Tags('Exploring')
+    async runSqlQuery(
+        @Path() projectUuid: string,
+        @Body() body: { sql: string },
+        @Request() req: express.Request,
+    ): Promise<{ status: 'ok'; results: ApiSqlQueryResults }> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await projectService.runSqlQuery(
+                req.user!,
+                projectUuid,
+                body.sql,
+            ),
         };
     }
 }

--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -123,8 +123,8 @@ export class RunViewChartQueryController extends Controller {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Post('/explores/{exploreId}/runQuery')
-    @OperationId('postRunQuery')
-    async postRunQuery(
+    @OperationId('RunMetricQuery')
+    async runMetricQuery(
         @Body() body: RunQueryRequest,
         @Path() projectUuid: string,
         @Path() exploreId: string,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1790,6 +1790,46 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string._type-DimensionType--__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.unknown_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSqlQueryResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                rows: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'Record_string.unknown_',
+                    },
+                    required: true,
+                },
+                fields: {
+                    ref: 'Record_string._type-DimensionType--__',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FieldId: {
         dataType: 'refAlias',
         type: { dataType: 'string', validators: {} },
@@ -4735,6 +4775,61 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.post(
+        '/api/v1/projects/:projectUuid/sqlQuery',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.runSqlQuery,
+        ),
+
+        function ProjectController_runSqlQuery(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        sql: { dataType: 'string', required: true },
+                    },
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new ProjectController();
+
+                const promise = controller.runSqlQuery.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
         '/api/v1/projects/:projectUuid/explores/:exploreId/runUnderlyingDataQuery',
         ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
         ...fetchMiddlewares<RequestHandler>(
@@ -4796,10 +4891,10 @@ export function RegisterRoutes(app: express.Router) {
         '/api/v1/projects/:projectUuid/explores/:exploreId/runQuery',
         ...fetchMiddlewares<RequestHandler>(RunViewChartQueryController),
         ...fetchMiddlewares<RequestHandler>(
-            RunViewChartQueryController.prototype.postRunQuery,
+            RunViewChartQueryController.prototype.runMetricQuery,
         ),
 
-        function RunViewChartQueryController_postRunQuery(
+        function RunViewChartQueryController_runMetricQuery(
             request: any,
             response: any,
             next: any,
@@ -4839,7 +4934,7 @@ export function RegisterRoutes(app: express.Router) {
 
                 const controller = new RunViewChartQueryController();
 
-                const promise = controller.postRunQuery.apply(
+                const promise = controller.runMetricQuery.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2063,6 +2063,31 @@
                 "required": ["role"],
                 "type": "object"
             },
+            "Record_string._type-DimensionType--__": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "Record_string.unknown_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "ApiSqlQueryResults": {
+                "properties": {
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/Record_string.unknown_"
+                        },
+                        "type": "array"
+                    },
+                    "fields": {
+                        "$ref": "#/components/schemas/Record_string._type-DimensionType--__"
+                    }
+                },
+                "required": ["rows", "fields"],
+                "type": "object"
+            },
             "FieldId": {
                 "type": "string"
             },
@@ -3701,7 +3726,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.661.0",
+        "version": "0.668.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -5150,6 +5175,76 @@
                 ]
             }
         },
+        "/api/v1/projects/{projectUuid}/sqlQuery": {
+            "post": {
+                "operationId": "RunSqlQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/components/schemas/ApiSqlQueryResults"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["results", "status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a raw sql query against the project's warehouse connection",
+                "tags": ["Exploring", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to run the query against",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "The query to run",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "sql": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["sql"],
+                                "type": "object",
+                                "description": "The query to run"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectUuid}/explores/{exploreId}/runUnderlyingDataQuery": {
             "post": {
                 "operationId": "postRunUnderlyingDataQuery",
@@ -5214,7 +5309,7 @@
         },
         "/api/v1/projects/{projectUuid}/explores/{exploreId}/runQuery": {
             "post": {
-                "operationId": "postRunQuery",
+                "operationId": "RunMetricQuery",
                 "responses": {
                     "200": {
                         "description": "Success",

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -454,29 +454,6 @@ projectRouter.patch(
 );
 
 projectRouter.post(
-    '/sqlQuery',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    unauthorisedInDemo,
-    async (req, res, next) => {
-        try {
-            const results: ApiSqlQueryResults =
-                await projectService.runSqlQuery(
-                    req.user!,
-                    req.params.projectUuid,
-                    req.body.sql,
-                );
-            res.json({
-                status: 'ok',
-                results,
-            });
-        } catch (e) {
-            next(e);
-        }
-    },
-);
-
-projectRouter.post(
     '/sqlRunner/downloadCsv',
     allowApiKeyAuthentication,
     isAuthenticated,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/discussions/6181

Breaking change for api consumers using auto-generated clients is renaming `postRunQuery` to `runMetricQuery` 
