### PR TITLE
fix: address ux after only chart with filter applied to is removed from dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -8,16 +8,11 @@ import {
 } from '../../common/Filters/configs';
 import FilterConfiguration, { FilterTabs } from '../FilterConfiguration';
 import { FilterModalContainer } from '../FilterSearch/FilterSearch.styles';
-import {
-    FilterValues,
-    InvalidFilterTag,
-    TagContainer,
-} from './ActiveFilters.styles';
+import { FilterValues, TagContainer } from './ActiveFilters.styles';
 
 type Props = {
     isEditMode: boolean;
-    fieldId: string;
-    field: FilterableField | undefined;
+    field: FilterableField;
     filterRule: DashboardFilterRule;
     onClick?: () => void;
     onRemove: () => void;
@@ -26,7 +21,6 @@ type Props = {
 
 const ActiveFilter: FC<Props> = ({
     isEditMode,
-    fieldId,
     field,
     filterRule,
     onClick,
@@ -42,13 +36,6 @@ const ActiveFilter: FC<Props> = ({
         return null;
     }
 
-    if (!field) {
-        return (
-            <InvalidFilterTag onRemove={onRemove}>
-                Tried to reference field with unknown id: {fieldId}
-            </InvalidFilterTag>
-        );
-    }
     const filterRuleLabels = getConditionalRuleLabel(filterRule, field);
     const filterRuleTables = getFilterRuleTables(
         filterRule,

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilters.styles.ts
@@ -1,22 +1,8 @@
-import { Colors, Tag } from '@blueprintjs/core';
+import { Tag } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const TagContainer = styled(Tag)`
     flex-shrink: 0;
-`;
-
-export const InvalidFilterTag = styled(TagContainer)`
-    background: transparent;
-    color: ${Colors.GRAY1};
-
-    & span,
-    & .bp4-tag-remove > .bp4-icon:first-child {
-        color: ${Colors.GRAY1};
-    }
-
-    & .bp4-tag-remove > .bp4-icon:first-child:hover {
-        color: ${Colors.GRAY3};
-    }
 `;
 
 export const FilterValues = styled.span`

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -25,34 +25,38 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
 
     return (
         <ActiveDashboardFiltersWrapper>
-            {dashboardFilters.dimensions.map((item, index) => (
-                <ActiveFilter
-                    key={item.id}
-                    isEditMode={isEditMode}
-                    fieldId={item.target.fieldId}
-                    field={fieldMap[item.target.fieldId]}
-                    filterRule={item}
-                    onRemove={() =>
-                        removeDimensionDashboardFilter(index, false)
-                    }
-                    onUpdate={(value) =>
-                        updateDimensionDashboardFilter(value, index, false)
-                    }
-                />
-            ))}
-            {dashboardTemporaryFilters.dimensions.map((item, index) => (
-                <ActiveFilter
-                    key={item.id}
-                    isEditMode={isEditMode}
-                    fieldId={item.target.fieldId}
-                    field={fieldMap[item.target.fieldId]}
-                    filterRule={item}
-                    onRemove={() => removeDimensionDashboardFilter(index, true)}
-                    onUpdate={(value) =>
-                        updateDimensionDashboardFilter(value, index, true)
-                    }
-                />
-            ))}
+            {dashboardFilters.dimensions
+                .filter((item) => !!fieldMap[item.target.fieldId])
+                .map((item, index) => (
+                    <ActiveFilter
+                        key={item.id}
+                        isEditMode={isEditMode}
+                        field={fieldMap[item.target.fieldId]}
+                        filterRule={item}
+                        onRemove={() =>
+                            removeDimensionDashboardFilter(index, false)
+                        }
+                        onUpdate={(value) =>
+                            updateDimensionDashboardFilter(value, index, false)
+                        }
+                    />
+                ))}
+            {dashboardTemporaryFilters.dimensions
+                .filter((item) => !!fieldMap[item.target.fieldId])
+                .map((item, index) => (
+                    <ActiveFilter
+                        key={item.id}
+                        isEditMode={isEditMode}
+                        field={fieldMap[item.target.fieldId]}
+                        filterRule={item}
+                        onRemove={() =>
+                            removeDimensionDashboardFilter(index, true)
+                        }
+                        onUpdate={(value) =>
+                            updateDimensionDashboardFilter(value, index, true)
+                        }
+                    />
+                ))}
         </ActiveDashboardFiltersWrapper>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6358 

### Description:

Remove active filter if not targeting any field id

Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/bc086d5d-4ffe-4f80-8939-10a32616bb51


