### PR TITLE
fix: dashboard filters should not show reset in edit mode

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -113,8 +113,12 @@ const FilterConfiguration: FC<Props> = ({
         }
     };
 
+    console.log({ originalFilterRule });
+
     const handleRevert = useCallback(() => {
         if (!originalFilterRule) return;
+
+        console.log({ draftFilterRule, originalFilterRule });
 
         setDraftFilterRule(
             draftFilterRule
@@ -290,7 +294,8 @@ const FilterConfiguration: FC<Props> = ({
 
                 {!isTemporary &&
                     isFilterModified &&
-                    selectedTabId === FilterTabs.SETTINGS && (
+                    selectedTabId === FilterTabs.SETTINGS &&
+                    !isEditMode && (
                         <Tooltip
                             label="Reset to original value"
                             position="left"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -113,12 +113,8 @@ const FilterConfiguration: FC<Props> = ({
         }
     };
 
-    console.log({ originalFilterRule });
-
     const handleRevert = useCallback(() => {
         if (!originalFilterRule) return;
-
-        console.log({ draftFilterRule, originalFilterRule });
 
         setDraftFilterRule(
             draftFilterRule


### PR DESCRIPTION
Closes: #6707 
