### PR TITLE
fix: hide create chart in dashboard

### DIFF
--- a/packages/e2e/cypress/e2e/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/dashboard.cy.ts
@@ -75,20 +75,21 @@ describe('Dashboard', () => {
         cy.findByRole('dialog').get('.mantine-MultiSelect-input').click(); // Close dropdown
         cy.findByText('Add').click();
 
-        cy.findAllByText('Add tile').click({ multiple: true });
-        cy.findByText('New chart').click();
-        cy.findByText('You are creating this chart from within "Title"').should(
-            'exist',
-        );
-        cy.findByText('Orders').click();
-        cy.findByText('Status').click();
-        cy.findByText('Average order size').click();
-        cy.findByText('Save chart').click();
-        cy.get('input#chart-name').type('Average order size per status');
-        cy.findByText('Save').click();
-        cy.findByText(
-            'Success! Average order size per status was added to Title',
-        ).should('exist');
+        // TODO: re-enable this section with creating charts from dashboards
+        // cy.findAllByText('Add tile').click({ multiple: true });
+        // cy.findByText('New chart').click();
+        // cy.findByText('You are creating this chart from within "Title"').should(
+        //     'exist',
+        // );
+        // cy.findByText('Orders').click();
+        // cy.findByText('Status').click();
+        // cy.findByText('Average order size').click();
+        // cy.findByText('Save chart').click();
+        // cy.get('input#chart-name').type('Average order size per status');
+        // cy.findByText('Save').click();
+        // cy.findByText(
+        //     'Success! Average order size per status was added to Title',
+        // ).should('exist');
 
         cy.findAllByText('Add tile').click({ multiple: true });
         cy.findByText('Markdown').click();

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuDivider, PopoverPosition } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import { Button, ButtonProps, Group, Text, Tooltip } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
@@ -20,6 +21,10 @@ const AddTileButton: FC<Props> = ({
     popoverPosition,
     disabled,
 }) => {
+    const [isCreateChartInDashboardEnabled] = useLocalStorage({
+        key: 'enable-create-chart-in-dashboard',
+        defaultValue: false,
+    });
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
@@ -55,51 +60,61 @@ const AddTileButton: FC<Props> = ({
 
                         <MenuDivider />
 
-                        <MenuItem2
-                            icon="series-add"
-                            text={
-                                <Group spacing="xxs">
-                                    <Text>New chart</Text>
-                                    <Tooltip label="Charts generated from here are exclusive to this dashboard">
-                                        <MantineIcon
-                                            icon={IconInfoCircle}
-                                            color="gray.6"
-                                        />
-                                    </Tooltip>
-                                </Group>
-                            }
-                            onClick={() => {
-                                sessionStorage.setItem(
-                                    'fromDashboard',
-                                    dashboard?.name ?? '',
-                                );
-                                sessionStorage.setItem(
-                                    'dashboardUuid',
-                                    dashboard?.uuid ?? '',
-                                );
-                                sessionStorage.setItem(
-                                    'unsavedDashboardTiles',
-                                    JSON.stringify(dashboardTiles),
-                                );
-                                if (
-                                    dashboardFilters.dimensions.length > 0 ||
-                                    dashboardFilters.metrics.length > 0
-                                ) {
-                                    sessionStorage.setItem(
-                                        'unsavedDashboardFilters',
-                                        JSON.stringify(dashboardFilters),
-                                    );
-                                }
-                                sessionStorage.setItem(
-                                    'hasDashboardChanges',
-                                    JSON.stringify(
-                                        haveTilesChanged || haveFiltersChanged,
-                                    ),
-                                );
-                                history.push(`/projects/${projectUuid}/tables`);
-                            }}
-                        />
-                        <MenuDivider />
+                        {isCreateChartInDashboardEnabled && (
+                            <>
+                                <MenuItem2
+                                    icon="series-add"
+                                    text={
+                                        <Group spacing="xxs">
+                                            <Text>New chart</Text>
+                                            <Tooltip label="Charts generated from here are exclusive to this dashboard">
+                                                <MantineIcon
+                                                    icon={IconInfoCircle}
+                                                    color="gray.6"
+                                                />
+                                            </Tooltip>
+                                        </Group>
+                                    }
+                                    onClick={() => {
+                                        sessionStorage.setItem(
+                                            'fromDashboard',
+                                            dashboard?.name ?? '',
+                                        );
+                                        sessionStorage.setItem(
+                                            'dashboardUuid',
+                                            dashboard?.uuid ?? '',
+                                        );
+                                        sessionStorage.setItem(
+                                            'unsavedDashboardTiles',
+                                            JSON.stringify(dashboardTiles),
+                                        );
+                                        if (
+                                            dashboardFilters.dimensions.length >
+                                                0 ||
+                                            dashboardFilters.metrics.length > 0
+                                        ) {
+                                            sessionStorage.setItem(
+                                                'unsavedDashboardFilters',
+                                                JSON.stringify(
+                                                    dashboardFilters,
+                                                ),
+                                            );
+                                        }
+                                        sessionStorage.setItem(
+                                            'hasDashboardChanges',
+                                            JSON.stringify(
+                                                haveTilesChanged ||
+                                                    haveFiltersChanged,
+                                            ),
+                                        );
+                                        history.push(
+                                            `/projects/${projectUuid}/tables`,
+                                        );
+                                    }}
+                                />
+                                <MenuDivider />
+                            </>
+                        )}
 
                         <MenuItem2
                             icon="new-text-box"

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -21,6 +21,8 @@ const AddTileButton: FC<Props> = ({
     popoverPosition,
     disabled,
 }) => {
+    // TODO: this is a feature flag. Remove when create chart
+    // in dashboard is ready
     const [isCreateChartInDashboardEnabled] = useLocalStorage({
         key: 'enable-create-chart-in-dashboard',
         defaultValue: false,


### PR DESCRIPTION
### Description

We are having a lot of issues with create chart in dashboard. This hides the feature behind a feature flag for now. We will remove this when it's ready. 

To enable the feature in the mean time:

`localStorage.setItem('enable-create-chart-in-dashboard', true)`

