### PR TITLE
fix: handle dotted field names when generating field id

### DIFF
--- a/packages/common/src/types/field.test.ts
+++ b/packages/common/src/types/field.test.ts
@@ -1,18 +1,47 @@
-import { convertFieldRefToFieldId } from './field';
+import { convertFieldRefToFieldId, fieldId } from './field';
 
 describe('field util functions', () => {
-    it('should convert field references to field ids', async () => {
-        expect(convertFieldRefToFieldId('table.field')).toEqual('table_field');
-        expect(convertFieldRefToFieldId('table.field', 'fallback')).toEqual(
-            'table_field',
-        );
-        expect(convertFieldRefToFieldId('field', 'fallback')).toEqual(
-            'fallback_field',
-        );
+    describe('convertFieldRefToFieldId', () => {
+        it('should convert field references to field ids', async () => {
+            expect(convertFieldRefToFieldId('table.field')).toEqual(
+                'table_field',
+            );
+            expect(convertFieldRefToFieldId('table.field', 'fallback')).toEqual(
+                'table_field',
+            );
+            expect(convertFieldRefToFieldId('field', 'fallback')).toEqual(
+                'fallback_field',
+            );
+        });
+        it('should throw error when field reference doesnt have a table and there is no fallback', async () => {
+            expect(() => convertFieldRefToFieldId('field')).toThrowError(
+                'Table calculation contains an invalid reference: field. References must be of the format "table.field"',
+            );
+        });
     });
-    it('should throw error when field reference doesnt have a table and there is no fallback', async () => {
-        expect(() => convertFieldRefToFieldId('field')).toThrowError(
-            'Table calculation contains an invalid reference: field. References must be of the format "table.field"',
-        );
+    describe('fieldId', () => {
+        it('should return field id', async () => {
+            expect(fieldId({ table: 'table', name: 'field' })).toEqual(
+                'table_field',
+            );
+            expect(fieldId({ table: 'table', name: 'field.nested' })).toEqual(
+                'table_field__nested',
+            );
+            expect(fieldId({ table: 'table', name: 'field_test' })).toEqual(
+                'table_field_test',
+            );
+            expect(fieldId({ table: 'table_test', name: 'field' })).toEqual(
+                'table_test_field',
+            );
+            expect(
+                fieldId({ table: 'table_test', name: 'field_test' }),
+            ).toEqual('table_test_field_test');
+            expect(
+                fieldId({ table: 'table_test', name: 'field.nested' }),
+            ).toEqual('table_test_field__nested');
+            expect(
+                fieldId({ table: 'table_test', name: 'field_test.nested' }),
+            ).toEqual('table_test_field_test__nested');
+        });
     });
 });

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -145,7 +145,7 @@ export const isField = (field: any): field is Field =>
 // Field ids are unique across the project
 export type FieldId = string;
 export const fieldId = (field: Pick<Field, 'table' | 'name'>): FieldId =>
-    `${field.table}_${field.name}`;
+    `${field.table}_${field.name.replaceAll('.', '__')}`;
 
 export const convertFieldRefToFieldId = (
     fieldRef: string,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4097 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

**Changes:**
When generating a field ID, replace all the `.` in the field name to `__` ( double underscore )

I'm using double underscore to avoid conflicts

eg: the fields `dimension.column` and `dimension_column` in the same table would both end up as `table_dimension_column` 
 
**Note 1:** Even with a double underscore is possible to cause this conflict but less likely. 

**Note 2:** This PR doesn't handle the necessary SQL to access json fields in each warehouse. The developer will have to define it in their yml.  

YML:

<img width="905" alt="Screenshot 2023-07-13 at 18 09 01" src="https://github.com/lightdash/lightdash/assets/9117144/7cf6fb37-6aaf-4242-bbd0-dd3461cf870e">

Manifest:

<img width="907" alt="Screenshot 2023-07-13 at 18 15 06" src="https://github.com/lightdash/lightdash/assets/9117144/81d7dcb5-1a71-4597-8164-f8198a04f638">



Query:

<img width="1607" alt="Screenshot 2023-07-13 at 18 08 40" src="https://github.com/lightdash/lightdash/assets/9117144/87a02a90-169f-4c8a-b0f9-b5f3e79b933a">



