### PR TITLE
feat: conditional formatting color range

### DIFF
--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -1,13 +1,29 @@
 import { ConditionalOperator, ConditionalRule } from './conditionalRule';
 import { FieldTarget } from './filter';
 
-export interface ConditionalFormattingRule<T = number>
-    extends ConditionalRule<ConditionalOperator, T> {
-    values: T[];
-}
+export type ConditionalFormattingWithConditionalOperator<T = number> =
+    ConditionalRule<ConditionalOperator, T> & {
+        values: T[];
+    };
 
-export interface ConditionalFormattingConfig {
+export const isConditionalFormattingRuleWithConditionalOperator = (
+    rule: ConditionalFormattingConfig['rules'][0],
+): rule is ConditionalFormattingWithConditionalOperator => 'values' in rule;
+
+export type ConditionalFormattingWithRange<T = number> = {
+    min: T;
+    max: T;
+};
+
+export const isConditionalFormattingRuleWithRange = (
+    rule: ConditionalFormattingConfig['rules'][0],
+): rule is ConditionalFormattingWithRange => 'min' in rule && 'max' in rule;
+
+export type ConditionalFormattingConfig = {
     target: FieldTarget | null;
-    rules: ConditionalFormattingRule[];
-    color: string;
-}
+    rules: (
+        | ConditionalFormattingWithConditionalOperator
+        | ConditionalFormattingWithRange
+    )[];
+    color: string | string[];
+};

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -6,24 +6,62 @@ export type ConditionalFormattingWithConditionalOperator<T = number> =
         values: T[];
     };
 
-export const isConditionalFormattingRuleWithConditionalOperator = (
-    rule: ConditionalFormattingConfig['rules'][0],
-): rule is ConditionalFormattingWithConditionalOperator => 'values' in rule;
-
 export type ConditionalFormattingWithRange<T = number> = {
     min: T;
     max: T;
 };
 
