### PR TITLE
feat: add searchable dashboard list when adding chart to dashboard

### DIFF
--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -217,6 +217,13 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                             d.spaceUuid === currentSpace?.uuid,
                                     )?.uuid
                                 }
+                                searchable
+                                nothingFound="No matching dashboards found"
+                                filter={(value, dashboard) =>
+                                    !!dashboard.label
+                                        ?.toLowerCase()
+                                        .includes(value.toLowerCase().trim())
+                                }
                                 withinPortal
                                 required
                                 {...form.getInputProps('dashboardUuid')}


### PR DESCRIPTION
Closes: #6781 

### Description:

As part of this PR, have made the dashboard list searchable when adding a chart to a dashboard.
Have attached video for reference. 

Please let me know in case of any feedback.

https://github.com/lightdash/lightdash/assets/20976813/dc8f072d-4d02-4913-8652-9993a91af3c3

