### PR TITLE
feat: save chart in dashboard

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -116,7 +116,7 @@
         "migrate-production": "knex migrate:latest --knexfile dist/database/knexfile.js",
         "seed": "knex seed:run --knexfile src/database/knexfile.ts",
         "seed-production": "knex seed:run --knexfile dist/database/knexfile.js",
-        "rollback-last": "knex migrate:rollback --knexfile src/database/knexfile.ts",
+        "rollback-last": "knex migrate:down --knexfile src/database/knexfile.ts",
         "rollback-all": "knex migrate:rollback --all --knexfile src/database/knexfile.ts",
         "rollback-all-production": "knex migrate:rollback --all --knexfile dist/database/knexfile.js"
     }

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -84,13 +84,13 @@ import {
     SavedChartAdditionalMetricTable,
     SavedChartAdditionalMetricTableName,
     SavedChartsTableName,
+    SavedChartTable,
     SavedChartVersionFieldsTable,
     SavedChartVersionFieldsTableName,
     SavedChartVersionSortsTable,
     SavedChartVersionSortsTableName,
     SavedChartVersionsTable,
     SavedChartVersionsTableName,
-    SavedQueryTable,
     SavedQueryTableCalculationTable,
     SavedQueryTableCalculationTableName,
 } from '../database/entities/savedCharts';
