### PR TITLE
fix: check if configure is disabled with visualisation context

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
@@ -1,16 +1,22 @@
 import { Button, Popover } from '@mantine/core';
 import { IconChevronDown } from '@tabler/icons-react';
-import useEcharts from '../../../hooks/echarts/useEcharts';
 import {
     COLLAPSABLE_CARD_BUTTON_PROPS,
     COLLAPSABLE_CARD_POPOVER_PROPS,
 } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
+import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import ChartConfigTabs from './ChartConfigTabs';
 
 const ChartConfigPanel: React.FC = () => {
-    const eChartsOptions = useEcharts();
-    const disabled = !eChartsOptions;
+    const { resultsData, explore, cartesianConfig } = useVisualizationContext();
+
+    const disabled =
+        !resultsData ||
+        resultsData?.rows.length === 0 ||
+        !explore ||
+        !cartesianConfig.validCartesianConfig;
+
     return (
         <Popover
             withinPortal={true}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6417 

### Description:

When viewing a chart, and when there's grouped series and we hide them all, the `Configure` button gets disabled. 

Reason for this is that the usage of `useEcharts` does not give enough granularity for this scenario: when `series` is a `[]` but `rows`/results data has length > 0.

Instead, use `useVisualisationProvider` like on other config panels to disable the button correctly. 

Screen recording:



https://github.com/lightdash/lightdash/assets/7611706/93ba69ac-b8b1-4b24-b5bf-2d03facdcb46

