### PR TITLE
fix: edit tile content fields are empty

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -212,7 +212,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     {tile.type === DashboardTileTypes.SAVED_CHART ? (
                         <ChartUpdateModal
                             opened={isEditingChartTile}
-                            chartTitle={chartName ?? ''}
+                            chartName={chartName ?? ''}
                             onClose={() => setIsEditingChartTile(false)}
                             onConfirm={(newTitle, newUuid) => {
                                 onEdit({

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -212,7 +212,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     {tile.type === DashboardTileTypes.SAVED_CHART ? (
                         <ChartUpdateModal
                             opened={isEditingChartTile}
-                            chartName={chartName ?? ''}
+                            tile={tile}
                             onClose={() => setIsEditingChartTile(false)}
                             onConfirm={(newTitle, newUuid) => {
                                 onEdit({

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -17,13 +17,13 @@ import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import MantineIcon from '../../common/MantineIcon';
 
 interface ChartUpdateModalProps extends ModalProps {
-    chartTitle: string;
+    chartName: string;
     onClose: () => void;
     onConfirm?: (newTitle: string, newChartUuid: string) => void;
 }
 
 const ChartUpdateModal = ({
-    chartTitle,
+    chartName,
     onClose,
     onConfirm,
     ...modalProps
@@ -42,6 +42,9 @@ const ChartUpdateModal = ({
             onConfirm?.(newTitle, newChartUuid);
         },
     );
+
+    const [chartUuid, setChartUuid] = React.useState<string | null>('');
+    const [chartTitle, setChartTitle] = React.useState<string>(chartName);
 
     const handleClose = () => {
         form.reset();
@@ -72,9 +75,12 @@ const ChartUpdateModal = ({
                         placeholder={
                             form.getInputProps('title').value.length > 0
                                 ? form.getInputProps('title').value
-                                : chartTitle
+                                : chartName
                         }
-                        {...form.getInputProps('title')}
+                        value={chartTitle}
+                        onChange={(event) => {
+                            setChartTitle(event.currentTarget.value);
+                        }}
                     />
                     <Select
                         styles={(theme) => ({
@@ -102,9 +108,11 @@ const ChartUpdateModal = ({
                         )}
                         disabled={isLoading}
                         withinPortal
-                        {...form.getInputProps('uuid')}
                         searchable
-                        placeholder="Search..."
+                        value={chartUuid}
+                        onChange={(value) => {
+                            setChartUuid(value);
+                        }}
                     />
                     <Group spacing="xs" position="right" mt="md">
                         <Button

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -36,7 +36,9 @@ const ChartUpdateModal = ({
     const [chartUuid, setChartUuid] = React.useState<string>(
         tile.properties.savedChartUuid ?? '',
     );
-    const [chartTitle, setChartTitle] = React.useState<string>('');
+    const [chartTitle, setChartTitle] = React.useState<string>(
+        tile.properties.title ?? '',
+    );
 
     const handleConfirm = form.onSubmit(() => {
         onConfirm?.(chartTitle, chartUuid);
@@ -75,9 +77,9 @@ const ChartUpdateModal = ({
                         }
                         value={chartTitle}
                         onChange={(event) => {
-                            event.preventDefault();
                             setChartTitle(event.currentTarget.value);
                         }}
+                        defaultValue={tile.properties.title}
                     />
                     <Select
                         styles={(theme) => ({
@@ -120,7 +122,9 @@ const ChartUpdateModal = ({
                         >
                             Cancel
                         </Button>
-                        <Button type="submit">Update</Button>
+                        <Button type="submit" disabled={}>
+                            Update
+                        </Button>
                     </Group>
                 </Stack>
             </form>


### PR DESCRIPTION
Closes: #6538 
A chunk of #6431 

### Description:
- [ ] The current chart should always be shown in the chart selection dropdown
- [ ]  If I have not updated the title, if I swap the chart, the placeholder text in the title field should update
- [ ]  If I update the title, the next time I open the modal, I should see the title instead of the placeholder

before
<img width="529" alt="Screenshot 2023-07-28 at 18 24 37" src="https://github.com/lightdash/lightdash/assets/67699259/58a90aab-278a-4db3-ad0d-6c338ce22ffd">

after

https://github.com/lightdash/lightdash/assets/67699259/e08bcd5f-3c10-454b-bbe0-4125a45e4bdf



