### PR TITLE
feat: add organization_id attribute to schedule worker task

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "ts-jest": "^29.0.0",
         "ts-node-dev": "^2.0.0",
         "tslib": "^2.6.0",
-        "typescript": "^5.1.6"
+        "typescript": "^4.9.5"
     },
     "scripts": {
         "common-dev": "yarn workspace @lightdash/common dev",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "ts-jest": "^29.0.0",
         "ts-node-dev": "^2.0.0",
         "tslib": "^2.6.0",
-        "typescript": "^4.8.3"
+        "typescript": "^5.1.6"
     },
     "scripts": {
         "common-dev": "yarn workspace @lightdash/common dev",

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -50,6 +50,7 @@ const traceTask = (taskName: string, task: Task): Task => {
             async (span) => {
                 const { job } = helpers;
 
+                // TODO: have clearer types for payload
                 let organizationUuidAttribute = {};
                 if (
                     typeof payload === 'object' &&

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -2,13 +2,13 @@ import { SchedulerJobStatus } from '@lightdash/common';
 import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
 import { getSchedule, stringToArray } from 'cron-converter';
 import {
-    Logger as GraphileLogger,
     JobHelpers,
+    Logger as GraphileLogger,
+    parseCronItems,
+    run as runGraphileWorker,
     Runner,
     Task,
     TaskList,
-    parseCronItems,
-    run as runGraphileWorker,
 } from 'graphile-worker';
 import moment from 'moment';
 import { schedulerClient } from '../clients/clients';

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -11,6 +11,7 @@ import {
     TaskList,
 } from 'graphile-worker';
 import moment from 'moment';
+import { isStringObject } from 'util/types';
 import { schedulerClient } from '../clients/clients';
 import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
@@ -49,12 +50,25 @@ const traceTask = (taskName: string, task: Task): Task => {
             `worker.task.${taskName}`,
             async (span) => {
                 const { job } = helpers;
+
+                let organizationUuidAttribute = {};
+                if (
+                    typeof payload === 'object' &&
+                    payload !== null &&
+                    'organizationUuid' in payload
+                ) {
+                    organizationUuidAttribute = {
+                        'worker.task.organization_id': payload.organizationUuid,
+                    };
+                }
+
                 span.setAttributes({
                     'worker.task.name': taskName,
                     'worker.job.id': job.id,
                     'worker.job.task_identifier': job.task_identifier,
                     'worker.job.attempts': job.attempts,
                     'worker.job.max_attempts': job.max_attempts,
+                    ...organizationUuidAttribute,
                 });
                 if (job.locked_at) {
                     span.setAttribute(

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -2,16 +2,15 @@ import { SchedulerJobStatus } from '@lightdash/common';
 import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
 import { getSchedule, stringToArray } from 'cron-converter';
 import {
-    JobHelpers,
     Logger as GraphileLogger,
-    parseCronItems,
-    run as runGraphileWorker,
+    JobHelpers,
     Runner,
     Task,
     TaskList,
+    parseCronItems,
+    run as runGraphileWorker,
 } from 'graphile-worker';
 import moment from 'moment';
-import { isStringObject } from 'util/types';
 import { schedulerClient } from '../clients/clients';
 import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -491,6 +491,7 @@ export class ProjectService {
 
         if (savedProject.dbtConnection.type !== DbtProjectType.NONE) {
             await schedulerClient.testAndCompileProject({
+                organizationUuid: user.organizationUuid,
                 createdByUserUuid: user.userUuid,
                 projectUuid,
                 requestMethod: method,
@@ -1528,6 +1529,7 @@ export class ProjectService {
 
         await schedulerClient.compileProject({
             createdByUserUuid: user.userUuid,
+            organizationUuid,
             projectUuid,
             requestMethod,
             jobUuid: job.jobUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -278,6 +278,7 @@ export type ApiCsvUrlResponse = {
 
 export type CompileProjectPayload = {
     createdByUserUuid: string;
+    organizationUuid: string;
     projectUuid: string;
     requestMethod: string;
     jobUuid: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18463,10 +18463,10 @@ typescript@^4.0.0, typescript@^4.9.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^4.8.3:
-  version "4.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz"
-  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
+typescript@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 typescript@~4.6.0:
   version "4.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18460,13 +18460,8 @@ typescript@^3.9.7:
 
 typescript@^4.0.0, typescript@^4.9.5:
   version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 typescript@~4.6.0:
   version "4.6.4"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

When running tasks on the scheduler, if there is an `organizationUuid`, pass it and set it as a span attribute.

This increases our traceability when looking at grafana logs


NOTE: upgraded `TypeScript` because narrowing down of types on an `unknown` object wasn't working on the type checker. This was fixed after 4.9  ref: https://www.reddit.com/r/typescript/comments/yv9tnk/narrowing_unknown_in_type_guard/iwew6ru/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button