### PR TITLE
fix: pie charts tooltip and label configuration

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -79,8 +79,6 @@ const ConditionalFormattingList = ({}) => {
         );
     }, [onSetConditionalFormattings, activeConfigs, defaultColors]);
 
-    console.log(activeConfigs);
-
     const handleRemove = useCallback(
         (index) =>
             onSetConditionalFormattings(


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6354

### Description:

- [x] when hovering over to a slice it should show group label and value
- [x] if there are no value/percentage selected it should just show the group label instead of nothing

⚠️ it seems like echarts or echarts react wrapper has a bug rendering "label lines" when changing configuration and happens when changing from "value label" between "Inside" and "Outside"

<img width="772" alt="CleanShot 2023-07-20 at 21 56 31@2x" src="https://github.com/lightdash/lightdash/assets/962095/c30adce3-8e8a-425e-9184-398f9a187a86">

<img width="231" alt="CleanShot 2023-07-20 at 22 00 13@2x" src="https://github.com/lightdash/lightdash/assets/962095/16be6d90-2237-4b51-b163-9f588cf542ce">
