### PR TITLE
fix: format boolean values as true/false

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -404,7 +404,7 @@ describe('Formatting', () => {
                     { ...dimension, type: DimensionType.BOOLEAN },
                     true,
                 ),
-            ).toEqual('Yes');
+            ).toEqual('True');
             expect(
                 formatFieldValue(
                     {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -58,7 +58,9 @@ export const currencies = [
 ];
 
 export const formatBoolean = <T>(v: T) =>
-    ['True', 'true', 'yes', 'Yes', '1', 'T'].includes(`${v}`) ? 'Yes' : 'No';
+    ['True', 'true', 'yes', 'Yes', '1', 'T'].includes(`${v}`)
+        ? 'True'
+        : 'False';
 
 export const getDateFormat = (
     timeInterval: TimeFrames | undefined = TimeFrames.DAY,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6101

### Description:

Users were confused that boolean values in results were formatted as Yes/No. This changes booleans in tables and filters to be 'True' or 'False'. 

Before:
<img width="384" alt="Screenshot 2023-08-23 at 14 51 27" src="https://github.com/lightdash/lightdash/assets/1864179/1cc6b18b-c806-4ad0-bfb9-24f7efd74e75">

After:
<img width="394" alt="Screenshot 2023-08-23 at 14 50 32" src="https://github.com/lightdash/lightdash/assets/1864179/8fab0c60-4014-42f7-a124-5e996a115a95">