@@ -167,7 +167,7 @@ declare module 'knex/types/tables' {
         [SessionTableName]: SessionTable;
         [WarehouseCredentialTableName]: WarehouseCredentialTable;
         [ProjectTableName]: ProjectTable;
-        [SavedChartsTableName]: SavedQueryTable;
+        [SavedChartsTableName]: SavedChartTable;
         [SavedChartVersionsTableName]: SavedChartVersionsTable;
         [SavedChartVersionFieldsTableName]: SavedChartVersionFieldsTable;
         [SavedChartVersionSortsTableName]: SavedChartVersionSortsTable;

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -13,10 +13,39 @@ import { Knex } from 'knex';
 export const SavedChartsTableName = 'saved_queries';
 export const SavedChartVersionsTableName = 'saved_queries_versions';
 
+type InsertChartInSpace = Pick<DbSavedChart, 'name' | 'description'> & {
+    space_id: number;
+    dashboard_uuid: null;
+};
+
+type InsertChartInDashboard = Pick<DbSavedChart, 'name' | 'description'> & {
+    space_id: null;
+    dashboard_uuid: string;
+};
+
+export type InsertChart = InsertChartInSpace | InsertChartInDashboard;
+
+export type SavedChartTable = Knex.CompositeTableType<
+    DbSavedChart,
+    InsertChart,
+    Partial<
+        Pick<
+            DbSavedChart,
+            | 'space_id'
+            | 'name'
+            | 'description'
+            | 'last_version_chart_kind'
+            | 'last_version_updated_at'
+            | 'last_version_updated_by_user_uuid'
+        >
+    >
+>;
+
 export type DbSavedChart = {
     saved_query_id: number;
     saved_query_uuid: string;
-    space_id: number;
+    space_id: number | null;
+    dashboard_uuid: string | null;
     name: string;
     created_at: Date;
     description: string | undefined;
@@ -24,12 +53,6 @@ export type DbSavedChart = {
     last_version_updated_at: Date;
     last_version_updated_by_user_uuid: string | undefined;
 };
-
-export type SavedChartTable = Knex.CompositeTableType<
-    DbSavedChart,
-    Pick<DbSavedChart, 'name' | 'space_id' | 'description'>,
-    Pick<DbSavedChart, 'name' | 'description'>
->;
 
 export type DbSavedChartVersion = {
     saved_queries_version_id: number;

--- a/packages/backend/src/database/migrations/20230718093901_add_dashbord_uuid_to_chart_table.ts
+++ b/packages/backend/src/database/migrations/20230718093901_add_dashbord_uuid_to_chart_table.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('saved_queries', (t) => {
+        t.uuid('dashboard_uuid')
+            .references('dashboard_uuid')
+            .inTable('dashboards')
+            .nullable()
+            .onDelete('CASCADE');
+        // make space id nullable
+        t.integer('space_id').nullable().alter({ alterType: false });
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('saved_queries', (t) => {
+        t.dropColumns('dashboard_uuid');
+        // make space id non nullable
+        t.integer('space_id').notNullable().alter({ alterType: false });
+    });
+}

--- a/packages/backend/src/database/migrations/20230718093901_add_dashbord_uuid_to_chart_table.ts
+++ b/packages/backend/src/database/migrations/20230718093901_add_dashbord_uuid_to_chart_table.ts
@@ -13,6 +13,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex('saved_queries').delete().where('space_id', null);
     await knex.schema.alterTable('saved_queries', (t) => {
         t.dropColumns('dashboard_uuid');
         // make space id non nullable

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -134,6 +134,7 @@ export const savedChartEntry: SavedChartTable['base'] = {
     last_version_chart_kind: ChartKind.VERTICAL_BAR,
     last_version_updated_at: new Date(),
     last_version_updated_by_user_uuid: undefined,
+    dashboard_uuid: null,
 };
 
 export const dashboardEntry: DashboardTable['base'] = {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -98,6 +98,7 @@ export class DashboardModel {
 
     private static async createVersion(
         trx: Transaction,
+        dashboardUuid: string,
         dashboardId: number,
         version: DashboardVersionedFields,
         projectUuid: string,
@@ -143,6 +144,7 @@ export class DashboardModel {
                             trx,
                             projectUuid,
                             userUuid,
+                            dashboardUuid,
                             tile.properties.newChartData,
                         );
                     }
@@ -673,6 +675,7 @@ export class DashboardModel {
 
             await DashboardModel.createVersion(
                 trx,
+                newDashboard.dashboard_uuid,
                 newDashboard.dashboard_id,
                 {
                     ...dashboard,
@@ -759,6 +762,7 @@ export class DashboardModel {
         await this.database.transaction(async (trx) => {
             await DashboardModel.createVersion(
                 trx,
+                dashboardUuid,
                 dashboard.dashboard_id,
                 {
                     ...version,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -875,11 +875,17 @@ export class ProjectModel {
                     ? await trx('saved_queries')
                           .insert(
                               charts.map((d) => {
+                                  if (!d.space_id) {
+                                      throw new Error(
+                                          `Chart ${d.saved_query_id} has no space_id`,
+                                      );
+                                  }
                                   const createChart = {
                                       ...d,
                                       saved_query_id: undefined,
                                       saved_query_uuid: undefined,
                                       space_id: getNewSpace(d.space_id),
+                                      dashboard_uuid: null,
                                   };
                                   delete createChart.saved_query_id;
                                   delete createChart.saved_query_uuid;
@@ -916,13 +922,19 @@ export class ProjectModel {
                     ? await trx('saved_queries_versions')
                           .insert(
                               chartVersions.map((d) => {
+                                  const newSavedQueryId = chartMapping.find(
+                                      (m) => m.id === d.saved_query_id,
+                                  )?.newId;
+                                  if (!newSavedQueryId) {
+                                      throw new Error(
+                                          `Cannot find new chart id for ${d.saved_query_id}`,
+                                      );
+                                  }
                                   const createChartVersion = {
                                       ...d,
                                       saved_queries_version_id: undefined,
                                       saved_queries_version_uuid: undefined,
-                                      saved_query_id: chartMapping.find(
-                                          (m) => m.id === d.saved_query_id,
-                                      )?.newId,
+                                      saved_query_id: newSavedQueryId,
                                   };
                                   delete createChartVersion.saved_queries_version_id;
                                   delete createChartVersion.saved_queries_version_uuid;

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -53,6 +53,7 @@ export const user: SessionUser = {
 export const chart: SavedChart = {
     uuid: 'chartUuid',
     projectUuid: 'projectUuid',
+    dashboardUuid: null,
     name: 'Test chart',
     tableName: 'table',
     updatedAt: new Date('2021-01-01'),

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -273,6 +273,7 @@ export type SavedChart = {
     spaceName: string;
     pinnedListUuid: string | null;
     pinnedListOrder: number | null;
+    dashboardUuid: string | null;
 };
 
 export type CreateSavedChart = Omit<
@@ -287,6 +288,7 @@ export type CreateSavedChart = Omit<
     | 'pinnedListOrder'
     | 'views'
     | 'firstViewedAt'
+    | 'dashboardUuid'
 > & { spaceUuid?: string };
 
 export type CreateSavedChartVersion = Omit<
@@ -302,6 +304,7 @@ export type CreateSavedChartVersion = Omit<
     | 'pinnedListOrder'
     | 'views'
     | 'firstViewedAt'
+    | 'dashboardUuid'
 >;
 
 export type UpdateSavedChart = Partial<

--- a/packages/e2e/cypress/e2e/api/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/api/dashboard.cy.ts
@@ -78,6 +78,12 @@ describe('Lightdash dashboard', () => {
             ).then((chartResponse) => {
                 expect(chartResponse.status).to.eq(200);
                 expect(chartResponse.body.results.name).to.eq(chartMock.name);
+                expect(chartResponse.body.results.dashboardUuid).to.eq(
+                    createDashboardResponse.body.results.uuid,
+                );
+                expect(chartResponse.body.results.spaceUuid).to.eq(
+                    createDashboardResponse.body.results.spaceUuid,
+                );
             });
 
             const updateDashboardMock: UpdateDashboard = {
@@ -131,6 +137,12 @@ describe('Lightdash dashboard', () => {
                     expect(chartResponse.status).to.eq(200);
                     expect(chartResponse.body.results.name).to.eq(
                         chartMock.name,
+                    );
+                    expect(chartResponse.body.results.dashboardUuid).to.eq(
+                        createDashboardResponse.body.results.uuid,
+                    );
+                    expect(chartResponse.body.results.spaceUuid).to.eq(
+                        createDashboardResponse.body.results.spaceUuid,
                     );
                 });
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Relates to: #6133 
Closes: #6227 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- amend knex table typing
- update chart table to have a dashboard uuid column and space id column be nullable


Table before:
```
create table saved_queries
(
    saved_query_id                    integer generated always as identity
        primary key,
    saved_query_uuid                  uuid         default uuid_generate_v4() not null
        constraint saved_queries_saved_query_uuid_unique
            unique,
    created_at                        timestamp    default CURRENT_TIMESTAMP  not null,
    name                              text                                    not null,
    space_id                          integer                                 not null
        constraint saved_queries_space_id_foreign
            references spaces
            on delete cascade,
    description                       text,
    last_version_chart_kind           varchar(255) default 'vertical_bar'::character varying,
    last_version_updated_at           timestamp    default CURRENT_TIMESTAMP,
    last_version_updated_by_user_uuid uuid
        constraint saved_queries_last_version_updated_by_user_uuid_foreign
            references users (user_uuid)
            on delete set null
);
```

Table now:

```
create table saved_queries
(
    saved_query_id                    integer generated always as identity
        primary key,
    saved_query_uuid                  uuid         default uuid_generate_v4() not null
        constraint saved_queries_saved_query_uuid_unique
            unique,
    created_at                        timestamp    default CURRENT_TIMESTAMP  not null,
    name                              text                                    not null,
    space_id                          integer
        constraint saved_queries_space_id_foreign
            references spaces
            on delete cascade,
    description                       text,
    last_version_chart_kind           varchar(255) default 'vertical_bar'::character varying,
    last_version_updated_at           timestamp    default CURRENT_TIMESTAMP,
    last_version_updated_by_user_uuid uuid
        constraint saved_queries_last_version_updated_by_user_uuid_foreign
            references users (user_uuid)
            on delete set null,
    dashboard_uuid                    uuid
        constraint saved_queries_dashboard_uuid_foreign
            references dashboards (dashboard_uuid)
            on delete cascade
);

```

E2e test passing:

<img width="592" alt="Screenshot 2023-07-18 at 15 43 46" src="https://github.com/lightdash/lightdash/assets/9117144/7b124869-00aa-473e-8fdd-1aa2caf628f9">


Preview:

https://github.com/lightdash/lightdash/assets/9117144/7f4329e9-619c-4147-89de-3fa603b728ef


