### PR TITLE
feat: hide setting pages if user cant update

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -219,8 +219,8 @@ export class SchedulerService {
         // Only allow editors to view scheduler logs
         if (
             user.ability.cannot(
-                'manage',
-                subject('Dashboard', {
+                'update',
+                subject('Project', {
                     organizationUuid: user.organizationUuid,
                     projectUuid,
                 }),

--- a/packages/frontend/src/components/NavBar/SettingsMenu.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu.tsx
@@ -21,14 +21,14 @@ const SettingsMenu: FC = () => {
     if (!user || !activeProjectUuid) return null;
 
     const userCanViewOrganization = user.ability.can(
-        'view',
+        'update',
         subject('Organization', {
             organizationUuid: user.organizationUuid,
         }),
     );
 
     const userCanCreateProject = user.ability.can(
-        'create',
+        'update',
         subject('Project', {
             organizationUuid: user.organizationUuid,
         }),

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -47,20 +47,28 @@ const ProjectListItem: FC<ProjectListItemProps> = ({
             </td>
             <td width="1%">
                 <Group noWrap position="right" spacing="sm">
-                    <Button
-                        component={Link}
-                        size="xs"
-                        to={`/generalSettings/projectManagement/${projectUuid}`}
-                        leftIcon={<MantineIcon icon={IconSettings} />}
-                        variant="outline"
-                        onClick={() => {
-                            if (!isCurrentProject) {
-                                updateActiveProjectMutation(projectUuid);
-                            }
-                        }}
+                    <Can
+                        I="update"
+                        this={subject('Project', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid,
+                        })}
                     >
-                        Settings
-                    </Button>
+                        <Button
+                            component={Link}
+                            size="xs"
+                            to={`/generalSettings/projectManagement/${projectUuid}`}
+                            leftIcon={<MantineIcon icon={IconSettings} />}
+                            variant="outline"
+                            onClick={() => {
+                                if (!isCurrentProject) {
+                                    updateActiveProjectMutation(projectUuid);
+                                }
+                            }}
+                        >
+                            Settings
+                        </Button>
+                    </Can>
 
                     <Can
                         I="delete"

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -152,8 +152,8 @@ const Settings: FC = () => {
                         </Box>
 
                         <Can
-                            I="update"
-                            this={subject('Organization', {
+                            I="create"
+                            this={subject('Project', {
                                 organizationUuid: organization.organizationUuid,
                             })}
                         >

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -176,7 +176,7 @@ const Settings: FC = () => {
                                 )}
 
                                 {user.ability.can(
-                                    'view',
+                                    'update',
                                     'OrganizationMemberProfile',
                                 ) && (
                                     <RouterNavLink
@@ -189,12 +189,16 @@ const Settings: FC = () => {
                                     />
                                 )}
 
-                                <RouterNavLink
-                                    label="Appearance"
-                                    exact
-                                    to="/generalSettings/appearance"
-                                    icon={<MantineIcon icon={IconPalette} />}
-                                />
+                                {user.ability.can('update', 'Organization') && (
+                                    <RouterNavLink
+                                        label="Appearance"
+                                        exact
+                                        to="/generalSettings/appearance"
+                                        icon={
+                                            <MantineIcon icon={IconPalette} />
+                                        }
+                                    />
+                                )}
 
                                 {health.hasSlack &&
                                     user.ability.can(
@@ -232,7 +236,7 @@ const Settings: FC = () => {
                         !organization.needsProject &&
                         project &&
                         user.ability.can(
-                            'view',
+                            'update',
                             subject('Project', {
                                 organizationUuid: organization.organizationUuid,
                                 projectUuid: project.projectUuid,
@@ -267,15 +271,25 @@ const Settings: FC = () => {
                                     to={`/generalSettings/projectManagement/${project.projectUuid}/projectAccess`}
                                     icon={<MantineIcon icon={IconUsers} />}
                                 />
-
-                                <RouterNavLink
-                                    label="dbt Cloud"
-                                    exact
-                                    to={`/generalSettings/projectManagement/${project.projectUuid}/integrations/dbtCloud`}
-                                    icon={
-                                        <MantineIcon icon={IconCloudSearch} />
-                                    }
-                                />
+                                {user.ability?.can(
+                                    'manage',
+                                    subject('Project', {
+                                        organizationUuid:
+                                            project.organizationUuid,
+                                        projectUuid: project.projectUuid,
+                                    }),
+                                ) ? (
+                                    <RouterNavLink
+                                        label="dbt Cloud"
+                                        exact
+                                        to={`/generalSettings/projectManagement/${project.projectUuid}/integrations/dbtCloud`}
+                                        icon={
+                                            <MantineIcon
+                                                icon={IconCloudSearch}
+                                            />
+                                        }
+                                    />
+                                ) : null}
 
                                 {user.ability.can(
                                     'view',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -152,8 +152,8 @@ const Settings: FC = () => {
                         </Box>
 
                         <Can
-                            I="create"
-                            this={subject('Project', {
+                            I="update"
+                            this={subject('Organization', {
                                 organizationUuid: organization.organizationUuid,
                             })}
                         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6362 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- amend permission in scheduled deliveries logs API
- hide "project/organization settings" navbar link if user doesn't have `update` permission
- hide "settings" button from projects list if user doesn't have `update` permission
- hide sidebar menu options if user doesn't have `update` permission


Viewer:
<img width="355" alt="Screenshot 2023-07-17 at 15 53 33" src="https://github.com/lightdash/lightdash/assets/9117144/a69b7f8f-426c-451d-b406-4866c87ca167">
Interactive viewer:
<img width="1608" alt="Screenshot 2023-07-17 at 15 57 49" src="https://github.com/lightdash/lightdash/assets/9117144/28b3f490-e4a3-4fd8-b5b0-d8022511de6a">

Editor:

<img width="402" alt="Screenshot 2023-07-17 at 15 51 12" src="https://github.com/lightdash/lightdash/assets/9117144/8cc1317b-a65c-4c22-b046-b0e3d3123817">

