### PR TITLE
fix: correct hover tooltip ux when no changes to save in dashboard button

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Divider, Intent, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Dashboard, SpaceSummary, UpdatedByUser } from '@lightdash/common';
+import { Box, Tooltip } from '@mantine/core';
 import {
     IconCheck,
     IconCopy,
@@ -174,21 +175,21 @@ const DashboardHeader = ({
             {userCanManageDashboard && isEditMode ? (
                 <PageActionsContainer>
                     <AddTileButton onAddTiles={onAddTiles} />
-                    <Tooltip2
+                    <Tooltip
+                        withinPortal
                         position="bottom"
-                        content={
-                            !hasDashboardChanged
-                                ? 'No changes to save'
-                                : undefined
-                        }
+                        label="No changes to save"
+                        disabled={hasDashboardChanged}
                     >
-                        <Button
-                            text="Save"
-                            disabled={!hasDashboardChanged || isSaving}
-                            intent={Intent.PRIMARY}
-                            onClick={onSaveDashboard}
-                        />
-                    </Tooltip2>
+                        <Box>
+                            <Button
+                                text="Save"
+                                disabled={!hasDashboardChanged || isSaving}
+                                intent={Intent.PRIMARY}
+                                onClick={onSaveDashboard}
+                            />
+                        </Box>
+                    </Tooltip>
                     <Button
                         text="Cancel"
                         disabled={isSaving}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6336

### Description:

`Tooltip`s from `blueprint` + `disabled` buttons don't work as expected. 

Instead, wrap the button with `mantine`'s `Tooltip` and wrap the button with a `Box` component so the `ref` is forwarded. 

Screen recording:

https://github.com/lightdash/lightdash/assets/7611706/8a5ff7d7-9df3-4a29-9125-32e856f2adf6

