### PR TITLE
fix: address ux on pinned items drag-and-drop

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconEye } from '@tabler/icons-react';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { ResourceIcon } from '../../ResourceIcon';
 import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
@@ -20,11 +20,13 @@ import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 interface ResourceViewGridChartItemProps
     extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {
     item: ResourceViewChartItem;
+    dragIcon: ReactNode;
 }
 
 const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
     item,
     onAction,
+    dragIcon,
 }) => {
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
@@ -34,36 +36,38 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
         <Paper
             ref={ref}
             component={Flex}
+            pos="relative"
             direction="column"
             p={0}
             withBorder
             bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
             h="100%"
         >
-            <Tooltip
-                label={item.data.description}
-                position="top"
-                disabled={!item.data.description}
+            {dragIcon}
+            <Group
+                p="md"
+                align="center"
+                spacing="md"
+                noWrap
+                sx={{
+                    flexGrow: 1,
+                    borderBottomWidth: 1,
+                    borderBottomStyle: 'solid',
+                    borderBottomColor: theme.colors.gray[3],
+                }}
             >
-                <Group
-                    p="md"
-                    align="center"
-                    spacing="md"
-                    noWrap
-                    sx={{
-                        flexGrow: 1,
-                        borderBottomWidth: 1,
-                        borderBottomStyle: 'solid',
-                        borderBottomColor: theme.colors.gray[3],
-                    }}
-                >
-                    <ResourceIcon item={item} />
+                <ResourceIcon item={item} />
 
+                <Tooltip
+                    label={item.data.description}
+                    position="top"
+                    disabled={!item.data.description}
+                >
                     <Text lineClamp={2} fz="sm" fw={600}>
                         {item.data.name}
                     </Text>
-                </Group>
-            </Tooltip>
+                </Tooltip>
+            </Group>
 
             <Flex pl="md" pr="xs" h={32} justify="space-between" align="center">
                 <Tooltip

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -43,7 +43,6 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
             bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
             h="100%"
         >
-            {dragIcon}
             <Group
                 p="md"
                 align="center"
@@ -56,6 +55,7 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                     borderBottomColor: theme.colors.gray[3],
                 }}
             >
+                {dragIcon}
                 <ResourceIcon item={item} />
 
                 <Tooltip

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -43,7 +43,6 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
             bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
             h="100%"
         >
-            {dragIcon}
             <Group
                 p="md"
                 align="center"
@@ -56,6 +55,7 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                     borderBottomColor: theme.colors.gray[3],
                 }}
             >
