### PR TITLE
feat: improve render filter list performance

### DIFF
--- a/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldAutoComplete.tsx
@@ -15,7 +15,7 @@ import {
     renderFilterItem,
     renderFilterItemWithoutTableName,
 } from './renderFilterItem';
-import renderFilterList from './renderFilterList';
+import RenderFilterList from './renderFilterList';
 
 const AutocompleteMaxHeight = createGlobalStyle`
   .autocomplete-max-height {
@@ -117,7 +117,12 @@ const FieldAutoComplete = <T extends Field | TableCalculation>({
                                 description: explore.description,
                                 name: explore.name,
                             })) ?? [];
-                        return renderFilterList(itemListRendererProps, tables);
+                        return (
+                            <RenderFilterList
+                                {...itemListRendererProps}
+                                tables={tables}
+                            />
+                        );
                     },
                 })}
                 activeItem={activeField}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to #6798 

### Description:

Users have reported that when they click to find a field to filter a dashboard by, it takes more than 1s to get the list of grouped fields. 

This is because of an expensive method to group items by their table to then provide a better experience to our users. 

This PR covers the following: 
* converting tables.find((t) => t.name === item.table to a JS `Map` which ensures lookup is O(n), instead of O(n^2)
* memoization of `groupedItems` with React's own `useMemo` and `useCallback`
* Creation of `useGroupedItems` hook - only specific to this component, so it stays on same file

Screen-recording: 

https://github.com/lightdash/lightdash/assets/7611706/b9a634a6-40d0-4cfd-90bb-fc7e75e35423

