### PR TITLE
feat: add chart icon next to tile target checkbox

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -474,6 +474,7 @@ export class DashboardModel {
                     first_viewed_at: Date | null;
                     belongs_to_dashboard: boolean;
                     name: string | null;
+                    last_version_chart_kind: string | null;
                 }[]
             >(
                 `${DashboardTilesTableName}.x_offset`,
@@ -484,6 +485,7 @@ export class DashboardModel {
                 `${DashboardTilesTableName}.dashboard_tile_uuid`,
                 `${SavedChartsTableName}.saved_query_uuid`,
                 `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.last_version_chart_kind`,
                 this.database.raw(
                     `${SavedChartsTableName}.dashboard_uuid IS NOT NULL AS belongs_to_dashboard`,
                 ),
@@ -573,6 +575,7 @@ export class DashboardModel {
                     content,
                     belongs_to_dashboard,
                     name,
+                    last_version_chart_kind,
                 }) => {
                     const base: Omit<
                         Dashboard['tiles'][number],
@@ -600,6 +603,8 @@ export class DashboardModel {
                                     savedChartUuid: saved_query_uuid,
                                     belongsToDashboard: belongs_to_dashboard,
                                     chartName: name,
+                                    lastVersionChartKind:
+                                        last_version_chart_kind,
                                 },
                             };
                         case DashboardTileTypes.MARKDOWN:

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { FilterableField } from './field';
 import { DashboardFilters } from './filter';
-import { SavedChartType } from './savedCharts';
+import { ChartKind, SavedChartType } from './savedCharts';
 import { UpdatedByUser } from './user';
 import { ValidationSummary } from './validation';
 
@@ -46,6 +46,7 @@ export type DashboardChartTileProperties = {
         savedChartUuid: string | null;
         belongsToDashboard?: boolean; // this should be required and not part of the "create" types, but we need to fix tech debt first. Open ticket https://github.com/lightdash/lightdash/issues/6450
         chartName?: string | null;
+        lastVersionChartKind?: ChartKind | null;
     };
 };
 

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -9,13 +9,22 @@ import {
     matchFieldByTypeAndName,
     matchFieldExact,
 } from '@lightdash/common';
-import { Box, Checkbox, Stack, Text, useMantineTheme } from '@mantine/core';
+import {
+    Box,
+    Checkbox,
+    Flex,
+    Stack,
+    Text,
+    useMantineTheme,
+} from '@mantine/core';
 import { useListState } from '@mantine/hooks';
 import { FC, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { FilterActions } from '.';
 import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import FieldAutoComplete from '../../common/Filters/FieldAutoComplete';
+import MantineIcon from '../../common/MantineIcon';
+import { getChartIcon } from '../../common/ResourceIcon';
 
 type Props = {
     tiles: DashboardTile[];
@@ -124,6 +133,11 @@ const TileFilterConfiguration: FC<Props> = ({
                 label: tileLabel,
                 checked: Boolean(isFilterAvailable && tileConfig),
                 tileUuid,
+                ...(tile &&
+                    isDashboardChartTileType(tile) && {
+                        tileChartKind:
+                            tile.properties.lastVersionChartKind ?? undefined,
+                    }),
                 sortedFilters,
                 selectedFilter,
             };
@@ -143,7 +157,15 @@ const TileFilterConfiguration: FC<Props> = ({
             <Checkbox
                 size="xs"
                 fw={500}
-                label={value.label}
+                label={
+                    <Flex align="center" gap="xxs">
+                        <MantineIcon
+                            color="blue.8"
+                            icon={getChartIcon(value.tileChartKind)}
+                        />
+                        {value.label}
+                    </Flex>
+                }
                 styles={{
                     label: {
                         paddingLeft: theme.spacing.xs,

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -64,7 +64,7 @@ export const IconBox: FC<IconBoxProps> = ({
     </Paper>
 );
 
-const getChartIcon = (chartType: ChartKind | undefined) => {
+export const getChartIcon = (chartType: ChartKind | undefined) => {
     switch (chartType) {
         case undefined:
         case ChartKind.VERTICAL_BAR:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6072

### Description:

* Get last-version-chart kind 
* Update type
* Get correct icon
* Display next to checkbox

<img width="609" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/e8585f58-0a80-4fee-bc4f-5f2e17a048d3">