-export const isConditionalFormattingRuleWithRange = (
-    rule: ConditionalFormattingConfig['rules'][0],
-): rule is ConditionalFormattingWithRange => 'min' in rule && 'max' in rule;
-
-export type ConditionalFormattingConfig = {
+// Single color -
+export type ConditionalFormattingConfigWithSingleColor = {
     target: FieldTarget | null;
-    rules: (
-        | ConditionalFormattingWithConditionalOperator
-        | ConditionalFormattingWithRange
-    )[];
-    color: string | string[];
+    color: string;
+    rules: ConditionalFormattingWithConditionalOperator[];
+};
+
+export const isConditionalFormattingConfigWithSingleColor = (
+    rule: ConditionalFormattingConfig,
+): rule is ConditionalFormattingConfigWithSingleColor =>
+    'color' in rule && typeof rule.color === 'string' && 'rules' in rule;
+// - Single color
+
+// Color range -
+export type ConditionalFormattingConfigWithColorRange = {
+    target: FieldTarget | null;
+    color: {
+        start: string;
+        end: string;
+        steps: 5;
+    };
+    rule: ConditionalFormattingWithRange;
+};
+
+export const isConditionalFormattingConfigWithColorRange = (
+    config: ConditionalFormattingConfig,
+): config is ConditionalFormattingConfigWithColorRange =>
+    'color' in config &&
+    typeof config.color === 'object' &&
+    'steps' in config.color;
+// - Color range
+
+export type ConditionalFormattingConfig =
+    | ConditionalFormattingConfigWithSingleColor
+    | ConditionalFormattingConfigWithColorRange;
+
+export enum ConditionalFormattingConfigType {
+    Single = 'single',
+    Range = 'range',
+}
+
+export const getConditionalFormattingConfigType = (
+    rule: ConditionalFormattingConfig,
+): ConditionalFormattingConfigType => {
+    if (isConditionalFormattingConfigWithSingleColor(rule)) {
+        return ConditionalFormattingConfigType.Single;
+    }
+
+    if (isConditionalFormattingConfigWithColorRange(rule)) {
+        return ConditionalFormattingConfigType.Range;
+    }
+
+    throw new Error('Invalid conditional formatting rule');
 };

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -11,7 +11,6 @@ export type ConditionalFormattingWithRange<T = number> = {
     max: T;
 };
 
-// Single color -
 export type ConditionalFormattingConfigWithSingleColor = {
     target: FieldTarget | null;
     color: string;
@@ -22,9 +21,7 @@ export const isConditionalFormattingConfigWithSingleColor = (
     rule: ConditionalFormattingConfig,
 ): rule is ConditionalFormattingConfigWithSingleColor =>
     'color' in rule && typeof rule.color === 'string' && 'rules' in rule;
-// - Single color
 
-// Color range -
 export type ConditionalFormattingConfigWithColorRange = {
     target: FieldTarget | null;
     color: {
@@ -41,7 +38,6 @@ export const isConditionalFormattingConfigWithColorRange = (
     'color' in config &&
     typeof config.color === 'object' &&
     'steps' in config.color;
-// - Color range
 
 export type ConditionalFormattingConfig =
     | ConditionalFormattingConfigWithSingleColor

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -17,6 +17,7 @@ import {
     isFilterableItem,
     TableCalculation,
 } from '../types/field';
+import { FieldTarget } from '../types/filter';
 import assertUnreachable from './assertUnreachable';
 import { getItemId, isNumericItem } from './item';
 
@@ -27,26 +28,28 @@ export const createConditionalFormatingRule =
         values: [],
     });
 
-export const createConditionalFormattingConfigWithSingleColor =
-    (): ConditionalFormattingConfigWithSingleColor => ({
-        target: null,
-        color: '',
-        rules: [createConditionalFormatingRule()],
-    });
+export const createConditionalFormattingConfigWithSingleColor = (
+    target: FieldTarget | null = null,
+): ConditionalFormattingConfigWithSingleColor => ({
+    target,
+    color: '',
+    rules: [createConditionalFormatingRule()],
+});
 
-export const createConditionalFormattingConfigWithColorRange =
-    (): ConditionalFormattingConfigWithColorRange => ({
-        target: null,
-        color: {
-            start: '',
-            end: '',
-            steps: 5,
-        },
-        rule: {
-            min: 0,
-            max: 100,
-        },
-    });
+export const createConditionalFormattingConfigWithColorRange = (
+    target: FieldTarget | null = null,
+): ConditionalFormattingConfigWithColorRange => ({
+    target,
+    color: {
+        start: '',
+        end: '',
+        steps: 5,
+    },
+    rule: {
+        min: 0,
+        max: 100,
+    },
+});
 
 export const hasMatchingConditionalRules = (
     value: unknown,

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -141,9 +141,9 @@ export const getConditionalFormattingDescription = (
         isConditionalFormattingConfigWithColorRange(conditionalFormattingConfig)
     ) {
         return [
-            conditionalFormattingConfig.rule.min,
-            conditionalFormattingConfig.rule.max,
-        ].join(' - ');
+            `is greater than or equal to ${conditionalFormattingConfig.rule.min}`,
+            `is less than or equal to ${conditionalFormattingConfig.rule.max}`,
+        ].join(' and ');
     }
 
     if (

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -1,11 +1,14 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
     ConditionalFormattingConfig,
-    ConditionalFormattingRule,
+    ConditionalFormattingConfigWithColorRange,
+    ConditionalFormattingConfigWithSingleColor,
+    ConditionalFormattingWithConditionalOperator,
+    isConditionalFormattingConfigWithColorRange,
+    isConditionalFormattingConfigWithSingleColor,
 } from '../types/conditionalFormatting';
 import {
     ConditionalOperator,
-    ConditionalRule,
     ConditionalRuleLabels,
 } from '../types/conditionalRule';
 import {
@@ -18,17 +21,31 @@ import assertUnreachable from './assertUnreachable';
 import { getItemId, isNumericItem } from './item';
 
 export const createConditionalFormatingRule =
-    (): ConditionalFormattingRule => ({
+    (): ConditionalFormattingWithConditionalOperator => ({
         id: uuidv4(),
         operator: ConditionalOperator.EQUALS,
         values: [],
     });
 
-export const createConditionalFormattingConfig =
-    (): ConditionalFormattingConfig => ({
+export const createConditionalFormattingConfigWithSingleColor =
+    (): ConditionalFormattingConfigWithSingleColor => ({
         target: null,
         color: '',
         rules: [createConditionalFormatingRule()],
+    });
+
+export const createConditionalFormattingConfigWithColorRange =
+    (): ConditionalFormattingConfigWithColorRange => ({
+        target: null,
+        color: {
+            start: '',
+            end: '',
+            steps: 5,
+        },
+        rule: {
+            min: 0,
+            max: 100,
+        },
     });
 
 export const hasMatchingConditionalRules = (
@@ -39,43 +56,53 @@ export const hasMatchingConditionalRules = (
 
     const parsedValue = typeof value === 'string' ? Number(value) : value;
 
-    return config.rules.every((rule) => {
-        switch (rule.operator) {
-            case ConditionalOperator.NULL:
-                return parsedValue === null;
-            case ConditionalOperator.NOT_NULL:
-                return parsedValue !== null;
-            case ConditionalOperator.EQUALS:
-                return rule.values.some((v) => parsedValue === v);
-            case ConditionalOperator.NOT_EQUALS:
-                return rule.values.some((v) => parsedValue !== v);
-            case ConditionalOperator.LESS_THAN:
-                return typeof parsedValue === 'number'
-                    ? rule.values.some((v) => parsedValue < v)
-                    : false;
-            case ConditionalOperator.GREATER_THAN:
-                return typeof parsedValue === 'number'
-                    ? rule.values.some((v) => parsedValue > v)
-                    : false;
-            case ConditionalOperator.STARTS_WITH:
-            case ConditionalOperator.ENDS_WITH:
-            case ConditionalOperator.INCLUDE:
-            case ConditionalOperator.NOT_INCLUDE:
-            case ConditionalOperator.LESS_THAN_OR_EQUAL:
-            case ConditionalOperator.GREATER_THAN_OR_EQUAL:
-            case ConditionalOperator.IN_THE_PAST:
-            case ConditionalOperator.NOT_IN_THE_PAST:
-            case ConditionalOperator.IN_THE_NEXT:
-            case ConditionalOperator.IN_THE_CURRENT:
-            case ConditionalOperator.IN_BETWEEN:
-                throw new Error('Not implemented');
-            default:
-                return assertUnreachable(
-                    rule.operator,
-                    'Unknown operator for conditional formatting',
-                );
-        }
-    });
+    if (isConditionalFormattingConfigWithSingleColor(config)) {
+        return config.rules.every((rule) => {
+            switch (rule.operator) {
+                case ConditionalOperator.NULL:
+                    return parsedValue === null;
+                case ConditionalOperator.NOT_NULL:
+                    return parsedValue !== null;
+                case ConditionalOperator.EQUALS:
+                    return rule.values.some((v) => parsedValue === v);
+                case ConditionalOperator.NOT_EQUALS:
+                    return rule.values.some((v) => parsedValue !== v);
+                case ConditionalOperator.LESS_THAN:
+                    return typeof parsedValue === 'number'
+                        ? rule.values.some((v) => parsedValue < v)
+                        : false;
+                case ConditionalOperator.GREATER_THAN:
+                    return typeof parsedValue === 'number'
+                        ? rule.values.some((v) => parsedValue > v)
+                        : false;
+                case ConditionalOperator.STARTS_WITH:
+                case ConditionalOperator.ENDS_WITH:
+                case ConditionalOperator.INCLUDE:
+                case ConditionalOperator.NOT_INCLUDE:
+                case ConditionalOperator.LESS_THAN_OR_EQUAL:
+                case ConditionalOperator.GREATER_THAN_OR_EQUAL:
+                case ConditionalOperator.IN_THE_PAST:
+                case ConditionalOperator.NOT_IN_THE_PAST:
+                case ConditionalOperator.IN_THE_NEXT:
+                case ConditionalOperator.IN_THE_CURRENT:
+                case ConditionalOperator.IN_BETWEEN:
+                    throw new Error('Not implemented');
+                default:
+                    return assertUnreachable(
+                        rule.operator,
+                        'Unknown operator for conditional formatting',
+                    );
+            }
+        });
+    }
+
+    if (isConditionalFormattingConfigWithColorRange(config)) {
+        if (typeof parsedValue !== 'number') return false;
+
+        return parsedValue >= config.rule.min && parsedValue <= config.rule.max;
+    }
+
+    return assertUnreachable(config, 'Unknown conditional formatting config');
 };
 
 export const getConditionalFormattingConfig = (
@@ -99,16 +126,36 @@ export const getConditionalFormattingDescription = (
     field: Field | TableCalculation | undefined,
     conditionalFormattingConfig: ConditionalFormattingConfig | undefined,
     getConditionalRuleLabel: (
-        rule: ConditionalRule,
+        rule: ConditionalFormattingWithConditionalOperator,
         item: FilterableItem,
     ) => ConditionalRuleLabels,
-) =>
-    field &&
-    isFilterableItem(field) &&
-    conditionalFormattingConfig &&
-    conditionalFormattingConfig?.rules.length > 0
-        ? conditionalFormattingConfig.rules
-              .map((r) => getConditionalRuleLabel(r, field))
-              .map((l) => `${l.operator} ${l.value}`)
-              .join(' and ')
-        : undefined;
+): string | undefined => {
+    if (!field || !isFilterableItem(field) || !conditionalFormattingConfig) {
+        return undefined;
+    }
+
+    if (
+        isConditionalFormattingConfigWithColorRange(conditionalFormattingConfig)
+    ) {
+        return [
+            conditionalFormattingConfig.rule.min,
+            conditionalFormattingConfig.rule.max,
+        ].join(' - ');
+    }
+
+    if (
+        isConditionalFormattingConfigWithSingleColor(
+            conditionalFormattingConfig,
+        )
+    ) {
+        return conditionalFormattingConfig.rules
+            .map((r) => getConditionalRuleLabel(r, field))
+            .map((l) => `${l.operator} ${l.value}`)
+            .join(' and ');
+    }
+
+    return assertUnreachable(
+        conditionalFormattingConfig,
+        'Unknown conditional formatting config',
+    );
+};

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -29,20 +29,22 @@ export const createConditionalFormatingRule =
     });
 
 export const createConditionalFormattingConfigWithSingleColor = (
+    defaultColor: string,
     target: FieldTarget | null = null,
 ): ConditionalFormattingConfigWithSingleColor => ({
     target,
-    color: '',
+    color: defaultColor,
     rules: [createConditionalFormatingRule()],
 });
 
 export const createConditionalFormattingConfigWithColorRange = (
+    defaultColor: string,
     target: FieldTarget | null = null,
 ): ConditionalFormattingConfigWithColorRange => ({
     target,
     color: {
-        start: '',
-        end: '',
+        start: '#ffffff',
+        end: defaultColor,
         steps: 5,
     },
     rule: {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -159,3 +159,48 @@ export const getConditionalFormattingDescription = (
         'Unknown conditional formatting config',
     );
 };
+
+export const getConditionalFormattingColor = (
+    value: unknown,
+    conditionalFormattingConfig: ConditionalFormattingConfig | undefined,
+    getColorFromRange: (
+        value: number,
+        config: {
+            color: {
+                start: string;
+                end: string;
+                steps: number;
+            };
+            rule: {
+                min: number;
+                max: number;
+            };
+        },
+    ) => string | undefined,
+) => {
+    if (!conditionalFormattingConfig) {
+        return undefined;
+    }
+
+    if (
+        isConditionalFormattingConfigWithColorRange(conditionalFormattingConfig)
+    ) {
+        const numericValue = typeof value === 'string' ? Number(value) : value;
+        if (typeof numericValue !== 'number') return undefined;
+
+        return getColorFromRange(numericValue, conditionalFormattingConfig);
+    }
+
+    if (
+        isConditionalFormattingConfigWithSingleColor(
+            conditionalFormattingConfig,
+        )
+    ) {
+        return conditionalFormattingConfig.color;
+    }
+
+    return assertUnreachable(
+        conditionalFormattingConfig,
+        'Unknown conditional formatting config',
+    );
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -31,7 +31,7 @@
         "@uiw/react-md-editor": "^3.10.0",
         "ace-builds": "^1.4.14",
         "cohere-js": "^1.0.19",
-        "colorjs.io": "^0.4.2",
+        "colorjs.io": "^0.4.5",
         "copy-to-clipboard": "^3.3.2",
         "cron-converter": "^2.0.0",
         "cronstrue": "^2.22.0",

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -41,7 +41,6 @@ import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
-import ColorSelector from '../ColorSelector';
 import FieldSelectItem from '../FieldSelectItem';
 import ConditionalFormattingRule from './ConditionalFormattingRule';
 
@@ -296,13 +295,15 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                             config,
                         ) ? (
                             <>
-                                <Group spacing="xs">
-                                    <Text fw={500}>Select color</Text>
-                                </Group>
-
-                                <ColorSelector
+                                <ColorInput
+                                    withinPortal={false}
+                                    withEyeDropper={false}
+                                    format="hex"
+                                    swatches={defaultColors}
+                                    swatchesPerRow={defaultColors.length}
+                                    label="Select color"
                                     color={config.color}
-                                    onColorChange={handleChangeSingleColor}
+                                    onChange={handleChangeSingleColor}
                                 />
 
                                 {config.rules.map((rule, ruleIndex) => (

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -106,11 +106,15 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
         switch (newConfigType) {
             case ConditionalFormattingConfigType.Single:
                 return handleChange(
-                    createConditionalFormattingConfigWithSingleColor(),
+                    createConditionalFormattingConfigWithSingleColor(
+                        config.target,
+                    ),
                 );
             case ConditionalFormattingConfigType.Range:
                 return handleChange(
-                    createConditionalFormattingConfigWithColorRange(),
+                    createConditionalFormattingConfigWithColorRange(
+                        config.target,
+                    ),
                 );
             default:
                 return assertUnreachable(newConfigType, 'Unknown config type');
@@ -346,6 +350,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                             <>
                                 <SimpleGrid cols={2}>
                                     <ColorInput
+                                        withinPortal={false}
                                         withEyeDropper={false}
                                         format="hex"
                                         swatches={defaultColors}
@@ -360,6 +365,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                     />
 
                                     <ColorInput
+                                        withinPortal={false}
                                         withEyeDropper={false}
                                         format="hex"
                                         swatches={defaultColors}
@@ -402,15 +408,19 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                             assertUnreachable(config, 'Unknown config type')
                         )}
 
-                        <Button
-                            sx={{ alignSelf: 'start' }}
-                            size="xs"
-                            variant="subtle"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                            onClick={handleAddRule}
-                        >
-                            Add new condition
-                        </Button>
+                        {isConditionalFormattingConfigWithSingleColor(
+                            config,
+                        ) ? (
+                            <Button
+                                sx={{ alignSelf: 'start' }}
+                                size="xs"
+                                variant="subtle"
+                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                onClick={handleAddRule}
+                            >
+                                Add new condition
+                            </Button>
+                        ) : null}
                     </Stack>
                 </Collapse>
             </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -1,10 +1,11 @@
 import {
     ConditionalFormattingConfig,
-    ConditionalFormattingRule as ConditionalFormattingRuleT,
+    ConditionalFormattingWithConditionalOperator,
     ConditionalOperator,
     createConditionalFormatingRule,
     FilterableItem,
     getItemId,
+    isConditionalFormattingRuleWithConditionalOperator,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -98,22 +99,31 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
     ) => {
         handleChange(
             produce(config, (draft) => {
-                draft.rules[index].operator = newOperator;
+                if (
+                    isConditionalFormattingRuleWithConditionalOperator(
+                        draft.rules[index],
+                    )
+                ) {
+                    draft.rules[index] = {
+                        ...draft.rules[index],
+                        operator: newOperator,
+                    };
+                }
             }),
         );
     };
 
     const handleChangeRule = (
         index: number,
-        newRule: ConditionalFormattingRuleT,
+        newRule: ConditionalFormattingWithConditionalOperator,
     ) => {
         handleChange(
             produce(config, (draft) => {
-                draft.rules[index] = newRule;
                 // FIXME: check if we can fix this problem in number input
-                draft.rules[index].values = draft.rules[index].values.map((v) =>
-                    Number(v),
-                );
+                draft.rules[index] = {
+                    ...newRule,
+                    values: newRule.values.map((v) => Number(v)),
+                };
             }),
         );
     };

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -111,12 +111,14 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                 case ConditionalFormattingConfigType.Single:
                     return handleChange(
                         createConditionalFormattingConfigWithSingleColor(
+                            defaultColors[0],
                             config.target,
                         ),
                     );
                 case ConditionalFormattingConfigType.Range:
                     return handleChange(
                         createConditionalFormattingConfigWithColorRange(
+                            defaultColors[0],
                             config.target,
                         ),
                     );
@@ -127,7 +129,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                     );
             }
         },
-        [handleChange, config],
+        [handleChange, config, defaultColors],
     );
 
     const handleAddRule = useCallback(() => {
@@ -296,6 +298,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                         />
 
                         <Select
+                            label="Select type"
                             value={getConditionalFormattingConfigType(config)}
                             data={[
                                 {
@@ -329,7 +332,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                     swatches={defaultColors}
                                     swatchesPerRow={defaultColors.length}
                                     label="Select color"
-                                    color={config.color}
+                                    value={config.color}
                                     onChange={handleChangeSingleColor}
                                 />
 
@@ -375,63 +378,61 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                         ) : isConditionalFormattingConfigWithColorRange(
                               config,
                           ) ? (
-                            <>
-                                <SimpleGrid cols={2}>
-                                    <ColorInput
-                                        withinPortal={false}
-                                        withEyeDropper={false}
-                                        format="hex"
-                                        swatches={defaultColors}
-                                        swatchesPerRow={defaultColors.length}
-                                        label="Start color"
-                                        value={config.color.start}
-                                        onChange={(newStartColor) =>
-                                            handleChangeColorRangeColor({
-                                                start: newStartColor,
-                                            })
-                                        }
-                                    />
+                            <SimpleGrid cols={2}>
+                                <ColorInput
+                                    withinPortal={false}
+                                    withEyeDropper={false}
+                                    format="hex"
+                                    swatches={defaultColors}
+                                    swatchesPerRow={defaultColors.length}
+                                    label="Start color"
+                                    value={config.color.start}
+                                    onChange={(newStartColor) =>
+                                        handleChangeColorRangeColor({
+                                            start: newStartColor,
+                                        })
+                                    }
+                                />
 
-                                    <ColorInput
-                                        withinPortal={false}
-                                        withEyeDropper={false}
-                                        format="hex"
-                                        swatches={defaultColors}
-                                        swatchesPerRow={defaultColors.length}
-                                        label="End color"
-                                        value={config.color.end}
-                                        onChange={(newEndColor) =>
-                                            handleChangeColorRangeColor({
-                                                end: newEndColor,
-                                            })
-                                        }
-                                    />
+                                <ColorInput
+                                    withinPortal={false}
+                                    withEyeDropper={false}
+                                    format="hex"
+                                    swatches={defaultColors}
+                                    swatchesPerRow={defaultColors.length}
+                                    label="End color"
+                                    value={config.color.end}
+                                    onChange={(newEndColor) =>
+                                        handleChangeColorRangeColor({
+                                            end: newEndColor,
+                                        })
+                                    }
+                                />
 
-                                    <NumberInput
-                                        label="Min value"
-                                        value={config.rule.min}
-                                        onChange={(newMin) => {
-                                            if (newMin === '') return;
+                                <NumberInput
+                                    label="Min value"
+                                    value={config.rule.min}
+                                    onChange={(newMin) => {
+                                        if (newMin === '') return;
 
-                                            handleChangeColorRangeRule({
-                                                min: newMin,
-                                            });
-                                        }}
-                                    />
+                                        handleChangeColorRangeRule({
+                                            min: newMin,
+                                        });
+                                    }}
+                                />
 
-                                    <NumberInput
-                                        label="Max value"
-                                        value={config.rule.max}
-                                        onChange={(newMax) => {
-                                            if (newMax === '') return;
+                                <NumberInput
+                                    label="Max value"
+                                    value={config.rule.max}
+                                    onChange={(newMax) => {
+                                        if (newMax === '') return;
 
-                                            handleChangeColorRangeRule({
-                                                max: newMax,
-                                            });
-                                        }}
-                                    />
-                                </SimpleGrid>
-                            </>
+                                        handleChangeColorRangeRule({
+                                            max: newMax,
+                                        });
+                                    }}
+                                />
+                            </SimpleGrid>
                         ) : (
                             assertUnreachable(config, 'Unknown config type')
                         )}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -68,14 +68,14 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
 }) => {
     const { data: org } = useOrganization();
 
+    const [isAddingRule, setIsAddingRule] = useState(false);
+    const [isOpen, setIsOpen] = useState(isDefaultOpen);
+    const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
+
     const defaultColors = useMemo(
         () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
         [org],
     );
-
-    const [isAddingRule, setIsAddingRule] = useState(false);
-    const [isOpen, setIsOpen] = useState(isDefaultOpen);
-    const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
 
     const field = useMemo(
         () => fields.find((f) => getItemId(f) === config?.target?.fieldId),

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -8,6 +8,7 @@ import {
     createConditionalFormatingRule,
     createConditionalFormattingConfigWithColorRange,
     createConditionalFormattingConfigWithSingleColor,
+    ECHARTS_DEFAULT_COLORS,
     FilterableItem,
     getConditionalFormattingConfigType,
     getItemId,
@@ -35,6 +36,7 @@ import {
 } from '@tabler/icons-react';
 import produce from 'immer';
 import React, { FC, useMemo, useState } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
@@ -65,6 +67,13 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
     onChange,
     onRemove,
 }) => {
+    const { data: org } = useOrganization();
+
+    const defaultColors = useMemo(
+        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
+        [org],
+    );
+
     const [isAddingRule, setIsAddingRule] = useState(false);
     const [isOpen, setIsOpen] = useState(isDefaultOpen);
     const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
@@ -338,6 +347,9 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                 <SimpleGrid cols={2}>
                                     <ColorInput
                                         withEyeDropper={false}
+                                        format="hex"
+                                        swatches={defaultColors}
+                                        swatchesPerRow={defaultColors.length}
                                         label="Start color"
                                         value={config.color.start}
                                         onChange={(newStartColor) =>
@@ -349,6 +361,9 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
 
                                     <ColorInput
                                         withEyeDropper={false}
+                                        format="hex"
+                                        swatches={defaultColors}
+                                        swatchesPerRow={defaultColors.length}
                                         label="End color"
                                         value={config.color.end}
                                         onChange={(newEndColor) =>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -35,7 +35,7 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import produce from 'immer';
-import React, { FC, useMemo, useState } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
@@ -82,45 +82,55 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
         [fields, config],
     );
 
-    const handleRemove = () => {
+    const handleRemove = useCallback(() => {
         onRemove();
-    };
+    }, [onRemove]);
 
-    const handleChange = (newConfig: ConditionalFormattingConfig) => {
-        setConfig(newConfig);
-        onChange(newConfig);
-    };
+    const handleChange = useCallback(
+        (newConfig: ConditionalFormattingConfig) => {
+            setConfig(newConfig);
+            onChange(newConfig);
+        },
+        [onChange],
+    );
 
-    const handleChangeField = (newFieldId: string) => {
-        handleChange(
-            produce(config, (draft) => {
-                draft.target = newFieldId ? { fieldId: newFieldId } : null;
-            }),
-        );
-    };
+    const handleChangeField = useCallback(
+        (newFieldId: string) => {
+            handleChange(
+                produce(config, (draft) => {
+                    draft.target = newFieldId ? { fieldId: newFieldId } : null;
+                }),
+            );
+        },
+        [handleChange, config],
+    );
 
-    const handleConfigTypeChange = (
-        newConfigType: ConditionalFormattingConfigType,
-    ) => {
-        switch (newConfigType) {
-            case ConditionalFormattingConfigType.Single:
-                return handleChange(
-                    createConditionalFormattingConfigWithSingleColor(
-                        config.target,
-                    ),
-                );
-            case ConditionalFormattingConfigType.Range:
-                return handleChange(
-                    createConditionalFormattingConfigWithColorRange(
-                        config.target,
-                    ),
-                );
-            default:
-                return assertUnreachable(newConfigType, 'Unknown config type');
-        }
-    };
+    const handleConfigTypeChange = useCallback(
+        (newConfigType: ConditionalFormattingConfigType) => {
+            switch (newConfigType) {
+                case ConditionalFormattingConfigType.Single:
+                    return handleChange(
+                        createConditionalFormattingConfigWithSingleColor(
+                            config.target,
+                        ),
+                    );
+                case ConditionalFormattingConfigType.Range:
+                    return handleChange(
+                        createConditionalFormattingConfigWithColorRange(
+                            config.target,
+                        ),
+                    );
+                default:
+                    return assertUnreachable(
+                        newConfigType,
+                        'Unknown config type',
+                    );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleAddRule = () => {
+    const handleAddRule = useCallback(() => {
         setIsAddingRule(true);
 
         if (isConditionalFormattingConfigWithSingleColor(config)) {
@@ -130,90 +140,107 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                 }),
             );
         }
-    };
+    }, [handleChange, config]);
 
-    const handleRemoveRule = (index: number) => {
-        if (isConditionalFormattingConfigWithSingleColor(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    draft.rules.splice(index, 1);
-                }),
-            );
-        }
-    };
+    const handleRemoveRule = useCallback(
+        (index: number) => {
+            if (isConditionalFormattingConfigWithSingleColor(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        draft.rules.splice(index, 1);
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleChangeRuleOperator = (
-        index: number,
-        newOperator: ConditionalOperator,
-    ) => {
-        if (isConditionalFormattingConfigWithSingleColor(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    draft.rules[index] = {
-                        ...draft.rules[index],
-                        operator: newOperator,
-                    };
-                }),
-            );
-        }
-    };
+    const handleChangeRuleOperator = useCallback(
+        (index: number, newOperator: ConditionalOperator) => {
+            if (isConditionalFormattingConfigWithSingleColor(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        draft.rules[index] = {
+                            ...draft.rules[index],
+                            operator: newOperator,
+                        };
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleChangeRule = (
-        index: number,
-        newRule: ConditionalFormattingWithConditionalOperator,
-    ) => {
-        if (isConditionalFormattingConfigWithSingleColor(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    // FIXME: check if we can fix this problem in number input
-                    draft.rules[index] = {
-                        ...newRule,
-                        values: newRule.values.map((v) => Number(v)),
-                    };
-                }),
-            );
-        }
-    };
+    const handleChangeRule = useCallback(
+        (
+            index: number,
+            newRule: ConditionalFormattingWithConditionalOperator,
+        ) => {
+            if (isConditionalFormattingConfigWithSingleColor(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        // FIXME: check if we can fix this problem in number input
+                        draft.rules[index] = {
+                            ...newRule,
+                            values: newRule.values.map((v) => Number(v)),
+                        };
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleChangeSingleColor = (newColor: string) => {
-        if (isConditionalFormattingConfigWithSingleColor(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    draft.color = newColor;
-                }),
-            );
-        }
-    };
+    const handleChangeSingleColor = useCallback(
+        (newColor: string) => {
+            if (isConditionalFormattingConfigWithSingleColor(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        draft.color = newColor;
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleChangeColorRangeColor = (
-        newColor: Partial<ConditionalFormattingConfigWithColorRange['color']>,
-    ) => {
-        if (isConditionalFormattingConfigWithColorRange(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    draft.color = {
-                        ...draft.color,
-                        ...newColor,
-                    };
-                }),
-            );
-        }
-    };
+    const handleChangeColorRangeColor = useCallback(
+        (
+            newColor: Partial<
+                ConditionalFormattingConfigWithColorRange['color']
+            >,
+        ) => {
+            if (isConditionalFormattingConfigWithColorRange(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        draft.color = {
+                            ...draft.color,
+                            ...newColor,
+                        };
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
-    const handleChangeColorRangeRule = (
-        newRule: Partial<ConditionalFormattingConfigWithColorRange['rule']>,
-    ) => {
-        if (isConditionalFormattingConfigWithColorRange(config)) {
-            handleChange(
-                produce(config, (draft) => {
-                    draft.rule = {
-                        ...draft.rule,
-                        ...newRule,
-                    };
-                }),
-            );
-        }
-    };
+    const handleChangeColorRangeRule = useCallback(
+        (
+            newRule: Partial<ConditionalFormattingConfigWithColorRange['rule']>,
+        ) => {
+            if (isConditionalFormattingConfigWithColorRange(config)) {
+                handleChange(
+                    produce(config, (draft) => {
+                        draft.rule = {
+                            ...draft.rule,
+                            ...newRule,
+                        };
+                    }),
+                );
+            }
+        },
+        [handleChange, config],
+    );
 
     return (
         <FiltersProvider>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -1,5 +1,6 @@
 import {
     createConditionalFormattingConfigWithSingleColor,
+    ECHARTS_DEFAULT_COLORS,
     FilterableItem,
     getItemId,
     getItemMap,
@@ -10,17 +11,25 @@ import { Button, Stack } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import produce from 'immer';
 import { useCallback, useMemo, useState } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import ConditionalFormatting from './ConditionalFormatting';
 
 const ConditionalFormattingList = ({}) => {
+    const { data: org } = useOrganization();
+
     const [isAddingNew, setIsAddingNew] = useState(false);
     const {
         explore,
         resultsData,
         tableConfig: { conditionalFormattings, onSetConditionalFormattings },
     } = useVisualizationContext();
+
+    const defaultColors = useMemo(
+        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
+        [org],
+    );
 
     const activeFields = useMemo(() => {
         if (!resultsData) return new Set<string>();
@@ -61,10 +70,16 @@ const ConditionalFormattingList = ({}) => {
         setIsAddingNew(true);
         onSetConditionalFormattings(
             produce(activeConfigs, (draft) => {
-                draft.push(createConditionalFormattingConfigWithSingleColor());
+                draft.push(
+                    createConditionalFormattingConfigWithSingleColor(
+                        defaultColors[0],
+                    ),
+                );
             }),
         );
-    }, [onSetConditionalFormattings, activeConfigs]);
+    }, [onSetConditionalFormattings, activeConfigs, defaultColors]);
+
+    console.log(activeConfigs);
 
     const handleRemove = useCallback(
         (index) =>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -1,5 +1,5 @@
 import {
-    createConditionalFormattingConfig,
+    createConditionalFormattingConfigWithSingleColor,
     FilterableItem,
     getItemId,
     getItemMap,
@@ -61,7 +61,7 @@ const ConditionalFormattingList = ({}) => {
         setIsAddingNew(true);
         onSetConditionalFormattings(
             produce(activeConfigs, (draft) => {
-                draft.push(createConditionalFormattingConfig());
+                draft.push(createConditionalFormattingConfigWithSingleColor());
             }),
         );
     }, [onSetConditionalFormattings, activeConfigs]);

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -1,6 +1,6 @@
 import { HTMLSelect } from '@blueprintjs/core';
 import {
-    ConditionalFormattingRule as ConditionalFormattingRuleT,
+    ConditionalFormattingWithConditionalOperator,
     ConditionalOperator,
     FilterableItem,
     FilterType,
@@ -24,10 +24,12 @@ const filterConfig = FilterTypeConfig[FilterType.NUMBER];
 interface ConditionalFormattingRuleProps {
     isDefaultOpen?: boolean;
     ruleIndex: number;
-    rule: ConditionalFormattingRuleT;
+    rule: ConditionalFormattingWithConditionalOperator;
     field: FilterableItem;
     hasRemove?: boolean;
-    onChangeRule: (newRule: ConditionalFormattingRuleT) => void;
+    onChangeRule: (
+        newRule: ConditionalFormattingWithConditionalOperator,
+    ) => void;
     onChangeRuleOperator: (newOperator: ConditionalOperator) => void;
     onRemoveRule: () => void;
 }

--- a/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
@@ -1,6 +1,7 @@
 import {
     ConditionalFormattingConfig,
     Field,
+    getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
     isNumericItem,
@@ -10,7 +11,7 @@ import {
 import { useClipboard, useHotkeys } from '@mantine/hooks';
 import { FC, useCallback, useMemo, useState } from 'react';
 
-import { isHexCodeColor, readableColor } from '../../../utils/colorUtils';
+import { getColorFromRange, readableColor } from '../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../Filters/configs';
 import Cell, { CellProps } from './Cell';
 import { usePivotTableCellStyles } from './tableStyles';
@@ -53,16 +54,20 @@ const ValueCell: FC<ValueCellProps> = ({
             getConditionalRuleLabel,
         );
 
-        if (
-            !conditionalFormattingConfig ||
-            !isHexCodeColor(conditionalFormattingConfig.color)
-        )
+        const conditionalFormattingColor = getConditionalFormattingColor(
+            value?.raw,
+            conditionalFormattingConfig,
+            getColorFromRange,
+        );
+
+        if (!conditionalFormattingColor) {
             return undefined;
+        }
 
         return {
             tooltipContent,
-            color: readableColor(conditionalFormattingConfig.color),
-            backgroundColor: conditionalFormattingConfig.color,
+            color: readableColor(conditionalFormattingColor),
+            backgroundColor: conditionalFormattingColor,
         };
     }, [conditionalFormattings, item, value]);
 

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,4 +1,5 @@
 import {
+    getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
     isNumericItem,
@@ -7,7 +8,7 @@ import {
 import { flexRender, Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { FC } from 'react';
-import { readableColor } from '../../../../utils/colorUtils';
+import { getColorFromRange, readableColor } from '../../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../../Filters/configs';
 import BodyCell from '../BodyCell';
 import { ROW_HEIGHT_PX, Tr } from '../Table.styles';
@@ -72,6 +73,13 @@ const TableRow: FC<TableRowProps> = ({
                         conditionalFormattings,
                     );
 
+                const conditionalFormattingColor =
+                    getConditionalFormattingColor(
+                        cellValue?.value.raw,
+                        conditionalFormattingConfig,
+                        getColorFromRange,
+                    );
+
                 const tooltipContent = getConditionalFormattingDescription(
                     field,
                     conditionalFormattingConfig,
@@ -83,10 +91,10 @@ const TableRow: FC<TableRowProps> = ({
                         minimal={minimal}
                         key={cell.id}
                         style={meta?.style}
-                        backgroundColor={conditionalFormattingConfig?.color}
+                        backgroundColor={conditionalFormattingColor}
                         fontColor={
-                            conditionalFormattingConfig?.color &&
-                            readableColor(conditionalFormattingConfig.color) ===
+                            conditionalFormattingColor &&
+                            readableColor(conditionalFormattingColor) ===
                                 'white'
                                 ? 'white'
                                 : undefined

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -12,3 +12,54 @@ export const readableColor = (backgroundColor: string) => {
     const onBlack = Math.abs(Color.contrastAPCA('black', backgroundColor));
     return onWhite > onBlack ? 'white' : 'black';
 };
+
+const getColorRange = (colorConfig: {
+    start: string;
+    end: string;
+    steps: number;
+}): string[] | undefined => {
+    if (
+        !isHexCodeColor(colorConfig.start) ||
+        !isHexCodeColor(colorConfig.end)
+    ) {
+        return undefined;
+    }
+
+    const colors = Color.steps(
+        new Color(colorConfig.start),
+        new Color(colorConfig.end),
+        {
+            steps: colorConfig.steps,
+            space: 'srgb',
+        },
+    );
+
+    return colors.map((c) => new Color(c).toString({ format: 'hex' }));
+};
+
+export const getColorFromRange = (
+    value: number,
+    config: {
+        color: {
+            start: string;
+            end: string;
+            steps: number;
+        };
+        rule: {
+            min: number;
+            max: number;
+        };
+    },
+): string | undefined => {
+    const colors = getColorRange(config.color);
+
+    if (!colors) {
+        return undefined;
+    }
+
+    const step = (config.rule.max - config.rule.min) / config.color.steps;
+
+    const index = Math.floor((value - config.rule.min) / step);
+
+    return colors[index];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6820,10 +6820,10 @@ colorette@^1.2.2:
   resolved "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
-colorjs.io@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/colorjs.io/-/colorjs.io-0.4.2.tgz#5338fc185a8be3b46674420cd2be88389a18145b"
-  integrity sha512-vtpiH+BTzZtzs4Yno0GyoC05Z20fTeLwNJ7lQzjxi8GJJb1SZO2o5yUBAUXzgvrO2JNuyIqur4gb1Z6HBjpd9A==
+colorjs.io@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/colorjs.io/-/colorjs.io-0.4.5.tgz#7775f787ff90aca7a38f6edb7b7c0f8cce1e6418"
+  integrity sha512-yCtUNCmge7llyfd/Wou19PMAcf5yC3XXhgFoAh6zsO2pGswhUPBaaUh8jzgHnXtXuZyFKzXZNAnyF5i+apICow==
 
 colors@^1.2.1:
   version "1.4.0"


### PR DESCRIPTION
Closes: #3936 

### Description:

acceptance criteria:
- [x] when I create a rule, I can pick if it's a `single color` rule or a `color range` rule
- [x] For a range of colours rule, you need to apply the following settings:
    - [x] Select a colour that you want to have for the minimum values in your colour range
    - [x] Select a colour that you want to have for the maximum values in your colour range.
    - [x] Select the minimum value that you want the range to start at.
    - [x] Select the maximum value for the range. 
- [x] Ranges are set to 5 colours (separate issue for setting a custom number of values in the colour range here: https://github.com/lightdash/lightdash/issues/3764).
- [x] for now, you can only set the min and max colour.

persisted configuration:

```js
conditionalFormattings: [
  // for single color range and conditional operator
  {
    "color": "#fac858",
    "rules": [
      {
        "id": "90f8b88a-b623-4853-9a9b-9ba460e7de4b",
        "values": [
          30
        ],
        "operator": "greaterThan"
      }
    ],
    "target": {
      "fieldId": "orders_total_order_amount"
    }
  },
  // for multi color range and min/max values
  {
    "rule": {
      "max": 40,
      "min": 30
    },
    "color": {
      "end": "#73c0de",
      "start": "#b39e6f",
      "steps": 5 // <--------- hardcoding `5` for now (generates 5 colors between `start` and `end`
    },
    "target": {
      "fieldId": "orders_customer_id"
    }
  }
]

```

video demo:

https://github.com/lightdash/lightdash/assets/962095/e83a4502-1e1e-469f-9711-bc412ea4a55b

in results table:
<img width="874" alt="CleanShot 2023-07-17 at 16 17 00@2x" src="https://github.com/lightdash/lightdash/assets/962095/62d38599-b5c5-4e07-96b9-498cdd7c96b3">

in pivot tables:
<img width="1157" alt="CleanShot 2023-07-17 at 16 13 48@2x" src="https://github.com/lightdash/lightdash/assets/962095/e7433bba-6981-4229-8f42-014da6dbb454">
