### PR TITLE
docs: remove hardcoded cloud urls

### DIFF
--- a/docs/docs/get-started/setup-lightdash/get-project-lightdash-ready.mdx
+++ b/docs/docs/get-started/setup-lightdash/get-project-lightdash-ready.mdx
@@ -64,10 +64,10 @@ We've automatically generated a personal access token that you can use to login 
 It's Step 2. and should look something like this:
 
 ```shell
-lightdash login https://app.lightdash.cloud --token my-super-secret-token
+lightdash login https://{{ lightdash_domain }} --token my-super-secret-token
 ```
 
-If you want to login using another method, then you [can check out our authentication methods here](/guides/cli/cli-authentication.mdx).
+Where `{{ lightdash_domain }}` is `app.lightdash.cloud` for Lightdash Cloud users. Or your own domain if self-hosting. If you want to login using another method, then you [can check out our authentication methods here](/guides/cli/cli-authentication.mdx).
 
 ---
 

--- a/docs/docs/guides/cli/cli-authentication.mdx
+++ b/docs/docs/guides/cli/cli-authentication.mdx
@@ -9,10 +9,10 @@ import PersonalAccessToken from './assets/personal-access-token.png';
   To login to your Lightdash instance run the following command and provide your login email and password:
 
   ```shell
-  lightdash login https://my-lightdash.domain.com
+  lightdash login https://{{ lightdash_domain }}
   ```
 
-where `https://my-lightdash.domain.com` is the address for your running Lightdash instance. For example Lightdash
+where `{{ lightdash_domain }}` is the address for your running Lightdash instance. For example Lightdash
 cloud users in the US would type `lightdash login https://app.lightdash.cloud` if you're in Europe you'd type
 `lightdash login https://eu1.lightdash.cloud`.
 
@@ -28,7 +28,7 @@ cloud users in the US would type `lightdash login https://app.lightdash.cloud` i
   Then, run the following command in your project:
 
   ```shell
-  lightdash login https://my-lightdash.domain.com --token
+  lightdash login https://{{ lightdash_domain }} --token
   ```
 
 where `https://my-lightdash.domain.com` is the address for your running Lightdash instance. For example Lightdash
@@ -49,8 +49,10 @@ You can use the following environment variables to authenticate yourself on each
 Example:
 
   ```shell
-  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://app.lightdash.cloud" LIGHTDASH_PROXY_AUTHENTICATION="Bearer <JWT_TOKEN>" lightdash preview
+  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://{{ lightdash_domain }}" LIGHTDASH_PROXY_AUTHENTICATION="Bearer <JWT_TOKEN>" lightdash preview
   ```
+
+Where `{{ lightdash_domain }}` is your domain. For Lightdash Cloud users use `https://app.lightdash.cloud`
 
 </details>
 

--- a/docs/docs/snippets/github-secrets.mdx
+++ b/docs/docs/snippets/github-secrets.mdx
@@ -25,7 +25,8 @@ The UUID for your project. For example, if your URL looks like `https://eu1.ligh
 
 #### `LIGHTDASH_URL`
 
-This is either `https://eu1.lightdash.cloud` or `https://app.lightdash.cloud` (check the URL to your Lightdash project)
+This is either `https://eu1.lightdash.cloud` or `https://app.lightdash.cloud` for Lightdash Cloud users (check the URL to your Lightdash project).
+If you self-host, this should be your own custom domain. 
 
 #### `DBT_PROFILES`
 


### PR DESCRIPTION
This confused some users with custom domains: https://lightdash.slack.com/archives/C05B9N87JPR/p1690997457011219?thread_ts=1690368212.693799&cid=C05B9N87JPR