### PR TITLE
fix: any-value filters could not be reset

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -133,7 +133,7 @@ export const getFilterTypeFromItem = (item: FilterableItem): FilterType => {
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     field: FilterableField,
     filterRule: T,
-    values?: any[],
+    values?: any[] | null,
 ): T => {
     const filterType = getFilterTypeFromItem(field);
     const filterRuleDefaults: Partial<FilterRule> = {};
@@ -141,7 +141,8 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     if (
         ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
             filterRule.operator,
-        )
+        ) &&
+        values !== null
     ) {
         switch (filterType) {
             case FilterType.DATE: {
@@ -294,18 +295,23 @@ export const applyDefaultTileTargets = (
 export const createDashboardFilterRuleFromField = (
     field: FilterableField,
     availableTileFilters: Record<string, FilterableField[] | undefined>,
+    includeDefaultValue: boolean,
 ): DashboardFilterRule =>
-    getFilterRuleWithDefaultValue(field, {
-        id: uuidv4(),
-        operator: FilterOperator.EQUALS,
-        target: {
-            fieldId: fieldId(field),
-            tableName: field.table,
+    getFilterRuleWithDefaultValue(
+        field,
+        {
+            id: uuidv4(),
+            operator: FilterOperator.EQUALS,
+            target: {
+                fieldId: fieldId(field),
+                tableName: field.table,
+            },
+            tileTargets: getDefaultTileTargets(field, availableTileFilters),
+            disabled: true,
+            label: undefined,
         },
-        tileTargets: getDefaultTileTargets(field, availableTileFilters),
-        disabled: true,
-        label: undefined,
-    });
+        includeDefaultValue ? [] : null,
+    );
 
 type AddFilterRuleArgs = {
     filters: Filters;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -39,17 +39,6 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         [filterType],
     );
 
-    useEffect(() => {
-        if (!isEditMode && isFilterDisabled) {
-            onChangeFilterRule({
-                ...filterRule,
-                disabled: false,
-                values: undefined,
-                settings: undefined,
-            });
-        }
-    }, [isEditMode, isFilterDisabled, onChangeFilterRule, filterRule]);
-
     // Set default label when using revert (undo) button
     useEffect(() => {
         if (filterLabel !== '') {
@@ -66,14 +55,27 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         );
     };
 
+    const showValueInput = useMemo(() => {
+        // Always show the input in view mode
+        if (!isEditMode) {
+            return true;
+        }
+        // In edit mode, only don't show input when disabled
+        if (isFilterDisabled) {
+            return false;
+        }
+        return true;
+    }, [isFilterDisabled, isEditMode]);
+
     const showAnyValueDisabledInput = useMemo(
         () =>
             isFilterDisabled &&
+            isEditMode &&
             ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
                 filterRule.operator,
             ),
 
-        [filterRule.operator, isFilterDisabled],
+        [filterRule.operator, isFilterDisabled, isEditMode],
     );
 
     return (
@@ -157,7 +159,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         })}
                     />
                 )}
-                {!isFilterDisabled && (
+                {showValueInput && (
                     <filterConfig.inputs
                         popoverProps={popoverProps}
                         filterType={filterType}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -125,6 +125,7 @@ const FilterConfiguration: FC<Props> = ({
                 createDashboardFilterRuleFromField(
                     newField,
                     availableTileFilters,
+                    !isEditMode,
                 ),
             );
             setSelectedField(newField);
@@ -134,15 +135,15 @@ const FilterConfiguration: FC<Props> = ({
     const handleRevert = useCallback(() => {
         if (!originalFilterRule) return;
 
-        setDraftFilterRule(
-            draftFilterRule
+        setDraftFilterRule((oldDraftFilterRule) => {
+            return oldDraftFilterRule
                 ? {
-                      ...draftFilterRule,
+                      ...oldDraftFilterRule,
                       ...getFilterRuleRevertableObject(originalFilterRule),
                   }
-                : undefined,
-        );
-    }, [originalFilterRule, setDraftFilterRule, draftFilterRule]);
+                : undefined;
+        });
+    }, [originalFilterRule, setDraftFilterRule]);
 
     const handleChangeFilterRule = useCallback(
         (newFilterRule: DashboardFilterRule) => {
@@ -301,7 +302,6 @@ const FilterConfiguration: FC<Props> = ({
                                     activeField={selectedField}
                                     onChange={handleChangeField}
                                     inputProps={{
-                                        // TODO: Remove once this component is migrated to Mantine
                                         style: {
                                             borderRadius: '4px',
                                             borderWidth: '1px',

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -51,6 +51,7 @@ export const getFilterRuleRevertableObject = (
     filterRule: DashboardFilterRule,
 ) => {
     return {
+        disabled: filterRule.disabled,
         values: filterRule.values,
         operator: filterRule.operator,
         settings: filterRule.settings,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -42,7 +42,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
-        disabled: rule.disabled,
+        disabled: rule.disabled && !rule.values,
     });
 
     switch (rule.operator) {
@@ -147,7 +147,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         defaultTimezone="UTC"
                         showTimezoneSelect={false}
                         value={
-                            rule.values
+                            rule.values && rule.values.length > 0
                                 ? new Date(rule.values[0]).toString()
                                 : null
                         }
@@ -185,7 +185,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     disabled={disabled}
                     fill
                     value={
-                        rule.values
+                        rule.values && rule.values.length > 0
                             ? formatDate(rule.values?.[0], undefined, false)
                             : null
                     }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -40,7 +40,9 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
-        disabled: isFilterRule(rule) ? rule.disabled : undefined,
+        disabled: isFilterRule(rule)
+            ? rule.disabled && !rule.values
+            : undefined,
     });
 
     switch (rule.operator) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6686 

### Description:

We had a problem where filters with 'any' value could not be reset. This patch does a few different things, all necessary to get the filters resetting. Here's a little breakdown of the main things this is doing and where:
- Add 'disabled' to the revertable properties (`/utils/index.ts`)
- Make it possible to initialize a rule with no default value (`filters.ts`). 
- Remove the useEffect that was overwriting the filterRule passes into it and switch to calculating whether to show the input based on props (`FilterSettings.tsx`)
- Fix usage of useState setter so it properly bases the new state on the old one (`FilterConfiguration/index.tsx`)
- Change inputs to show the right message when there is no value.


