### PR TITLE
chore: mantine and blueprint z indices

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -184,7 +184,6 @@ export const CustomMetricModal = () => {
     return item ? (
         <Modal
             size="xl"
-            zIndex={15}
             onClick={(e) => e.stopPropagation()}
             opened={isOpen}
             onClose={() => toggleModal(undefined)}

--- a/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
@@ -67,7 +67,6 @@ export const SearchIconWithIndicator: FC<{
                 multiline: true,
                 offset: -2,
                 position: 'bottom',
-                zIndex: 201,
             }}
             tooltipLabel={
                 canUserManageValidation ? (

--- a/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
@@ -251,8 +251,6 @@ const GlobalSearch: FC<GlobalSearchProps> = ({ projectUuid }) => {
 
             <MantineProvider inherit theme={{ colorScheme: 'light' }}>
                 <SpotlightProvider
-                    // FIXME: remove setting of zIndex after Mantine migration is complete
-                    zIndex={200}
                     actions={
                         query && query.length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH
                             ? searchItems

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -5,6 +5,7 @@ import {
     Button,
     Center,
     Divider,
+    getDefaultZIndex,
     Group,
     Header,
     MantineProvider,
@@ -71,8 +72,7 @@ const NavBar = memo(() => {
                 mt={isCurrentProjectPreview ? PREVIEW_BANNER_HEIGHT : 'none'}
                 display="flex"
                 px="md"
-                // FIXME: adjust after removing Blueprint
-                zIndex={300}
+                zIndex={getDefaultZIndex('app')}
                 sx={{
                     alignItems: 'center',
                     boxShadow: 'lg',

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -1,4 +1,5 @@
 import { Colors, HTMLTable } from '@blueprintjs/core';
+import { getDefaultZIndex } from '@mantine/core';
 import { transparentize } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -182,7 +183,7 @@ export const Td = styled.td<{
         $isSelected
             ? `
                 position: relative;
-                z-index: 21;
+                z-index: ${getDefaultZIndex('popover') + 1} !important;
             `
             : ''}
 

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -112,25 +112,10 @@ export const getMantineThemeOverride = (overrides?: {
             }),
         },
 
-        Indicator: {
-            styles: () => ({
-                // FIXME: this is a hack to fix position of the Indicator under overlays. Remove after Blueprint migration is complete
-                root: {
-                    zIndex: 20,
-                },
-            }),
-        },
-
         Tooltip: {
             defaultProps: {
                 withArrow: true,
             },
-            styles: () => ({
-                // FIXME: this is a hack to fix tooltip position. remove after Blueprint migration is complete
-                root: {
-                    zIndex: 20,
-                },
-            }),
         },
 
         Modal: {

--- a/packages/frontend/src/providers/BlueprintProvider.tsx
+++ b/packages/frontend/src/providers/BlueprintProvider.tsx
@@ -1,12 +1,14 @@
-// WARNING: We need to import the datetime css until this bug is fixed: https://github.com/palantir/blueprint/issues/5388
-import '@blueprintjs/datetime/lib/css/blueprint-datetime.css';
-import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
-import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
-import '@blueprintjs/select/lib/css/blueprint-select.css';
-// WARNING: exposes global overrides. DO NOT IMPORT THIS FILE.
+// FIXME: remove after blueprint migration is complete
+// WARNING: DO NOT IMPORT THESE FILES - EXPOSES GLOBAL STYLES
 // import '@blueprintjs/core/lib/css/blueprint.css';
+// import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
 // below is a cleaner version of the above
 import './../styles/blueprint-core.css';
+import './../styles/blueprint-popover2.css';
+// NOTE: imports below does not have a conflicting z-indexes
+import '@blueprintjs/datetime/lib/css/blueprint-datetime.css';
+import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
+import '@blueprintjs/select/lib/css/blueprint-select.css';
 
 import { Colors, Dialog, FocusStyleManager } from '@blueprintjs/core';
 import { FC } from 'react';

--- a/packages/frontend/src/styles/blueprint-core.css
+++ b/packages/frontend/src/styles/blueprint-core.css
@@ -13174,7 +13174,7 @@ body.bp4-overlay-open {
     position: static;
     right: 0;
     top: 0;
-    z-index: 20;
+    z-index: 400;
 }
 .bp4-overlay:not(.bp4-overlay-open) {
     pointer-events: none;
@@ -13200,7 +13200,7 @@ body.bp4-overlay-open {
 
 .bp4-overlay-content {
     position: fixed;
-    z-index: 20;
+    z-index: 400;
 }
 .bp4-overlay-inline .bp4-overlay-content,
 .bp4-overlay-scroll-container .bp4-overlay-content {
@@ -13220,7 +13220,7 @@ body.bp4-overlay-open {
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    z-index: 20;
+    z-index: 400;
 }
 .bp4-overlay-backdrop.bp4-overlay-enter,
 .bp4-overlay-backdrop.bp4-overlay-appear {
@@ -13583,7 +13583,7 @@ body.bp4-overlay-open {
     transform: scale(1);
     border-radius: 2px;
     display: inline-block;
-    z-index: 20;
+    z-index: 300;
 }
 .bp4-popover .bp4-popover-arrow {
     height: 30px;
@@ -13925,7 +13925,7 @@ body.bp4-overlay-open {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
-    z-index: 20;
+    z-index: 300;
 }
 .bp4-transition-container.bp4-popover-enter,
 .bp4-transition-container.bp4-popover-appear {
@@ -15690,7 +15690,7 @@ span.bp4-popover-target {
     padding: 0 20px 20px;
     pointer-events: none;
     right: 0;
-    z-index: 40;
+    z-index: 500;
 }
 .bp4-toast-container.bp4-toast-container-in-portal {
     position: fixed;

--- a/packages/frontend/src/styles/blueprint-core.css
+++ b/packages/frontend/src/styles/blueprint-core.css
@@ -13174,7 +13174,7 @@ body.bp4-overlay-open {
     position: static;
     right: 0;
     top: 0;
-    z-index: 400;
+    z-index: 300;
 }
 .bp4-overlay:not(.bp4-overlay-open) {
     pointer-events: none;
@@ -13200,7 +13200,7 @@ body.bp4-overlay-open {
 
 .bp4-overlay-content {
     position: fixed;
-    z-index: 400;
+    z-index: 300;
 }
 .bp4-overlay-inline .bp4-overlay-content,
 .bp4-overlay-scroll-container .bp4-overlay-content {
@@ -13220,7 +13220,7 @@ body.bp4-overlay-open {
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    z-index: 400;
+    z-index: 300;
 }
 .bp4-overlay-backdrop.bp4-overlay-enter,
 .bp4-overlay-backdrop.bp4-overlay-appear {

--- a/packages/frontend/src/styles/blueprint-popover2.css
+++ b/packages/frontend/src/styles/blueprint-popover2.css
@@ -721,4 +721,3 @@ a > .bp4-dark .bp4-tooltip2 .bp4-running-text code {
     border-bottom: dotted 1px;
     cursor: help;
 }
-/*# sourceMappingURL=blueprint-popover2.css.map */

--- a/packages/frontend/src/styles/blueprint-popover2.css
+++ b/packages/frontend/src/styles/blueprint-popover2.css
@@ -1,0 +1,724 @@
+.bp4-context-menu2-virtual-target {
+    position: fixed;
+}
+.bp4-popover2 {
+    -webkit-box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1),
+        0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2);
+    box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2),
+        0 8px 24px rgba(17, 20, 24, 0.2);
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    border-radius: 2px;
+    display: inline-block;
+    z-index: 300;
+}
+.bp4-popover2 .bp4-popover2-arrow {
+    height: 30px;
+    position: absolute;
+    width: 30px;
+}
+.bp4-popover2 .bp4-popover2-arrow::before {
+    height: 20px;
+    margin: 5px;
+    width: 20px;
+}
+.bp4-popover2 .bp4-popover2-content {
+    background: #fff;
+}
+.bp4-popover2 .bp4-popover2-content,
+.bp4-popover2 .bp4-heading {
+    color: inherit;
+}
+.bp4-popover2 .bp4-popover2-arrow::before {
+    -webkit-box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.2);
+    box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.2);
+}
+.bp4-popover2 .bp4-popover2-arrow-border {
+    fill: #111418;
+    fill-opacity: 0.1;
+}
+.bp4-popover2 .bp4-popover2-arrow-fill {
+    fill: #fff;
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-popover2 .bp4-popover2-arrow-fill {
+        fill: buttonborder;
+    }
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-popover2 {
+        border: 1px solid buttonborder;
+    }
+}
+.bp4-popover2-enter > .bp4-popover2,
+.bp4-popover2-appear > .bp4-popover2 {
+    -webkit-transform: scale(0.3);
+    transform: scale(0.3);
+}
+.bp4-popover2-enter-active > .bp4-popover2,
+.bp4-popover2-appear-active > .bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 300ms;
+    transition-duration: 300ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+}
+.bp4-popover2-exit > .bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+.bp4-popover2-exit-active > .bp4-popover2 {
+    -webkit-transform: scale(0.3);
+    transform: scale(0.3);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 300ms;
+    transition-duration: 300ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+    transition-timing-function: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+}
+.bp4-popover2 .bp4-popover2-content {
+    border-radius: 2px;
+    position: relative;
+}
+.bp4-popover2.bp4-popover2-content-sizing .bp4-popover2-content {
+    max-width: 350px;
+    padding: 20px;
+}
+.bp4-popover2-target + .bp4-overlay .bp4-popover2.bp4-popover2-content-sizing {
+    width: 350px;
+}
+.bp4-popover2.bp4-minimal {
+    margin: 0 !important;
+}
+.bp4-popover2.bp4-minimal .bp4-popover2-arrow {
+    display: none;
+}
+.bp4-popover2.bp4-minimal.bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+.bp4-popover2-enter > .bp4-popover2.bp4-minimal.bp4-popover2,
+.bp4-popover2-appear > .bp4-popover2.bp4-minimal.bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+.bp4-popover2-enter-active > .bp4-popover2.bp4-minimal.bp4-popover2,
+.bp4-popover2-appear-active > .bp4-popover2.bp4-minimal.bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-popover2-exit > .bp4-popover2.bp4-minimal.bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+.bp4-popover2-exit-active > .bp4-popover2.bp4-minimal.bp4-popover2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-popover2.bp4-popover2-match-target-width {
+    width: 100%;
+}
+.bp4-popover2.bp4-dark,
+.bp4-dark .bp4-popover2 {
+    -webkit-box-shadow: 0 0 0 1px hsl(215deg, 3%, 38%),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 2px 4px rgba(17, 20, 24, 0.4), 0 8px 24px rgba(17, 20, 24, 0.4);
+    box-shadow: 0 0 0 1px hsl(215deg, 3%, 38%),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 2px 4px rgba(17, 20, 24, 0.4), 0 8px 24px rgba(17, 20, 24, 0.4);
+}
+.bp4-popover2.bp4-dark .bp4-popover2-content,
+.bp4-dark .bp4-popover2 .bp4-popover2-content {
+    background: #2f343c;
+}
+.bp4-popover2.bp4-dark .bp4-popover2-content,
+.bp4-popover2.bp4-dark .bp4-heading,
+.bp4-dark .bp4-popover2 .bp4-popover2-content,
+.bp4-dark .bp4-popover2 .bp4-heading {
+    color: inherit;
+}
+.bp4-popover2.bp4-dark .bp4-popover2-arrow::before,
+.bp4-dark .bp4-popover2 .bp4-popover2-arrow::before {
+    -webkit-box-shadow: 0 0 0 1px #777a7e, 1px 1px 6px rgba(17, 20, 24, 0.4);
+    box-shadow: 0 0 0 1px #777a7e, 1px 1px 6px rgba(17, 20, 24, 0.4);
+}
+.bp4-popover2.bp4-dark .bp4-popover2-arrow-border,
+.bp4-dark .bp4-popover2 .bp4-popover2-arrow-border {
+    fill: #111418;
+    fill-opacity: 0.2;
+}
+.bp4-popover2.bp4-dark .bp4-popover2-arrow-fill,
+.bp4-dark .bp4-popover2 .bp4-popover2-arrow-fill {
+    fill: #2f343c;
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-popover2.bp4-dark .bp4-popover2-arrow-fill,
+    .bp4-dark .bp4-popover2 .bp4-popover2-arrow-fill {
+        fill: buttonborder;
+    }
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-popover2.bp4-dark,
+    .bp4-dark .bp4-popover2 {
+        border: 1px solid buttonborder;
+    }
+}
+
+.bp4-popover2-arrow::before {
+    border-radius: 1px;
+    content: '';
+    display: block;
+    position: absolute;
+    -webkit-transform: rotate(45deg);
+    transform: rotate(45deg);
+}
+
+.bp4-overlay-backdrop.bp4-popover2-backdrop {
+    background: rgba(255, 255, 255, 0);
+}
+
+.bp4-popover2-transition-container {
+    opacity: 1;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    z-index: 300;
+}
+.bp4-popover2-transition-container.bp4-popover2-enter,
+.bp4-popover2-transition-container.bp4-popover2-appear {
+    opacity: 0;
+}
+.bp4-popover2-transition-container.bp4-popover2-enter-active,
+.bp4-popover2-transition-container.bp4-popover2-appear-active {
+    opacity: 1;
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: opacity;
+    transition-property: opacity;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-popover2-transition-container.bp4-popover2-exit {
+    opacity: 1;
+}
+.bp4-popover2-transition-container.bp4-popover2-exit-active {
+    opacity: 0;
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: opacity;
+    transition-property: opacity;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-popover2-transition-container:focus {
+    outline: none;
+}
+.bp4-popover2-transition-container.bp4-popover2-leave .bp4-popover2-content {
+    pointer-events: none;
+}
+
+span.bp4-popover2-target {
+    display: inline-block;
+}
+
+.bp4-popover2-target.bp4-fill {
+    width: 100%;
+}
+.bp4-button-group:not(.bp4-minimal)
+    > .bp4-popover2-target:not(:first-child)
+    .bp4-button {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+}
+.bp4-button-group:not(.bp4-minimal)
+    > .bp4-popover2-target:not(:last-child)
+    .bp4-button {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    margin-right: -1px;
+}
+.bp4-button-group .bp4-popover2-target {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-flex: 1;
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+}
+.bp4-button-group.bp4-vertical:not(.bp4-minimal)
+    > .bp4-popover2-target:first-child
+    .bp4-button {
+    border-radius: 2px 2px 0 0;
+}
+.bp4-button-group.bp4-vertical:not(.bp4-minimal)
+    > .bp4-popover2-target:last-child
+    .bp4-button {
+    border-radius: 0 0 2px 2px;
+}
+.bp4-button-group.bp4-vertical:not(.bp4-minimal)
+    > .bp4-popover2-target:not(:last-child)
+    .bp4-button {
+    margin-bottom: -1px;
+}
+.bp4-control-group .bp4-popover2-target {
+    border-radius: inherit;
+}
+label.bp4-label .bp4-popover2-target {
+    display: block;
+    margin-top: 5px;
+    text-transform: none;
+}
+.bp4-submenu .bp4-popover2-target {
+    display: block;
+}
+.bp4-submenu.bp4-popover2 {
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    padding: 0 5px;
+}
+.bp4-submenu.bp4-popover2 > .bp4-popover2-content {
+    -webkit-box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1),
+        0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2);
+    box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2),
+        0 8px 24px rgba(17, 20, 24, 0.2);
+}
+.bp4-dark .bp4-submenu.bp4-popover2,
+.bp4-submenu.bp4-popover2.bp4-dark {
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+.bp4-dark .bp4-submenu.bp4-popover2 > .bp4-popover2-content,
+.bp4-submenu.bp4-popover2.bp4-dark > .bp4-popover2-content {
+    -webkit-box-shadow: 0 0 0 1px hsl(215deg, 3%, 38%),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 2px 4px rgba(17, 20, 24, 0.4), 0 8px 24px rgba(17, 20, 24, 0.4);
+    box-shadow: 0 0 0 1px hsl(215deg, 3%, 38%),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 2px 4px rgba(17, 20, 24, 0.4), 0 8px 24px rgba(17, 20, 24, 0.4);
+}
+.bp4-tree-node-secondary-label .bp4-popover2-target {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+}
+.bp4-tooltip2 {
+    -webkit-box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1),
+        0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2);
+    box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2),
+        0 8px 24px rgba(17, 20, 24, 0.2);
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    color: #f6f7f9;
+}
+.bp4-tooltip2 .bp4-popover2-arrow {
+    height: 22px;
+    position: absolute;
+    width: 22px;
+}
+.bp4-tooltip2 .bp4-popover2-arrow::before {
+    height: 14px;
+    margin: 4px;
+    width: 14px;
+}
+.bp4-tooltip2 .bp4-popover2-content {
+    background: #404854;
+}
+.bp4-tooltip2 .bp4-popover2-content,
+.bp4-tooltip2 .bp4-heading {
+    color: #f6f7f9;
+}
+.bp4-tooltip2 .bp4-popover2-arrow::before {
+    -webkit-box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.2);
+    box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.2);
+}
+.bp4-tooltip2 .bp4-popover2-arrow-border {
+    fill: #111418;
+    fill-opacity: 0.1;
+}
+.bp4-tooltip2 .bp4-popover2-arrow-fill {
+    fill: #404854;
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-tooltip2 .bp4-popover2-arrow-fill {
+        fill: buttonborder;
+    }
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-tooltip2 {
+        border: 1px solid buttonborder;
+    }
+}
+.bp4-popover2-enter > .bp4-tooltip2,
+.bp4-popover2-appear > .bp4-tooltip2 {
+    -webkit-transform: scale(0.8);
+    transform: scale(0.8);
+}
+.bp4-popover2-enter-active > .bp4-tooltip2,
+.bp4-popover2-appear-active > .bp4-tooltip2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-popover2-exit > .bp4-tooltip2 {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+.bp4-popover2-exit-active > .bp4-tooltip2 {
+    -webkit-transform: scale(0.8);
+    transform: scale(0.8);
+    -webkit-transition-delay: 0;
+    transition-delay: 0;
+    -webkit-transition-duration: 100ms;
+    transition-duration: 100ms;
+    -webkit-transition-property: -webkit-transform;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+    transition-timing-function: cubic-bezier(0.4, 1, 0.75, 0.9);
+}
+.bp4-tooltip2 .bp4-text-muted {
+    color: #abb3bf;
+}
+.bp4-tooltip2 .bp4-text-disabled {
+    color: rgba(171, 179, 191, 0.6);
+}
+.bp4-tooltip2 .bp4-running-text hr {
+    border-color: rgba(255, 255, 255, 0.2);
+}
+.bp4-tooltip2 a {
+    color: #8abbff;
+}
+.bp4-tooltip2 a:hover {
+    color: #8abbff;
+}
+.bp4-tooltip2 a .bp4-icon,
+.bp4-tooltip2 a .bp4-icon-standard,
+.bp4-tooltip2 a .bp4-icon-large {
+    color: inherit;
+}
+.bp4-tooltip2 a code {
+    color: inherit;
+}
+.bp4-tooltip2 .bp4-code,
+.bp4-tooltip2 .bp4-running-text code {
+    background: rgba(17, 20, 24, 0.3);
+    -webkit-box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.4);
+    color: #abb3bf;
+}
+a > .bp4-tooltip2 .bp4-code,
+a > .bp4-tooltip2 .bp4-running-text code {
+    color: inherit;
+}
+.bp4-tooltip2 .bp4-code-block,
+.bp4-tooltip2 .bp4-running-text pre {
+    background: rgba(17, 20, 24, 0.3);
+    -webkit-box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.4);
+    color: #f6f7f9;
+}
+.bp4-tooltip2 .bp4-code-block > code,
+.bp4-tooltip2 .bp4-running-text pre > code {
+    background: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    color: inherit;
+}
+.bp4-tooltip2 .bp4-key,
+.bp4-tooltip2 .bp4-running-text kbd {
+    background: #383e47;
+    -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 1px 1px 0 rgba(17, 20, 24, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+        0 1px 1px 0 rgba(17, 20, 24, 0.4);
+    color: #abb3bf;
+}
+.bp4-tooltip2 .bp4-icon.bp4-intent-primary,
+.bp4-tooltip2 .bp4-icon-standard.bp4-intent-primary,
+.bp4-tooltip2 .bp4-icon-large.bp4-intent-primary {
+    color: #8abbff;
+}
+.bp4-tooltip2 .bp4-icon.bp4-intent-success,
+.bp4-tooltip2 .bp4-icon-standard.bp4-intent-success,
+.bp4-tooltip2 .bp4-icon-large.bp4-intent-success {
+    color: #72ca9b;
+}
+.bp4-tooltip2 .bp4-icon.bp4-intent-warning,
+.bp4-tooltip2 .bp4-icon-standard.bp4-intent-warning,
+.bp4-tooltip2 .bp4-icon-large.bp4-intent-warning {
+    color: #fbb360;
+}
+.bp4-tooltip2 .bp4-icon.bp4-intent-danger,
+.bp4-tooltip2 .bp4-icon-standard.bp4-intent-danger,
+.bp4-tooltip2 .bp4-icon-large.bp4-intent-danger {
+    color: #fa999c;
+}
+.bp4-tooltip2 .bp4-popover2-content {
+    padding: 10px 12px;
+}
+.bp4-tooltip2.bp4-compact .bp4-popover2-content {
+    line-height: 1rem;
+    padding: 5px 7px;
+}
+.bp4-tooltip2.bp4-compact .bp4-code {
+    vertical-align: text-bottom;
+}
+.bp4-tooltip2.bp4-popover2-placement-top .bp4-popover2-arrow {
+    -webkit-transform: translateY(-3px);
+    transform: translateY(-3px);
+}
+.bp4-tooltip2.bp4-popover2-placement-left .bp4-popover2-arrow {
+    -webkit-transform: translateX(-3px);
+    transform: translateX(-3px);
+}
+.bp4-tooltip2.bp4-popover2-placement-bottom .bp4-popover2-arrow {
+    -webkit-transform: translateY(3px);
+    transform: translateY(3px);
+}
+.bp4-tooltip2.bp4-popover2-placement-right .bp4-popover2-arrow {
+    -webkit-transform: translateX(3px);
+    transform: translateX(3px);
+}
+.bp4-tooltip2.bp4-dark,
+.bp4-dark .bp4-tooltip2 {
+    -webkit-box-shadow: 0 2px 4px rgba(17, 20, 24, 0.4),
+        0 8px 24px rgba(17, 20, 24, 0.4);
+    box-shadow: 0 2px 4px rgba(17, 20, 24, 0.4),
+        0 8px 24px rgba(17, 20, 24, 0.4);
+}
+.bp4-tooltip2.bp4-dark .bp4-popover2-content,
+.bp4-dark .bp4-tooltip2 .bp4-popover2-content {
+    background: #e5e8eb;
+}
+.bp4-tooltip2.bp4-dark .bp4-popover2-content,
+.bp4-tooltip2.bp4-dark .bp4-heading,
+.bp4-dark .bp4-tooltip2 .bp4-popover2-content,
+.bp4-dark .bp4-tooltip2 .bp4-heading {
+    color: #404854;
+}
+.bp4-tooltip2.bp4-dark .bp4-popover2-arrow::before,
+.bp4-dark .bp4-tooltip2 .bp4-popover2-arrow::before {
+    -webkit-box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.4);
+    box-shadow: 1px 1px 6px rgba(17, 20, 24, 0.4);
+}
+.bp4-tooltip2.bp4-dark .bp4-popover2-arrow-border,
+.bp4-dark .bp4-tooltip2 .bp4-popover2-arrow-border {
+    fill: #111418;
+    fill-opacity: 0.2;
+}
+.bp4-tooltip2.bp4-dark .bp4-popover2-arrow-fill,
+.bp4-dark .bp4-tooltip2 .bp4-popover2-arrow-fill {
+    fill: #e5e8eb;
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-tooltip2.bp4-dark .bp4-popover2-arrow-fill,
+    .bp4-dark .bp4-tooltip2 .bp4-popover2-arrow-fill {
+        fill: buttonborder;
+    }
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-tooltip2.bp4-dark,
+    .bp4-dark .bp4-tooltip2 {
+        border: 1px solid buttonborder;
+    }
+}
+.bp4-tooltip2.bp4-dark .bp4-text-muted,
+.bp4-dark .bp4-tooltip2 .bp4-text-muted {
+    color: #5f6b7c;
+}
+.bp4-tooltip2.bp4-dark .bp4-text-disabled,
+.bp4-dark .bp4-tooltip2 .bp4-text-disabled {
+    color: rgba(95, 107, 124, 0.6);
+}
+.bp4-tooltip2.bp4-dark .bp4-running-text hr,
+.bp4-dark .bp4-tooltip2 .bp4-running-text hr {
+    border-color: rgba(17, 20, 24, 0.15);
+}
+.bp4-tooltip2.bp4-dark a,
+.bp4-dark .bp4-tooltip2 a {
+    color: #215db0;
+}
+.bp4-tooltip2.bp4-dark a:hover,
+.bp4-dark .bp4-tooltip2 a:hover {
+    color: #215db0;
+}
+.bp4-tooltip2.bp4-dark a .bp4-icon,
+.bp4-tooltip2.bp4-dark a .bp4-icon-standard,
+.bp4-tooltip2.bp4-dark a .bp4-icon-large,
+.bp4-dark .bp4-tooltip2 a .bp4-icon,
+.bp4-dark .bp4-tooltip2 a .bp4-icon-standard,
+.bp4-dark .bp4-tooltip2 a .bp4-icon-large {
+    color: inherit;
+}
+.bp4-tooltip2.bp4-dark a code,
+.bp4-dark .bp4-tooltip2 a code {
+    color: inherit;
+}
+.bp4-tooltip2.bp4-dark .bp4-code,
+.bp4-tooltip2.bp4-dark .bp4-running-text code,
+.bp4-dark .bp4-tooltip2 .bp4-code,
+.bp4-dark .bp4-tooltip2 .bp4-running-text code {
+    background: rgba(255, 255, 255, 0.7);
+    -webkit-box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.2);
+    color: #5f6b7c;
+}
+a > .bp4-tooltip2.bp4-dark .bp4-code,
+a > .bp4-tooltip2.bp4-dark .bp4-running-text code,
+a > .bp4-dark .bp4-tooltip2 .bp4-code,
+a > .bp4-dark .bp4-tooltip2 .bp4-running-text code {
+    color: #2d72d2;
+}
+.bp4-tooltip2.bp4-dark .bp4-code-block,
+.bp4-tooltip2.bp4-dark .bp4-running-text pre,
+.bp4-dark .bp4-tooltip2 .bp4-code-block,
+.bp4-dark .bp4-tooltip2 .bp4-running-text pre {
+    background: rgba(255, 255, 255, 0.7);
+    -webkit-box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.15);
+    box-shadow: inset 0 0 0 1px rgba(17, 20, 24, 0.15);
+    color: #1c2127;
+}
+.bp4-tooltip2.bp4-dark .bp4-code-block > code,
+.bp4-tooltip2.bp4-dark .bp4-running-text pre > code,
+.bp4-dark .bp4-tooltip2 .bp4-code-block > code,
+.bp4-dark .bp4-tooltip2 .bp4-running-text pre > code {
+    background: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    color: inherit;
+}
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .bp4-tooltip2.bp4-dark .bp4-code-block,
+    .bp4-tooltip2.bp4-dark .bp4-running-text pre,
+    .bp4-dark .bp4-tooltip2 .bp4-code-block,
+    .bp4-dark .bp4-tooltip2 .bp4-running-text pre {
+        border: 1px solid buttonborder;
+        -webkit-box-shadow: none;
+        box-shadow: none;
+    }
+}
+.bp4-tooltip2.bp4-dark .bp4-key,
+.bp4-tooltip2.bp4-dark .bp4-running-text kbd,
+.bp4-dark .bp4-tooltip2 .bp4-key,
+.bp4-dark .bp4-tooltip2 .bp4-running-text kbd {
+    background: #fff;
+    -webkit-box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1),
+        0 1px 1px rgba(17, 20, 24, 0.2);
+    box-shadow: 0 0 0 1px rgba(17, 20, 24, 0.1), 0 1px 1px rgba(17, 20, 24, 0.2);
+    color: #5f6b7c;
+}
+.bp4-tooltip2.bp4-dark .bp4-icon.bp4-intent-primary,
+.bp4-tooltip2.bp4-dark .bp4-icon-standard.bp4-intent-primary,
+.bp4-tooltip2.bp4-dark .bp4-icon-large.bp4-intent-primary,
+.bp4-dark .bp4-tooltip2 .bp4-icon.bp4-intent-primary,
+.bp4-dark .bp4-tooltip2 .bp4-icon-standard.bp4-intent-primary,
+.bp4-dark .bp4-tooltip2 .bp4-icon-large.bp4-intent-primary {
+    color: #215db0;
+}
+.bp4-tooltip2.bp4-dark .bp4-icon.bp4-intent-success,
+.bp4-tooltip2.bp4-dark .bp4-icon-standard.bp4-intent-success,
+.bp4-tooltip2.bp4-dark .bp4-icon-large.bp4-intent-success,
+.bp4-dark .bp4-tooltip2 .bp4-icon.bp4-intent-success,
+.bp4-dark .bp4-tooltip2 .bp4-icon-standard.bp4-intent-success,
+.bp4-dark .bp4-tooltip2 .bp4-icon-large.bp4-intent-success {
+    color: #1c6e42;
+}
+.bp4-tooltip2.bp4-dark .bp4-icon.bp4-intent-warning,
+.bp4-tooltip2.bp4-dark .bp4-icon-standard.bp4-intent-warning,
+.bp4-tooltip2.bp4-dark .bp4-icon-large.bp4-intent-warning,
+.bp4-dark .bp4-tooltip2 .bp4-icon.bp4-intent-warning,
+.bp4-dark .bp4-tooltip2 .bp4-icon-standard.bp4-intent-warning,
+.bp4-dark .bp4-tooltip2 .bp4-icon-large.bp4-intent-warning {
+    color: #935610;
+}
+.bp4-tooltip2.bp4-dark .bp4-icon.bp4-intent-danger,
+.bp4-tooltip2.bp4-dark .bp4-icon-standard.bp4-intent-danger,
+.bp4-tooltip2.bp4-dark .bp4-icon-large.bp4-intent-danger,
+.bp4-dark .bp4-tooltip2 .bp4-icon.bp4-intent-danger,
+.bp4-dark .bp4-tooltip2 .bp4-icon-standard.bp4-intent-danger,
+.bp4-dark .bp4-tooltip2 .bp4-icon-large.bp4-intent-danger {
+    color: #ac2f33;
+}
+.bp4-tooltip2.bp4-intent-primary .bp4-popover2-content {
+    background: #2d72d2;
+    color: #fff;
+}
+.bp4-tooltip2.bp4-intent-primary .bp4-popover2-arrow-fill {
+    fill: #2d72d2;
+}
+.bp4-tooltip2.bp4-intent-success .bp4-popover2-content {
+    background: #238551;
+    color: #fff;
+}
+.bp4-tooltip2.bp4-intent-success .bp4-popover2-arrow-fill {
+    fill: #238551;
+}
+.bp4-tooltip2.bp4-intent-warning .bp4-popover2-content {
+    background: #c87619;
+    color: #fff;
+}
+.bp4-tooltip2.bp4-intent-warning .bp4-popover2-arrow-fill {
+    fill: #c87619;
+}
+.bp4-tooltip2.bp4-intent-danger .bp4-popover2-content {
+    background: #cd4246;
+    color: #fff;
+}
+.bp4-tooltip2.bp4-intent-danger .bp4-popover2-arrow-fill {
+    fill: #cd4246;
+}
+
+.bp4-tooltip2-indicator {
+    border-bottom: dotted 1px;
+    cursor: help;
+}
+/*# sourceMappingURL=blueprint-popover2.css.map */


### PR DESCRIPTION
Closes: #6273

### Description:

- alters blueprint-core.css with new z-indexes that is aligned with mantine
- clones blueprint-popover2.css
- alters blueprint-popover2.css with new z-indexes
- cleans up mantine z-index patches

tested:
- homepage / content pages / action modals and menus
- settings + project settings
- dashboards with modals and menus + dashboard filters
- explore:
  - all chart configs
  - custom filters
  - filters
  - sorting
  - limits
  - export csv
  - table / viz context menus and underlying data + etc..