### PR TITLE
feat: update dashboard filters tiles tab

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -193,7 +193,12 @@ const TileFilterConfiguration: FC<Props> = ({
                 indeterminate={indeterminate}
                 label={
                     <Text span fz="10px" color="gray.8" fw={500}>
-                        Select all
+                        Select all{' '}
+                        {indeterminate
+                            ? ` (${
+                                  values.filter((v) => v.checked).length
+                              } charts selected)`
+                            : ''}
                     </Text>
                 }
                 styles={{

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -154,7 +154,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     handlers.setItem(index, {
                         ...value,
                         checked: event.currentTarget.checked,
-                        selectedFilter: field,
+                        selectedFilter: value.selectedFilter ?? field,
                     });
 
                     onChange(
@@ -233,6 +233,9 @@ const TileFilterConfiguration: FC<Props> = ({
                         current.map((value) => ({
                             ...value,
                             checked: !allChecked,
+                            ...(!value.checked && {
+                                selectedFilter: value.selectedFilter || field,
+                            }),
                         })),
                     )
                 }

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -123,12 +123,16 @@ const TileFilterConfiguration: FC<Props> = ({
     const indeterminate = values.some(({ checked }) => checked) && !allChecked;
 
     const items = values.map((value, index) => (
-        <>
+        <Box key={value.key}>
             <Checkbox
                 size="xs"
                 fw={500}
                 label={value.label}
-                key={value.key}
+                styles={{
+                    label: {
+                        paddingLeft: theme.spacing.xs,
+                    },
+                }}
                 checked={value.checked}
                 onChange={(event) => {
                     handlers.setItemProp(
@@ -147,7 +151,7 @@ const TileFilterConfiguration: FC<Props> = ({
             />
 
             {value.sortedFilters && (
-                <Box ml={24} display={!value.checked ? 'none' : 'auto'}>
+                <Box ml={24} mt={6} display={!value.checked ? 'none' : 'auto'}>
                     <FieldAutoComplete
                         disabled={!value.checked}
                         popoverProps={{
@@ -178,7 +182,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     />
                 </Box>
             )}
-        </>
+        </Box>
     ));
 
     return (
@@ -188,10 +192,15 @@ const TileFilterConfiguration: FC<Props> = ({
                 checked={allChecked}
                 indeterminate={indeterminate}
                 label={
-                    <Text fw={500} fz="xs" color="gray.7">
+                    <Text span fz="10px" color="gray.8" fw={500}>
                         Select all
                     </Text>
                 }
+                styles={{
+                    label: {
+                        paddingLeft: theme.spacing.xs,
+                    },
+                }}
                 transitionDuration={0}
                 onChange={() =>
                     handlers.setState((current) =>
@@ -202,9 +211,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     )
                 }
             />
-            <Stack spacing="xs" ml={8}>
-                {items}
-            </Stack>
+            <Stack spacing="md">{items}</Stack>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -77,7 +77,7 @@ const TileFilterConfiguration: FC<Props> = ({
             .sort(([, a], [, b]) => tilesSortBy(matchFieldExact, a, b));
     }, [tilesSortBy, availableTileFilters]);
 
-    const initialFilterTilesValues = sortedTileEntries.map(
+    const initialFilterTileTargets = sortedTileEntries.map(
         ([tileUuid, filters], index) => {
             const tile = tiles.find((t) => t.uuid === tileUuid);
             const tileConfig = filterRule.tileTargets?.[tileUuid];
@@ -117,12 +117,15 @@ const TileFilterConfiguration: FC<Props> = ({
         },
     );
 
-    const [values, handlers] = useListState(initialFilterTilesValues);
+    const [tileTargetCheckboxes, handlers] = useListState(
+        initialFilterTileTargets,
+    );
 
-    const allChecked = values.every(({ checked }) => checked);
-    const indeterminate = values.some(({ checked }) => checked) && !allChecked;
+    const allChecked = tileTargetCheckboxes.every(({ checked }) => checked);
+    const indeterminate =
+        tileTargetCheckboxes.some(({ checked }) => checked) && !allChecked;
 
-    const items = values.map((value, index) => (
+    const tileTargets = tileTargetCheckboxes.map((value, index) => (
         <Box key={value.key}>
             <Checkbox
                 size="xs"
@@ -196,7 +199,8 @@ const TileFilterConfiguration: FC<Props> = ({
                         Select all{' '}
                         {indeterminate
                             ? ` (${
-                                  values.filter((v) => v.checked).length
+                                  tileTargetCheckboxes.filter((v) => v.checked)
+                                      .length
                               } charts selected)`
                             : ''}
                     </Text>
@@ -216,7 +220,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     )
                 }
             />
-            <Stack spacing="md">{items}</Stack>
+            <Stack spacing="md">{tileTargets}</Stack>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -167,7 +167,7 @@ const TileFilterConfiguration: FC<Props> = ({
             />
 
             {value.sortedFilters && (
-                <Box ml={24} mt={6} display={!value.checked ? 'none' : 'auto'}>
+                <Box ml="xl" mt="sm" display={!value.checked ? 'none' : 'auto'}>
                     <FieldAutoComplete
                         disabled={!value.checked}
                         popoverProps={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes half of #6072

left to do: ` Show the chart icon type next to the chart name `

### Description:

Refactor current implementation in `TileFilterConfiguration`;

Use `useListState` from `mantine hooks` to control group of checkboxes: example https://mantine.dev/core/checkbox/#indeterminate-state

Ensure there's always a defined field when checking a checkbox 

**in View mode**


https://github.com/lightdash/lightdash/assets/7611706/0e408219-49b7-4db9-b001-a12dddb9e68d


**in Edit mode**


https://github.com/lightdash/lightdash/assets/7611706/e8e4b438-22f0-4bbb-ba76-4697de5f6af0


