### PR TITLE
feat: update delete chart tile modal and options

### DIFF
--- a/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
@@ -1,0 +1,57 @@
+import {
+    Button,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { FC } from 'react';
+import MantineIcon from '../MantineIcon';
+
+interface Props extends ModalProps {
+    name: string;
+    onConfirm: () => void;
+}
+
+const DeleteChartTileThatBelongsToDashboardModal: FC<Props> = ({
+    name,
+    onConfirm,
+    ...modelProps
+}) => (
+    <Modal
+        size="md"
+        title={
+            <Group spacing="xs">
+                <MantineIcon size="lg" icon={IconAlertCircle} color="red" />
+                <Title order={4}>Delete chart</Title>
+            </Group>
+        }
+        {...modelProps}
+    >
+        <Stack>
+            <Text>
+                Are you sure you want to delete the chart <b>{name}</b>?
+            </Text>
+            <Text>
+                This chart was created from within the dashboard, so removing
+                the tile will also result in the permanent deletion of the
+                chart.
+            </Text>
+
+            <Group position="right" spacing="xs">
+                <Button variant="outline" onClick={modelProps.onClose}>
+                    Cancel
+                </Button>
+
+                <Button color="red" onClick={onConfirm} type="submit">
+                    Delete
+                </Button>
+            </Group>
+        </Stack>
+    </Modal>
+);
+
+export default DeleteChartTileThatBelongsToDashboardModal;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6241 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Changes for tiles where the chart belongs to dashboard:
- [x] hide "edit content" 
- [x] show "Delete chart" instead of "Remove tile"
- [x] show delete modal

<img width="1023" alt="Screenshot 2023-07-26 at 14 49 06" src="https://github.com/lightdash/lightdash/assets/9117144/e883d876-1278-4faf-9479-9a220d07ff81">
<img width="436" alt="Screenshot 2023-07-26 at 14 50 05" src="https://github.com/lightdash/lightdash/assets/9117144/07fe82c7-f8fa-4e91-ab8b-0c04eec93616">

