### PR TITLE
fix: set to default tab filter tab when saving

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -189,7 +189,7 @@ const FilterConfiguration: FC<Props> = ({
                     </Tabs.List>
                 ) : null}
 
-                <Tabs.Panel value="settings">
+                <Tabs.Panel value={FilterTabs.SETTINGS}>
                     <FilterSettings
                         isEditMode={isEditMode}
                         field={field}
@@ -200,7 +200,7 @@ const FilterConfiguration: FC<Props> = ({
                     />
                 </Tabs.Panel>
 
-                <Tabs.Panel value="tiles">
+                <Tabs.Panel value={FilterTabs.TILES}>
                     <TileFilterConfiguration
                         field={field}
                         filterRule={internalFilterRule}
@@ -248,7 +248,10 @@ const FilterConfiguration: FC<Props> = ({
                             internalFilterRule,
                         )
                     }
-                    onClick={() => onSave(internalFilterRule)}
+                    onClick={() => {
+                        onSave(internalFilterRule);
+                        onTabChange(FilterTabs.SETTINGS);
+                    }}
                 >
                     Apply
                 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Steps to reproduce bug: 
* Go to dashboard
* enable edit mode
* click on saved filter
* go to tiles tab
* click 'apply'
* save dashboard
* (now on view mode)
* click on same filter
* can only view tiles tab (not the correct view mode tab) 

When applying/saving a filter, reset tab to be the default - `FilterTabs.SETTINGS`. This fixes the issue. 

current bug

https://github.com/lightdash/lightdash/assets/7611706/de253354-1b59-4a44-b72b-2186255d7aa4

fixed with this pr:

https://github.com/lightdash/lightdash/assets/7611706/3ce3f477-85eb-4f90-b24b-a019e1bc3a02


