### PR TITLE
feat: improve chart from dashboard edit ux

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -8,7 +8,9 @@ import {
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
+import { Box, Tooltip } from '@mantine/core';
 import {
+    IconArrowBack,
     IconCheck,
     IconCirclePlus,
     IconCopy,
@@ -324,9 +326,20 @@ const SavedChartsHeader: FC = () => {
                                 </Button>
 
                                 {isFromDashboard && (
-                                    <Button onClick={handleGoBackClick}>
-                                        Go back
-                                    </Button>
+                                    <Tooltip
+                                        offset={-1}
+                                        label="Return to dashboard"
+                                    >
+                                        <Box>
+                                            <Button
+                                                style={{ padding: '5px 7px' }}
+                                                icon={
+                                                    <IconArrowBack size={16} />
+                                                }
+                                                onClick={handleGoBackClick}
+                                            />
+                                        </Box>
+                                    </Tooltip>
                                 )}
                             </>
                         )}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -62,6 +62,7 @@ const SavedChartsHeader: FC = () => {
         projectUuid: string;
     }>();
     const dashboardUuid = useSearchParams('fromDashboard');
+    const isFromDashboard = !!dashboardUuid;
     const spaceUuid = useSearchParams('fromSpace');
 
     const history = useHistory();
@@ -166,6 +167,31 @@ const SavedChartsHeader: FC = () => {
             projectUuid,
         }),
     );
+
+    const handleGoBackClick = () => {
+        if (hasUnsavedChanges && isEditMode) {
+            history.block((prompt) => {
+                setBlockedNavigationLocation(prompt.pathname);
+                setIsSaveWarningModalOpen(true);
+                return false; //blocks history
+            });
+        }
+
+        history.push({
+            pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardUuid}`,
+        });
+        sessionStorage.removeItem('fromDashboard');
+        sessionStorage.removeItem('dashboardUuid');
+    };
+
+    const handleCancelClick = () => {
+        reset();
+
+        if (!isFromDashboard)
+            history.push({
+                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`,
+            });
+    };
 
     return (
         <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
@@ -289,26 +315,19 @@ const SavedChartsHeader: FC = () => {
                             <>
                                 <SaveChartButton />
                                 <Button
-                                    onClick={() => {
-                                        reset();
-                                        if (dashboardUuid) {
-                                            history.push({
-                                                pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardUuid}`,
-                                            });
-                                            sessionStorage.removeItem(
-                                                'fromDashboard',
-                                            );
-                                            sessionStorage.removeItem(
-                                                'dashboardUuid',
-                                            );
-                                        } else
-                                            history.push({
-                                                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`,
-                                            });
-                                    }}
+                                    disabled={
+                                        isFromDashboard && !hasUnsavedChanges
+                                    }
+                                    onClick={handleCancelClick}
                                 >
-                                    Cancel
+                                    Cancel {isFromDashboard ? 'changes' : ''}
                                 </Button>
+
+                                {isFromDashboard && (
+                                    <Button onClick={handleGoBackClick}>
+                                        Go back
+                                    </Button>
+                                )}
                             </>
                         )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6752

### Description:

When editing a chart from a dashboard: 
* See `Save changes`
* See `Cancel changes` **only** when there are unsaved changes
* Add go-back (Icon arrow back) button that goes back only, displays a prompt if the user has unsaved changes, before going back to the og dashboard. 
* Display tooltip on hover of new go-back button


Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/5c30fc41-29c5-4438-b6c2-e4d7f57cd20d

