### PR TITLE
refactor: move field selector to common

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -15,11 +15,11 @@ import {
     TextInput,
 } from '@mantine/core';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import FieldSelectItem from '../../common/FieldSelect/FieldSelectItem';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-import FieldSelectItem from '../FieldSelectItem';
 
 const StyleOptions = [
     { value: '', label: 'none' },

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -19,10 +19,10 @@ import {
 import { IconPlus } from '@tabler/icons-react';
 import { FC, useCallback, useMemo } from 'react';
 import { EMPTY_X_AXIS } from '../../../hooks/cartesianChartConfig/useCartesianChartConfig';
+import FieldSelect from '../../common/FieldSelect/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import { MAX_PIVOTS } from '../TableConfigPanel/GeneralSettings';
-import FieldSelect from './FieldSelect';
 
 type Props = {
     items: (Field | TableCalculation)[];

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -32,13 +32,13 @@ import {
 } from '@mantine/core';
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
 import { useOrganization } from '../../../../hooks/organization/useOrganization';
+import FieldSelect from '../../../common/FieldSelect/FieldSelect';
 import MantineIcon from '../../../common/MantineIcon';
 import MonthAndYearInput from '../../../common/MonthAndYearInput';
 import { ReferenceLineField } from '../../../common/ReferenceLine';
 import WeekPicker from '../../../common/WeekPicker';
 import YearInput from '../../../common/YearInput';
 import { useVisualizationContext } from '../../../LightdashVisualization/VisualizationProvider';
-import FieldSelect from '../FieldSelect';
 
 type Props = {
     index: number;

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -1,11 +1,11 @@
 import { fieldId, isField } from '@lightdash/common';
 import { Box, Button, Select, Stack, Switch, Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
+import FieldSelectItem from '../../common/FieldSelect/FieldSelectItem';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-import FieldSelectItem from '../FieldSelectItem';
 
 const PieChartLayoutConfig: React.FC = () => {
     const {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -39,11 +39,11 @@ import {
 import produce from 'immer';
 import React, { FC, useCallback, useMemo, useState } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import FieldSelectItem from '../../common/FieldSelect/FieldSelectItem';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import { fieldLabelText } from '../../common/Filters/FieldLabel';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
-import FieldSelectItem from '../FieldSelectItem';
 import ConditionalFormattingRule from './ConditionalFormattingRule';
 
 interface ConditionalFormattingProps {

--- a/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
@@ -9,9 +9,6 @@ type Props = Omit<SelectProps, 'data'> & {
     label?: string;
     selectedField?: Field | TableCalculation;
     fieldOptions: (Field | TableCalculation)[];
-    placeholder?: string;
-    disabled?: boolean;
-    onChange: (newValue: string | null) => void;
 };
 
 const FieldSelect: FC<Props> = ({

--- a/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
@@ -15,9 +15,6 @@ const FieldSelect: FC<Props> = ({
     label,
     selectedField,
     fieldOptions,
-    placeholder,
-    disabled,
-    onChange,
     ...rest
 }) => {
     return (
@@ -25,8 +22,6 @@ const FieldSelect: FC<Props> = ({
             label={label}
             sx={{ flexGrow: 1 }}
             searchable
-            disabled={disabled}
-            placeholder={placeholder}
             icon={selectedField && <FieldIcon item={selectedField} />}
             value={selectedField ? getItemId(selectedField) : null}
             data={fieldOptions.map((field) => {
@@ -40,7 +35,6 @@ const FieldSelect: FC<Props> = ({
                 };
             })}
             itemComponent={FieldSelectItem}
-            onChange={onChange}
             {...rest}
         />
     );

--- a/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/FieldSelect.tsx
@@ -1,18 +1,18 @@
 import { Field, getItemId, TableCalculation } from '@lightdash/common';
-import { Select } from '@mantine/core';
+import { Select, SelectProps } from '@mantine/core';
 import { FC } from 'react';
-import FieldIcon from '../../common/Filters/FieldIcon';
-import { fieldLabelText } from '../../common/Filters/FieldLabel';
-import FieldSelectItem from '../FieldSelectItem';
+import FieldIcon from '../Filters/FieldIcon';
+import { fieldLabelText } from '../Filters/FieldLabel';
+import FieldSelectItem from './FieldSelectItem';
 
-interface Props {
+type Props = Omit<SelectProps, 'data'> & {
     label?: string;
     selectedField?: Field | TableCalculation;
     fieldOptions: (Field | TableCalculation)[];
     placeholder?: string;
     disabled?: boolean;
     onChange: (newValue: string | null) => void;
-}
+};
 
 const FieldSelect: FC<Props> = ({
     label,
@@ -21,6 +21,7 @@ const FieldSelect: FC<Props> = ({
     placeholder,
     disabled,
     onChange,
+    ...rest
 }) => {
     return (
         <Select
@@ -43,6 +44,7 @@ const FieldSelect: FC<Props> = ({
             })}
             itemComponent={FieldSelectItem}
             onChange={onChange}
+            {...rest}
         />
     );
 };

--- a/packages/frontend/src/components/common/FieldSelect/FieldSelectItem.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/FieldSelectItem.tsx
@@ -1,8 +1,8 @@
 import { Field, Metric, TableCalculation } from '@lightdash/common';
 import { Group, SelectItemProps, Text } from '@mantine/core';
 import React, { forwardRef } from 'react';
-import FieldIcon from '../common/Filters/FieldIcon';
-import FieldLabel from '../common/Filters/FieldLabel';
+import FieldIcon from '../Filters/FieldIcon';
+import FieldLabel from '../Filters/FieldLabel';
 
 interface ItemProps extends SelectItemProps {
     icon: React.ReactNode;


### PR DESCRIPTION
### Description:

Moves the FieldSelect and FieldItem components from chart config to common. We are going to use the select in filters as well. Also updates its props. 

