### PR TITLE
docs: removes spaces in front of attribute definition

### DIFF
--- a/docs/docs/references/user-attributes.mdx
+++ b/docs/docs/references/user-attributes.mdx
@@ -46,7 +46,7 @@ There are several places in Lightdash where you can customise behaviour based on
 
 When referencing user attributes in SQL you can use the following [SQL variables](./sql-variables.mdx):
 
-- `${ lightdash.attributes.my_attr_1 }` - a user attribute called `my_attr_1`
+- `${lightdash.attributes.my_attr_1 }` - a user attribute called `my_attr_1`
   - (optional) `ld` as an alias for `lightdash`
   - (optional) `attribute` or `attr` as an alias for `attributes`
 
@@ -54,14 +54,14 @@ When referencing user attributes in SQL you can use the following [SQL variables
 
 You can use user attributes to filter the rows returned by a query. This is useful if you want to restrict the data 
 based on the user's attributes. To reference a user attribute in your sql, use the special lightdash reference 
-`${ lightdash.attributes.<attribute_name> }`. For example, if you have a user attribute called `sales_region` you can
+`${lightdash.attributes.<attribute_name> }`. For example, if you have a user attribute called `sales_region` you can
 use it in your sql like this:
 
 ```yaml
 models:
   - name: my_model
     meta:
-      sql_filter: ${TABLE}.sales_region = ${ lightdash.attributes.sales_region }
+      sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region }
 ```
 
 ### 2. Filtering joins with `sql_on`
@@ -81,7 +81,7 @@ models:
         - join: joined
           sql_on: >
             ${base}.id = ${joined}.id
-            AND ${joined}.sales_region = ${ lightdash.attributes.sales_region }
+            AND ${joined}.sales_region = ${lightdash.attributes.sales_region }
 ```
 
 # Demo: filtering a chart based on user attributes


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes the attribute definition in the docs (adding a space before `lightdash` causes an error at query time)