### PR TITLE
feat: delete orphan charts when updating dashboard

### DIFF
--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -102,6 +102,7 @@ export const dashboardService = new DashboardService({
     analyticsModel,
     pinnedListModel,
     schedulerModel,
+    savedChartModel,
 });
 
 export const savedChartsService = new SavedChartService({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6394 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- [x] after dashboard update, delete all unused charts that belong to that dashboard
- [x] track 'saved_chart.deleted` event per each one



https://github.com/lightdash/lightdash/assets/9117144/49895ef5-292b-4b59-a5af-769ec4a1d46f

