### PR TITLE
fix: show dashboard unsaved changes alert in chartindash flow

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -35,8 +35,13 @@ const AddTileButton: FC<Props> = ({ onAddTiles, intent, popoverPosition }) => {
     const { projectUuid } = useParams<{
         projectUuid: string;
     }>();
-    const { dashboard, dashboardTiles, dashboardFilters } =
-        useDashboardContext();
+    const {
+        dashboard,
+        dashboardTiles,
+        dashboardFilters,
+        haveTilesChanged,
+        haveFiltersChanged,
+    } = useDashboardContext();
     const history = useHistory();
 
     return (
@@ -93,6 +98,13 @@ const AddTileButton: FC<Props> = ({ onAddTiles, intent, popoverPosition }) => {
                                                 ),
                                             );
                                         }
+                                        sessionStorage.setItem(
+                                            'hasDashboardChanges',
+                                            JSON.stringify(
+                                                haveTilesChanged ||
+                                                    haveFiltersChanged,
+                                            ),
+                                        );
                                         history.push(
                                             `/projects/${projectUuid}/tables`,
                                         );

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,4 +1,4 @@
-import { FC, memo } from 'react';
+import React, { FC, memo, useEffect } from 'react';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { Can } from '../../common/Authorization';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
@@ -18,6 +18,24 @@ const ExplorerHeader: FC = memo(() => {
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
     );
+
+    useEffect(() => {
+        const hasUnsavedDashboardChanges = JSON.parse(
+            sessionStorage.getItem('hasDashboardChanges') ?? 'false',
+        );
+        const checkReload = (event: BeforeUnloadEvent) => {
+            if (hasUnsavedDashboardChanges) {
+                const message =
+                    'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
+                event.returnValue = message;
+                return message;
+            }
+        };
+        window.addEventListener('beforeunload', checkReload);
+        return () => {
+            window.removeEventListener('beforeunload', checkReload);
+        };
+    }, []);
 
     return (
         <Wrapper>

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -152,7 +152,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
             `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
         );
         showToastSuccess({
-            title: `'Success! ${name} was added to ${fromDashboard}`,
+            title: `Success! ${name} was added to ${fromDashboard}`,
         });
     }, [
         fromDashboard,


### PR DESCRIPTION
Closes: #6605 

### Description:
Implemented but creates a side-effect bug.
If I click `Cancel` on the alert, I'm taken out of the chart-in-dashboard flow

https://github.com/lightdash/lightdash/assets/67699259/0e076a34-ba89-42a0-9adb-3c0e5668ad84

