### PR TITLE
fix: filter close icon color

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/ActiveFilter.tsx
@@ -3,16 +3,14 @@ import {
     DashboardFilterRule,
     FilterableField,
 } from '@lightdash/common';
-import { ActionIcon, Button, Popover, Text, Tooltip } from '@mantine/core';
+import { Button, CloseButton, Popover, Text, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconX } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import {
     getConditionalRuleLabel,
     getFilterRuleTables,
 } from '../../common/Filters/configs';
-import MantineIcon from '../../common/MantineIcon';
 import FilterConfiguration from '../FilterConfiguration';
 
 type Props = {
@@ -112,13 +110,7 @@ const ActiveFilter: FC<Props> = ({
                         mr="xxs"
                         rightIcon={
                             (isEditMode || isTemporary) && (
-                                <ActionIcon
-                                    color="dark"
-                                    size="xs"
-                                    onClick={onRemove}
-                                >
-                                    <MantineIcon icon={IconX} />
-                                </ActionIcon>
+                                <CloseButton size="sm" onClick={onRemove} />
                             )
                         }
                         styles={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6719 

### Description:

Change the filter close button color. I did this by just using the built-in mantine CloseButton

Before:
<img width="316" alt="Screenshot 2023-08-15 at 15 07 14" src="https://github.com/lightdash/lightdash/assets/1864179/25328239-a532-4a5b-9c9e-17277844786c">

After:
<img width="225" alt="Screenshot 2023-08-15 at 15 07 26" src="https://github.com/lightdash/lightdash/assets/1864179/b7956761-db9f-4633-ad6e-7ac458ff0f48">

