### PR TITLE
fix: check if markdown tile title is empty and reduce height

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -4,6 +4,7 @@ import styled, { createGlobalStyle, css } from 'styled-components';
 interface HeaderContainerProps {
     $isEditMode: boolean;
     $isHovering?: boolean;
+    $isEmpty?: boolean;
 }
 
 export const TileBaseWrapper = styled.div<HeaderContainerProps>`
@@ -45,6 +46,14 @@ export const HeaderContainer = styled.div<HeaderContainerProps>`
                 }
             `
             : ''}
+
+    ${({ $isEmpty }) =>
+        $isEmpty
+            ? css`
+                  position: absolute;
+                  right: 16px;
+              `
+            : ''}
 `;
 
 export const GlobalTileStyles = createGlobalStyle`
@@ -55,6 +64,7 @@ export const GlobalTileStyles = createGlobalStyle`
 
 interface TileTitleProps {
     $hovered?: boolean;
+    $test?: boolean;
 }
 
 export const TitleWrapper = styled.div<TileTitleProps>`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -64,7 +64,6 @@ export const GlobalTileStyles = createGlobalStyle`
 
 interface TileTitleProps {
     $hovered?: boolean;
-    $test?: boolean;
 }
 
 export const TitleWrapper = styled.div<TileTitleProps>`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -73,6 +73,9 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     const belongsToDashboard: boolean =
         isChartTile(tile) && !!tile.properties.belongsToDashboard;
 
+    const isMarkdownTileTitleEmpty =
+        tile.type === DashboardTileTypes.MARKDOWN && !title;
+
     return (
         <TileBaseWrapper
             className={isLoading ? Classes.SKELETON : undefined}
@@ -86,6 +89,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         $isEditMode={isEditMode}
                         onMouseEnter={() => setIsHovering(true)}
                         onMouseLeave={() => setIsHovering(false)}
+                        $isEmpty={isMarkdownTileTitleEmpty}
                     >
                         <Tooltip
                             disabled={!description}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3174 #5773

### Description:

If Dashboard title `MARKDOWN` has an empty `title`(`''`), then remove the height reserved for the header, but still make sure that the 3-dot-vertical icon actions are styled and working correctly. 

Screen recording: 


https://github.com/lightdash/lightdash/assets/7611706/1c0a53c3-e4ff-4ad7-b4a5-82ee47352edd


