### PR TITLE
feat: dashboard filters default value

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -303,6 +303,7 @@ export const createDashboardFilterRuleFromField = (
             tableName: field.table,
         },
         tileTargets: getDefaultTileTargets(field, availableTileFilters),
+        disabled: true,
         label: undefined,
     });
 

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -74,8 +74,16 @@ const ActiveFilter: FC<Props> = ({
                 >
                     <>
                         {filterRule.label || filterRuleLabels.field}:{' '}
-                        {filterRuleLabels.operator}{' '}
-                        <FilterValues>{filterRuleLabels.value}</FilterValues>
+                        {filterRule.disabled ? (
+                            <>is any value</>
+                        ) : (
+                            <>
+                                {filterRuleLabels.operator}{' '}
+                                <FilterValues>
+                                    {filterRuleLabels.value}
+                                </FilterValues>
+                            </>
+                        )}
                     </>
                 </Tooltip2>
             </TagContainer>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -68,6 +68,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                     popoverProps={popoverProps}
                     filterType={filterType}
                     field={field}
+                    disabled={filterRule.disabled}
                     rule={filterRule}
                     onChange={(newFilterRule) =>
                         onChangeFilterRule(newFilterRule as DashboardFilterRule)

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core';
+import { HTMLSelect } from '@blueprintjs/core';
 import { Popover2Props } from '@blueprintjs/popover2';
 import {
     DashboardFilterRule,
@@ -7,9 +7,9 @@ import {
     FilterType,
     getFilterTypeFromItem,
 } from '@lightdash/common';
+import { Stack, Switch, TextInput } from '@mantine/core';
 import { FC, useMemo } from 'react';
 import { FilterTypeConfig } from '../../common/Filters/configs';
-import { BolderLabel } from '../FilterSearch/FilterSearch.styles';
 
 interface FilterSettingsProps {
     isEditMode: boolean;
@@ -36,8 +36,20 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     );
 
     return (
-        <>
-            <FormGroup label={<BolderLabel>Value</BolderLabel>}>
+        <Stack>
+            <Stack spacing="xs">
+                <Switch
+                    label="Default value"
+                    labelPosition="left"
+                    checked={!filterRule.disabled}
+                    onChange={() => {
+                        onChangeFilterRule({
+                            ...filterRule,
+                            disabled: !filterRule.disabled,
+                        });
+                    }}
+                />
+
                 <HTMLSelect
                     fill
                     onChange={(e) =>
@@ -48,9 +60,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                     options={filterConfig.operatorOptions}
                     value={filterRule.operator}
                 />
-            </FormGroup>
 
-            <FormGroup>
                 <filterConfig.inputs
                     popoverProps={popoverProps}
                     filterType={filterType}
@@ -60,24 +70,22 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         onChangeFilterRule(newFilterRule as DashboardFilterRule)
                     }
                 />
-            </FormGroup>
+            </Stack>
 
             {isEditMode && (
-                <FormGroup label={<BolderLabel>Label</BolderLabel>}>
-                    <InputGroup
-                        fill
-                        onChange={(e) =>
-                            onChangeFilterRule({
-                                ...filterRule,
-                                label: e.target.value || undefined,
-                            })
-                        }
-                        placeholder={`Defaults to "${field.label}"`}
-                        value={filterRule.label || ''}
-                    />
-                </FormGroup>
+                <TextInput
+                    label="Label"
+                    onChange={(e) =>
+                        onChangeFilterRule({
+                            ...filterRule,
+                            label: e.target.value || undefined,
+                        })
+                    }
+                    placeholder={`Defaults to "${field.label}"`}
+                    value={filterRule.label || ''}
+                />
             )}
-        </>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -46,6 +46,9 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         onChangeFilterRule({
                             ...filterRule,
                             disabled: !e.currentTarget.checked,
+                            values: e.currentTarget.checked
+                                ? filterRule.values
+                                : [],
                         });
                     }}
                 />

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -42,10 +42,10 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                     label="Default value"
                     labelPosition="left"
                     checked={!filterRule.disabled}
-                    onChange={() => {
+                    onChange={(e) => {
                         onChangeFilterRule({
                             ...filterRule,
-                            disabled: !filterRule.disabled,
+                            disabled: !e.currentTarget.checked,
                         });
                     }}
                 />

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -206,6 +206,7 @@ const FilterConfiguration: FC<Props> = ({
                     intent={Intent.PRIMARY}
                     text="Apply"
                     disabled={
+                        !internalFilterRule.disabled &&
                         ![
                             FilterOperator.NULL,
                             FilterOperator.NOT_NULL,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -410,10 +410,16 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     <div key={field.name}>
                         <Tag minimal style={{ color: 'white' }}>
                             {filterRuleLabels.field}:{' '}
-                            {filterRuleLabels.operator}{' '}
-                            <FilterValues>
-                                {filterRuleLabels.value}
-                            </FilterValues>
+                            {filterRule.disabled ? (
+                                <>is any value</>
+                            ) : (
+                                <>
+                                    {filterRuleLabels.operator}{' '}
+                                    <FilterValues>
+                                        {filterRuleLabels.value}
+                                    </FilterValues>
+                                </>
+                            )}
                         </Tag>
                     </div>
                 );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -1,9 +1,5 @@
 import { HTMLSelect } from '@blueprintjs/core';
-import {
-    ConditionalRule,
-    FilterOperator,
-    isFilterRule,
-} from '@lightdash/common';
+import { ConditionalRule, FilterOperator } from '@lightdash/common';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 
 const BooleanFilterInputs = <T extends ConditionalRule>(
@@ -11,17 +7,13 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
 ) => {
     const { rule, onChange, disabled } = props;
 
-    const isDefaultDisabled = isFilterRule(rule)
-        ? rule.disabled || disabled
-        : disabled ?? false;
-
     switch (rule.operator) {
         case FilterOperator.EQUALS: {
             return (
                 <HTMLSelect
                     fill
-                    className={isDefaultDisabled ? 'disabled-filter' : ''}
-                    disabled={isDefaultDisabled}
+                    className={disabled ? 'disabled-filter' : ''}
+                    disabled={disabled}
                     onChange={(e) =>
                         onChange({
                             ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -1,18 +1,27 @@
 import { HTMLSelect } from '@blueprintjs/core';
-import { ConditionalRule, FilterOperator } from '@lightdash/common';
+import {
+    ConditionalRule,
+    FilterOperator,
+    isFilterRule,
+} from '@lightdash/common';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 
 const BooleanFilterInputs = <T extends ConditionalRule>(
     props: React.PropsWithChildren<FilterInputsProps<T>>,
 ) => {
     const { rule, onChange, disabled } = props;
+
+    const isDefaultDisabled = isFilterRule(rule)
+        ? rule.disabled || disabled
+        : disabled ?? false;
+
     switch (rule.operator) {
         case FilterOperator.EQUALS: {
             return (
                 <HTMLSelect
                     fill
-                    className={disabled ? 'disabled-filter' : ''}
-                    disabled={disabled}
+                    className={isDefaultDisabled ? 'disabled-filter' : ''}
+                    disabled={isDefaultDisabled}
                     onChange={(e) =>
                         onChange({
                             ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -39,8 +39,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
         throw new Error('DateFilterInputs expects a FilterRule');
     }
 
-    const isDefaultDisabled = rule.disabled || disabled;
-
     switch (rule.operator) {
         case FilterOperator.EQUALS:
         case FilterOperator.NOT_EQUALS:
@@ -57,7 +55,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     week commencing
                                 </span>
                                 <WeekPicker
-                                    disabled={isDefaultDisabled}
+                                    disabled={disabled}
                                     value={rule.values?.[0] || new Date()}
                                     popoverProps={popoverProps}
                                     startOfWeek={startOfWeek}
@@ -73,7 +71,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     case TimeFrames.MONTH:
                         return (
                             <MonthAndYearInput
-                                disabled={isDefaultDisabled}
+                                disabled={disabled}
                                 value={rule.values?.[0] || new Date()}
                                 onChange={(value: Date) => {
                                     onChange({
@@ -90,7 +88,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     case TimeFrames.YEAR:
                         return (
                             <YearInput
-                                disabled={isDefaultDisabled}
+                                disabled={disabled}
                                 value={rule.values?.[0] || new Date()}
                                 onChange={(value: Date) => {
                                     onChange({
@@ -112,15 +110,15 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             if (isTimestamp) {
                 return (
                     <DateInput2
-                        className={isDefaultDisabled ? 'disabled-filter' : ''}
-                        disabled={isDefaultDisabled}
+                        className={disabled ? 'disabled-filter' : ''}
+                        disabled={disabled}
                         fill
                         defaultTimezone="UTC"
                         showTimezoneSelect={false}
                         value={
                             rule.values?.[0]
                                 ? new Date(rule.values?.[0]).toString()
-                                : new Date().toString()
+                                : null
                         }
                         timePrecision={'millisecond'}
                         formatDate={(value: Date) =>
@@ -129,7 +127,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         parseDate={(value) =>
                             moment(value, `YYYY-MM-DD, HH:mm:ss:SSS`).toDate()
                         }
-                        defaultValue={new Date().toString()}
+                        defaultValue={disabled ? '' : new Date().toString()}
                         onChange={(value: string | null) => {
                             if (value) {
                                 onChange({
@@ -153,19 +151,19 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             }
             return (
                 <DateInput2
-                    className={isDefaultDisabled ? 'disabled-filter' : ''}
-                    disabled={isDefaultDisabled}
+                    className={disabled ? 'disabled-filter' : ''}
+                    disabled={disabled}
                     fill
                     value={
                         rule.values?.[0]
-                            ? formatDate(rule.values?.[0], undefined, false)
-                            : new Date().toString()
+                            ? formatDate(rule.values[0], undefined, false)
+                            : null
                     }
                     formatDate={(value: Date) =>
                         formatDate(value, undefined, false)
                     }
                     parseDate={parseDate}
-                    defaultValue={new Date().toString()}
+                    defaultValue={disabled ? '' : new Date().toString()}
                     onChange={(value: string | null) => {
                         if (value) {
                             onChange({
@@ -193,9 +191,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <NumericInput
-                        className={isDefaultDisabled ? 'disabled-filter' : ''}
+                        className={disabled ? 'disabled-filter' : ''}
                         fill
-                        disabled={isDefaultDisabled}
+                        disabled={disabled}
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
                         onValueChange={(value) =>
@@ -206,7 +204,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         }
                     />
                     <UnitOfTimeAutoComplete
-                        disabled={isDefaultDisabled}
+                        disabled={disabled}
                         isTimestamp={isTimestamp}
                         unitOfTime={
                             rule.settings?.unitOfTime || UnitOfTime.days
@@ -229,7 +227,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <UnitOfTimeAutoComplete
-                        disabled={isDefaultDisabled}
+                        disabled={disabled}
                         isTimestamp={isTimestamp}
                         unitOfTime={
                             rule.settings?.unitOfTime || UnitOfTime.days
@@ -256,10 +254,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     <MultipleInputsWrapper>
                         <StyledDateRangeInput
                             allowSingleDayRange
-                            className={
-                                isDefaultDisabled ? 'disabled-filter' : ''
-                            }
-                            disabled={isDefaultDisabled}
+                            className={disabled ? 'disabled-filter' : ''}
+                            disabled={disabled}
                             formatDate={(value: Date) =>
                                 moment(value)
                                     .format(`YYYY-MM-DD, HH:mm:ss:SSS`)
@@ -316,8 +312,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <StyledDateRangeInput
-                        className={isDefaultDisabled ? 'disabled-filter' : ''}
-                        disabled={isDefaultDisabled}
+                        className={disabled ? 'disabled-filter' : ''}
+                        disabled={disabled}
                         formatDate={(value: Date) =>
                             formatDate(value, undefined, false)
                         }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -39,6 +39,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
         throw new Error('DateFilterInputs expects a FilterRule');
     }
 
+    const isDefaultDisabled = rule.disabled || disabled;
+
     switch (rule.operator) {
         case FilterOperator.EQUALS:
         case FilterOperator.NOT_EQUALS:
@@ -55,7 +57,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     week commencing
                                 </span>
                                 <WeekPicker
-                                    disabled={disabled}
+                                    disabled={isDefaultDisabled}
                                     value={rule.values?.[0] || new Date()}
                                     popoverProps={popoverProps}
                                     startOfWeek={startOfWeek}
@@ -71,7 +73,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     case TimeFrames.MONTH:
                         return (
                             <MonthAndYearInput
-                                disabled={disabled}
+                                disabled={isDefaultDisabled}
                                 value={rule.values?.[0] || new Date()}
                                 onChange={(value: Date) => {
                                     onChange({
@@ -88,7 +90,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     case TimeFrames.YEAR:
                         return (
                             <YearInput
-                                disabled={disabled}
+                                disabled={isDefaultDisabled}
                                 value={rule.values?.[0] || new Date()}
                                 onChange={(value: Date) => {
                                     onChange({
@@ -110,8 +112,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             if (isTimestamp) {
                 return (
                     <DateInput2
-                        className={disabled ? 'disabled-filter' : ''}
-                        disabled={disabled}
+                        className={isDefaultDisabled ? 'disabled-filter' : ''}
+                        disabled={isDefaultDisabled}
                         fill
                         defaultTimezone="UTC"
                         showTimezoneSelect={false}
@@ -151,8 +153,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             }
             return (
                 <DateInput2
-                    className={disabled ? 'disabled-filter' : ''}
-                    disabled={disabled}
+                    className={isDefaultDisabled ? 'disabled-filter' : ''}
+                    disabled={isDefaultDisabled}
                     fill
                     value={
                         rule.values?.[0]
@@ -191,9 +193,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <NumericInput
-                        className={disabled ? 'disabled-filter' : ''}
+                        className={isDefaultDisabled ? 'disabled-filter' : ''}
                         fill
-                        disabled={disabled}
+                        disabled={isDefaultDisabled}
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
                         onValueChange={(value) =>
@@ -204,7 +206,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         }
                     />
                     <UnitOfTimeAutoComplete
-                        disabled={disabled}
+                        disabled={isDefaultDisabled}
                         isTimestamp={isTimestamp}
                         unitOfTime={
                             rule.settings?.unitOfTime || UnitOfTime.days
@@ -227,7 +229,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <UnitOfTimeAutoComplete
-                        disabled={disabled}
+                        disabled={isDefaultDisabled}
                         isTimestamp={isTimestamp}
                         unitOfTime={
                             rule.settings?.unitOfTime || UnitOfTime.days
@@ -254,8 +256,10 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     <MultipleInputsWrapper>
                         <StyledDateRangeInput
                             allowSingleDayRange
-                            className={disabled ? 'disabled-filter' : ''}
-                            disabled={disabled}
+                            className={
+                                isDefaultDisabled ? 'disabled-filter' : ''
+                            }
+                            disabled={isDefaultDisabled}
                             formatDate={(value: Date) =>
                                 moment(value)
                                     .format(`YYYY-MM-DD, HH:mm:ss:SSS`)
@@ -312,8 +316,8 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             return (
                 <MultipleInputsWrapper>
                     <StyledDateRangeInput
-                        className={disabled ? 'disabled-filter' : ''}
-                        disabled={disabled}
+                        className={isDefaultDisabled ? 'disabled-filter' : ''}
+                        disabled={isDefaultDisabled}
                         formatDate={(value: Date) =>
                             formatDate(value, undefined, false)
                         }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -36,6 +36,10 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
         ? getField(rule)?.suggestions
         : undefined;
 
+    const isDefaultDisabled = isFilterRule(rule)
+        ? rule.disabled || disabled
+        : disabled ?? false;
+
     switch (rule.operator) {
         case FilterOperator.NULL:
         case FilterOperator.NOT_NULL:
@@ -50,7 +54,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                 return (
                     <MultiAutoComplete
                         filterId={rule.id}
-                        disabled={disabled}
+                        disabled={isDefaultDisabled}
                         field={field}
                         values={(rule.values || []).filter(isString)}
                         suggestions={suggestions || []}
@@ -66,9 +70,9 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
             }
             return (
                 <TagInput
-                    className={disabled ? 'disabled-filter' : ''}
+                    className={isDefaultDisabled ? 'disabled-filter' : ''}
                     fill
-                    disabled={disabled}
+                    disabled={isDefaultDisabled}
                     addOnBlur
                     inputProps={{
                         type:
@@ -109,8 +113,8 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
 
             return (
                 <StyledNumericInput
-                    className={disabled ? 'disabled-filter' : ''}
-                    disabled={disabled}
+                    className={isDefaultDisabled ? 'disabled-filter' : ''}
+                    disabled={isDefaultDisabled}
                     fill
                     type="number"
                     defaultValue={parsedValue}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -36,10 +36,6 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
         ? getField(rule)?.suggestions
         : undefined;
 
-    const isDefaultDisabled = isFilterRule(rule)
-        ? rule.disabled || disabled
-        : disabled ?? false;
-
     switch (rule.operator) {
         case FilterOperator.NULL:
         case FilterOperator.NOT_NULL:
@@ -54,7 +50,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                 return (
                     <MultiAutoComplete
                         filterId={rule.id}
-                        disabled={isDefaultDisabled}
+                        disabled={disabled}
                         field={field}
                         values={(rule.values || []).filter(isString)}
                         suggestions={suggestions || []}
@@ -70,9 +66,9 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
             }
             return (
                 <TagInput
-                    className={isDefaultDisabled ? 'disabled-filter' : ''}
+                    className={disabled ? 'disabled-filter' : ''}
                     fill
-                    disabled={isDefaultDisabled}
+                    disabled={disabled}
                     addOnBlur
                     inputProps={{
                         type:
@@ -113,8 +109,8 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
 
             return (
                 <StyledNumericInput
-                    className={isDefaultDisabled ? 'disabled-filter' : ''}
-                    disabled={isDefaultDisabled}
+                    className={disabled ? 'disabled-filter' : ''}
+                    disabled={disabled}
                     fill
                     type="number"
                     defaultValue={parsedValue}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/UnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/UnitOfTimeAutoComplete.tsx
@@ -117,70 +117,76 @@ const UnitOfTimeAutoComplete: FC<Props> = ({
     onClosed,
     popoverProps,
     disabled,
-}) => (
-    <>
-        <AutocompleteMaxHeight />
-        <FieldSuggest
-            className={disabled ? 'disabled-filter' : ''}
-            disabled={disabled}
-            items={UnitOfTimeOptions({
-                isTimestamp,
-                showCompletedOptions,
-                showOptionsInPlural,
-            })}
-            itemsEqual={(value, other) =>
-                value.unitOfTime === other.unitOfTime &&
-                value.completed === other.completed
-            }
-            popoverProps={{
-                fill: true,
-                minimal: true,
-                onClosed,
-                popoverClassName: 'autocomplete-max-height',
-                ...popoverProps,
-            }}
-            itemRenderer={renderItem}
-            activeItem={{
-                label: getUnitOfTimeLabel(
-                    unitOfTime,
-                    showOptionsInPlural,
-                    completed,
-                ),
-                unitOfTime,
-                completed,
-            }}
-            noResults={<MenuItem2 disabled text="No results." />}
-            onItemSelect={onChange}
-            itemPredicate={(
-                query: string,
-                field: UnitOfTimeOption,
-                index?: undefined | number,
-                exactMatch?: undefined | false | true,
-            ) => {
-                if (exactMatch) {
-                    return query.toLowerCase() === field.label.toLowerCase();
-                }
-                return field.label.toLowerCase().includes(query.toLowerCase());
-            }}
-        >
-            <Button
+}) => {
+    return (
+        <>
+            <AutocompleteMaxHeight />
+            <FieldSuggest
                 className={disabled ? 'disabled-filter' : ''}
                 disabled={disabled}
-                rightIcon="caret-down"
-                text={getUnitOfTimeLabel(
-                    unitOfTime,
+                items={UnitOfTimeOptions({
+                    isTimestamp,
+                    showCompletedOptions,
                     showOptionsInPlural,
-                    completed,
-                )}
-                fill
-                style={{
-                    display: 'inline-flex',
-                    justifyContent: 'space-between',
-                    whiteSpace: 'nowrap',
+                })}
+                itemsEqual={(value, other) =>
+                    value.unitOfTime === other.unitOfTime &&
+                    value.completed === other.completed
+                }
+                popoverProps={{
+                    fill: true,
+                    minimal: true,
+                    onClosed,
+                    popoverClassName: 'autocomplete-max-height',
+                    ...popoverProps,
                 }}
-            />
-        </FieldSuggest>
-    </>
-);
+                itemRenderer={renderItem}
+                activeItem={{
+                    label: getUnitOfTimeLabel(
+                        unitOfTime,
+                        showOptionsInPlural,
+                        completed,
+                    ),
+                    unitOfTime,
+                    completed,
+                }}
+                noResults={<MenuItem2 disabled text="No results." />}
+                onItemSelect={onChange}
+                itemPredicate={(
+                    query: string,
+                    field: UnitOfTimeOption,
+                    index?: undefined | number,
+                    exactMatch?: undefined | false | true,
+                ) => {
+                    if (exactMatch) {
+                        return (
+                            query.toLowerCase() === field.label.toLowerCase()
+                        );
+                    }
+                    return field.label
+                        .toLowerCase()
+                        .includes(query.toLowerCase());
+                }}
+            >
+                <Button
+                    className={disabled ? 'disabled-filter' : ''}
+                    disabled={disabled}
+                    rightIcon="caret-down"
+                    text={getUnitOfTimeLabel(
+                        unitOfTime,
+                        showOptionsInPlural,
+                        completed,
+                    )}
+                    fill
+                    style={{
+                        display: 'inline-flex',
+                        justifyContent: 'space-between',
+                        whiteSpace: 'nowrap',
+                    }}
+                />
+            </FieldSuggest>
+        </>
+    );
+};
 
 export default UnitOfTimeAutoComplete;

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -21,6 +21,7 @@ const useDashboardFiltersForExplore = (
     const overrideTileFilters = useCallback(
         (rules: DashboardFilterRule[]) =>
             rules
+                .filter((rule) => !rule.disabled)
                 .filter((f) => f.tileTargets?.[tileUuid] ?? true)
                 .map((filter) => {
                     const { tileTargets, ...rest } = filter;


### PR DESCRIPTION
### Description:

**changes in popover:**
<img width="344" alt="CleanShot 2023-08-01 at 16 25 10@2x" src="https://github.com/lightdash/lightdash/assets/962095/42791854-a230-430f-96ad-4f4401d87faa">

---

**default is disabled:**
<img width="371" alt="CleanShot 2023-08-01 at 16 31 44@2x" src="https://github.com/lightdash/lightdash/assets/962095/5310ff94-d79f-4b5c-8223-f4a158284eee">

---

**changes in active dashboard filters:**
<img width="530" alt="CleanShot 2023-08-01 at 16 25 20@2x" src="https://github.com/lightdash/lightdash/assets/962095/c9e099f5-d97a-4c56-8f5a-9f8f2d85b799">

---

**changes in dashboard chart tile:**
<img width="840" alt="CleanShot 2023-08-01 at 16 25 38@2x" src="https://github.com/lightdash/lightdash/assets/962095/85cf955b-c785-4c11-9c04-baac144ca123">