### PR TITLE
fix: titles not showing on filters panel

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -96,7 +96,8 @@ const TileFilterConfiguration: FC<TileFilterConfigurationProps> = ({
 
                 const title =
                     tile &&
-                    tile.properties.title === undefined &&
+                    (!tile.properties.title ||
+                        tile.properties.title.length === 0) &&
                     isDashboardChartTileType(tile)
                         ? savedCharts?.find(
                               (chart) =>


### PR DESCRIPTION
Closes: #6459 

### Description:
before
<img width="556" alt="Screenshot 2023-07-24 at 12 53 39" src="https://github.com/lightdash/lightdash/assets/67699259/6357c5a6-9f5c-4f1a-9b8a-e04ee0b12621">



after
<img width="584" alt="Screenshot 2023-07-24 at 12 53 25" src="https://github.com/lightdash/lightdash/assets/67699259/62e7896c-420f-4d41-ac48-eb443e37f406">
