### PR TITLE
feat: remove footer from Dashboard page

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -451,7 +451,6 @@ const Dashboard: FC = () => {
             </Alert>
 
             <Page
-                withFooter
                 withPaddedContent
                 title={dashboard.name}
                 header={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Remove footer from Dashboard page.

`Home` is the only page with Footer.
