### PR TITLE
chore: profile mounting times in dashboard and tiles

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import {
     DashboardTile,
     DashboardTileTypes,
 } from '@lightdash/common';
+import { useProfiler, withProfiler } from '@sentry/react';
 import React, {
     FC,
     memo,
@@ -78,6 +79,10 @@ const GridTile: FC<
     >
 > = memo((props) => {
     const { tile } = props;
+
+    const t = useProfiler(`Dashboard-${tile.type}`);
+
+    console.log({ t });
 
     const savedChartUuid: string | undefined =
         tile.type === DashboardTileTypes.SAVED_CHART
@@ -482,10 +487,12 @@ const Dashboard: FC = () => {
     );
 };
 
+const DashboardWithProfiler = withProfiler(Dashboard, { name: 'Dashboard' });
+
 const DashboardPage: FC = () => {
     return (
         <DashboardProvider>
-            <Dashboard />
+            <DashboardWithProfiler />
         </DashboardProvider>
     );
 };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import {
     DashboardTile,
     DashboardTileTypes,
 } from '@lightdash/common';
-import { useProfiler, withProfiler } from '@sentry/react';
+import { useProfiler } from '@sentry/react';
 import React, {
     FC,
     memo,
@@ -80,9 +80,7 @@ const GridTile: FC<
 > = memo((props) => {
     const { tile } = props;
 
-    const t = useProfiler(`Dashboard-${tile.type}`);
-
-    console.log({ t });
+    useProfiler(`Dashboard-${tile.type}`);
 
     const savedChartUuid: string | undefined =
         tile.type === DashboardTileTypes.SAVED_CHART
@@ -487,12 +485,11 @@ const Dashboard: FC = () => {
     );
 };
 
-const DashboardWithProfiler = withProfiler(Dashboard, { name: 'Dashboard' });
-
 const DashboardPage: FC = () => {
+    useProfiler('Dashboard');
     return (
         <DashboardProvider>
-            <DashboardWithProfiler />
+            <Dashboard />
         </DashboardProvider>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6031 

### Description:

Uses Sentry's `useProfiler` to track the following React components: 
* `Dashboard`
* `Dashboard tiles per type`

Followed this guide: https://docs.sentry.io/platforms/javascript/guides/react/features/component-tracking/

example: https://lightdash.sentry.io/performance/summary/spans/?environment=development&project=5959292&query=&statsPeriod=30d&transaction=%2Fprojects%2F%3AprojectUuid%2Fdashboards%2F%3AdashboardUuid%2F%3Amode%3F

Can see it being added to the transaction _waterfall_ here: https://lightdash.sentry.io/performance/lightdash:94f33550c0d946e78b124063648ee0f8/?environment=development&project=5959292&query=&statsPeriod=1h&transaction=%2Fprojects%2F%3AprojectUuid%2Fdashboards%2F%3AdashboardUuid%2F%3Amode%3F#span-b46dfb3131718207

^ You will see duplicate `.mount`s, it's because I've tested it on React development mode. It should not happen in Production - as Sentry stated in their docs.

