### PR TITLE
feat: only show intercom to cloud customers

### DIFF
--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -1,3 +1,4 @@
+import { LightdashMode } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
 import {
     IconBook,
@@ -8,10 +9,14 @@ import {
 } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useIntercom } from 'react-use-intercom';
+import useHealth from '../../hooks/health/useHealth';
 import LargeMenuItem from '../common/LargeMenuItem';
 import MantineIcon from '../common/MantineIcon';
 
 const HelpMenu: FC = () => {
+    const health = useHealth();
+    const isCloudCustomer = health.data?.mode === LightdashMode.CLOUD_BETA;
+
     const { show: showIntercom } = useIntercom();
 
     return (
@@ -29,12 +34,14 @@ const HelpMenu: FC = () => {
             </Menu.Target>
 
             <Menu.Dropdown>
-                <LargeMenuItem
-                    onClick={() => showIntercom()}
-                    title="Contact support"
-                    description="Drop us a message and we’ll get back to you asap!"
-                    icon={IconMessages}
-                />
+                {isCloudCustomer && (
+                    <LargeMenuItem
+                        onClick={() => showIntercom()}
+                        title="Contact support"
+                        description="Drop us a message and we’ll get back to you asap!"
+                        icon={IconMessages}
+                    />
+                )}
 
                 <LargeMenuItem
                     component="a"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Hide intercom for non-cloud customers

For example, on local you can't see it:
<img width="715" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/26506941-fb9c-4aa8-ac63-4c5f90ea6130">

