### PR TITLE
fix: pivot table dashboard filters

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -81,6 +81,8 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             getFieldLabel={getFieldLabel}
                             getField={getField}
                             hideRowNumbers={hideRowNumbers}
+                            isDashboard={isDashboard}
+                            tileUuid={tileUuid}
                         />
                     ) : (
                         <LoadingChart />

--- a/packages/frontend/src/components/common/PivotTable/DashboardValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/DashboardValueCellMenu.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import useDashboardFiltersForExplore from '../../../hooks/dashboard/useDashboardFiltersForExplore';
+import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
+import ValueCellMenu, { ValueCellMenuProps } from './ValueCellMenu';
+
+type Props = ValueCellMenuProps & {
+    tileUuid: string;
+};
+
+const DashboardValueCellMenu: FC<Props> = ({
+    tileUuid,
+    ...contextMenuProps
+}) => {
+    const { explore } = useVisualizationContext();
+
+    const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
+        tileUuid,
+        explore,
+    );
+
+    return (
+        <ValueCellMenu
+            dashboardFilters={dashboardFiltersThatApplyToChart}
+            {...contextMenuProps}
+        />
+    );
+};
+
+export default DashboardValueCellMenu;

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -1,5 +1,10 @@
 import { subject } from '@casl/ability';
-import { Field, ResultValue, TableCalculation } from '@lightdash/common';
+import {
+    DashboardFilters,
+    Field,
+    ResultValue,
+    TableCalculation,
+} from '@lightdash/common';
 import { Menu, MenuProps } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import { FC } from 'react';
@@ -11,7 +16,7 @@ import { EventName } from '../../../types/Events';
 import { useMetricQueryDataContext } from '../../MetricQueryData/MetricQueryDataProvider';
 import MantineIcon from '../MantineIcon';
 
-type ValueCellMenuProps = {
+export type ValueCellMenuProps = {
     value?: ResultValue | null;
     onCopy: () => void;
 
@@ -22,6 +27,8 @@ type ValueCellMenuProps = {
         colIndex: number,
         rowIndex: number,
     ) => Record<string, ResultValue>;
+
+    dashboardFilters?: DashboardFilters;
 } & Pick<MenuProps, 'opened' | 'onOpen' | 'onClose'>;
 
 const ValueCellMenu: FC<ValueCellMenuProps> = ({
@@ -35,6 +42,7 @@ const ValueCellMenu: FC<ValueCellMenuProps> = ({
     onOpen,
     onClose,
     onCopy,
+    dashboardFilters,
 }) => {
     const { user } = useApp();
     const tracking = useTracking(true);
@@ -92,6 +100,7 @@ const ValueCellMenu: FC<ValueCellMenuProps> = ({
             item,
             value,
             fieldValues: underlyingFieldValues,
+            dashboardFilters,
         });
 
         track({
@@ -122,6 +131,7 @@ const ValueCellMenu: FC<ValueCellMenuProps> = ({
         openDrillDownModel({
             item,
             fieldValues: underlyingFieldValues,
+            dashboardFilters,
         });
 
         track({

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -41,6 +41,8 @@ type PivotTableProps = TableProps &
         hideRowNumbers: boolean;
         getFieldLabel: (fieldId: string) => string | undefined;
         getField: (fieldId: string) => Field | TableCalculation;
+        isDashboard: boolean;
+        tileUuid?: string;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
@@ -51,6 +53,8 @@ const PivotTable: FC<PivotTableProps> = ({
     getFieldLabel,
     getField,
     className,
+    isDashboard,
+    tileUuid,
     ...tableProps
 }) => {
     const { cx, classes } = usePivotTableStyles();
@@ -411,6 +415,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                         conditionalFormattings={
                                             conditionalFormattings
                                         }
+                                        isDashboard={isDashboard}
+                                        tileUuid={tileUuid}
                                     />
                                 );
                             })}


### PR DESCRIPTION
Closes: 

### Description:

- before <img width="813" alt="CleanShot 2023-08-14 at 14 47 40@2x" src="https://github.com/lightdash/lightdash/assets/962095/9ad044cf-620a-4396-890f-2d47077e2d83">
- after <img width="892" alt="CleanShot 2023-08-14 at 14 48 13@2x" src="https://github.com/lightdash/lightdash/assets/962095/f5555f0c-063f-43d2-924b-2eb3dd82c28c">