### PR TITLE
fix: add a tooltip when apply button is disabled

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -283,22 +283,31 @@ const FilterConfiguration: FC<Props> = ({
                         </Tooltip>
                     )}
 
-                <Button
-                    size="xs"
-                    variant="filled"
-                    className={Classes.POPOVER2_DISMISS}
-                    disabled={
-                        !isFilterConfigurationApplyButtonEnabled(
-                            draftFilterRule,
-                        )
-                    }
-                    onClick={() => {
-                        setSelectedTabId(FilterTabs.SETTINGS);
-                        if (!!draftFilterRule) onSave(draftFilterRule);
-                    }}
+                <Tooltip
+                    label="Filter field and value required"
+                    disabled={isFilterConfigurationApplyButtonEnabled(
+                        draftFilterRule,
+                    )}
                 >
-                    Apply
-                </Button>
+                    <Box>
+                        <Button
+                            size="xs"
+                            variant="filled"
+                            className={Classes.POPOVER2_DISMISS}
+                            disabled={
+                                !isFilterConfigurationApplyButtonEnabled(
+                                    draftFilterRule,
+                                )
+                            }
+                            onClick={() => {
+                                setSelectedTabId(FilterTabs.SETTINGS);
+                                if (!!draftFilterRule) onSave(draftFilterRule);
+                            }}
+                        >
+                            Apply
+                        </Button>
+                    </Box>
+                </Tooltip>
             </Flex>
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6702

### Description:

Adds a tooltip explaining why the apply button is disabled. 

Note that the original bug here is mostly fixed elsewhere -- this is the final part, making it clear why you are in this state. 
