### PR TITLE
Feat/multiple ux improvements chart in dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -138,7 +138,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                                 }
                                                             />
                                                         )}
-                                                        <MenuDivider />
                                                         {belongsToDashboard ? (
                                                             <MenuItem2
                                                                 icon="delete"
@@ -151,16 +150,19 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                                 }
                                                             />
                                                         ) : (
-                                                            <MenuItem2
-                                                                icon="delete"
-                                                                intent="danger"
-                                                                text="Remove tile"
-                                                                onClick={() =>
-                                                                    onDelete(
-                                                                        tile,
-                                                                    )
-                                                                }
-                                                            />
+                                                            <>
+                                                                <MenuDivider />
+                                                                <MenuItem2
+                                                                    icon="delete"
+                                                                    intent="danger"
+                                                                    text="Remove tile"
+                                                                    onClick={() =>
+                                                                        onDelete(
+                                                                            tile,
+                                                                        )
+                                                                    }
+                                                                />
+                                                            </>
                                                         )}
                                                     </>
                                                 )}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -291,6 +291,12 @@ const SavedChartsHeader: FC = () => {
                                             history.push({
                                                 pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardUuid}`,
                                             });
+                                            sessionStorage.removeItem(
+                                                'fromDashboard',
+                                            );
+                                            sessionStorage.removeItem(
+                                                'dashboardUuid',
+                                            );
                                         } else
                                             history.push({
                                                 pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`,

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -10,8 +10,9 @@ import {
     Header,
     MantineProvider,
     Text,
+    Tooltip,
 } from '@mantine/core';
-import { IconInfoCircle, IconTool, IconX } from '@tabler/icons-react';
+import { IconInfoCircle, IconTool } from '@tabler/icons-react';
 import { FC, memo, useEffect, useMemo } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
@@ -72,23 +73,30 @@ const DashboardExplorerBanner: FC<{
             <Text color="white" fw={500} fz="xs" mx="xxs">
                 You are {action} this chart from within "{dashboardName}"
             </Text>
-            <ActionIcon
-                onClick={() => {
-                    history.push(
-                        `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
-                            savedQueryUuid ? 'view' : 'edit'
-                        }`,
-                    );
-                    sessionStorage.removeItem('fromDashboard');
-                    sessionStorage.removeItem('dashboardUuid');
-                }}
-                size="sm"
-                mx="xxs"
-                variant="outline"
-                color="white"
+            <Tooltip
+                withinPortal
+                label="Cancel chart creation and return to dashboard"
+                position="bottom"
+                maw={350}
             >
-                <MantineIcon icon={IconX} color="white" size="sm" />
-            </ActionIcon>
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
+                                savedQueryUuid ? 'view' : 'edit'
+                            }`,
+                        );
+                        sessionStorage.removeItem('fromDashboard');
+                        sessionStorage.removeItem('dashboardUuid');
+                    }}
+                    size="xs"
+                    ml="md"
+                    variant="white"
+                    compact
+                >
+                    Cancel
+                </Button>
+            </Tooltip>
         </Center>
     );
 };

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -332,10 +332,10 @@ export const useDashboardDeleteMutation = () => {
     });
 };
 
-export const appendNewTilesToBottom = (
-    existingTiles: DashboardTile[] | [],
-    newTiles: DashboardTile[],
-): DashboardTile[] => {
+export const appendNewTilesToBottom = <T extends Pick<DashboardTile, 'y'>>(
+    existingTiles: T[] | [],
+    newTiles: T[],
+): T[] => {
     const tilesY =
         existingTiles &&
         existingTiles.map(function (tile) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:

- [x] update dashboard banner button from cross icon to Cancel. On hover, the tooltip should read "Cancel chart creation and return to dashboard"
- [x] update copy in save chart modal to have the dashboard name eg: "Save chart to KPI dashboard"
- [x] There should a be confirmation toast (success) when you land in the dashboard after creating a chart. 'Success! [Chart name] was added to [Dashboard name]'
- [x] remove "dashboard" header when user cancel edit the chart that belongs to the dashboard
- [x] remove double divider in tile menu


