### PR TITLE
fix: loading state for dashboard filters

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -1,4 +1,5 @@
 import { FieldId, fieldId, FilterableField } from '@lightdash/common';
+import { Group, Skeleton } from '@mantine/core';
 import { FC } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import Filter from '../Filter';
@@ -14,6 +15,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
         updateDimensionDashboardFilter,
         removeDimensionDashboardFilter,
         allFilterableFields,
+        isLoadingDashboardFilters,
     } = useDashboardContext();
 
     if (!allFilterableFields) return null;
@@ -22,7 +24,15 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
         Record<FieldId, FilterableField>
     >((acc, field) => ({ ...acc, [fieldId(field)]: field }), {});
 
-    return (
+    return isLoadingDashboardFilters ? (
+        <Group spacing="xs" ml="xs">
+            <Skeleton h={30} w={100} radius={4} />
+            <Skeleton h={30} w={100} radius={4} />
+            <Skeleton h={30} w={100} radius={4} />
+            <Skeleton h={30} w={100} radius={4} />
+            <Skeleton h={30} w={100} radius={4} />
+        </Group>
+    ) : (
         <>
             {dashboardFilters.dimensions
                 .filter((item) => !!fieldMap[item.target.fieldId])

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -18,21 +18,25 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
         isLoadingDashboardFilters,
     } = useDashboardContext();
 
+    if (isLoadingDashboardFilters) {
+        return (
+            <Group spacing="xs" ml="xs">
+                <Skeleton h={30} w={100} radius={4} />
+                <Skeleton h={30} w={100} radius={4} />
+                <Skeleton h={30} w={100} radius={4} />
+                <Skeleton h={30} w={100} radius={4} />
+                <Skeleton h={30} w={100} radius={4} />
+            </Group>
+        );
+    }
+
     if (!allFilterableFields) return null;
 
-    const fieldMap = allFilterableFields.reduce<
+    const fieldMap = allFilterableFields?.reduce<
         Record<FieldId, FilterableField>
     >((acc, field) => ({ ...acc, [fieldId(field)]: field }), {});
 
-    return isLoadingDashboardFilters ? (
-        <Group spacing="xs" ml="xs">
-            <Skeleton h={30} w={100} radius={4} />
-            <Skeleton h={30} w={100} radius={4} />
-            <Skeleton h={30} w={100} radius={4} />
-            <Skeleton h={30} w={100} radius={4} />
-            <Skeleton h={30} w={100} radius={4} />
-        </Group>
-    ) : (
+    return (
         <>
             {dashboardFilters.dimensions
                 .filter((item) => !!fieldMap[item.target.fieldId])

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -1,7 +1,6 @@
 import {
     applyDefaultTileTargets,
     DashboardFilterRule,
-    DashboardTileTypes,
     FilterableField,
 } from '@lightdash/common';
 import { Button, CloseButton, Popover, Text, Tooltip } from '@mantine/core';
@@ -64,12 +63,6 @@ const Filter: FC<Props> = ({
         (item) => filterRule && item.id === filterRule.id,
     );
 
-    //Only used by Add filters
-    const hasChartTiles =
-        dashboardTiles.filter(
-            (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
-        ).length >= 1;
-
     const filterRuleLabels =
         filterRule && field
             ? getConditionalRuleLabel(filterRule, field)
@@ -95,8 +88,6 @@ const Filter: FC<Props> = ({
         },
         [isCreatingNew, onSave, onUpdate, handleClose],
     );
-
-    if (!hasChartTiles) return null;
 
     return (
         <Popover
@@ -138,7 +129,7 @@ const Filter: FC<Props> = ({
                             leftIcon={
                                 <MantineIcon color="blue" icon={IconFilter} />
                             }
-                            disabled={!hasChartTiles}
+                            disabled={!allFilterableFields}
                             loading={isLoadingDashboardFilters}
                             onClick={togglePopover}
                         >

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -89,6 +89,9 @@ const Filter: FC<Props> = ({
         [isCreatingNew, onSave, onUpdate, handleClose],
     );
 
+    const isPopoverDisabled =
+        !filterableFieldsByTileUuid || !allFilterableFields;
+
     return (
         <Popover
             position="bottom-start"
@@ -97,7 +100,7 @@ const Filter: FC<Props> = ({
             closeOnEscape={!isSubPopoverOpen}
             closeOnClickOutside={!isSubPopoverOpen}
             onClose={handleClose}
-            disabled={isLoadingDashboardFilters}
+            disabled={isPopoverDisabled}
             transitionProps={{
                 transition: 'pop',
             }}

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -42,6 +42,7 @@ const Filter: FC<Props> = ({
         dashboardTiles,
         allFilterableFields,
         filterableFieldsByTileUuid,
+        isLoadingDashboardFilters,
     } = useDashboardContext();
 
     const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
@@ -140,6 +141,7 @@ const Filter: FC<Props> = ({
                                 <MantineIcon color="blue" icon={IconFilter} />
                             }
                             disabled={!hasChartTiles}
+                            loading={isLoadingDashboardFilters}
                             onClick={togglePopover}
                         >
                             Add filter

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -96,9 +96,7 @@ const Filter: FC<Props> = ({
         [isCreatingNew, onSave, onUpdate, handleClose],
     );
 
-    if (!filterableFieldsByTileUuid || !allFilterableFields) {
-        return null;
-    }
+    if (!hasChartTiles) return null;
 
     return (
         <Popover
@@ -108,7 +106,7 @@ const Filter: FC<Props> = ({
             closeOnEscape={!isSubPopoverOpen}
             closeOnClickOutside={!isSubPopoverOpen}
             onClose={handleClose}
-            disabled={!hasChartTiles}
+            disabled={isLoadingDashboardFilters}
             transitionProps={{
                 transition: 'pop',
             }}
@@ -166,7 +164,6 @@ const Filter: FC<Props> = ({
                         onClick={togglePopover}
                     >
                         <Text fz="xs">
-                            {' '}
                             <Tooltip
                                 withinPortal
                                 position="top-start"
@@ -221,25 +218,27 @@ const Filter: FC<Props> = ({
             </Popover.Target>
 
             <Popover.Dropdown ml={5}>
-                <FilterConfiguration
-                    isCreatingNew={isCreatingNew}
-                    isEditMode={isEditMode}
-                    isTemporary={isTemporary}
-                    field={field}
-                    fields={allFilterableFields || []}
-                    tiles={dashboardTiles}
-                    originalFilterRule={originalFilterRule}
-                    availableTileFilters={filterableFieldsByTileUuid}
-                    defaultFilterRule={defaultFilterRule}
-                    onSave={handelSaveChanges}
-                    // FIXME: remove this once we migrate off of Blueprint
-                    popoverProps={{
-                        onOpened: () => openSubPopover(),
-                        onOpening: () => openSubPopover(),
-                        onClose: () => closeSubPopover(),
-                        onClosing: () => closeSubPopover(),
-                    }}
-                />
+                {filterableFieldsByTileUuid && (
+                    <FilterConfiguration
+                        isCreatingNew={isCreatingNew}
+                        isEditMode={isEditMode}
+                        isTemporary={isTemporary}
+                        field={field}
+                        fields={allFilterableFields || []}
+                        tiles={dashboardTiles}
+                        originalFilterRule={originalFilterRule}
+                        availableTileFilters={filterableFieldsByTileUuid}
+                        defaultFilterRule={defaultFilterRule}
+                        onSave={handelSaveChanges}
+                        // FIXME: remove this once we migrate off of Blueprint
+                        popoverProps={{
+                            onOpened: () => openSubPopover(),
+                            onOpening: () => openSubPopover(),
+                            onClose: () => closeSubPopover(),
+                            onClosing: () => closeSubPopover(),
+                        }}
+                    />
+                )}
             </Popover.Dropdown>
         </Popover>
     );

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -24,8 +24,13 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
     const project = useProject(projectUuid);
-    const { allFilters, fieldsWithSuggestions, addDimensionDashboardFilter } =
-        useDashboardContext();
+    const {
+        allFilters,
+        fieldsWithSuggestions,
+        addDimensionDashboardFilter,
+        hasChartTiles,
+    } = useDashboardContext();
+
     // Load data on filter mount
     useExplores(projectUuid);
 
@@ -45,6 +50,8 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
         });
         addDimensionDashboardFilter(value, !isEditMode);
     };
+
+    if (!hasChartTiles) return null;
 
     return (
         // TODO is this provider necessary?

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -6,6 +6,7 @@ import {
     DashboardAvailableFilters,
     DashboardFilterRule,
     DashboardFilters,
+    DashboardTileTypes,
     fieldId,
     FilterableField,
     isDashboardChartTileType,
@@ -71,6 +72,7 @@ type DashboardContext = {
     allFilterableFields: FilterableField[] | undefined;
     filterableFieldsBySavedQueryUuid: DashboardAvailableFilters | undefined;
     filterableFieldsByTileUuid: DashboardAvailableFilters | undefined;
+    hasChartTiles: boolean;
 };
 
 const Context = createContext<DashboardContext | undefined>(undefined);
@@ -331,6 +333,14 @@ export const DashboardProvider: React.FC = ({ children }) => {
         };
     }, [dashboardFilters, dashboardTemporaryFilters]);
 
+    const hasChartTiles = useMemo(
+        () =>
+            dashboardTiles.filter(
+                (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+            ).length >= 1,
+        [dashboardTiles],
+    );
+
     const value = {
         dashboard,
         dashboardError,
@@ -355,6 +365,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         isLoadingDashboardFilters,
         filterableFieldsByTileUuid,
         allFilters,
+        hasChartTiles,
     };
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -45,6 +45,7 @@ type DashboardContext = {
     dashboardFilters: DashboardFilters;
     dashboardTemporaryFilters: DashboardFilters;
     allFilters: DashboardFilters;
+    isLoadingDashboardFilters: boolean;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     setDashboardTemporaryFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (
@@ -93,8 +94,10 @@ export const DashboardProvider: React.FC = ({ children }) => {
             .filter((uuid): uuid is string => !!uuid);
     }, [dashboardTiles]);
 
-    const { isLoading, data: filterableFieldsBySavedQueryUuid } =
-        useDashboardsAvailableFilters(tileSavedChartUuids);
+    const {
+        isLoading: isLoadingDashboardFilters,
+        data: filterableFieldsBySavedQueryUuid,
+    } = useDashboardsAvailableFilters(tileSavedChartUuids);
 
     const filterableFieldsByTileUuid = useMemo(() => {
         if (!dashboard || !dashboardTiles || !filterableFieldsBySavedQueryUuid)
@@ -115,7 +118,8 @@ export const DashboardProvider: React.FC = ({ children }) => {
     }, [dashboard, dashboardTiles, filterableFieldsBySavedQueryUuid]);
 
     const allFilterableFields = useMemo(() => {
-        if (isLoading || !filterableFieldsBySavedQueryUuid) return;
+        if (isLoadingDashboardFilters || !filterableFieldsBySavedQueryUuid)
+            return;
 
         const allFilters = Object.values(
             filterableFieldsBySavedQueryUuid,
@@ -123,7 +127,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         if (allFilters.length === 0) return;
 
         return uniqBy(allFilters, (f) => fieldId(f));
-    }, [isLoading, filterableFieldsBySavedQueryUuid]);
+    }, [isLoadingDashboardFilters, filterableFieldsBySavedQueryUuid]);
 
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
@@ -348,6 +352,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         addSuggestions,
         allFilterableFields,
         filterableFieldsBySavedQueryUuid,
+        isLoadingDashboardFilters,
         filterableFieldsByTileUuid,
         allFilters,
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6681

### Description:

Add loading state to the following: 
* `Add filter` button - should be in `loading` state if dashboard filters are loading
* Add `Skeleton`s to Dashboard filter pills list whilst dashboard filters are loading

Other improvements:
* Do not show anything related to Dashboard Filters if there are no chart tiles in dashboard (added `hasChartTiles` to DashboardContext)

Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/49453016-72c9-4419-9b38-f683669f4be0


