### PR TITLE
fix: add any option to boolean filter

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -1,4 +1,4 @@
-import { HTMLSelect } from '@blueprintjs/core';
+import { HTMLSelect, OptionProps } from '@blueprintjs/core';
 import {
     ConditionalRule,
     FilterOperator,
@@ -35,11 +35,19 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
                         })
                     }
                     placeholder={placeholder}
-                    options={[
-                        { value: 'any', label: placeholder, disabled: true },
-                        { value: 'true', label: 'True' },
-                        { value: 'false', label: 'False' },
-                    ]}
+                    options={
+                        [
+                            {
+                                value: 'any',
+                                label: placeholder,
+                                disabled: true,
+                                hidden: true,
+                            },
+                            { value: 'true', label: 'True' },
+                            { value: 'false', label: 'False' },
+                            // adding explicit type conversion because `hidden` is not in the typings but it actually works
+                        ] as OptionProps[]
+                    }
                     value={selectValue}
                 />
             );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -1,17 +1,25 @@
 import { HTMLSelect } from '@blueprintjs/core';
-import { ConditionalRule, FilterOperator } from '@lightdash/common';
+import {
+    ConditionalRule,
+    FilterOperator,
+    isFilterRule,
+} from '@lightdash/common';
+import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 
 const BooleanFilterInputs = <T extends ConditionalRule>(
     props: React.PropsWithChildren<FilterInputsProps<T>>,
 ) => {
-    const { rule, onChange, disabled } = props;
+    const { rule, onChange, disabled, filterType } = props;
 
-    let selectValue = 'any';
+    const placeholder = getPlaceholderByFilterTypeAndOperator({
+        type: filterType,
+        operator: rule.operator,
+        disabled: isFilterRule(rule) ? rule.disabled : false,
+    });
 
-    if (rule.values !== undefined) {
-        selectValue = rule.values[0] ? 'true' : 'false';
-    }
+    const selectValue =
+        rule.values === undefined ? 'any' : rule.values[0] ? 'true' : 'false';
 
     switch (rule.operator) {
         case FilterOperator.EQUALS: {
@@ -26,12 +34,9 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
                             values: [e.currentTarget.value === 'true'],
                         })
                     }
+                    placeholder={placeholder}
                     options={[
-                        {
-                            value: 'any',
-                            label: 'Any',
-                            disabled: !!selectValue && selectValue !== 'any',
-                        },
+                        { value: 'any', label: placeholder, disabled: true },
                         { value: 'true', label: 'True' },
                         { value: 'false', label: 'False' },
                     ]}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -7,6 +7,12 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
 ) => {
     const { rule, onChange, disabled } = props;
 
+    let selectValue = 'any';
+
+    if (rule.values !== undefined) {
+        selectValue = rule.values[0] ? 'true' : 'false';
+    }
+
     switch (rule.operator) {
         case FilterOperator.EQUALS: {
             return (
@@ -21,10 +27,15 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
                         })
                     }
                     options={[
+                        {
+                            value: 'any',
+                            label: 'Any',
+                            disabled: !!selectValue && selectValue !== 'any',
+                        },
                         { value: 'true', label: 'True' },
                         { value: 'false', label: 'False' },
                     ]}
-                    value={rule.values?.[0] ? 'true' : 'false'}
+                    value={selectValue}
                 />
             );
         }

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -100,6 +100,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
         case FilterType.BOOLEAN:
             switch (operator) {
                 case FilterOperator.EQUALS:
+                    return 'True / False';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

On dashboard: 
1. Edit
2. Add boolean filter (disabled/no default value) 
3. Save
4. Click on `disabled`/no-value filter
5. See `any` option
6. Click on `True` or `False`
7. See `Any` option disabled

Also checked on the chart filters and this option is disabled, so all good

Screen recording


https://github.com/lightdash/lightdash/assets/7611706/953f9570-8825-4253-a921-ba7d3189f58b

charts still ok: 

https://github.com/lightdash/lightdash/assets/7611706/f5b38042-f23a-4bc4-9cb3-e8c52717444b


