### PR TITLE
fix: move dashboard filter default value switch

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -97,47 +97,6 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         value={filterLabel}
                     />
                 )}
-                {isEditMode && (
-                    <Tooltip
-                        withinPortal
-                        position="right"
-                        label={
-                            isFilterDisabled
-                                ? 'Toggle on to set a default filter value'
-                                : 'Toggle off to leave the filter value empty, allowing users to populate it in view mode'
-                        }
-                        openDelay={500}
-                    >
-                        <div style={{ width: 'max-content' }}>
-                            <Switch
-                                label={
-                                    <Text size="xs" mt="two" fw={500}>
-                                        Default value
-                                    </Text>
-                                }
-                                labelPosition="left"
-                                checked={!isFilterDisabled}
-                                onChange={(e) => {
-                                    const newFilter: DashboardFilterRule = {
-                                        ...filterRule,
-                                        disabled: !e.currentTarget.checked,
-                                    };
-
-                                    onChangeFilterRule(
-                                        e.currentTarget.checked
-                                            ? newFilter
-                                            : getFilterRuleWithDefaultValue(
-                                                  field,
-                                                  newFilter,
-                                                  null,
-                                              ),
-                                    );
-                                }}
-                            />
-                        </div>
-                    </Tooltip>
-                )}
-
                 {isCreatingNew && !isEditMode && (
                     <Text size="xs" fw={500}>
                         Value
@@ -172,6 +131,46 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                             )
                         }
                     />
+                )}
+                {isEditMode && (
+                    <Tooltip
+                        withinPortal
+                        position="right"
+                        label={
+                            isFilterDisabled
+                                ? 'Toggle on to set a default filter value'
+                                : 'Toggle off to leave the filter value empty, allowing users to populate it in view mode'
+                        }
+                        openDelay={500}
+                    >
+                        <div style={{ width: 'max-content' }}>
+                            <Switch
+                                label={
+                                    <Text size="xs" mt="two" fw={500}>
+                                        Provide default value
+                                    </Text>
+                                }
+                                labelPosition="right"
+                                checked={!isFilterDisabled}
+                                onChange={(e) => {
+                                    const newFilter: DashboardFilterRule = {
+                                        ...filterRule,
+                                        disabled: !e.currentTarget.checked,
+                                    };
+
+                                    onChangeFilterRule(
+                                        e.currentTarget.checked
+                                            ? newFilter
+                                            : getFilterRuleWithDefaultValue(
+                                                  field,
+                                                  newFilter,
+                                                  null,
+                                              ),
+                                    );
+                                }}
+                            />
+                        </div>
+                    </Tooltip>
                 )}
             </Stack>
         </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6761 

### Description:

Move the default value switch below the filters. And change copy. 
