### PR TITLE
fix: do not add column to columns if not part of columnOrder

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -27,6 +27,7 @@ type Args = {
     isColumnFrozen: (key: string) => boolean;
     showTableNames: boolean;
     getFieldLabelOverride: (key: string) => string | undefined;
+    columnOrder: string[];
 };
 
 const getDataAndColumns = ({
@@ -37,6 +38,7 @@ const getDataAndColumns = ({
     isColumnFrozen,
     showTableNames,
     getFieldLabelOverride,
+    columnOrder,
 }: Args): {
     rows: ResultRow[];
     columns: Array<TableHeader | TableColumn>;
@@ -51,7 +53,8 @@ const getDataAndColumns = ({
             const item = itemsMap[itemId] as
                 | typeof itemsMap[number]
                 | undefined;
-            if (!isColumnVisible(itemId)) {
+
+            if (!isColumnVisible(itemId) || !columnOrder.includes(itemId)) {
                 return acc;
             }
             const headerOverride = getFieldLabelOverride(itemId);

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -182,8 +182,10 @@ const useTableConfig = (
             showTableNames,
             getFieldLabelOverride,
             isColumnFrozen,
+            columnOrder,
         });
     }, [
+        columnOrder,
         selectedItemIds,
         pivotDimensions,
         itemsMap,
@@ -293,7 +295,7 @@ const useTableConfig = (
         worker,
     ]);
 
-    // Remove columProperties from map if the column has been removed from results
+    // Remove columnProperties from map if the column has been removed from results
     useEffect(() => {
         if (Object.keys(columnProperties).length > 0 && selectedItemIds) {
             const columnsRemoved = Object.keys(columnProperties).filter(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6422

### Description:

Ensure we do not add column X if it's not referenced in `columnOrder`

Screen recording:

https://github.com/lightdash/lightdash/assets/7611706/b21c5c9f-f4d2-4912-ba8f-a8e3d347f4b5


