### PR TITLE
fix: write null dates to csvs

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -126,4 +126,36 @@ $4.00,value_4,2020-03-16
 
         expect(csv).toEqual([1, 'value_1', '2020-03-16']);
     });
+
+    it('Should convert with row with null date', async () => {
+        const row = {
+            column_number: 1,
+            column_string: `value_1`,
+            column_date: null,
+        };
+
+        const csv = CsvService.convertRowToCsv(row, itemMap, false, [
+            'column_number',
+            'column_string',
+            'column_date',
+        ]);
+
+        expect(csv).toEqual(['$1.00', 'value_1', null]);
+    });
+
+    it('Should convert with row with undefined value', async () => {
+        const row = {
+            column_number: undefined,
+            column_string: `value_1`,
+            column_date: '2020-03-16T11:32:55.000Z',
+        };
+
+        const csv = CsvService.convertRowToCsv(row, itemMap, false, [
+            'column_number',
+            'column_string',
+            'column_date',
+        ]);
+
+        expect(csv).toEqual([undefined, 'value_1', '2020-03-16']);
+    });
 });

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -161,6 +161,10 @@ export class CsvService {
             const data = row[id];
             const item = itemMap[id];
 
+            if (data === null || data === undefined) {
+                return data;
+            }
+
             const itemIsField = isField(item);
             if (itemIsField && item.type === DimensionType.TIMESTAMP) {
                 return moment(data).format('YYYY-MM-DD HH:mm:ss');
@@ -168,7 +172,11 @@ export class CsvService {
             if (itemIsField && item.type === DimensionType.DATE) {
                 return moment(data).format('YYYY-MM-DD');
             }
+
+            // Return raw value and let csv-stringify handle the rest
             if (onlyRaw) return data;
+
+            // Use standard Lightdash formatting based on the item formatting configuration
             return formatItemValue(item, data);
         });
     }


### PR DESCRIPTION
Closes: #6502

Fixes a bug in `convertRowToCsv` that tried to convert `null` values with `moment()` leading to `Invalid Date` appearing in csvs.

Note this is a breaking change:

 - Existing `null` strings returned `'∅'`
 - Existing `undefined` strings returned `'-'`
 - Now `null` and `undefined` both return `null` and `undefined` respectively

Nulls and undefined are handled by `csv-stringify` and print `,,` 

![CleanShot 2023-08-04 at 17 58 51@2x](https://github.com/lightdash/lightdash/assets/11660098/7713953e-5b0b-4de4-855c-e4d1e649be6b)

