### PR TITLE
fix: add cursor: pointer to checkboxes and radios

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -49,6 +49,8 @@ export const getMantineThemeOverride = (overrides?: {
 
     lineHeight: 1.2858142857,
 
+    cursorType: 'pointer',
+
     components: {
         TextInput: {
             styles: (theme, _params) => ({


### PR DESCRIPTION
### Description:

For some reason Mantine doesn't apply cursor: pointer to checkboxes and radios by default. This sets the setting to do so. 

More here:
https://mantine.dev/theming/theme-object/#cursortype
