### PR TITLE
feat: create chart before updating dashboard

### DIFF
--- a/packages/backend/src/database/seeds/development/02_saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/02_saved_queries.ts
@@ -22,7 +22,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: 'How much revenue do we have per payment method?',
             description:
@@ -93,7 +92,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: `What's our total revenue to date?`,
             description: `A single number showing the sum of all historical revenue`,
@@ -137,7 +135,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: 'How many orders we have over time ?',
             description:
@@ -210,7 +207,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: "What's the average spend per customer?",
             description: 'Average order size for each customer id',
@@ -262,7 +258,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: 'Which customers have not recently ordered an item?',
             description:
@@ -308,7 +303,6 @@ export async function seed(knex: Knex): Promise<void> {
     await savedChartModel.create(
         SEED_PROJECT.project_uuid,
         SEED_ORG_1_ADMIN.user_uuid,
-        undefined,
         {
             name: 'How many orders did we get on February?',
             description:

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -219,7 +219,6 @@ export const createSavedChart = async (
     db: Knex,
     projectUuid: string,
     userUuid: string,
-    dashboardUuid: string | undefined,
     {
         name,
         description,
@@ -230,7 +229,8 @@ export const createSavedChart = async (
         pivotConfig,
         updatedByUser,
         spaceUuid,
-    }: CreateSavedChart,
+        dashboardUuid,
+    }: CreateSavedChart & { updatedByUser: UpdatedByUser },
 ): Promise<string> =>
     db.transaction(async (trx) => {
         let chart: InsertChart;
@@ -288,35 +288,13 @@ export class SavedChartModel {
     async create(
         projectUuid: string,
         userUuid: string,
-        dashboardUuid: string | undefined,
-        {
-            name,
-            description,
-            tableName,
-            metricQuery,
-            chartConfig,
-            tableConfig,
-            pivotConfig,
-            updatedByUser,
-            spaceUuid,
-        }: CreateSavedChart & { updatedByUser: UpdatedByUser },
+        data: CreateSavedChart & { updatedByUser: UpdatedByUser },
     ): Promise<SavedChart> {
         const newSavedChartUuid = await createSavedChart(
             this.database,
             projectUuid,
             userUuid,
-            dashboardUuid,
-            {
-                name,
-                description,
-                tableName,
-                metricQuery,
-                chartConfig,
-                tableConfig,
-                pivotConfig,
-                updatedByUser,
-                spaceUuid,
-            },
+            data,
         );
         return this.get(newSavedChartUuid);
     }

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -101,25 +101,6 @@ export const dashboard: Dashboard = {
     firstViewedAt: new Date(1),
 };
 
-export const dashboardWithChartThatBelongsToDashboard: Dashboard = {
-    ...dashboard,
-    tiles: [
-        ...dashboard.tiles,
-        {
-            uuid: 'my-tile',
-            type: DashboardTileTypes.SAVED_CHART,
-            x: 4,
-            y: 3,
-            h: 2,
-            w: 1,
-            properties: {
-                savedChartUuid: 'chart_in_dashboard',
-                belongsToDashboard: true,
-            },
-        },
-    ],
-};
-
 export const chart: SavedChart = {
     uuid: 'chart_uuid',
     projectUuid: dashboard.projectUuid,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -23,7 +23,6 @@ import {
     createDashboardWithTileIds,
     dashboard,
     dashboardsDetails,
-    dashboardWithChartThatBelongsToDashboard,
     privateSpace,
     publicSpace,
     space,
@@ -252,21 +251,6 @@ describe('DashboardService', () => {
             2,
             expect.objectContaining({
                 event: 'dashboard_version.created',
-            }),
-        );
-    });
-    test('should track creation of chart in dashboard when updating dashboard version', async () => {
-        (dashboardModel.addVersion as jest.Mock).mockImplementationOnce(
-            async () => dashboardWithChartThatBelongsToDashboard,
-        );
-
-        await service.update(user, dashboardUuid, updateDashboardTiles);
-
-        expect(dashboardModel.addVersion).toHaveBeenCalledTimes(1);
-        expect(analytics.track).toHaveBeenCalledTimes(2);
-        expect(analytics.track).toHaveBeenCalledWith(
-            expect.objectContaining({
-                event: 'saved_chart.created',
             }),
         );
     });

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -16,6 +16,7 @@ import {
     SavedChart,
     SchedulerAndTargets,
     SessionUser,
+    UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
     ViewStatistics,
@@ -502,7 +503,6 @@ export class SavedChartService {
         const newSavedChart = await this.savedChartModel.create(
             projectUuid,
             user.userUuid,
-            undefined,
             {
                 ...savedChart,
                 updatedByUser: user,
@@ -544,15 +544,30 @@ export class SavedChartService {
                 "You don't have access to the space this chart belongs to",
             );
         }
-        const duplicatedChart = {
+        let duplicatedChart: CreateSavedChart & {
+            updatedByUser: UpdatedByUser;
+        };
+        const base = {
             ...chart,
             name: `Copy of ${chart.name}`,
             updatedByUser: user,
         };
+        if (chart.dashboardUuid) {
+            duplicatedChart = {
+                ...base,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: null,
+            };
+        } else {
+            duplicatedChart = {
+                ...base,
+                dashboardUuid: null,
+            };
+        }
+
         const newSavedChart = await this.savedChartModel.create(
             projectUuid,
             user.userUuid,
-            undefined,
             duplicatedChart,
         );
         const newSavedChartProperties =

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { FilterableField } from './field';
 import { DashboardFilters } from './filter';
-import { CreateSavedChart, SavedChartType } from './savedCharts';
+import { SavedChartType } from './savedCharts';
 import { UpdatedByUser } from './user';
 import { ValidationSummary } from './validation';
 
@@ -49,27 +49,6 @@ export type DashboardChartTileProperties = {
     };
 };
 
-type CreateChartTileWithSavedChartUuid =
-    DashboardChartTileProperties['properties'] & {
-        savedChartUuid: string | null;
-        newChartData?: null;
-    };
-
-type CreateChartTileWithNewChartData =
-    DashboardChartTileProperties['properties'] & {
-        savedChartUuid: null;
-        newChartData: CreateSavedChart;
-    };
-
-export type CreateDashboardChartTileProperties = Omit<
-    DashboardChartTileProperties,
-    'properties'
-> & {
-    properties:
-        | CreateChartTileWithSavedChartUuid
-        | CreateChartTileWithNewChartData;
-};
-
 export type CreateDashboardMarkdownTile = CreateDashboardTileBase &
     DashboardMarkdownTileProperties;
 export type DashboardMarkdownTile = DashboardTileBase &
@@ -80,7 +59,7 @@ export type CreateDashboardLoomTile = CreateDashboardTileBase &
 export type DashboardLoomTile = DashboardTileBase & DashboardLoomTileProperties;
 
 export type CreateDashboardChartTile = CreateDashboardTileBase &
-    CreateDashboardChartTileProperties;
+    DashboardChartTileProperties;
 export type DashboardChartTile = DashboardTileBase &
     DashboardChartTileProperties;
 

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -282,21 +282,28 @@ export type SavedChart = {
     dashboardName: string | null;
 };
 
-export type CreateSavedChart = Omit<
+type CreateChartBase = Pick<
     SavedChart,
-    | 'uuid'
-    | 'updatedAt'
-    | 'projectUuid'
-    | 'organizationUuid'
-    | 'spaceUuid'
-    | 'spaceName'
-    | 'pinnedListUuid'
-    | 'pinnedListOrder'
-    | 'views'
-    | 'firstViewedAt'
-    | 'dashboardUuid'
-    | 'dashboardName'
-> & { spaceUuid?: string };
+    | 'name'
+    | 'description'
+    | 'tableName'
+    | 'metricQuery'
+    | 'pivotConfig'
+    | 'chartConfig'
+    | 'tableConfig'
+>;
+
+export type CreateChartInSpace = CreateChartBase & {
+    spaceUuid?: string;
+    dashboardUuid?: null;
+};
+
+export type CreateChartInDashboard = CreateChartBase & {
+    dashboardUuid: string;
+    spaceUuid?: null;
+};
+
+export type CreateSavedChart = CreateChartInSpace | CreateChartInDashboard;
 
 export type CreateSavedChartVersion = Omit<
     SavedChart,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -224,17 +224,8 @@ const ValidDashboardChartTileMinimal: FC<{
 
 const InvalidDashboardChartTile: FC<
     Pick<DashboardChartTileMainProps, 'tile'>
-> = ({ tile }) => {
-    //TODO fix typing for dashboard tiles, ticket open here: https://github.com/lightdash/lightdash/issues/6450
-    // @ts-ignore
-    return tile.properties.newChartData ? (
-        <NonIdealState
-            // @ts-ignore
-            title={tile.properties.newChartData.name}
-            icon="chart"
-            description="Save your dashboard to see this new chart appear in the tile"
-        />
-    ) : (
+> = () => {
+    return (
         <NonIdealState
             title="No chart available"
             description="Chart might have been deleted or you don't have permissions to see it."

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -8,6 +8,7 @@ import {
     InputGroup,
 } from '@blueprintjs/core';
 import {
+    CreateChartInDashboard,
     CreateDashboardChartTile,
     CreateSavedChartVersion,
     DashboardTileTypes,
@@ -121,19 +122,20 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
         showSpaceInput,
     ]);
 
-    const handleSaveChartInDashboard = useCallback(() => {
+    const handleSaveChartInDashboard = useCallback(async () => {
         if (!fromDashboard || !unsavedDashboardTiles || !dashboardUuid) return;
+        const newChartInDashboard: CreateChartInDashboard = {
+            ...savedData,
+            name,
+            description,
+            dashboardUuid,
+        };
         const newTile: CreateDashboardChartTile = {
             uuid: uuid4(),
             type: DashboardTileTypes.SAVED_CHART,
             properties: {
                 belongsToDashboard: true,
-                savedChartUuid: null,
-                newChartData: {
-                    ...savedData,
-                    name,
-                    description,
-                },
+                savedChartUuid: (await mutateAsync(newChartInDashboard)).uuid,
             },
             ...getDefaultChartTileSize(savedData.chartConfig?.type),
         };
@@ -156,6 +158,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
         fromDashboard,
         unsavedDashboardTiles,
         dashboardUuid,
+        mutateAsync,
         savedData,
         name,
         description,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [Create chart in dashboard before creating dashboard tile #6510](https://github.com/lightdash/lightdash/issues/6510)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We had to rollback changes from the initial implementation. 

Before: 
- we would send the chart data in the dashboard tile ( `newChartData` ) 
- the DashboardModel would create the chart and save the uuid in the new tile
- the DashboardService would figure out which charts were created and record a `saved_chart.created` event

Now:
- we create a chart with dashboardUuid ( this triggers the `saved_chart.created` event )
- we update the dashboard with the new chart uuid ( the same way we add other chart tiles )

Pros:
The newly created chart shows up while editing the dashboard.

Cons: 
We track `saved_chart.created` before it is saved in the dashboard. 
There is an edge case where the user cancels the dashboard update after creating a chart, this will not have an impact on the user but might be confusing for our analytics. Created a ticket to address that [Delete orphan dashboard charts on edit cancelation #6591](https://github.com/lightdash/lightdash/issues/6591), worst case the chart is deleted on the next dashboard update.

Main changes:
- remove chart creation in DashboardModel
- remove chart creation event from DashboardService + unit test
- remove dashboard chart tile types
- CreateChartModal now creates a chart and adds the chart uuid to a new tile
- refactor e2e test

How to enable this feature in the PR env:
```localStorage.setItem('CHARTS_IN_DASHBOARDS', true)```

Demo: 


https://github.com/lightdash/lightdash/assets/9117144/8411f58f-950c-4526-af60-a49e471cc981

