### PR TITLE
feat: make dashboard tiles borders lighter on view mode

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -20,7 +20,7 @@ export const TileBaseWrapper = styled.div<HeaderContainerProps>`
     ${(props) =>
         props.$isEditMode
             ? `border: 1px dashed #7ea5ff;`
-            : `box-shadow: 0 0 0 1px #11141826;`}
+            : `box-shadow: 0 0 0 1px #bec1c426;`}
 `;
 
 export const TILE_HEADER_HEIGHT = 24;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

make dashboard tile borders a bit lighter in view mode

before
<img width="1258" alt="Screenshot 2023-08-11 at 11 11 49" src="https://github.com/lightdash/lightdash/assets/7611706/72bfe6a3-e5bd-41ed-aa2c-dfd6bcc43883">

after
<img width="1258" alt="Screenshot 2023-08-11 at 11 12 32" src="https://github.com/lightdash/lightdash/assets/7611706/ee8f74d5-e072-4096-9667-df5457732c9c">
