### PR TITLE
feat: chart config tabs in mantine

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
@@ -1,4 +1,3 @@
-import { Tab, Tabs } from '@blueprintjs/core';
 import {
     convertAdditionalMetric,
     fieldId,
@@ -8,8 +7,8 @@ import {
     Metric,
     TableCalculation,
 } from '@lightdash/common';
-import { Box } from '@mantine/core';
-import { FC, useState } from 'react';
+import { Tabs } from '@mantine/core';
+import { FC } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import AxesOptions from './AxesOptions';
 import FieldLayoutOptions from './FieldLayoutOptions';
@@ -19,7 +18,6 @@ import SeriesTab from './Series';
 
 const ChartConfigTabs: FC = () => {
     const { explore, resultsData } = useVisualizationContext();
-    const [tab, setTab] = useState<string | number>('layout');
 
     const dimensionsInMetricQuery = explore
         ? getDimensions(explore).filter((field) =>
@@ -58,35 +56,40 @@ const ChartConfigTabs: FC = () => {
     const items = [...dimensionsInMetricQuery, ...metricsAndTableCalculations];
 
     return (
-        <Box w={320}>
-            <Tabs
-                onChange={setTab}
-                selectedTabId={tab}
-                renderActiveTabPanelOnly
-            >
-                <Tab
-                    id="layout"
-                    title="Layout"
-                    panel={<FieldLayoutOptions items={items} />}
-                />
-                <Tab
-                    id="series"
-                    title="Series"
-                    panel={<SeriesTab items={items} />}
-                />
-                <Tab
-                    id="axes"
-                    title="Axes"
-                    panel={<AxesOptions items={items} />}
-                />
-                <Tab
-                    id="legend"
-                    title="Display"
-                    panel={<LegendPanel items={items} />}
-                />
-                <Tab id="grid" title="Margins" panel={<GridPanel />} />
-            </Tabs>
-        </Box>
+        <Tabs w={335} defaultValue="layout">
+            <Tabs.List mb="sm">
+                <Tabs.Tab px="sm" value="layout">
+                    Layout
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="series">
+                    Series
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="axes">
+                    Axes
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="legend">
+                    Display
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="grid">
+                    Margins
+                </Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panel value="layout">
+                <FieldLayoutOptions items={items} />
+            </Tabs.Panel>
+            <Tabs.Panel value="series">
+                <SeriesTab items={items} />
+            </Tabs.Panel>
+            <Tabs.Panel value="axes">
+                <AxesOptions items={items} />
+            </Tabs.Panel>
+            <Tabs.Panel value="legend">
+                <LegendPanel items={items} />
+            </Tabs.Panel>
+            <Tabs.Panel value="grid">
+                <GridPanel />
+            </Tabs.Panel>
+        </Tabs>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6272 

### Description:

Move the chart config tabs to mantine. Note that this required making the chart config a little wider than the others to keep the tabs from wrapping. I think it still looks fine. It covers more of the chart, but not by much. And we are planning on making that experience better anyway. 
