### PR TITLE
fix: error for broken urls in tables is covered up

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@blueprintjs/core';
-import { MenuItem2, Tooltip2 } from '@blueprintjs/popover2';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
     FieldUrl,
@@ -13,6 +13,7 @@ import {
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
+import { Box, Tooltip } from '@mantine/core';
 import { Cell } from '@tanstack/react-table';
 import { FC, useMemo } from 'react';
 import { useTracking } from '../../../providers/TrackingProvider';
@@ -81,9 +82,11 @@ const UrlMenuItem: FC<{
             text={urlConfig.label}
             labelElement={
                 error && (
-                    <Tooltip2 content={error}>
-                        <Icon icon="issue" />
-                    </Tooltip2>
+                    <Tooltip label={error} position="right">
+                        <Box>
+                            <Icon icon="issue" />
+                        </Box>
+                    </Tooltip>
                 )
             }
             disabled={!url}


### PR DESCRIPTION
### Description:

When there is an error with a URL in the results table, the tooltip showing the error is covered (z-index issue). This moves it and updates the component to use mantine. Before and after below.

Before:
<img width="669" alt="Screenshot 2023-08-14 at 14 22 49" src="https://github.com/lightdash/lightdash/assets/1864179/dd6bf178-e1c8-48d3-8ffe-11d360db3305">

After fix:
<img width="707" alt="Screenshot 2023-08-14 at 14 52 17" src="https://github.com/lightdash/lightdash/assets/1864179/587e0be4-067f-4bb6-9041-193bdee8a334">
