### PR TITLE
fix: date pickers in chart config close popup

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -69,6 +69,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                     return (
                         <WeekPicker
                             value={moment(value).toDate()}
+                            popoverProps={{ usePortal: false }}
                             startOfWeek={startOfWeek}
                             onChange={(dateValue: Date) => {
                                 onChange(
@@ -121,6 +122,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                 <DateInput2
                     fill
                     value={value}
+                    popoverProps={{ usePortal: false }}
                     formatDate={(dateValue: Date) =>
                         formatDate(dateValue, undefined, false)
                     }


### PR DESCRIPTION
### Description:

Date picker popups in the chart config were causing the config popover to close. This sets the (blueprint-based) date pickers to open in portals and fixes them closing the popup. Here's a video of it working:

https://github.com/lightdash/lightdash/assets/1864179/6403c356-39f6-4b11-b0a7-86443447c28b

