### PR TITLE
style: add padding to datepicker caption select

### DIFF
--- a/packages/frontend/src/styles/blueprint-core.css
+++ b/packages/frontend/src/styles/blueprint-core.css
@@ -9007,7 +9007,8 @@ label.bp4-label:not(.bp4-inline) .bp4-popover-target {
 }
 
 .bp4-datepicker-caption > .bp4-html-select > select {
-    padding-right: 4px;
+    padding-right: 16px;
+    padding-left: 5px;
 }
 
 .bp4-select::after {

--- a/packages/frontend/src/styles/blueprint-core.css
+++ b/packages/frontend/src/styles/blueprint-core.css
@@ -9006,6 +9006,10 @@ label.bp4-label:not(.bp4-inline) .bp4-popover-target {
     color: #abb3bf;
 }
 
+.bp4-datepicker-caption > .bp4-html-select > select {
+    padding-right: 4px;
+}
+
 .bp4-select::after {
     font-family: 'blueprint-icons-16', sans-serif;
     font-size: 16px;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6421 

### Description:

Padding isn't applied to date picker caption on production bundles: 
![image](https://github.com/lightdash/lightdash/assets/7611706/9d88700c-f2ba-45a1-b443-754bed356a0f)


locally: 
![image](https://github.com/lightdash/lightdash/assets/7611706/b866b209-d367-4ce8-aa13-d496028aa64f)


Add style with higher specificity to override the padding not being set. 
