### PR TITLE
chore: debug logs for moving dashboards

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -111,7 +111,17 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     );
 
     const handleMoveToSpace = useCallback(() => {
+        // TODO: remove when #6626 is closed
+        console.log('--------------------');
+        console.log('handleMoveToSpace in ResourceActionHandlers');
+        console.log('action.type', action.type);
+
         if (action.type !== ResourceViewItemAction.MOVE_TO_SPACE) return;
+
+        // TODO: remove when #6626 is closed
+        console.log('action.item.data.uuid', action.item.data.uuid);
+        console.log('action.item.data.name', action.item.data.name);
+        console.log('====================');
 
         switch (action.item.type) {
             case ResourceViewItemType.CHART:

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -229,6 +229,20 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                         }
                                         component="button"
                                         onClick={() => {
+                                            // TODO: remove when #6626 is closed
+                                            console.log('--------------------');
+                                            console.log(
+                                                'onClick in ResourceActionMenu',
+                                            );
+                                            console.log(
+                                                'item.data.spaceUuid',
+                                                item.data.spaceUuid,
+                                            );
+                                            console.log(
+                                                'space.uuid',
+                                                space.uuid,
+                                            );
+                                            console.log('====================');
                                             if (
                                                 item.data.spaceUuid !==
                                                 space.uuid

--- a/packages/frontend/src/components/common/ResourceView/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/index.tsx
@@ -85,6 +85,11 @@ const ResourceView: React.FC<ResourceViewProps> = ({
 
     const handleAction = useCallback(
         (newAction: ResourceViewItemActionState) => {
+            // TODO: remove when #6626 is closed
+            console.log('--------------------');
+            console.log('handleAction in ResourceView');
+            console.log('newAction', newAction);
+            console.log('====================');
             setAction(newAction);
         },
         [],


### PR DESCRIPTION
### Description:

A customer is seeing a silent failure when trying to move dashboards between spaces from the resource list. We can't repro it and can't seem to get enough data. This adds some temporary logging around this to gather more data. We will remove it when we have enough info. 

Many details in this thread:

https://lightdash.slack.com/archives/C02KDBTN9RV/p1690872099600449
