### PR TITLE
docs: fix lowercase broken link in metric docs

### DIFF
--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -220,7 +220,7 @@ Here are all of the properties you can customize:
 
 Takes the percentile of the values in the given field. Like SQL's `PERCENTILE_CONT` function.
 
-The `percentile` metric can be used on any numeric dimension or, [for custom SQL](#using-custom-SQL-in-aggregate-metrics), any valid SQL expression that gives a numeric table column.
+The `percentile` metric can be used on any numeric dimension or, [for custom SQL](#using-custom-sql-in-aggregate-metrics), any valid SQL expression that gives a numeric table column.
 
 For example, this creates a metric `median_price` by taking the 50% percentile of the `item_price` dimension:
 


### PR DESCRIPTION

### Description:
link not recognised because `sql` has to be lowercase

<img width="1055" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/8d323c87-ddfd-44b0-9ce8-b28e010d91cf">
