### PR TITLE
fix: improve saving state on dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,7 +1,7 @@
 import { Menu, MenuDivider, PopoverPosition } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
-import { Button, Group, Text, Tooltip } from '@mantine/core';
+import { Button, ButtonProps, Group, Text, Tooltip } from '@mantine/core';
 import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
@@ -13,9 +13,13 @@ import { TileAddModal } from './TileForms/TileAddModal';
 type Props = {
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     popoverPosition?: PopoverPosition;
-};
+} & Pick<ButtonProps, 'disabled'>;
 
-const AddTileButton: FC<Props> = ({ onAddTiles, popoverPosition }) => {
+const AddTileButton: FC<Props> = ({
+    onAddTiles,
+    popoverPosition,
+    disabled,
+}) => {
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
@@ -126,6 +130,7 @@ const AddTileButton: FC<Props> = ({ onAddTiles, popoverPosition }) => {
                 <Button
                     size="xs"
                     variant="default"
+                    disabled={disabled}
                     leftIcon={<MantineIcon icon={IconPlus} />}
                 >
                     Add tile

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -174,7 +174,10 @@ const DashboardHeader = ({
             </PageTitleAndDetailsContainer>
             {userCanManageDashboard && isEditMode ? (
                 <PageActionsContainer>
-                    <AddTileButton onAddTiles={onAddTiles} />
+                    <AddTileButton
+                        onAddTiles={onAddTiles}
+                        disabled={isSaving}
+                    />
                     <Tooltip
                         fz="xs"
                         withinPortal
@@ -185,7 +188,8 @@ const DashboardHeader = ({
                         <Box>
                             <Button
                                 size="xs"
-                                disabled={!hasDashboardChanged || isSaving}
+                                disabled={!hasDashboardChanged}
+                                loading={isSaving}
                                 onClick={onSaveDashboard}
                             >
                                 Save


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Found this while working on #6798;

Disabled `add tile` button when dashboard is saving
Add loading state when dashboard is saving 


https://github.com/lightdash/lightdash/assets/7611706/5deb0d0e-abab-4f8a-b520-0d99e72ff01f

