### PR TITLE
feat: delete dashboard modal updated

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -487,6 +487,7 @@ export class DashboardModel {
                     views: string;
                     first_viewed_at: Date | null;
                     belongs_to_dashboard: boolean;
+                    name: string | null;
                 }[]
             >(
                 `${DashboardTilesTableName}.x_offset`,
@@ -496,6 +497,7 @@ export class DashboardModel {
                 `${DashboardTilesTableName}.height`,
                 `${DashboardTilesTableName}.dashboard_tile_uuid`,
                 `${SavedChartsTableName}.saved_query_uuid`,
+                `${SavedChartsTableName}.name`,
                 this.database.raw(
                     `${SavedChartsTableName}.dashboard_uuid IS NOT NULL AS belongs_to_dashboard`,
                 ),
@@ -560,6 +562,7 @@ export class DashboardModel {
                 `${DashboardTilesTableName}.dashboard_version_id`,
                 dashboard.dashboard_version_id,
             );
+        console.log(tiles);
 
         return {
             organizationUuid: dashboard.organization_uuid,
@@ -584,6 +587,7 @@ export class DashboardModel {
                     url,
                     content,
                     belongs_to_dashboard,
+                    name,
                 }) => {
                     const base: Omit<
                         Dashboard['tiles'][number],
@@ -610,6 +614,7 @@ export class DashboardModel {
                                     ...commonProperties,
                                     savedChartUuid: saved_query_uuid,
                                     belongsToDashboard: belongs_to_dashboard,
+                                    chartName: name,
                                 },
                             };
                         case DashboardTileTypes.MARKDOWN:

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -562,7 +562,6 @@ export class DashboardModel {
                 `${DashboardTilesTableName}.dashboard_version_id`,
                 dashboard.dashboard_version_id,
             );
-        console.log(tiles);
 
         return {
             organizationUuid: dashboard.organization_uuid,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -45,6 +45,7 @@ export type DashboardChartTileProperties = {
         hideTitle?: boolean;
         savedChartUuid: string | null;
         belongsToDashboard?: boolean; // this should be required and not part of the "create" types, but we need to fix tech debt first. Open ticket https://github.com/lightdash/lightdash/issues/6450
+        chartName?: string | null;
     };
 };
 
@@ -201,3 +202,8 @@ export const getDefaultChartTileSize = (
             return defaultTileSize;
     }
 };
+
+export const hasChartsInDashboard = (dashboard: Dashboard) =>
+    dashboard.tiles.some(
+        (tile) => isChartTile(tile) && tile.properties.belongsToDashboard,
+    );

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -243,7 +243,7 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                 case ResourceViewItemType.DASHBOARD:
                     return (
                         <DashboardDeleteModal
-                            isOpen
+                            opened
                             uuid={action.item.data.uuid}
                             onClose={handleReset}
                             onConfirm={handleReset}

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -1,17 +1,23 @@
+import { hasChartsInDashboard, isChartTile } from '@lightdash/common';
 import {
     Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    DialogProps,
-} from '@blueprintjs/core';
+    Group,
+    List,
+    Modal,
+    ModalProps,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
 import { FC } from 'react';
 import {
     useDashboardDeleteMutation,
     useDashboardQuery,
 } from '../../../hooks/dashboard/useDashboard';
+import MantineIcon from '../MantineIcon';
 
-interface DashboardDeleteModalProps extends DialogProps {
+interface DashboardDeleteModalProps extends ModalProps {
     uuid: string;
     onConfirm?: () => void;
 }
@@ -34,31 +40,67 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
         onConfirm?.();
     };
 
+    const chartsInDashboardTiles = dashboard.tiles.filter(
+        (tile) => isChartTile(tile) && tile.properties.belongsToDashboard,
+    );
+
     return (
-        <Dialog lazy title="Delete Dashboard" icon="trash" {...modalProps}>
-            <DialogBody>
-                <p>
-                    Are you sure you want to delete the dashboard{' '}
-                    <b>"{dashboard.name}"</b>?
-                </p>
-            </DialogBody>
+        <Modal
+            title={
+                <Group spacing="xs">
+                    <MantineIcon icon={IconTrash} color="red" size="lg" />
+                    <Title order={4}>Delete dashboard</Title>
+                </Group>
+            }
+            {...modalProps}
+        >
+            <Stack mx="xs">
+                {hasChartsInDashboard(dashboard) ? (
+                    <Stack>
+                        <Text>
+                            Are you sure you want to delete the dashboard{' '}
+                            <b>"{dashboard.name}"</b>?
+                        </Text>
+                        <Text>
+                            This action will also permanently delete the
+                            following charts that were created from within it:
+                        </Text>
+                        <List size="sm">
+                            {chartsInDashboardTiles.map(
+                                (tile) =>
+                                    isChartTile(tile) && (
+                                        <List.Item key={tile.uuid}>
+                                            <Text>
+                                                {tile.properties.chartName}
+                                            </Text>
+                                        </List.Item>
+                                    ),
+                            )}
+                        </List>
+                    </Stack>
+                ) : (
+                    <Text>
+                        Are you sure you want to delete the dashboard{' '}
+                        <b>"{dashboard.name}"</b>?
+                    </Text>
+                )}
 
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={modalProps.onClose}>Cancel</Button>
+                <Group position="right" spacing="xs">
+                    <Button variant="outline" onClick={modalProps.onClose}>
+                        Cancel
+                    </Button>
 
-                        <Button
-                            loading={isDeleting}
-                            intent="danger"
-                            onClick={handleConfirm}
-                        >
-                            Delete
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                    <Button
+                        color="red"
+                        loading={isDeleting}
+                        onClick={handleConfirm}
+                        type="submit"
+                    >
+                        Delete
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -54,7 +54,7 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
             }
             {...modalProps}
         >
-            <Stack mx="xs">
+            <Stack>
                 {hasChartsInDashboard(dashboard) ? (
                     <Stack>
                         <Text>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -331,24 +331,6 @@ const Dashboard: FC = () => {
     const handleDeleteDashboard = () => {
         if (!dashboard) return;
         setIsDeleteModalOpen(true);
-        // if (hasChartsInDashboard(dashboard)) {
-        //     return (
-        // );
-        // }
-        // deleteDashboard(dashboard.uuid).then(() => {
-        //     history.replace(`/projects/${projectUuid}/dashboards`);
-        // });
-
-        // return (
-        //     <DashboardDeleteModal
-        //         opened
-        //         uuid={dashboard.uuid}
-        //         onClose={() =>
-        //             history.replace(`/projects/${projectUuid}/dashboards`)
-        //         }
-        //         onConfirm={() => deleteDashboard(dashboard.uuid)}
-        //     />
-        // );
     };
 
     const handleExportDashboard = () => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import { useHistory, useParams } from 'react-router-dom';
 
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import ErrorState from '../components/common/ErrorState';
+import DashboardDeleteModal from '../components/common/modal/DashboardDeleteModal';
 import Page from '../components/common/Page/Page';
 import DashboardFilter from '../components/DashboardFilter';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
@@ -172,6 +173,8 @@ const Dashboard: FC = () => {
     });
     const { mutateAsync: deleteDashboard } = useDashboardDeleteMutation();
     const { mutate: exportDashboard } = useExportDashboard();
+
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
     const layouts = useMemo(
         () => ({
@@ -327,9 +330,25 @@ const Dashboard: FC = () => {
 
     const handleDeleteDashboard = () => {
         if (!dashboard) return;
-        deleteDashboard(dashboard.uuid).then(() => {
-            history.replace(`/projects/${projectUuid}/dashboards`);
-        });
+        setIsDeleteModalOpen(true);
+        // if (hasChartsInDashboard(dashboard)) {
+        //     return (
+        // );
+        // }
+        // deleteDashboard(dashboard.uuid).then(() => {
+        //     history.replace(`/projects/${projectUuid}/dashboards`);
+        // });
+
+        // return (
+        //     <DashboardDeleteModal
+        //         opened
+        //         uuid={dashboard.uuid}
+        //         onClose={() =>
+        //             history.replace(`/projects/${projectUuid}/dashboards`)
+        //         }
+        //         onConfirm={() => deleteDashboard(dashboard.uuid)}
+        //     />
+        // );
     };
 
     const handleExportDashboard = () => {
@@ -501,11 +520,24 @@ const Dashboard: FC = () => {
                         isEditMode={isEditMode}
                     />
                 )}
+
+                {isDeleteModalOpen && (
+                    <DashboardDeleteModal
+                        opened
+                        uuid={dashboard.uuid}
+                        onClose={() => setIsDeleteModalOpen(false)}
+                        onConfirm={() => {
+                            deleteDashboard(dashboard.uuid);
+                            history.replace(
+                                `/projects/${projectUuid}/dashboards`,
+                            );
+                        }}
+                    />
+                )}
             </Page>
         </>
     );
 };
-
 const DashboardPage: FC = () => {
     useProfiler('Dashboard');
     return (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -32,7 +32,6 @@ import MetricQueryDataProvider from '../components/MetricQueryData/MetricQueryDa
 import UnderlyingDataModal from '../components/MetricQueryData/UnderlyingDataModal';
 import {
     appendNewTilesToBottom,
-    useDashboardDeleteMutation,
     useDuplicateDashboardMutation,
     useExportDashboard,
     useMoveDashboardMutation,
@@ -171,7 +170,6 @@ const Dashboard: FC = () => {
     const { mutate: duplicateDashboard } = useDuplicateDashboardMutation({
         showRedirectButton: true,
     });
-    const { mutateAsync: deleteDashboard } = useDashboardDeleteMutation();
     const { mutate: exportDashboard } = useExportDashboard();
 
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -509,7 +507,6 @@ const Dashboard: FC = () => {
                         uuid={dashboard.uuid}
                         onClose={() => setIsDeleteModalOpen(false)}
                         onConfirm={() => {
-                            deleteDashboard(dashboard.uuid);
                             history.replace(
                                 `/projects/${projectUuid}/dashboards`,
                             );


### PR DESCRIPTION
Closes: #6239 
Closes: #6495 

### Description:
- out of scope bonus: migrated modal to Mantine
- modal added to dashboard too

no charts in dashboard
<img width="1624" alt="Screenshot 2023-07-26 at 13 57 47" src="https://github.com/lightdash/lightdash/assets/67699259/804a5b6b-396f-4c6b-b94f-b96ed1260676">


with charts in dashboard
<img width="1624" alt="Screenshot 2023-07-26 at 13 57 41" src="https://github.com/lightdash/lightdash/assets/67699259/cb5521c4-6747-4272-bcfd-b31a1c9fbb10">

