### PR TITLE
style: decrease dashboard header height

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -121,7 +121,7 @@ const DashboardHeader = ({
     );
 
     return (
-        <PageHeader>
+        <PageHeader h="auto">
             <PageTitleAndDetailsContainer>
                 <PageTitleContainer className={Classes.TEXT_OVERFLOW_ELLIPSIS}>
                     <PageTitle>{dashboardName}</PageTitle>

--- a/packages/frontend/src/components/common/Page/PageHeader.tsx
+++ b/packages/frontend/src/components/common/Page/PageHeader.tsx
@@ -1,15 +1,15 @@
-import { Card, Flex } from '@mantine/core';
+import { Card, CardProps, Flex } from '@mantine/core';
 import { FC } from 'react';
 
 export const PAGE_HEADER_HEIGHT = 80;
 
-const PageHeader: FC = ({ children }) => (
+const PageHeader: FC<Pick<CardProps, 'h'>> = ({ h, children }) => (
     <Card
         component={Flex}
         justify="flex-end"
         align="center"
         pos="relative"
-        h={PAGE_HEADER_HEIGHT}
+        h={h ?? PAGE_HEADER_HEIGHT}
         px="lg"
         py="md"
         bg="white"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

decrease dashboard header height by passing `h` `auto` to page header

before:
<img width="1074" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/acdedb75-6ecc-4b16-b4f5-09df3046e465">


after
<img width="1075" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/a6a7605a-f4aa-44a6-8894-62be7dffb639">



