### PR TITLE
chore: remove deprecated github action

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -7,26 +7,16 @@ env:
 jobs:
   prepare-preview:
     # Only trigger for correct environment and status
-    if: ${{ github.event.deployment_status.state == 'success' && (contains(github.event.deployment.environment, '- lightdash PR ') || contains(github.event.deployment.environment, '- lightdash-')) }}
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
-      url: ${{ steps.deployment-url.outputs.url }}
+      url: ${{ github.event.deployment_status.environment_url }}
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github.event) }}
+      - name: is render ready
+        if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null }}
         run: |
-          echo "$GITHUB_CONTEXT"
-      - name: Get PR number
-        id: regex
-        uses: AsasInnab/regex-action@v1
-        with:
-          regex_pattern: '[0-9]+$'
-          regex_flags: 'gm'
-          search_string: ${{github.event.deployment.environment}}
-      - name: Get deployment url
-        id: deployment-url
-        run: echo "url=https://lightdash-pr-${{steps.regex.outputs.first_match}}.onrender.com" >> "$GITHUB_OUTPUT"
+          echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }}"
+          exit 1
 
   cli-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -13,9 +13,9 @@ jobs:
       url: ${{ github.event.deployment_status.environment_url }}
     steps:
       - name: is render ready
-        if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null }}
+        if: ${{ !(github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null) }}
         run: |
-          echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }}"
+          echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }} ${{ github.event.deployment_status.environment_url }}"
           exit 1
 
   cli-tests:

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -12,6 +12,11 @@ jobs:
     outputs:
       url: ${{ steps.deployment-url.outputs.url }}
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github.event) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
       - name: Get PR number
         id: regex
         uses: AsasInnab/regex-action@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,9 +9,9 @@ jobs:
       url: ${{ github.event.deployment_status.environment_url }}
     steps:
       - name: is render ready
-        if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null }}
+        if: ${{ !(github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null) }}
         run: |
-          echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }}"
+          echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }} ${{ github.event.deployment_status.environment_url }}"
           exit 1
 
   app-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,24 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     outputs:
-      url: ${{ steps.deployment-url.outputs.url }}
+      url: ${{ github.event.deployment_status.environment_url }}
     steps:
       - name: is render ready
-        # This works assuming "Lightdash PR" is always the last deployment_status to be "success"
-        if: ${{ !( github.event.deployment_status.state == 'success' && (contains(github.event.deployment.environment, '- lightdash PR ') || contains(github.event.deployment.environment, '- lightdash-')) ) }}
+        if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != null }}
         run: |
           echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }}"
           exit 1
-      - name: Get PR number
-        id: regex
-        uses: AsasInnab/regex-action@v1
-        with:
-          regex_pattern: '[0-9]+$'
-          regex_flags: 'gm'
-          search_string: ${{github.event.deployment.environment}}
-      - name: Get deployment url
-        id: deployment-url
-        run: echo "url=https://lightdash-pr-${{steps.regex.outputs.first_match}}.onrender.com" >> "$GITHUB_OUTPUT"
 
   app-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Github action `AsasInnab/regex-action@v1` is no longer maintained and will soon stop working. 

![Screenshot 2023-08-21 at 17 33 41](https://github.com/lightdash/lightdash/assets/9117144/e124086c-c65d-4be8-8cf5-eefa687cb29c)

The deployment url is already available in the github event so we don't need a regex.
