### PR TITLE
chore: pin dbt-trino to 1.5.0

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -39,7 +39,7 @@ RUN /usr/local/dbt1.5/bin/pip install \
     "dbt-snowflake~=1.5.0" \
     "dbt-bigquery~=1.5.0" \
     "dbt-databricks~=1.5.0" \
-    "dbt-trino~=1.5.0" \
+    "dbt-trino==1.5.0" \
     "psycopg2-binary==2.8.6"
 RUN ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5
 

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -38,7 +38,7 @@ RUN /usr/local/dbt1.5/bin/pip install \
     "dbt-snowflake~=1.5.0" \
     "dbt-bigquery~=1.5.0" \
     "dbt-databricks~=1.5.0" \
-    "dbt-trino~=1.5.0" \
+    "dbt-trino==1.5.0" \
     "psycopg2-binary==2.8.6"
 RUN ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After this release: https://github.com/starburstdata/dbt-trino/blob/master/CHANGELOG.md

our Docker build started failing. First instance: https://github.com/lightdash/lightdash/actions/runs/5579941834/jobs/10196171946

Pinning `dbt-trino` to its previous version works, but this is a temporary solution - we need to figure out which deps are clashing and how to handle it: on the code and/or by reporting a bug 