### PR TITLE
fix: unlock clipboard copy when visualising tables

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
@@ -8,7 +8,7 @@ import {
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
-import { useClipboard, useHotkeys } from '@mantine/hooks';
+import { useClipboard } from '@mantine/hooks';
 import { FC, useCallback, useMemo, useState } from 'react';
 
 import { getColorFromRange, readableColor } from '../../../utils/colorUtils';
@@ -80,8 +80,6 @@ const ValueCell: FC<ValueCellProps> = ({
             clipboard.copy(value?.formatted);
         }
     }, [clipboard, value, isMenuOpen]);
-
-    useHotkeys([['mod+c', handleCopy]]);
 
     const { cx, classes } = usePivotTableCellStyles({
         conditionalFormatting,

--- a/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCell.tsx
@@ -8,8 +8,8 @@ import {
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
-import { useClipboard } from '@mantine/hooks';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { getHotkeyHandler, useClipboard } from '@mantine/hooks';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getColorFromRange, readableColor } from '../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../Filters/configs';
@@ -86,6 +86,17 @@ const ValueCell: FC<ValueCellProps> = ({
     });
 
     const formattedValue = value?.formatted;
+
+    useEffect(() => {
+        const handleKeyDown = getHotkeyHandler([['mod+C', handleCopy]]);
+        if (isMenuOpen) {
+            document.body.addEventListener('keydown', handleKeyDown);
+        }
+
+        return () => {
+            document.body.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleCopy, isMenuOpen]);
 
     return (
         <ValueCellMenu

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -1,5 +1,5 @@
 import { ConditionalFormattingConfig, ResultRow } from '@lightdash/common';
-import { useHotkeys } from '@mantine/hooks';
+import { getHotkeyHandler } from '@mantine/hooks';
 import {
     Cell,
     ColumnOrderState,
@@ -181,7 +181,7 @@ export const TableProvider: FC<Props> = ({
 
     const [copyingCellId, setCopyingCellId] = useState<string>();
 
-    const onCopyCell = () => {
+    const onCopyCell = useCallback(() => {
         if (!selectedCell) return;
 
         const value = (selectedCell.getValue() as ResultRow[0]).value;
@@ -195,9 +195,18 @@ export const TableProvider: FC<Props> = ({
             setTimeout(() => setCopyingCellId(undefined), 300);
             return selectedCell.id;
         });
-    };
+    }, [selectedCell, showToastSuccess]);
 
-    useHotkeys([['mod + c', onCopyCell]]);
+    useEffect(() => {
+        const handleKeyDown = getHotkeyHandler([['mod+C', onCopyCell]]);
+        if (selectedCell) {
+            document.body.addEventListener('keydown', handleKeyDown);
+        }
+
+        return () => {
+            document.body.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [onCopyCell, selectedCell]);
 
     return (
         <Context.Provider


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6193 

### Description:

When visualising tables, the `ValueCell` component that currently uses `useHotKeys` would allow the copy of the `Cell` value if user pressed `mod + c`. However, this is blocking the copy-to-clipboard functionality everywhere else that is not a `ValueCell`. 
I believe the usage of the `useHotKeys` is affecting the other elements due to the way we're implementing the `ValueCellMenu`+`ValueCell`. 

Instead of adding the `onKeyDown` events to the `td` elements, we listen to: 
* is isMenuOpen truthy
* if user presses the copy keyboard shortcut (we now use `getHotkeyHandler`  https://mantine.dev/hooks/use-hotkeys/#targeting-elements )

NOTE: `td` elements aren't focusable by nature, so this addresses that


Don't have a screen-recording bc Quicktime player + keyboard shortcuts aren't working as expected for me. PLease use Render to review UX
