### PR TITLE
feat: add dashed border to tiles on edit mode

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -14,14 +14,13 @@ export const TileBaseWrapper = styled.div<HeaderContainerProps>`
     padding: 16px;
     background: ${Colors.WHITE};
     border-radius: 2px;
-    box-shadow: 0 0 0 1px #11141826;
+    box-sizing: border-box;
+    border: 1px solid transparent;
 
     ${(props) =>
-        props.$isEditMode && props.$isHovering
-            ? `
-                box-shadow: 0 0 0 1px ${Colors.GRAY4};
-            `
-            : ''}
+        props.$isEditMode
+            ? `border: 1px dashed #7ea5ff;`
+            : `box-shadow: 0 0 0 1px #11141826;`}
 `;
 
 export const TILE_HEADER_HEIGHT = 24;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

When viewing or editing a dashboard, it's hard to visually distinguish which state the user is in. 

Added a dashed border to the tiles when in edit mode. 

screen recording:

https://github.com/lightdash/lightdash/assets/7611706/b64af742-fb82-46b8-8b0d-1e550b3bf2de


