### PR TITLE
feat: lighten dashboard-header's shadow

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -188,7 +188,7 @@ const SavedChartsHeader: FC = () => {
                 </p>
             </Alert>
 
-            <PageHeader>
+            <PageHeader withShadow>
                 <PageTitleAndDetailsContainer>
                     {savedChart && (
                         <>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -188,7 +188,7 @@ const SavedChartsHeader: FC = () => {
                 </p>
             </Alert>
 
-            <PageHeader withShadow>
+            <PageHeader>
                 <PageTitleAndDetailsContainer>
                     {savedChart && (
                         <>

--- a/packages/frontend/src/components/common/Page/PageHeader.tsx
+++ b/packages/frontend/src/components/common/Page/PageHeader.tsx
@@ -13,6 +13,10 @@ const PageHeader: FC = ({ children }) => (
         px="lg"
         py="md"
         bg="white"
+        /**
+         * FIXME: This shadow should be sourced from Mantine's theme config;
+         * Once migration from Blueprint is complete, address default shadow
+         */
         shadow="0 0 0 1px #bec1c426"
         radius="unset"
         sx={{ zIndex: 1 }}

--- a/packages/frontend/src/components/common/Page/PageHeader.tsx
+++ b/packages/frontend/src/components/common/Page/PageHeader.tsx
@@ -1,11 +1,9 @@
 import { Card, Flex } from '@mantine/core';
-import { FC, ReactNode } from 'react';
+import { FC } from 'react';
 
 export const PAGE_HEADER_HEIGHT = 80;
 
-type Props = { withShadow?: boolean; children: ReactNode };
-
-const PageHeader: FC<Props> = ({ withShadow, children }) => (
+const PageHeader: FC = ({ children }) => (
     <Card
         component={Flex}
         justify="flex-end"
@@ -15,7 +13,7 @@ const PageHeader: FC<Props> = ({ withShadow, children }) => (
         px="lg"
         py="md"
         bg="white"
-        shadow={withShadow ? 'xs' : 'none'}
+        shadow="0 0 0 1px #bec1c426"
         radius="unset"
         sx={{ zIndex: 1 }}
     >

--- a/packages/frontend/src/components/common/Page/PageHeader.tsx
+++ b/packages/frontend/src/components/common/Page/PageHeader.tsx
@@ -1,26 +1,26 @@
 import { Card, Flex } from '@mantine/core';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 
 export const PAGE_HEADER_HEIGHT = 80;
 
-const PageHeader: FC = ({ children }) => {
-    return (
-        <Card
-            component={Flex}
-            justify="flex-end"
-            align="center"
-            pos="relative"
-            h={PAGE_HEADER_HEIGHT}
-            px="lg"
-            py="md"
-            bg="white"
-            shadow="xs"
-            radius="unset"
-            sx={{ zIndex: 1 }}
-        >
-            {children}
-        </Card>
-    );
-};
+type Props = { withShadow?: boolean; children: ReactNode };
+
+const PageHeader: FC<Props> = ({ withShadow, children }) => (
+    <Card
+        component={Flex}
+        justify="flex-end"
+        align="center"
+        pos="relative"
+        h={PAGE_HEADER_HEIGHT}
+        px="lg"
+        py="md"
+        bg="white"
+        shadow={withShadow ? 'xs' : 'none'}
+        radius="unset"
+        sx={{ zIndex: 1 }}
+    >
+        {children}
+    </Card>
+);
 
 export default PageHeader;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Lighten `pageheader`'s shadow.


before: 
<img width="1512" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/1deea777-a6c9-4977-9a76-f44781e677ea">


after:
<img width="1263" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/eec572e6-edf2-404a-885e-1674e2fa6651">

