### PR TITLE
fix: remove extra quotes on rotate transform

### DIFF
--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -100,7 +100,7 @@ export const ChartIcon: FC<{ chartType: ChartKind | undefined }> = ({
         icon={getChartIcon(chartType)}
         color="blue.8"
         transform={
-            chartType === ChartKind.HORIZONTAL_BAR ? `"rotate(90)"` : undefined
+            chartType === ChartKind.HORIZONTAL_BAR ? 'rotate(90)' : undefined
         }
     />
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

remove extra quotes when transform-rotating `bar chart` icon for horizontal bar charts

screenshot
<img width="452" alt="Screenshot 2023-08-21 at 10 38 52" src="https://github.com/lightdash/lightdash/assets/7611706/3c1eb3a9-f25c-4803-9923-ca7493c8ddb7">
