### PR TITLE
style: change headway sparkles icon size to 16px

### DIFF
--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -72,7 +72,7 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
                 pos="relative"
                 id="headway-trigger"
             >
-                <MantineIcon icon={IconSparkles} size="lg" />
+                <MantineIcon icon={IconSparkles} />
                 <Box
                     id="headway-badge"
                     pos="absolute"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5781

### Description:

Change headway icon to 16px:16px

screenshot:

<img width="194" alt="Screenshot 2023-07-28 at 11 06 08" src="https://github.com/lightdash/lightdash/assets/7611706/e9926fe2-3ca4-46c7-a039-de0d6441f4ff">
<img width="584" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/c8cda3d5-0f02-48ba-8a82-58d50fb25e37">