+                {dragIcon}
                 <ResourceIcon item={item} />
                 <Tooltip
                     position="top"

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconEye } from '@tabler/icons-react';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { ResourceIcon } from '../../ResourceIcon';
 import ResourceViewActionMenu, {
     ResourceViewActionMenuCommonProps,
@@ -20,11 +20,13 @@ import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 interface ResourceViewGridDashboardItemProps
     extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {
     item: ResourceViewDashboardItem;
+    dragIcon: ReactNode;
 }
 
 const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
     item,
     onAction,
+    dragIcon,
 }) => {
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
@@ -34,36 +36,37 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
         <Paper
             ref={ref}
             component={Flex}
+            pos="relative"
             direction="column"
             p={0}
             withBorder
             bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
             h="100%"
         >
-            <Tooltip
-                label={item.data.description}
-                position="top"
-                disabled={!item.data.description}
+            {dragIcon}
+            <Group
+                p="md"
+                align="center"
+                spacing="md"
+                noWrap
+                sx={{
+                    flexGrow: 1,
+                    borderBottomWidth: 1,
+                    borderBottomStyle: 'solid',
+                    borderBottomColor: theme.colors.gray[3],
+                }}
             >
-                <Group
-                    p="md"
-                    align="center"
-                    spacing="md"
-                    noWrap
-                    sx={{
-                        flexGrow: 1,
-                        borderBottomWidth: 1,
-                        borderBottomStyle: 'solid',
-                        borderBottomColor: theme.colors.gray[3],
-                    }}
+                <ResourceIcon item={item} />
+                <Tooltip
+                    position="top"
+                    label={item.data.description}
+                    disabled={!item.data.description}
                 >
-                    <ResourceIcon item={item} />
-
                     <Text lineClamp={2} fz="sm" fw={600}>
                         {item.data.name}
                     </Text>
-                </Group>
-            </Tooltip>
+                </Tooltip>
+            </Group>
 
             <Flex pl="md" pr="xs" h={32} justify="space-between" align="center">
                 <Tooltip

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -4,9 +4,9 @@ import {
     Flex,
     Group,
     Paper,
-    Popover,
     Stack,
     Text,
+    Tooltip,
     useMantineTheme,
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
@@ -18,7 +18,7 @@ import {
     IconUser,
     IconUsers,
 } from '@tabler/icons-react';
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 
 import { ResourceIcon } from '../../ResourceIcon';
 import ResourceViewActionMenu, {
@@ -28,6 +28,7 @@ import ResourceViewActionMenu, {
 interface ResourceViewGridSpaceItemProps
     extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {
     item: ResourceViewSpaceItem;
+    dragIcon: ReactNode;
 }
 
 enum ResourceAccess {
@@ -100,6 +101,7 @@ const AttributeCount: FC<{ Icon: IconType; count: number }> = ({
 const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
     item,
     onAction,
+    dragIcon,
 }) => {
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
@@ -127,91 +129,81 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
     }, [item]);
 
     return (
-        <Popover
-            position="top"
-            opened={hovered || opened}
-            withArrow
-            styles={{
-                dropdown: { backgroundColor: theme.colors.dark[6] },
-                arrow: { backgroundColor: theme.colors.dark[6] },
-            }}
+        <Paper
+            ref={ref}
+            pos="relative"
+            p={0}
+            withBorder
+            bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
+            h="100%"
         >
-            <Popover.Target>
-                <Paper
-                    ref={ref}
-                    p={0}
-                    withBorder
-                    bg={
-                        hovered
-                            ? theme.fn.rgba(theme.colors.gray[0], 0.5)
-                            : undefined
-                    }
-                    h="100%"
-                >
-                    <Group p="md" align="center" spacing="md" noWrap>
-                        <ResourceIcon item={item} />
+            {dragIcon}
+            <Group p="md" align="center" spacing="md" noWrap>
+                <ResourceIcon item={item} />
 
-                        <Stack spacing={4} sx={{ flexGrow: 1, flexShrink: 1 }}>
-                            <Text
-                                lineClamp={1}
-                                fz="sm"
-                                fw={600}
-                                sx={{ overflowWrap: 'anywhere' }}
-                            >
-                                {item.data.name}
+                <Tooltip
+                    position="top"
+                    withArrow
+                    label={
+                        <Stack spacing={4}>
+                            <Text lineClamp={1} fz="xs" fw={600} color="white">
+                                {tooltipText}
                             </Text>
-
-                            <Group spacing="sm">
-                                <Flex align="center" gap={4}>
-                                    <AccessInfo item={item} />
-                                </Flex>
+                            <Group>
+                                <AttributeCount
+                                    Icon={IconLayoutDashboard}
+                                    count={item.data.dashboardCount}
+                                />
+                                <AttributeCount
+                                    Icon={IconChartBar}
+                                    count={item.data.chartCount}
+                                />
                             </Group>
                         </Stack>
-                        <Box
-                            sx={{
-                                flexGrow: 0,
-                                flexShrink: 0,
-                                // FIXME: change logic to use position absolute
-                                // transition: 'opacity 0.2s',
-                                // opacity: hovered || opened ? 1 : 0,
-                                display: hovered || opened ? 'block' : 'none',
-                            }}
-                            component="div"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                            }}
+                    }
+                >
+                    <Stack spacing={4} sx={{ flexGrow: 1, flexShrink: 1 }}>
+                        <Text
+                            lineClamp={1}
+                            fz="sm"
+                            fw={600}
+                            sx={{ overflowWrap: 'anywhere' }}
                         >
-                            <ResourceViewActionMenu
-                                item={item}
-                                isOpen={opened}
-                                onOpen={handlers.open}
-                                onClose={handlers.close}
-                                onAction={onAction}
-                            />
-                        </Box>
-                    </Group>
-                </Paper>
-            </Popover.Target>
+                            {item.data.name}
+                        </Text>
 
-            <Popover.Dropdown>
-                <Stack spacing={4}>
-                    <Text lineClamp={1} fz="sm" fw={600} color="white">
-                        {tooltipText}
-                    </Text>
-                    <Group>
-                        <AttributeCount
-                            Icon={IconLayoutDashboard}
-                            count={item.data.dashboardCount}
-                        />
-                        <AttributeCount
-                            Icon={IconChartBar}
-                            count={item.data.chartCount}
-                        />
-                    </Group>
-                </Stack>
-            </Popover.Dropdown>
-        </Popover>
+                        <Group spacing="sm">
+                            <Flex align="center" gap={4}>
+                                <AccessInfo item={item} />
+                            </Flex>
+                        </Group>
+                    </Stack>
+                </Tooltip>
+                <Box
+                    sx={{
+                        flexGrow: 0,
+                        flexShrink: 0,
+                        // FIXME: change logic to use position absolute
+                        // transition: 'opacity 0.2s',
+                        // opacity: hovered || opened ? 1 : 0,
+                        display: hovered || opened ? 'block' : 'none',
+                    }}
+                    component="div"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                    }}
+                >
+                    <ResourceViewActionMenu
+                        item={item}
+                        isOpen={opened}
+                        onOpen={handlers.open}
+                        onClose={handlers.close}
+                        onAction={onAction}
+                    />
+                </Box>
+            </Group>
+        </Paper>
     );
 };
 

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -137,8 +137,8 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
             bg={hovered ? theme.fn.rgba(theme.colors.gray[0], 0.5) : undefined}
             h="100%"
         >
