### PR TITLE
fix: reference chart_count in all_spaces query

### DIFF
--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -243,7 +243,7 @@ const getAllSpaces = async (
             isPrivate: row.is_private,
             accessListLength: row.access_list_length,
             dashboardCount: row.dashboard_count,
-            chartCount: row.saved_query_count,
+            chartCount: row.chart_count,
             access: row.access,
         },
     }));


### PR DESCRIPTION
duplicate of `fix: I can't see the number of charts in a Pinned Space when I hover over it #6368` #6368