### PR TITLE
fix: create dashboard cancel button doesnt work

### DIFF
--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -169,9 +169,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                 <DialogFooter
                     actions={
                         <>
-                            <Button onClick={() => modalProps.onClosed}>
-                                Cancel
-                            </Button>
+                            <Button onClick={handleClose}>Cancel</Button>
                             <Button
                                 disabled={!form.formState.isValid}
                                 loading={isCreatingDashboard || isCreatingSpace}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6870 

### Description:

The cancel button on the create dashboard dialog was a no-op. Fixed callback.
