### PR TITLE
chore: table config popup in Mantine

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,5 +1,5 @@
-import { Checkbox, FormGroup } from '@blueprintjs/core';
-import { Box, Title, Tooltip } from '@mantine/core';
+import { FormGroup } from '@blueprintjs/core';
+import { Box, Checkbox, Stack, Title, Tooltip } from '@mantine/core';
 import React, { FC, useCallback, useMemo, useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -174,7 +174,7 @@ const GeneralSettings: FC = () => {
                 }
                 position="top"
             >
-                <Box>
+                <Box my="sm">
                     <Checkbox
                         disabled={!canUsePivotTable}
                         label="Show metrics as rows"
@@ -199,7 +199,7 @@ const GeneralSettings: FC = () => {
                 ))}
             </FormGroup>
             <Title order={6}>Options</Title>
-            <FormGroup>
+            <Stack mt="sm" spacing="xs">
                 <Checkbox
                     label="Show table names"
                     checked={showTableNames}
@@ -238,7 +238,7 @@ const GeneralSettings: FC = () => {
                         setShowResultsTotal(!showResultsTotal);
                     }}
                 />
-            </FormGroup>
+            </Stack>
         </>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
@@ -1,5 +1,4 @@
-import { Colors, Tab, Tabs } from '@blueprintjs/core';
-import { Box, Button, Popover } from '@mantine/core';
+import { Button, Popover, Tabs } from '@mantine/core';
 import { IconChevronDown } from '@tabler/icons-react';
 import React from 'react';
 import {
@@ -30,31 +29,21 @@ const TableConfigPanel: React.FC = () => {
             </Popover.Target>
 
             <Popover.Dropdown>
-                <Box
-                    w={320}
-                    sx={{
-                        // FIXME: remove after Blueprint migration is complete
-                        'label.bp4-label': {
-                            display: 'inline-flex',
-                            gap: '0.214em',
-                            color: Colors.DARK_GRAY1,
-                            fontWeight: 600,
-                        },
-                    }}
-                >
-                    <Tabs>
-                        <Tab
-                            id="general"
-                            title="General"
-                            panel={<GeneralSettings />}
-                        />
-                        <Tab
-                            id="conditional-formatting"
-                            title="Conditional formatting"
-                            panel={<ConditionalFormattingList />}
-                        />
-                    </Tabs>
-                </Box>
+                <Tabs w={320} defaultValue="general">
+                    <Tabs.List mb="sm">
+                        <Tabs.Tab value="general">General</Tabs.Tab>
+                        <Tabs.Tab value="conditional-formatting">
+                            Conditional formatting
+                        </Tabs.Tab>
+                    </Tabs.List>
+
+                    <Tabs.Panel value="general">
+                        <GeneralSettings />
+                    </Tabs.Panel>
+                    <Tabs.Panel value="conditional-formatting">
+                        <ConditionalFormattingList />
+                    </Tabs.Panel>
+                </Tabs>
             </Popover.Dropdown>
         </Popover>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6258 

### Description:

Moves the table config popup, tabs and checkboxes to Mantine. 

### Criteria
- [ ] use mantine popover
- [ ] use mantine tabs for general / conditional formatting (pie charts config as a reference)
- [ ] use mantine form elements for "options"
