### PR TITLE
chore: remove extra `}` when dbt error

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -186,7 +186,7 @@ export class DbtCliClient implements DbtClient {
             throw new DbtError(
                 `Failed to run "${dbtExec} ${command.join(
                     ' ',
-                )}" with dbt version "${this.dbtVersion}}"`,
+                )}" with dbt version "${this.dbtVersion}"`,
                 DbtCliClient.parseDbtJsonLogs(e.all),
             );
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Remove `}` on dbt error: 

<img width="401" alt="Screenshot 2023-08-15 at 17 36 59" src="https://github.com/lightdash/lightdash/assets/7611706/c82bf9ff-345a-4194-8118-1dc825afea59">
