### PR TITLE
feature: json viewer for complex types

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,6 +1,6 @@
 import { Field, getItemMap, TableCalculation } from '@lightdash/common';
 import { Box, Text } from '@mantine/core';
-import { FC, memo, useCallback, useMemo } from 'react';
+import { FC, memo, useCallback, useMemo, useState } from 'react';
 
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
@@ -8,6 +8,7 @@ import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import Table from '../../common/Table';
+import { JsonViewerModal } from '../../JsonViewerModal';
 import CellContextMenu from './CellContextMenu';
 import ColumnHeaderContextMenu from './ColumnHeaderContextMenu';
 import {
@@ -52,6 +53,22 @@ export const ExplorerResults = memo(() => {
         (context) =>
             context.state.unsavedChartVersion.metricQuery.additionalMetrics,
     );
+    const [isExpandModalOpened, setIsExpandModalOpened] = useState(false);
+    const [expandData, setExpandData] = useState<{
+        name: string;
+        jsonObject: object;
+    }>({
+        name: 'unknown',
+        jsonObject: {},
+    });
+
+    const handleCellExpand = (name: string, data: object) => {
+        setExpandData({
+            name: name,
+            jsonObject: data,
+        });
+        setIsExpandModalOpened(true);
+    };
 
     const itemsMap: Record<string, Field | TableCalculation> | undefined =
         useMemo(() => {
@@ -71,6 +88,7 @@ export const ExplorerResults = memo(() => {
                 isEditMode={isEditMode}
                 {...props}
                 itemsMap={itemsMap}
+                onExpand={handleCellExpand}
             />
         ),
         [isEditMode, itemsMap],
@@ -139,6 +157,12 @@ export const ExplorerResults = memo(() => {
                     idleState={IdleState}
                     pagination={pagination}
                     footer={footer}
+                />
+                <JsonViewerModal
+                    heading={`Field: ${expandData.name}`}
+                    jsonObject={expandData.jsonObject}
+                    opened={isExpandModalOpened}
+                    onClose={() => setIsExpandModalOpened(false)}
                 />
             </Box>
         </TrackSection>

--- a/packages/frontend/src/components/JsonViewerModal.tsx
+++ b/packages/frontend/src/components/JsonViewerModal.tsx
@@ -1,0 +1,63 @@
+import {
+    ActionIcon,
+    Box,
+    CopyButton,
+    Modal,
+    Stack,
+    Title,
+    Tooltip,
+} from '@mantine/core';
+import { ModalRootProps } from '@mantine/core/lib/Modal/ModalRoot/ModalRoot';
+import { IconCheck, IconCopy } from '@tabler/icons-react';
+import ReactJson from 'react-json-view';
+import MantineIcon from './common/MantineIcon';
+
+type Props = ModalRootProps & {
+    heading: string;
+    jsonObject: object;
+};
+
+export const JsonViewerModal = ({
+    heading,
+    jsonObject,
+    opened,
+    onClose,
+}: Props) => {
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={<Title order={4}>{heading}</Title>}
+        >
+            <Stack>
+                <Box
+                    sx={{
+                        overflow: 'auto',
+                    }}
+                >
+                    <ReactJson enableClipboard={false} src={jsonObject} />
+                </Box>
+
+                <CopyButton value={JSON.stringify(jsonObject)} timeout={2000}>
+                    {({ copied, copy }) => (
+                        <Tooltip
+                            label={copied ? 'Copied' : 'Copy'}
+                            withArrow
+                            position="right"
+                        >
+                            <ActionIcon
+                                sx={{ alignSelf: 'end' }}
+                                color={copied ? 'teal' : 'gray'}
+                                onClick={copy}
+                            >
+                                <MantineIcon
+                                    icon={copied ? IconCheck : IconCopy}
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </CopyButton>
+            </Stack>
+        </Modal>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6578 

### Description:

Adds a JSON viewer to the results table. Cells that parse as JSON have an expand option added to their context menu which opens a JSON viewer dialog. 

Note that this is only added to the results table for now. We could bring it to more tables if it seems like a good idea, but this was the first thing asked for and the smallest useful change. 

For reviewers: you can test this by putting JSON in a table calculation. 
