### PR TITLE
Refactor/move usedownload to own file in api folder

### DIFF
--- a/packages/frontend/src/api/csv.ts
+++ b/packages/frontend/src/api/csv.ts
@@ -69,15 +69,15 @@ const getCsvFileUrl = async (
         });
 };
 
-export const pollCsvFileUrl = async ({ jobId }: ApiScheduledDownloadCsv) => {
-    return new Promise<string>((resolve, reject) => {
+export const pollCsvFileUrl = async ({ jobId }: ApiScheduledDownloadCsv) =>
+    new Promise<string>((resolve, reject) => {
         getCsvFileUrl(
             { jobId },
             (url) => resolve(url),
             (error) => reject(error),
         );
     });
-};
+
 export const downloadCsvFromSqlRunner = async ({
     projectUuid,
     sql,
@@ -86,10 +86,9 @@ export const downloadCsvFromSqlRunner = async ({
     projectUuid: string;
     sql: string;
     customLabels?: Record<string, string>;
-}) => {
-    return lightdashApi<ApiDownloadCsv>({
+}) =>
+    lightdashApi<ApiDownloadCsv>({
         url: `/projects/${projectUuid}/sqlRunner/downloadCsv`,
         method: 'POST',
         body: JSON.stringify({ sql, customLabels }),
     });
-};

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -34,12 +34,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Text } from '@mantine/core';
 import { IconFolders } from '@tabler/icons-react';
+import { downloadCsv } from '../../api/csv';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
 import useSavedQueryWithDashboardFilters from '../../hooks/dashboard/useSavedQueryWithDashboardFilters';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
 import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
 import useToaster from '../../hooks/toaster/useToaster';
-import { downloadCsv } from '../../hooks/useDownloadCsv';
 import { useExplore } from '../../hooks/useExplore';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useChartResults } from '../../hooks/useQueryResults';

--- a/packages/frontend/src/components/DownloadCsvButton/index.tsx
+++ b/packages/frontend/src/components/DownloadCsvButton/index.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@blueprintjs/core';
 import { ApiScheduledDownloadCsv } from '@lightdash/common';
 import { FC, memo } from 'react';
+import { pollCsvFileUrl } from '../../api/csv';
 import useToaster from '../../hooks/toaster/useToaster';
-import { pollCsvFileUrl } from '../../hooks/useDownloadCsv';
 
 type Props = {
     disabled: boolean;

--- a/packages/frontend/src/components/Explorer/ExportGsheets/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExportGsheets/index.tsx
@@ -5,10 +5,10 @@ import { useMutation } from 'react-query';
 import { Spinner } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 import { Button } from '@mantine/core';
+import { pollCsvFileUrl } from '../../../api/csv';
 import { useGdriveAccessToken } from '../../../hooks/gdrive/useGdrive';
 import useHealth from '../../../hooks/health/useHealth';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { pollCsvFileUrl } from '../../../hooks/useDownloadCsv';
 import { AppToaster } from '../../AppToaster';
 
 export type ExportGsheetProps = {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -3,8 +3,8 @@ import { Button, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { FC, memo, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { downloadCsv } from '../../../api/csv';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
-import { downloadCsv } from '../../../hooks/useDownloadCsv';
 import { useApp } from '../../../providers/AppProvider';
 import {
     ExplorerSection,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -2,9 +2,9 @@ import { NotFoundError } from '@lightdash/common';
 import { FC, memo, useCallback, useMemo, useState } from 'react';
 
 import { Space } from '@mantine/core';
+import { downloadCsv } from '../../../api/csv';
 import { EChartSeries } from '../../../hooks/echarts/useEcharts';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
-import { downloadCsv } from '../../../hooks/useDownloadCsv';
 import { useExplore } from '../../../hooks/useExplore';
 import {
     ExplorerSection,

--- a/packages/frontend/src/components/ExportCSV/index.tsx
+++ b/packages/frontend/src/components/ExportCSV/index.tsx
@@ -14,9 +14,9 @@ import { Classes } from '@blueprintjs/popover2';
 import { ApiScheduledDownloadCsv, ResultRow } from '@lightdash/common';
 import { FC, Fragment, memo, useState } from 'react';
 import { useMutation } from 'react-query';
+import { pollCsvFileUrl } from '../../api/csv';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
-import { pollCsvFileUrl } from '../../hooks/useDownloadCsv';
 import { AppToaster } from '../AppToaster';
 import { InputWrapper, LimitWarning, Title } from './ExportCSV.styles';
 

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -19,7 +19,7 @@ import {
 import { FC, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import { downloadCsv } from '../../hooks/useDownloadCsv';
+import { downloadCsv } from '../../api/csv';
 import { useExplore } from '../../hooks/useExplore';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useUnderlyingDataResults } from '../../hooks/useQueryResults';

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 
+import { downloadCsvFromSqlRunner } from '../api/csv';
 import { ChartDownloadMenu } from '../components/ChartDownload';
 import CollapsableCard from '../components/common/CollapsableCard';
 import MantineIcon from '../components/common/MantineIcon';
@@ -31,7 +32,6 @@ import RunSqlQueryButton from '../components/SqlRunner/RunSqlQueryButton';
 import SqlRunnerInput from '../components/SqlRunner/SqlRunnerInput';
 import SqlRunnerResultsTable from '../components/SqlRunner/SqlRunnerResultsTable';
 import { useProjectDbtCloudMetrics } from '../hooks/dbtCloud/useProjectDbtCloudMetrics';
-import { downloadCsvFromSqlRunner } from '../hooks/useDownloadCsv';
 import { useProjectCatalog } from '../hooks/useProjectCatalog';
 import {
     ProjectCatalogTreeNode,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

With the newly-proposed FE structure, we've agreed on moving API calls to their own folder. 

This tests the renaming (and moving) of `useDownloadCsv` to `api/csv.ts`


