### PR TITLE
feat: dashboard filters simplified view mode

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -13,6 +13,7 @@ import { FilterValues, TagContainer } from './ActiveFilters.styles';
 
 type Props = {
     isEditMode: boolean;
+    isTemporary?: boolean;
     field: FilterableField;
     filterRule: DashboardFilterRule;
     onRemove: () => void;
@@ -21,6 +22,7 @@ type Props = {
 
 const ActiveFilter: FC<Props> = ({
     isEditMode,
+    isTemporary,
     field,
     filterRule,
     onRemove,
@@ -107,6 +109,7 @@ const ActiveFilter: FC<Props> = ({
                 <FilterModalContainer $wide={selectedTabId === 'tiles'}>
                     <FilterConfiguration
                         isEditMode={isEditMode}
+                        isTemporary={isTemporary}
                         tiles={dashboardTiles}
                         selectedTabId={selectedTabId}
                         field={field}

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,6 +1,7 @@
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { DashboardFilterRule, FilterableField } from '@lightdash/common';
-import { FC, useState } from 'react';
+import { Popover, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { FC, useCallback, useState } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import {
     getConditionalRuleLabel,
@@ -14,7 +15,6 @@ type Props = {
     isEditMode: boolean;
     field: FilterableField;
     filterRule: DashboardFilterRule;
-    onClick?: () => void;
     onRemove: () => void;
     onUpdate: (value: DashboardFilterRule) => void;
 };
@@ -23,12 +23,21 @@ const ActiveFilter: FC<Props> = ({
     isEditMode,
     field,
     filterRule,
-    onClick,
     onRemove,
     onUpdate,
 }) => {
     const { dashboardTiles, allFilterableFields, filterableFieldsByTileUuid } =
         useDashboardContext();
+
+    const [isPopoverOpen, { close: closePopover, open: openPopover }] =
+        useDisclosure();
+    const [_, { close: closeSubPopover, open: openSubPopover }] =
+        useDisclosure();
+
+    const handleClose = useCallback(() => {
+        closeSubPopover();
+        closePopover();
+    }, [closeSubPopover, closePopover]);
 
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>();
 
@@ -44,50 +53,71 @@ const ActiveFilter: FC<Props> = ({
     );
 
     return (
-        <Popover2
-            lazy
-            placement="bottom-start"
-            content={
-                <FilterModalContainer $wide={selectedTabId === 'tiles'}>
-                    <FilterConfiguration
-                        isEditMode={isEditMode}
-                        tiles={dashboardTiles}
-                        selectedTabId={selectedTabId}
-                        onTabChange={setSelectedTabId}
-                        field={field}
-                        availableTileFilters={filterableFieldsByTileUuid}
-                        filterRule={filterRule}
-                        onSave={onUpdate}
-                    />
-                </FilterModalContainer>
-            }
+        <Popover
+            position="bottom-start"
+            withArrow
+            shadow="md"
+            opened={isPopoverOpen}
+            onClose={handleClose}
         >
-            <TagContainer interactive onRemove={onRemove} onClick={onClick}>
-                <Tooltip2
-                    interactionKind="hover"
-                    placement="bottom-start"
-                    content={
+            <Popover.Target>
+                <Tooltip
+                    withinPortal
+                    position="top-start"
+                    label={
                         filterRuleTables.length === 0
                             ? `Table: ${filterRuleTables[0]}`
                             : `Tables: ${filterRuleTables.join(', ')}`
                     }
                 >
-                    <>
-                        {filterRule.label || filterRuleLabels.field}:{' '}
-                        {filterRule.disabled ? (
-                            <>is any value</>
-                        ) : (
-                            <>
-                                {filterRuleLabels.operator}{' '}
-                                <FilterValues>
-                                    {filterRuleLabels.value}
-                                </FilterValues>
-                            </>
-                        )}
-                    </>
-                </Tooltip2>
-            </TagContainer>
-        </Popover2>
+                    <div>
+                        <TagContainer
+                            interactive
+                            onRemove={onRemove}
+                            onClick={openPopover}
+                        >
+                            {filterRule.label || filterRuleLabels.field}:{' '}
+                            {filterRule.disabled ? (
+                                <>is any value</>
+                            ) : (
+                                <>
+                                    {filterRuleLabels.operator}{' '}
+                                    <FilterValues>
+                                        {filterRuleLabels.value}
+                                    </FilterValues>
+                                </>
+                            )}
+                        </TagContainer>
+                    </div>
+                </Tooltip>
+            </Popover.Target>
+
+            {/* FIXME: remove p={0} once we remove Blueprint popover from FilterSearch */}
+            <Popover.Dropdown p={0}>
+                <FilterModalContainer $wide={selectedTabId === 'tiles'}>
+                    <FilterConfiguration
+                        isActiveFilter
+                        isEditMode={isEditMode}
+                        tiles={dashboardTiles}
+                        selectedTabId={selectedTabId}
+                        field={field}
+                        availableTileFilters={filterableFieldsByTileUuid}
+                        filterRule={filterRule}
+                        onTabChange={setSelectedTabId}
+                        onSave={(dashboardFilterRule) => {
+                            onUpdate(dashboardFilterRule);
+                            handleClose();
+                        }}
+                        popoverProps={{
+                            onOpened: () => openSubPopover(),
+                            onOpening: () => openSubPopover(),
+                            onClose: () => closeSubPopover(),
+                            onClosing: () => closeSubPopover(),
+                        }}
+                    />
+                </FilterModalContainer>
+            </Popover.Dropdown>
+        </Popover>
     );
 };
 

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -31,7 +31,7 @@ const ActiveFilter: FC<Props> = ({
 
     const [isPopoverOpen, { close: closePopover, open: openPopover }] =
         useDisclosure();
-    const [_, { close: closeSubPopover, open: openSubPopover }] =
+    const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
         useDisclosure();
 
     const handleClose = useCallback(() => {
@@ -58,6 +58,8 @@ const ActiveFilter: FC<Props> = ({
             withArrow
             shadow="md"
             opened={isPopoverOpen}
+            closeOnEscape={!isSubPopoverOpen}
+            closeOnClickOutside={!isSubPopoverOpen}
             onClose={handleClose}
         >
             <Popover.Target>

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -29,7 +29,7 @@ const ActiveFilter: FC<Props> = ({
     const { dashboardTiles, allFilterableFields, filterableFieldsByTileUuid } =
         useDashboardContext();
 
-    const [isPopoverOpen, { close: closePopover, open: openPopover }] =
+    const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
         useDisclosure();
     const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
         useDisclosure();
@@ -76,7 +76,7 @@ const ActiveFilter: FC<Props> = ({
                         <TagContainer
                             interactive
                             onRemove={onRemove}
-                            onClick={openPopover}
+                            onClick={togglePopover}
                         >
                             {filterRule.label || filterRuleLabels.field}:{' '}
                             {filterRule.disabled ? (

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -119,6 +119,7 @@ const ActiveFilter: FC<Props> = ({
                             onUpdate(dashboardFilterRule);
                             handleClose();
                         }}
+                        // FIXME: get rid of this once we migrate off Blueprint
                         popoverProps={{
                             onOpened: () => openSubPopover(),
                             onOpening: () => openSubPopover(),

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -26,8 +26,16 @@ const ActiveFilter: FC<Props> = ({
     onRemove,
     onUpdate,
 }) => {
-    const { dashboardTiles, allFilterableFields, filterableFieldsByTileUuid } =
-        useDashboardContext();
+    const {
+        dashboard,
+        dashboardTiles,
+        allFilterableFields,
+        filterableFieldsByTileUuid,
+    } = useDashboardContext();
+
+    const originalFilterRule = dashboard?.filters?.dimensions.find(
+        (item) => item.id === filterRule.id,
+    );
 
     const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
         useDisclosure();
@@ -104,6 +112,7 @@ const ActiveFilter: FC<Props> = ({
                         selectedTabId={selectedTabId}
                         field={field}
                         availableTileFilters={filterableFieldsByTileUuid}
+                        originalFilterRule={originalFilterRule}
                         filterRule={filterRule}
                         onTabChange={setSelectedTabId}
                         onSave={(dashboardFilterRule) => {

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -106,7 +106,6 @@ const ActiveFilter: FC<Props> = ({
             <Popover.Dropdown p={0}>
                 <FilterModalContainer $wide={selectedTabId === 'tiles'}>
                     <FilterConfiguration
-                        isActiveFilter
                         isEditMode={isEditMode}
                         tiles={dashboardTiles}
                         selectedTabId={selectedTabId}
@@ -119,7 +118,7 @@ const ActiveFilter: FC<Props> = ({
                             onUpdate(dashboardFilterRule);
                             handleClose();
                         }}
-                        // FIXME: get rid of this once we migrate off Blueprint
+                        // FIXME: remove this once we migrate off of Blueprint
                         popoverProps={{
                             onOpened: () => openSubPopover(),
                             onOpening: () => openSubPopover(),

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -47,6 +47,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
                 .map((item, index) => (
                     <ActiveFilter
                         key={item.id}
+                        isTemporary
                         isEditMode={isEditMode}
                         field={fieldMap[item.target.fieldId]}
                         filterRule={item}

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -41,6 +41,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
                         }
                     />
                 ))}
+
             {dashboardTemporaryFilters.dimensions
                 .filter((item) => !!fieldMap[item.target.fieldId])
                 .map((item, index) => (

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterConfiguration.styled.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@blueprintjs/core';
 import styled from 'styled-components';
 
 export const ConfigureFilterWrapper = styled.div`
@@ -6,19 +5,4 @@ export const ConfigureFilterWrapper = styled.div`
     display: flex;
     flex-direction: column;
     gap: 15px;
-`;
-
-export const FieldLabelAndIconWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-`;
-
-export const ActionsWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
-export const ApplyButton = styled(Button)`
-    margin-left: auto;
 `;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -30,9 +30,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     onChangeFilterOperator,
     onChangeFilterRule,
 }) => {
-    const [filterLabel, setFilterLabel] = useState<string>(
-        filterRule.label ?? field.label,
-    );
+    const [filterLabel, setFilterLabel] = useState<string>();
     const filterType = field ? getFilterTypeFromItem(field) : FilterType.STRING;
 
     const filterConfig = useMemo(
@@ -50,6 +48,13 @@ const FilterSettings: FC<FilterSettingsProps> = ({
             });
         }
     }, [isEditMode, onChangeFilterRule, filterRule]);
+
+    // Set default label when using revert (undo) button
+    useEffect(() => {
+        if (filterLabel !== '') {
+            setFilterLabel(filterRule.label ?? field.label);
+        }
+    }, [filterLabel, filterRule.label, field.label]);
 
     return (
         <Stack>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -47,7 +47,7 @@ interface Props {
     filterRule?: DashboardFilterRule;
     popoverProps?: Popover2Props;
     selectedTabId?: string;
-    isActiveFilter?: boolean;
+    isCreatingNewFilter?: boolean;
     isEditMode: boolean;
     onTabChange: (tabId: FilterTabs) => void;
     onSave: (value: DashboardFilterRule) => void;
@@ -55,7 +55,7 @@ interface Props {
 }
 
 const FilterConfiguration: FC<Props> = ({
-    isActiveFilter = false,
+    isCreatingNewFilter = false,
     isEditMode,
     selectedTabId = DEFAULT_TAB,
     tiles,
@@ -83,9 +83,9 @@ const FilterConfiguration: FC<Props> = ({
         );
 
     const isFilterModified = useMemo(() => {
-        if (!originalFilterRule || !originalFilterRule) return false;
+        if (!originalFilterRule) return false;
 
-        // fix serialization of date fields
+        // fixes serialization of date values
         const serializedInternalFilterRule = produce(
             internalFilterRule,
             (draft) => {
@@ -175,7 +175,7 @@ const FilterConfiguration: FC<Props> = ({
                 value={selectedTabId}
                 onTabChange={(tabId: FilterTabs) => onTabChange(tabId)}
             >
-                {isEditMode || !isActiveFilter ? (
+                {isCreatingNewFilter || isEditMode ? (
                     <Tabs.List mb="md">
                         <Tooltip
                             label="Select the value you want to filter your dimension by"
@@ -226,7 +226,7 @@ const FilterConfiguration: FC<Props> = ({
                 <Box sx={{ flexGrow: 1 }} />
 
                 {isFilterModified && (
-                    <Tooltip label="Reset to original value">
+                    <Tooltip label="Reset to original value" position="left">
                         <Button
                             size="xs"
                             variant="default"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,5 +1,4 @@
-import { Intent, Tab, Tabs } from '@blueprintjs/core';
-import { Classes, Popover2Props, Tooltip2 } from '@blueprintjs/popover2';
+import { Classes, Popover2Props } from '@blueprintjs/popover2';
 
 import {
     applyDefaultTileTargets,
@@ -15,17 +14,12 @@ import {
     matchFieldByTypeAndName,
     matchFieldExact,
 } from '@lightdash/common';
+import { Box, Button, Flex, Group, Tabs, Tooltip } from '@mantine/core';
 import produce from 'immer';
 import { FC, useCallback, useState } from 'react';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import FieldLabel from '../../common/Filters/FieldLabel';
-import SimpleButton from '../../common/SimpleButton';
-import {
-    ActionsWrapper,
-    ApplyButton,
-    ConfigureFilterWrapper,
-    FieldLabelAndIconWrapper,
-} from './FilterConfiguration.styled';
+import { ConfigureFilterWrapper } from './FilterConfiguration.styled';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 import { isFilterConfigurationApplyButtonEnabled } from './utils';
@@ -49,6 +43,7 @@ interface Props {
     filterRule?: DashboardFilterRule;
     popoverProps?: Popover2Props;
     selectedTabId?: string;
+    isActiveFilter?: boolean;
     isEditMode: boolean;
     onTabChange: (tabId: FilterTabs) => void;
     onSave: (value: DashboardFilterRule) => void;
@@ -56,6 +51,7 @@ interface Props {
 }
 
 const FilterConfiguration: FC<Props> = ({
+    isActiveFilter = false,
     isEditMode,
     selectedTabId = DEFAULT_TAB,
     tiles,
@@ -138,81 +134,79 @@ const FilterConfiguration: FC<Props> = ({
 
     return (
         <ConfigureFilterWrapper>
-            <FieldLabelAndIconWrapper>
+            <Group spacing="xs">
                 <FieldIcon item={field} />
                 <FieldLabel item={field} />
-            </FieldLabelAndIconWrapper>
+            </Group>
 
             <Tabs
-                selectedTabId={selectedTabId}
-                onChange={onTabChange}
-                renderActiveTabPanelOnly
+                value={selectedTabId}
+                onTabChange={(tabId: FilterTabs) => onTabChange(tabId)}
             >
-                <Tab
-                    id="settings"
-                    title={
-                        <Tooltip2
-                            content="Select the value you want to filter your dimension by"
-                            position="bottom"
+                {isEditMode || !isActiveFilter ? (
+                    <Tabs.List mb="md">
+                        <Tooltip
+                            label="Select the value you want to filter your dimension by"
+                            position="top-start"
                         >
-                            Settings
-                        </Tooltip2>
-                    }
-                    panel={
-                        <FilterSettings
-                            isEditMode={isEditMode}
-                            field={field}
-                            filterRule={internalFilterRule}
-                            onChangeFilterOperator={handleChangeFilterOperator}
-                            onChangeFilterRule={handleChangeFilterRule}
-                            popoverProps={popoverProps}
-                        />
-                    }
-                />
+                            <Tabs.Tab value="settings">Settings</Tabs.Tab>
+                        </Tooltip>
 
-                <Tab
-                    id="tiles"
-                    title={
-                        <Tooltip2
-                            content="Select tiles to apply filter to and which field to filter by"
-                            position="bottom"
+                        <Tooltip
+                            label="Select tiles to apply filter to and which field to filter by"
+                            position="top-start"
                         >
-                            Tiles
-                        </Tooltip2>
-                    }
-                    panel={
-                        <TileFilterConfiguration
-                            field={field}
-                            filterRule={internalFilterRule}
-                            popoverProps={popoverProps}
-                            tiles={tiles}
-                            availableTileFilters={availableTileFilters}
-                            onChange={handleChangeTileConfiguration}
-                        />
-                    }
-                />
+                            <Tabs.Tab value="tiles">Tiles</Tabs.Tab>
+                        </Tooltip>
+                    </Tabs.List>
+                ) : null}
+
+                <Tabs.Panel value="settings">
+                    <FilterSettings
+                        isEditMode={isEditMode}
+                        field={field}
+                        filterRule={internalFilterRule}
+                        onChangeFilterOperator={handleChangeFilterOperator}
+                        onChangeFilterRule={handleChangeFilterRule}
+                        popoverProps={popoverProps}
+                    />
+                </Tabs.Panel>
+
+                <Tabs.Panel value="tiles">
+                    <TileFilterConfiguration
+                        field={field}
+                        filterRule={internalFilterRule}
+                        popoverProps={popoverProps}
+                        tiles={tiles}
+                        availableTileFilters={availableTileFilters}
+                        onChange={handleChangeTileConfiguration}
+                    />
+                </Tabs.Panel>
             </Tabs>
 
-            <ActionsWrapper>
+            <Flex>
                 {onBack && (
-                    <SimpleButton small onClick={onBack}>
+                    <Button size="xs" variant="subtle" onClick={onBack}>
                         Back
-                    </SimpleButton>
+                    </Button>
                 )}
 
-                <ApplyButton
-                    type="submit"
+                <Box sx={{ flexGrow: 1 }} />
+
+                <Button
+                    size="xs"
+                    variant="filled"
                     className={Classes.POPOVER2_DISMISS}
-                    intent={Intent.PRIMARY}
-                    text="Apply"
                     disabled={
                         !isFilterConfigurationApplyButtonEnabled(
                             internalFilterRule,
                         )
                     }
                     onClick={() => onSave(internalFilterRule)}
-                />
-            </ActionsWrapper>
+                >
+                    Apply
+                </Button>
+            </Flex>
         </ConfigureFilterWrapper>
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -47,16 +47,18 @@ interface Props {
     filterRule?: DashboardFilterRule;
     popoverProps?: Popover2Props;
     selectedTabId?: string;
-    isCreatingNewFilter?: boolean;
     isEditMode: boolean;
+    isCreatingNew?: boolean;
+    isTemporary?: boolean;
     onTabChange: (tabId: FilterTabs) => void;
     onSave: (value: DashboardFilterRule) => void;
     onBack?: () => void;
 }
 
 const FilterConfiguration: FC<Props> = ({
-    isCreatingNewFilter = false,
     isEditMode,
+    isCreatingNew = false,
+    isTemporary = false,
     selectedTabId = DEFAULT_TAB,
     tiles,
     field,
@@ -182,7 +184,7 @@ const FilterConfiguration: FC<Props> = ({
                 value={selectedTabId}
                 onTabChange={(tabId: FilterTabs) => onTabChange(tabId)}
             >
-                {isCreatingNewFilter || isEditMode ? (
+                {isCreatingNew || isEditMode || isTemporary ? (
                     <Tabs.List mb="md">
                         <Tooltip
                             label="Select the value you want to filter your dimension by"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -17,7 +17,6 @@ import {
 import { Box, Button, Flex, Group, Tabs, Tooltip } from '@mantine/core';
 import { IconRotate2 } from '@tabler/icons-react';
 import produce from 'immer';
-import pick from 'lodash-es/pick';
 import { FC, useCallback, useMemo, useState } from 'react';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import FieldLabel from '../../common/Filters/FieldLabel';
@@ -26,9 +25,9 @@ import { ConfigureFilterWrapper } from './FilterConfiguration.styled';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 import {
-    DASHBOARD_FILTER_REVERTABLE_FIELDS,
+    getFilterRuleRevertableObject,
+    isFilterConfigRevertButtonEnabled,
     isFilterConfigurationApplyButtonEnabled,
-    isFilterConfigurationRevertButtonEnabled,
 } from './utils';
 
 export enum FilterTabs {
@@ -91,7 +90,7 @@ const FilterConfiguration: FC<Props> = ({
     const isFilterModified = useMemo(() => {
         if (!originalFilterRule) return false;
 
-        return isFilterConfigurationRevertButtonEnabled(
+        return isFilterConfigRevertButtonEnabled(
             originalFilterRule,
             internalFilterRule,
         );
@@ -102,7 +101,7 @@ const FilterConfiguration: FC<Props> = ({
 
         setInternalFilterRule((rule) => ({
             ...rule,
-            ...pick(originalFilterRule, DASHBOARD_FILTER_REVERTABLE_FIELDS),
+            ...getFilterRuleRevertableObject(originalFilterRule),
         }));
     }, [originalFilterRule]);
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -225,7 +225,7 @@ const FilterConfiguration: FC<Props> = ({
 
                 <Box sx={{ flexGrow: 1 }} />
 
-                {isFilterModified && (
+                {isFilterModified && selectedTabId === FilterTabs.SETTINGS && (
                     <Tooltip label="Reset to original value" position="left">
                         <Button
                             size="xs"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -90,7 +90,9 @@ const FilterConfiguration: FC<Props> = ({
             internalFilterRule,
             (draft) => {
                 if (draft.values && draft.values.length > 0) {
-                    draft.values = draft.values.map((v) => v.toString());
+                    draft.values = draft.values.map((v) =>
+                        v instanceof Date ? v.toISOString() : v,
+                    );
                 }
             },
         );

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -85,6 +85,13 @@ const FilterConfiguration: FC<Props> = ({
     const isFilterModified = useMemo(() => {
         if (!originalFilterRule) return false;
 
+        if (
+            originalFilterRule.disabled &&
+            internalFilterRule.values === undefined
+        ) {
+            return false;
+        }
+
         // fixes serialization of date values
         const serializedInternalFilterRule = produce(
             internalFilterRule,

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -234,21 +234,26 @@ const FilterConfiguration: FC<Props> = ({
 
                 <Box sx={{ flexGrow: 1 }} />
 
-                {isFilterModified && selectedTabId === FilterTabs.SETTINGS && (
-                    <Tooltip label="Reset to original value" position="left">
-                        <Button
-                            size="xs"
-                            variant="default"
-                            color="gray"
-                            onClick={() => {
-                                if (!originalFilterRule) return;
-                                handleChangeFilterRule(originalFilterRule);
-                            }}
+                {!isTemporary &&
+                    isFilterModified &&
+                    selectedTabId === FilterTabs.SETTINGS && (
+                        <Tooltip
+                            label="Reset to original value"
+                            position="left"
                         >
-                            <MantineIcon icon={IconRotate2} />
-                        </Button>
-                    </Tooltip>
-                )}
+                            <Button
+                                size="xs"
+                                variant="default"
+                                color="gray"
+                                onClick={() => {
+                                    if (!originalFilterRule) return;
+                                    handleChangeFilterRule(originalFilterRule);
+                                }}
+                            >
+                                <MantineIcon icon={IconRotate2} />
+                            </Button>
+                        </Tooltip>
+                    )}
 
                 <Button
                     size="xs"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import produce from 'immer';
 import isEqual from 'lodash-es/isEqual';
-import pick from 'lodash-es/pick';
 
 export const isFilterConfigurationApplyButtonEnabled = (
     filterRule: DashboardFilterRule,
@@ -46,14 +45,18 @@ export const isFilterConfigurationApplyButtonEnabled = (
     }
 };
 
-export const DASHBOARD_FILTER_REVERTABLE_FIELDS = [
-    'label',
-    'values',
-    'operator',
-    'settings',
-];
+export const getFilterRuleRevertableObject = (
+    filterRule: DashboardFilterRule,
+) => {
+    return {
+        values: filterRule.values,
+        operator: filterRule.operator,
+        settings: filterRule.settings,
+        label: filterRule.label,
+    };
+};
 
-export const isFilterConfigurationRevertButtonEnabled = (
+export const isFilterConfigRevertButtonEnabled = (
     originalFilterRule: DashboardFilterRule,
     filterRule: DashboardFilterRule,
 ) => {
@@ -72,7 +75,7 @@ export const isFilterConfigurationRevertButtonEnabled = (
     });
 
     return !isEqual(
-        pick(originalFilterRule, DASHBOARD_FILTER_REVERTABLE_FIELDS),
-        pick(serializedInternalFilterRule, DASHBOARD_FILTER_REVERTABLE_FIELDS),
+        getFilterRuleRevertableObject(originalFilterRule),
+        getFilterRuleRevertableObject(serializedInternalFilterRule),
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -103,6 +103,7 @@ const FilterSearch: FC<Props> = ({
                 </FormGroup>
             ) : (
                 <FilterConfiguration
+                    isCreatingNewFilter
                     isEditMode={isEditMode}
                     selectedTabId={selectedTabId}
                     onTabChange={setSelectedTabId}

--- a/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterSearch/index.tsx
@@ -103,7 +103,7 @@ const FilterSearch: FC<Props> = ({
                 </FormGroup>
             ) : (
                 <FilterConfiguration
-                    isCreatingNewFilter
+                    isCreatingNew
                     isEditMode={isEditMode}
                     selectedTabId={selectedTabId}
                     onTabChange={setSelectedTabId}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -83,6 +83,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <MonthAndYearInput
                                 disabled={disabled}
                                 placeholder={placeholder}
+                                // FIXME: remove this once we migrate off of Blueprint
+                                // we are doing type conversion here because Blueprint expects DOM element
+                                // Mantine does not provide a DOM element on onOpen/onClose
                                 popoverProps={{
                                     onOpen: () =>
                                         popoverProps?.onOpened?.(null as any),
@@ -107,6 +110,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <YearInput
                                 disabled={disabled}
                                 placeholder={placeholder}
+                                // FIXME: remove this once we migrate off of Blueprint
+                                // we are doing type conversion here because Blueprint expects DOM element
+                                // Mantine does not provide a DOM element on onOpen/onClose
                                 popoverProps={{
                                     onOpen: () =>
                                         popoverProps?.onOpened?.(null as any),

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -83,6 +83,12 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <MonthAndYearInput
                                 disabled={disabled}
                                 placeholder={placeholder}
+                                popoverProps={{
+                                    onOpen: () =>
+                                        popoverProps?.onOpened?.(null as any),
+                                    onClose: () =>
+                                        popoverProps?.onClose?.(null as any),
+                                }}
                                 value={rule.values ? rule.values[0] : null}
                                 onChange={(value: Date) => {
                                     onChange({
@@ -101,6 +107,12 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <YearInput
                                 disabled={disabled}
                                 placeholder={placeholder}
+                                popoverProps={{
+                                    onOpen: () =>
+                                        popoverProps?.onOpened?.(null as any),
+                                    onClose: () =>
+                                        popoverProps?.onClose?.(null as any),
+                                }}
                                 value={rule.values ? rule.values[0] : null}
                                 onChange={(value: Date) => {
                                     onChange({

--- a/packages/frontend/src/components/common/MonthAndYearInput.tsx
+++ b/packages/frontend/src/components/common/MonthAndYearInput.tsx
@@ -23,6 +23,7 @@ const MonthAndYearInput: FC<Props> = ({ value, onChange, ...props }) => {
                 withArrow: true,
                 withinPortal: false,
                 shadow: 'md',
+                // FIXME: remove this once we migrate off of Blueprint
                 ...props.popoverProps,
                 opened: isPopoverOpen,
                 onOpen: () => {

--- a/packages/frontend/src/components/common/MonthAndYearInput.tsx
+++ b/packages/frontend/src/components/common/MonthAndYearInput.tsx
@@ -38,6 +38,7 @@ const MonthAndYearInput: FC<Props> = ({ value, onChange, ...props }) => {
             onChange={(date) => {
                 if (!date || Array.isArray(date)) return;
                 onChange(date);
+                close();
             }}
         />
     );

--- a/packages/frontend/src/components/common/MonthAndYearInput.tsx
+++ b/packages/frontend/src/components/common/MonthAndYearInput.tsx
@@ -1,34 +1,42 @@
 import { MonthPickerInput, MonthPickerInputProps } from '@mantine/dates';
+import { useDisclosure } from '@mantine/hooks';
 import moment from 'moment';
 import { FC } from 'react';
 
-type Props = {
+type Props = Omit<MonthPickerInputProps, 'value' | 'onChange'> & {
     value: Date | null;
     onChange: (value: Date) => void;
-} & Pick<MonthPickerInputProps, 'disabled' | 'placeholder'>;
+};
 
-const MonthAndYearInput: FC<Props> = ({
-    value,
-    onChange,
-    disabled,
-    placeholder,
-}) => {
+const MonthAndYearInput: FC<Props> = ({ value, onChange, ...props }) => {
+    const [isPopoverOpen, { open, close, toggle }] = useDisclosure();
+
     const yearValue = value ? moment(value).toDate() : null;
 
     return (
         <MonthPickerInput
             sx={{ width: '100%' }}
             size="xs"
+            onClick={toggle}
+            {...props}
             popoverProps={{
                 withArrow: true,
                 withinPortal: false,
                 shadow: 'md',
+                ...props.popoverProps,
+                opened: isPopoverOpen,
+                onOpen: () => {
+                    props.popoverProps?.onOpen?.();
+                    open();
+                },
+                onClose: () => {
+                    props.popoverProps?.onClose?.();
+                    close();
+                },
             }}
-            disabled={disabled}
-            placeholder={placeholder}
             value={yearValue}
             onChange={(date) => {
-                if (!date) return;
+                if (!date || Array.isArray(date)) return;
                 onChange(date);
             }}
         />

--- a/packages/frontend/src/components/common/YearInput.tsx
+++ b/packages/frontend/src/components/common/YearInput.tsx
@@ -39,6 +39,7 @@ const YearInput: FC<Props> = ({ value, onChange, ...props }) => {
             onChange={(date) => {
                 if (!date || Array.isArray(date)) return;
                 onChange(date);
+                close();
             }}
         />
     );

--- a/packages/frontend/src/components/common/YearInput.tsx
+++ b/packages/frontend/src/components/common/YearInput.tsx
@@ -1,32 +1,44 @@
 import { YearPickerInput, YearPickerInputProps } from '@mantine/dates';
+import { useDisclosure } from '@mantine/hooks';
 import moment from 'moment';
 import { FC } from 'react';
 
-type Props = {
+type Props = Omit<YearPickerInputProps, 'value' | 'onChange'> & {
     value: Date | null;
     onChange: (value: Date) => void;
-} & Pick<YearPickerInputProps, 'disabled' | 'placeholder'>;
+};
+const YearInput: FC<Props> = ({ value, onChange, ...props }) => {
+    const [isPopoverOpen, { open, close, toggle }] = useDisclosure();
 
-const YearInput: FC<Props> = ({ value, onChange, disabled, placeholder }) => {
     const yearValue = value ? moment(value).toDate() : null;
 
     return (
         <YearPickerInput
             sx={{ width: '100%' }}
             size="xs"
-            popoverProps={{
-                withinPortal: false,
-                withArrow: true,
-                shadow: 'md',
-            }}
-            disabled={disabled}
-            placeholder={placeholder}
             minDate={moment().year(1000).toDate()}
             maxDate={moment().year(9999).toDate()}
+            onClick={toggle}
+            {...props}
+            popoverProps={{
+                withArrow: true,
+                withinPortal: false,
+                shadow: 'md',
+                ...props.popoverProps,
+                opened: isPopoverOpen,
+                onOpen: () => {
+                    props.popoverProps?.onOpen?.();
+                    open();
+                },
+                onClose: () => {
+                    props.popoverProps?.onClose?.();
+                    close();
+                },
+            }}
             value={yearValue}
-            onChange={(year) => {
-                if (!year) return;
-                onChange(year);
+            onChange={(date) => {
+                if (!date || Array.isArray(date)) return;
+                onChange(date);
             }}
         />
     );

--- a/packages/frontend/src/components/common/YearInput.tsx
+++ b/packages/frontend/src/components/common/YearInput.tsx
@@ -24,6 +24,7 @@ const YearInput: FC<Props> = ({ value, onChange, ...props }) => {
                 withArrow: true,
                 withinPortal: false,
                 shadow: 'md',
+                // FIXME: remove this once we migrate off of Blueprint
                 ...props.popoverProps,
                 opened: isPopoverOpen,
                 onOpen: () => {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6478

### Description:

- [x] Removed "tiles" configuration tab
- [x] Removed tabs from top
- [x] Removed filter label
- [x] If default values were entered by editor, show them in the widget
- [x] If default values were not entered, show Placeholder text in the widget (but `any value` in the pill)
- [x] Reset action

<img width="404" alt="CleanShot 2023-08-04 at 20 57 47@2x" src="https://github.com/lightdash/lightdash/assets/962095/ff2efedb-ae13-4f47-9b28-21324439fda7">

reset to original value:
<img width="378" alt="CleanShot 2023-08-07 at 16 40 03@2x" src="https://github.com/lightdash/lightdash/assets/962095/5f367ee5-a13b-4592-8109-80d15924a580">
