### PR TITLE
fix: add an input for percentile in metrics

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -454,6 +454,7 @@ const models: TsoaRoute.Models = {
                     { dataType: 'enum', enums: [null] },
                 ],
             },
+            percentile: { dataType: 'double' },
         },
         additionalProperties: false,
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -469,6 +469,10 @@
                     "uuid": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "percentile": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "required": ["type", "sql", "table", "name"],
@@ -3969,7 +3973,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.753.0",
+        "version": "0.755.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -133,6 +133,7 @@ export interface Field {
     hidden: boolean;
     compact?: CompactOrAlias;
     round?: number;
+    percentile?: number;
     format?: Format;
     groupLabel?: string;
     urls?: FieldUrl[];

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -133,7 +133,6 @@ export interface Field {
     hidden: boolean;
     compact?: CompactOrAlias;
     round?: number;
-    percentile?: number;
     format?: Format;
     groupLabel?: string;
     urls?: FieldUrl[];

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -25,6 +25,7 @@ export interface AdditionalMetric {
     filters?: MetricFilterRule[];
     baseDimensionName?: string;
     uuid?: string | null;
+    percentile?: number;
 }
 
 export const isAdditionalMetric = (value: any): value is AdditionalMetric =>

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -151,8 +151,6 @@ export const CustomMetricModal = () => {
                 percentile,
             });
 
-            console.log(data);
-
             if (isEditing && isAdditionalMetric(item)) {
                 editAdditionalMetric(
                     {
@@ -218,6 +216,8 @@ export const CustomMetricModal = () => {
                     {customMetricType === MetricType.PERCENTILE && (
                         <NumberInput
                             w={100}
+                            max={100}
+                            min={0}
                             required
                             label="Percentile"
                             {...form.getInputProps('percentile')}

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -98,9 +98,7 @@ export const prepareCustomMetricData = ({
             : defaultRound;
 
     const percentile =
-        shouldCopyFormatting && dimension.percentile
-            ? dimension.percentile
-            : metricPercentile;
+        type === MetricType.PERCENTILE ? metricPercentile || 50 : undefined;
 
     const customMetricFilters: MetricFilterRule[] =
         customMetricFiltersWithIds.map(

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -63,6 +63,7 @@ export const prepareCustomMetricData = ({
     isEditingCustomMetric,
     item,
     exploreData,
+    percentile: metricPercentile,
 }: {
     dimension: Dimension | AdditionalMetric;
     type: MetricType;
@@ -71,6 +72,7 @@ export const prepareCustomMetricData = ({
     isEditingCustomMetric: boolean;
     item: Dimension | AdditionalMetric;
     exploreData?: Explore;
+    percentile?: number;
 }) => {
     const shouldCopyFormatting = [
         MetricType.PERCENTILE,
@@ -95,6 +97,11 @@ export const prepareCustomMetricData = ({
             ? { round: dimension.round }
             : defaultRound;
 
+    const percentile =
+        shouldCopyFormatting && dimension.percentile
+            ? dimension.percentile
+            : metricPercentile;
+
     const customMetricFilters: MetricFilterRule[] =
         customMetricFiltersWithIds.map(
             ({
@@ -111,6 +118,7 @@ export const prepareCustomMetricData = ({
     return {
         ...format,
         ...round,
+        percentile,
         ...compact,
         filters: customMetricFilters.length > 0 ? customMetricFilters : [],
         label: customMetricLabel,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6773 

### Description:

Custom metric for percentile didn't have anywhere to choose the percentile. This adds an input box to choose what you want the percentile to be and plumbs that through. 

I hadn't interacted with these things much -- if anyone sees something I didn't think of or should have done differently, I'm very open to changing this. 