### PR TITLE
refactor: create ChartIcon component

### DIFF
--- a/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/SearchIcon.tsx
@@ -12,7 +12,7 @@ import {
 import { FC } from 'react';
 import { Link } from 'react-router-dom';
 import {
-    getChartIcon,
+    ChartIcon,
     IconBox,
     ResourceIndicator,
 } from '../../common/ResourceIcon';
@@ -38,8 +38,12 @@ export const SearchIcon: FC<SearchIconProps> = ({ searchItem }) => {
         case 'dashboard':
             return <IconBox icon={IconLayoutDashboard} color="green.8" />;
         case 'saved_chart':
-            return getChartIcon(
-                (searchItem.item as SavedChartSearchResult)?.chartType,
+            return (
+                <ChartIcon
+                    chartType={
+                        (searchItem.item as SavedChartSearchResult)?.chartType
+                    }
+                />
             );
         case 'space':
             return <IconBox icon={IconFolder} color="violet.8" />;

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -27,7 +27,7 @@ import { useLocation } from 'react-router-dom';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { useDeleteValidation } from '../../../hooks/validation/useValidation';
 import MantineIcon from '../../common/MantineIcon';
-import { getChartIcon, IconBox } from '../../common/ResourceIcon';
+import { ChartIcon, IconBox } from '../../common/ResourceIcon';
 import { ErrorMessage } from './ErrorMessage';
 import { useScrollAndHighlight } from './hooks/useScrollAndHighlight';
 
@@ -54,7 +54,7 @@ const isDeleted = (validationError: ValidationResponse) =>
 
 const Icon = ({ validationError }: { validationError: ValidationResponse }) => {
     if (isChartValidationError(validationError))
-        return getChartIcon(validationError.chartType);
+        return <ChartIcon chartType={validationError.chartType} />;
     if (isDashboardValidationError(validationError))
         return <IconBox icon={IconLayoutDashboard} color="green.8" />;
     return <IconBox icon={IconTable} color="indigo.6" />;

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -64,33 +64,27 @@ export const IconBox: FC<IconBoxProps> = ({
     </Paper>
 );
 
-export const getChartIcon = (chartType: ChartKind | undefined) => {
+const getChartIcon = (chartType: ChartKind | undefined) => {
     switch (chartType) {
         case undefined:
         case ChartKind.VERTICAL_BAR:
-            return <IconBox icon={IconChartBar} color="blue.8" />;
+            return IconChartBar;
         case ChartKind.HORIZONTAL_BAR:
-            return (
-                <IconBox
-                    icon={IconChartBar}
-                    color="blue.8"
-                    transform="rotate(90)"
-                />
-            );
+            return IconChartBar;
         case ChartKind.LINE:
-            return <IconBox icon={IconChartLine} color="blue.8" />;
+            return IconChartLine;
         case ChartKind.SCATTER:
-            return <IconBox icon={IconChartDots} color="blue.8" />;
+            return IconChartDots;
         case ChartKind.AREA:
-            return <IconBox icon={IconChartArea} color="blue.8" />;
+            return IconChartArea;
         case ChartKind.MIXED:
-            return <IconBox icon={IconChartAreaLine} color="blue.8" />;
+            return IconChartAreaLine;
         case ChartKind.PIE:
-            return <IconBox icon={IconChartPie} color="blue.8" />;
+            return IconChartPie;
         case ChartKind.TABLE:
-            return <IconBox icon={IconTable} color="blue.8" />;
+            return IconTable;
         case ChartKind.BIG_NUMBER:
-            return <IconBox icon={IconSquareNumber1} color="blue.8" />;
+            return IconSquareNumber1;
         default:
             return assertUnreachable(
                 chartType,
@@ -99,6 +93,18 @@ export const getChartIcon = (chartType: ChartKind | undefined) => {
     }
 };
 
+export const ChartIcon: FC<{ chartType: ChartKind | undefined }> = ({
+    chartType,
+}) => (
+    <IconBox
+        icon={getChartIcon(chartType)}
+        color="blue.8"
+        transform={
+            chartType === ChartKind.HORIZONTAL_BAR ? `"rotate(90)"` : undefined
+        }
+    />
+);
+
 export const ResourceIcon: FC<ResourceIconProps> = ({ item }) => {
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
@@ -106,7 +112,7 @@ export const ResourceIcon: FC<ResourceIconProps> = ({ item }) => {
         case ResourceViewItemType.SPACE:
             return <IconBox icon={IconFolder} color="violet.8" />;
         case ResourceViewItemType.CHART:
-            return getChartIcon(item.data.chartType);
+            return <ChartIcon chartType={item.data.chartType} />;
         default:
             return assertUnreachable(item, 'Resource type not supported');
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

When starting work on https://github.com/lightdash/lightdash/issues/6072, more specifically on adding the icon next to the checkbox, I realised that the `getChartIcon` util would apply default styles. 

With this in mind:
* `getChartIcon` returns only the Icon for each type
* `ChartIcon` component is a shared, styled `IconBox` with the correct Icon from `getChartIcon`, utilised in many places.