### PR TITLE
fix: filter empty chart title

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -5,12 +5,15 @@ import {
     DashboardTile,
     fieldId as getFieldId,
     FilterableField,
+    isDashboardChartTileType,
     matchFieldByType,
     matchFieldByTypeAndName,
     matchFieldExact,
 } from '@lightdash/common';
 import { FC, useCallback, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import { FilterActions } from '.';
+import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import FieldAutoComplete from '../../common/Filters/FieldAutoComplete';
 
 interface TileFilterConfigurationProps {
@@ -34,6 +37,10 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
     popoverProps,
     onChange,
 }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    const { data: savedCharts } = useChartSummaries(projectUuid);
+
     const tilesSortBy = useCallback(
         (
             matcher: (a: FilterableField) => (b: FilterableField) => boolean,
@@ -87,10 +94,19 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
                     .sort((a, b) => itemsSortBy(matchFieldByTypeAndName, a, b))
                     .sort((a, b) => itemsSortBy(matchFieldExact, a, b));
 
+                const title =
+                    tile &&
+                    tile.properties.title === undefined &&
+                    isDashboardChartTileType(tile)
+                        ? savedCharts?.find(
+                              (chart) =>
+                                  chart.uuid === tile.properties.savedChartUuid,
+                          )?.name
+                        : tile?.properties.title;
                 return (
                     <FormGroup key={tileUuid}>
                         <Checkbox
-                            label={tile?.properties.title || undefined}
+                            label={title}
                             disabled={!isAvailable}
                             checked={isChecked}
                             onChange={() => {

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1414,7 +1414,7 @@ const useEcharts = (validCartesianConfigLegend?: LegendValues) => {
             tooltip: {
                 show: true,
                 confine: true,
-                trigger: 'item',
+                trigger: 'axis',
                 axisPointer: {
                     type: 'shadow',
                     label: { show: true },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6301
### Description:
<!-- Add a description of the changes proposed in the pull request. -->
I think this is the best way to fix it without introducing extra attributes to the chart ChartTile, but le tme know if you prefer a different approach.

<!-- Even better add a screenshot / gif / loom -->

Before:

![image](https://github.com/lightdash/lightdash/assets/1983672/a8976fd7-9de6-4ff7-b3ca-dc461eacc922)



After:


![image](https://github.com/lightdash/lightdash/assets/1983672/b82154cd-a79c-4f33-bdfa-70e42db667cd)