-            {dragIcon}
             <Group p="md" align="center" spacing="md" noWrap>
+                {dragIcon}
                 <ResourceIcon item={item} />
 
                 <Tooltip

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Anchor, Box, SimpleGrid, Stack, Text } from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
-import { IconArrowsMove } from '@tabler/icons-react';
+import { IconGripVertical } from '@tabler/icons-react';
 import produce from 'immer';
 import orderBy from 'lodash/orderBy';
 import { FC, useMemo } from 'react';
@@ -63,7 +63,7 @@ const DraggableItem: FC<DraggableItemProps> = ({
                 const DragIcon = (
                     <Box
                         pos="absolute"
-                        right={0}
+                        left={0}
                         p={4}
                         {...dragProvided.dragHandleProps}
                     >
@@ -71,7 +71,7 @@ const DraggableItem: FC<DraggableItemProps> = ({
                             display={isHovered && hasReorder ? 'block' : 'none'}
                             size="sm"
                             color="gray.6"
-                            icon={IconArrowsMove}
+                            icon={IconGripVertical}
                         />
                     </Box>
                 );

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -3,7 +3,9 @@ import {
     ResourceViewItem,
     ResourceViewItemType,
 } from '@lightdash/common';
-import { Anchor, SimpleGrid, Stack, Text } from '@mantine/core';
+import { Anchor, Box, SimpleGrid, Stack, Text } from '@mantine/core';
+import { mergeRefs, useHover } from '@mantine/hooks';
+import { IconArrowsMove } from '@tabler/icons-react';
 import produce from 'immer';
 import orderBy from 'lodash/orderBy';
 import { FC, useMemo } from 'react';
@@ -16,6 +18,7 @@ import {
 import { Link, useParams } from 'react-router-dom';
 import { ResourceViewCommonProps } from '..';
 import { usePinnedItemsContext } from '../../../../providers/PinnedItemsProvider';
+import MantineIcon from '../../MantineIcon';
 import { ResourceViewItemActionState } from '../ResourceActionHandlers';
 import { getResourceName, getResourceUrl } from '../resourceUtils';
 import ResourceViewGridChartItem from './ResourceViewGridChartItem';
@@ -31,6 +34,93 @@ type ResourceViewGridProps = ResourceViewGridCommonProps &
     Pick<ResourceViewCommonProps, 'items'> & {
         onAction: (newAction: ResourceViewItemActionState) => void;
     };
+
+type DraggableItemProps = Pick<ResourceViewGridProps, 'onAction'> & {
+    item: ResourceViewItem;
+    index: number;
+    onAction: (newAction: ResourceViewItemActionState) => void;
+    projectUuid: string;
+    hasReorder: boolean;
+};
+
+const DraggableItem: FC<DraggableItemProps> = ({
+    item,
+    index,
+    onAction,
+    projectUuid,
+    hasReorder,
+}) => {
+    const { hovered: isHovered, ref: hoverRef } = useHover<HTMLAnchorElement>();
+
+    return (
+        <Draggable
+            draggableId={item.data.name}
+            index={index}
+            key={item.type + '-' + item.data.uuid}
+            isDragDisabled={!hasReorder}
+        >
+            {(dragProvided) => {
+                const DragIcon = (
+                    <Box
+                        pos="absolute"
+                        right={0}
+                        p={4}
+                        {...dragProvided.dragHandleProps}
+                    >
+                        <MantineIcon
+                            display={isHovered && hasReorder ? 'block' : 'none'}
+                            size="sm"
+                            color="gray.6"
+                            icon={IconArrowsMove}
+                        />
+                    </Box>
+                );
+
+                return (
+                    <Anchor
+                        component={Link}
+                        to={getResourceUrl(projectUuid, item)}
+                        sx={{
+                            display: 'block',
+                            color: 'unset',
+                            ':hover': {
+                                color: 'unset',
+                                textDecoration: 'unset',
+                            },
+                        }}
+                        ref={mergeRefs(dragProvided.innerRef, hoverRef)}
+                        {...dragProvided.draggableProps}
+                    >
+                        {item.type === ResourceViewItemType.SPACE ? (
+                            <ResourceViewGridSpaceItem
+                                item={item}
+                                onAction={onAction}
+                                dragIcon={DragIcon}
+                            />
+                        ) : item.type === ResourceViewItemType.DASHBOARD ? (
+                            <ResourceViewGridDashboardItem
+                                item={item}
+                                onAction={onAction}
+                                dragIcon={DragIcon}
+                            />
+                        ) : item.type === ResourceViewItemType.CHART ? (
+                            <ResourceViewGridChartItem
+                                item={item}
+                                onAction={onAction}
+                                dragIcon={DragIcon}
+                            />
+                        ) : (
+                            assertUnreachable(
+                                item,
+                                `Resource type not supported`,
+                            )
+                        )}
+                    </Anchor>
+                );
+            }}
+        </Draggable>
+    );
+};
 
 const ResourceViewGrid: FC<ResourceViewGridProps> = ({
     items,
@@ -131,61 +221,16 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
                                     {...dropProvided.droppableProps}
                                 >
                                     {group.items.map((item, index) => (
-                                        <Draggable
-                                            draggableId={item.data.name}
-                                            index={index}
+                                        <DraggableItem
                                             key={
                                                 item.type + '-' + item.data.uuid
                                             }
-                                            isDragDisabled={!hasReorder}
-                                        >
-                                            {(dragProvided) => (
-                                                <Anchor
-                                                    component={Link}
-                                                    to={getResourceUrl(
-                                                        projectUuid,
-                                                        item,
-                                                    )}
-                                                    sx={{
-                                                        display: 'block',
-                                                        color: 'unset',
-                                                        ':hover': {
-                                                            color: 'unset',
-                                                            textDecoration:
-                                                                'unset',
-                                                        },
-                                                    }}
-                                                    ref={dragProvided.innerRef}
-                                                    {...dragProvided.dragHandleProps}
-                                                    {...dragProvided.draggableProps}
-                                                >
-                                                    {item.type ===
-                                                    ResourceViewItemType.SPACE ? (
-                                                        <ResourceViewGridSpaceItem
-                                                            item={item}
-                                                            onAction={onAction}
-                                                        />
-                                                    ) : item.type ===
-                                                      ResourceViewItemType.DASHBOARD ? (
-                                                        <ResourceViewGridDashboardItem
-                                                            item={item}
-                                                            onAction={onAction}
-                                                        />
-                                                    ) : item.type ===
-                                                      ResourceViewItemType.CHART ? (
-                                                        <ResourceViewGridChartItem
-                                                            item={item}
-                                                            onAction={onAction}
-                                                        />
-                                                    ) : (
-                                                        assertUnreachable(
-                                                            item,
-                                                            `Resource type not supported`,
-                                                        )
-                                                    )}
-                                                </Anchor>
-                                            )}
-                                        </Draggable>
+                                            item={item}
+                                            index={index}
+                                            onAction={onAction}
+                                            projectUuid={projectUuid}
+                                            hasReorder={hasReorder}
+                                        />
                                     ))}
                                     {dropProvided.placeholder}
                                 </SimpleGrid>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6278 

### Description:

Drag-and-drop enhancements:
- Add drag icon to corner of Resource Item that can be dragged. 
- Pass the drag handler props to the `DragIcon` instead
- Only show icon on hover
- Cursor should only be in _drag_ mode if the `DragIcon` is clicked


https://github.com/lightdash/lightdash/assets/7611706/33a7f6df-21ad-481a-8901-9ad054f72b83



Tooltip changes:
- only display tooltip on hover of the item `name`
- changed `Space`'s `Popover`->`Tooltip`, seems to be working fine!


https://github.com/lightdash/lightdash/assets/7611706/6a6ec937-cc2e-43f1-b613-8384369cdc02


NOTE: when viewing `All Spaces`, the drag and drop icon does not get displayed because draggability is disabled in that context. 
