### PR TITLE
fix: dashboard filters keep state when not applied

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -1,8 +1,12 @@
-import { DashboardFilterRule, FilterableField } from '@lightdash/common';
+import {
+    applyDefaultTileTargets,
+    DashboardFilterRule,
+    FilterableField,
+} from '@lightdash/common';
 import { ActionIcon, Button, Popover, Text, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
-import { FC, useCallback } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import {
     getConditionalRuleLabel,
@@ -39,15 +43,27 @@ const ActiveFilter: FC<Props> = ({
         (item) => item.id === filterRule.id,
     );
 
+    const defaultFilterRule = filterableFieldsByTileUuid
+        ? applyDefaultTileTargets(filterRule, field, filterableFieldsByTileUuid)
+        : undefined;
+
     const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
         useDisclosure();
     const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
         useDisclosure();
 
+    const [draftFilterRule, setDraftFilterRule] = useState<
+        DashboardFilterRule | undefined
+    >(defaultFilterRule);
+
+    const handleSetDraftFilterRule = (newRule?: DashboardFilterRule) =>
+        setDraftFilterRule(newRule);
+
     const handleClose = useCallback(() => {
         closeSubPopover();
         closePopover();
-    }, [closeSubPopover, closePopover]);
+        setDraftFilterRule(defaultFilterRule);
+    }, [closeSubPopover, closePopover, defaultFilterRule, setDraftFilterRule]);
 
     if (!filterableFieldsByTileUuid || !allFilterableFields) {
         return null;
@@ -68,9 +84,14 @@ const ActiveFilter: FC<Props> = ({
             opened={isPopoverOpen}
             closeOnEscape={!isSubPopoverOpen}
             closeOnClickOutside={!isSubPopoverOpen}
-            onClose={handleClose}
+            onClose={() => {
+                handleClose();
+            }}
             offset={-1}
             keepMounted
+            transitionProps={{
+                duration: 0,
+            }}
         >
             <Popover.Target>
                 <Tooltip
@@ -139,10 +160,12 @@ const ActiveFilter: FC<Props> = ({
                     field={field}
                     availableTileFilters={filterableFieldsByTileUuid}
                     originalFilterRule={originalFilterRule}
-                    filterRule={filterRule}
+                    draftFilterRule={draftFilterRule}
+                    onChangeDraftFilterRule={handleSetDraftFilterRule}
                     onSave={(dashboardFilterRule) => {
+                        closeSubPopover();
+                        closePopover();
                         onUpdate(dashboardFilterRule);
-                        handleClose();
                     }}
                     // FIXME: remove this once we migrate off of Blueprint
                     popoverProps={{

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -42,9 +42,16 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         addDimensionDashboardFilter,
     } = useDashboardContext();
 
+    const [draftFilterRule, setDraftFilterRule] = useState<
+        DashboardFilterRule | undefined
+    >();
+
+    const handleSetDraftFilterRule = (newRule?: DashboardFilterRule) =>
+        setDraftFilterRule(newRule);
+
     const handleClose = useCallback(() => {
         setSelectedField(undefined);
-
+        setDraftFilterRule(undefined);
         closeSubPopover();
         closePopover();
     }, [closeSubPopover, closePopover]);
@@ -136,6 +143,10 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
                                 tiles={dashboardTiles}
                                 availableTileFilters={
                                     filterableFieldsByTileUuid
+                                }
+                                draftFilterRule={draftFilterRule}
+                                onChangeDraftFilterRule={
+                                    handleSetDraftFilterRule
                                 }
                                 onSave={handleSave}
                                 // FIXME: remove this once we migrate off of Blueprint


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6716

### Description:

We weren't clearing the dashboard editor state when closing it without applying changes. This sets the state back when the editor is closed. 

Note that this is a fairly targeted fix for this bug. Ideally we should refactor the code a bit and combine ActiveFilter with DashboardFilter. This improves the situation though. 
