### PR TITLE
chore: add chart in dashboard events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -202,16 +202,24 @@ type TrackUserDeletedEvent = BaseTrack & {
     };
 };
 
-type TrackSavedChart = BaseTrack & {
-    event: 'saved_chart.updated' | 'saved_chart.deleted';
+type UpdateSavedChartEvent = BaseTrack & {
+    event: 'saved_chart.updated';
+    properties: {
+        projectId: string;
+        savedQueryId: string;
+        dashboardId: string | undefined;
+    };
+};
+type DeleteSavedChartEvent = BaseTrack & {
+    event: 'saved_chart.deleted';
     properties: {
         projectId: string;
         savedQueryId: string;
     };
 };
 
-export type CreateSavedChartOrVersionEvent = BaseTrack & {
-    event: 'saved_chart.created' | 'saved_chart_version.created';
+export type CreateSavedChartVersionEvent = BaseTrack & {
+    event: 'saved_chart_version.created';
     properties: {
         projectId: string;
         savedQueryId: string;
@@ -243,6 +251,13 @@ export type CreateSavedChartOrVersionEvent = BaseTrack & {
         bigValue?: {
             hasBigValueComparison?: boolean;
         };
+    };
+};
+
+export type CreateSavedChartEvent = BaseTrack & {
+    event: 'saved_chart.created';
+    properties: CreateSavedChartVersionEvent['properties'] & {
+        dashboardId: string | undefined;
         duplicated?: boolean;
     };
 };
@@ -711,8 +726,10 @@ type Track =
     | VerifiedUserEvent
     | UserJoinOrganizationEvent
     | QueryExecutionEvent
-    | TrackSavedChart
-    | CreateSavedChartOrVersionEvent
+    | UpdateSavedChartEvent
+    | DeleteSavedChartEvent
+    | CreateSavedChartEvent
+    | CreateSavedChartVersionEvent
     | TrackUserDeletedEvent
     | ProjectErrorEvent
     | ApiErrorEvent

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -1,11 +1,13 @@
 import { Ability } from '@casl/ability';
 import {
+    ChartType,
     CreateDashboard,
     CreateDashboardChartTile,
     Dashboard,
     DashboardBasicDetails,
     DashboardTileTypes,
     OrganizationMemberRole,
+    SavedChart,
     SessionUser,
     Space,
     UpdateDashboard,
@@ -97,6 +99,54 @@ export const dashboard: Dashboard = {
     pinnedListOrder: null,
     views: 1,
     firstViewedAt: new Date(1),
+};
+
+export const dashboardWithChartThatBelongsToDashboard: Dashboard = {
+    ...dashboard,
+    tiles: [
+        ...dashboard.tiles,
+        {
+            uuid: 'my-tile',
+            type: DashboardTileTypes.SAVED_CHART,
+            x: 4,
+            y: 3,
+            h: 2,
+            w: 1,
+            properties: {
+                savedChartUuid: 'chart_in_dashboard',
+                belongsToDashboard: true,
+            },
+        },
+    ],
+};
+
+export const chart: SavedChart = {
+    uuid: 'chart_uuid',
+    projectUuid: dashboard.projectUuid,
+    name: 'chart name',
+    tableName: 'table_name',
+    metricQuery: {
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 0,
+        tableCalculations: [],
+    },
+    chartConfig: {
+        type: ChartType.TABLE,
+    },
+    tableConfig: {
+        columnOrder: [],
+    },
+    updatedAt: new Date(),
+    organizationUuid: user.organizationUuid!,
+    spaceUuid: 'spaceUuid',
+    spaceName: 'space name',
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    dashboardUuid: dashboard.uuid,
+    dashboardName: dashboard.name,
 };
 
 export const dashboardsDetails: DashboardBasicDetails[] = [

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -24,7 +24,7 @@ import cronstrue from 'cronstrue';
 import { analytics } from '../../analytics/client';
 import {
     ConditionalFormattingRuleSavedEvent,
-    CreateSavedChartOrVersionEvent,
+    CreateSavedChartVersionEvent,
 } from '../../analytics/LightdashAnalytics';
 import { schedulerClient, slackClient } from '../../clients/clients';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
@@ -102,7 +102,7 @@ export class SavedChartService {
 
     static getCreateEventProperties(
         savedChart: SavedChart,
-    ): CreateSavedChartOrVersionEvent['properties'] {
+    ): CreateSavedChartVersionEvent['properties'] {
         const echartsConfig =
             savedChart.chartConfig.type === ChartType.CARTESIAN
                 ? savedChart.chartConfig.config.eChartsConfig
@@ -303,6 +303,7 @@ export class SavedChartService {
             properties: {
                 projectId: savedChart.projectUuid,
                 savedQueryId: savedChartUuid,
+                dashboardId: savedChart.dashboardUuid ?? undefined,
             },
         });
         return savedChart;
@@ -509,8 +510,10 @@ export class SavedChartService {
         analytics.track({
             event: 'saved_chart.created',
             userId: user.userUuid,
-            properties:
-                SavedChartService.getCreateEventProperties(newSavedChart),
+            properties: {
+                ...SavedChartService.getCreateEventProperties(newSavedChart),
+                dashboardId: newSavedChart.dashboardUuid ?? undefined,
+            },
         });
 
         SavedChartService.getConditionalFormattingEventProperties(
@@ -559,6 +562,7 @@ export class SavedChartService {
             properties: {
                 ...newSavedChartProperties,
                 duplicated: true,
+                dashboardId: newSavedChart.dashboardUuid ?? undefined,
             },
         });
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -83,6 +83,10 @@ export type CreateDashboardChartTile = CreateDashboardTileBase &
 export type DashboardChartTile = DashboardTileBase &
     DashboardChartTileProperties;
 
+export const isChartTile = (
+    tile: DashboardTileBase,
+): tile is DashboardChartTile => tile.type === DashboardTileTypes.SAVED_CHART;
+
 export type CreateDashboard = {
     name: string;
     description?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6388 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Requirements:

 - [x] trigger saved_chart_created when creating a chart that belongs to a dashboard
 - [x] add `dashboard_id` to `saved_chart_created` and `saved_chart_updated` when chart belongs to a dashboard

Chart created in dashboard:
<img width="1525" alt="Screenshot 2023-07-25 at 13 36 02" src="https://github.com/lightdash/lightdash/assets/9117144/bb400983-b163-46f2-adaa-794552a26b74">

Chart that belongs to dashboard updated:
<img width="1549" alt="Screenshot 2023-07-25 at 13 38 04" src="https://github.com/lightdash/lightdash/assets/9117144/7b466e32-7c57-4cea-ac26-35b0e3ba5424">

Chart created in space ( doesn't have dashboard id ):
<img width="1539" alt="Screenshot 2023-07-25 at 13 41 15" src="https://github.com/lightdash/lightdash/assets/9117144/68da4106-2042-438d-8cd4-c5797e171d82">

