### PR TITLE
feat: add refresh button to dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -16,9 +16,10 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
         removeDimensionDashboardFilter,
         allFilterableFields,
         isLoadingDashboardFilters,
+        isFetchingDashboardFilters,
     } = useDashboardContext();
 
-    if (isLoadingDashboardFilters) {
+    if (isLoadingDashboardFilters || isFetchingDashboardFilters) {
         return (
             <Group spacing="xs" ml="xs">
                 <Skeleton h={30} w={100} radius={4} />

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -42,6 +42,7 @@ const Filter: FC<Props> = ({
         allFilterableFields,
         filterableFieldsByTileUuid,
         isLoadingDashboardFilters,
+        isFetchingDashboardFilters,
     } = useDashboardContext();
 
     const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
@@ -134,7 +135,10 @@ const Filter: FC<Props> = ({
                                 <MantineIcon color="blue" icon={IconFilter} />
                             }
                             disabled={!allFilterableFields}
-                            loading={isLoadingDashboardFilters}
+                            loading={
+                                isLoadingDashboardFilters ||
+                                isFetchingDashboardFilters
+                            }
                             onClick={togglePopover}
                         >
                             Add filter

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -236,6 +236,7 @@ const DashboardHeader = ({
                 <PageActionsContainer>
                     <Button
                         size="xs"
+                        disabled={isEditMode}
                         loading={isOneAtLeastFetching}
                         leftIcon={<MantineIcon icon={IconRefresh} />}
                         onClick={invalidateDashboardRelatedQueries}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -236,25 +236,29 @@ const DashboardHeader = ({
                 <PageActionsContainer>
                     <Button
                         size="xs"
-                        disabled={isEditMode}
                         loading={isOneAtLeastFetching}
                         leftIcon={<MantineIcon icon={IconRefresh} />}
                         onClick={invalidateDashboardRelatedQueries}
                     >
                         Refresh
                     </Button>
-                    <Button
-                        size="xs"
-                        variant="default"
-                        leftIcon={<MantineIcon icon={IconPencil} />}
-                        onClick={() => {
-                            history.replace(
-                                `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
-                            );
-                        }}
+
+                    <Tooltip
+                        label="Edit dashboard"
+                        withinPortal
+                        position="bottom"
                     >
-                        Edit dashboard
-                    </Button>
+                        <ActionIcon
+                            variant="default"
+                            onClick={() => {
+                                history.replace(
+                                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                                );
+                            }}
+                        >
+                            <MantineIcon icon={IconPencil} />
+                        </ActionIcon>
+                    </Tooltip>
 
                     <ShareLinkButton url={`${window.location.href}`} />
 

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -19,6 +19,7 @@ import {
     IconInfoCircle,
     IconPencil,
     IconPlus,
+    IconRefresh,
     IconSend,
     IconTrash,
     IconUpload,
@@ -26,6 +27,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
+import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
 import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
@@ -95,6 +97,8 @@ const DashboardHeader = ({
         projectUuid: string;
         dashboardUuid: string;
     }>();
+    const { isOneAtLeastFetching, invalidateDashboardRelatedQueries } =
+        useDashboardRefresh(dashboardUuid);
     const history = useHistory();
     const { track } = useTracking();
     const [isUpdating, setIsUpdating] = useState(false);
@@ -232,6 +236,15 @@ const DashboardHeader = ({
                 <PageActionsContainer>
                     <Button
                         size="xs"
+                        loading={isOneAtLeastFetching}
+                        leftIcon={<MantineIcon icon={IconRefresh} />}
+                        onClick={invalidateDashboardRelatedQueries}
+                    >
+                        Refresh
+                    </Button>
+                    <Button
+                        size="xs"
+                        variant="default"
                         leftIcon={<MantineIcon icon={IconPencil} />}
                         onClick={() => {
                             history.replace(

--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
@@ -4,6 +4,7 @@ export const useDashboardRefresh = (dashboardUuid: string) => {
     const queryClient = useQueryClient();
 
     const queriesToRefresh = [
+        { queryKey: ['queryResults'] },
         { queryKey: ['saved_query'] },
         { queryKey: ['saved_dashboard_query', dashboardUuid] },
         { queryKey: ['dashboards', 'availableFilters'] },

--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
@@ -1,0 +1,23 @@
+import { useQueries, useQueryClient } from 'react-query';
+
+export const useDashboardRefresh = (dashboardUuid: string) => {
+    const queryClient = useQueryClient();
+
+    const queriesToRefresh = [
+        { queryKey: ['saved_query'] },
+        { queryKey: ['saved_dashboard_query', dashboardUuid] },
+        { queryKey: ['dashboards', 'availableFilters'] },
+    ];
+
+    const queries = useQueries(queriesToRefresh);
+
+    const isOneAtLeastFetching = queries.some((query) => query.isFetching);
+
+    const invalidateDashboardRelatedQueries = () => {
+        queriesToRefresh.forEach((query) => {
+            queryClient.invalidateQueries(query.queryKey);
+        });
+    };
+
+    return { invalidateDashboardRelatedQueries, isOneAtLeastFetching };
+};

--- a/packages/frontend/src/hooks/dashboard/useSavedQueryWithDashboardFilters.ts
+++ b/packages/frontend/src/hooks/dashboard/useSavedQueryWithDashboardFilters.ts
@@ -14,6 +14,7 @@ const useSavedQueryWithDashboardFilters = (
     const {
         data: savedQuery,
         isLoading,
+        isFetching,
         isError,
     } = useSavedQuery({
         id: savedChartUuid || undefined,
@@ -43,11 +44,17 @@ const useSavedQueryWithDashboardFilters = (
         };
     }
 
-    if (isLoading || isLoadingExplore || !savedQuery || !explore) {
+    if (
+        isLoading ||
+        isFetching ||
+        isLoadingExplore ||
+        !savedQuery ||
+        !explore
+    ) {
         return {
             data: undefined,
             dashboardFilters: undefined,
-            isLoading,
+            isLoading: isLoading || isFetching,
             isError,
         };
     }

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -47,6 +47,7 @@ type DashboardContext = {
     dashboardTemporaryFilters: DashboardFilters;
     allFilters: DashboardFilters;
     isLoadingDashboardFilters: boolean;
+    isFetchingDashboardFilters: boolean;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     setDashboardTemporaryFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (
@@ -98,6 +99,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const {
         isLoading: isLoadingDashboardFilters,
+        isFetching: isFetchingDashboardFilters,
         data: filterableFieldsBySavedQueryUuid,
     } = useDashboardsAvailableFilters(tileSavedChartUuids);
 
@@ -363,6 +365,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         allFilterableFields,
         filterableFieldsBySavedQueryUuid,
         isLoadingDashboardFilters,
+        isFetchingDashboardFilters,
         filterableFieldsByTileUuid,
         allFilters,
         hasChartTiles,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6796 

### Description:

Add Refresh button to trigger the invalidation of the following queries: 

```
{ queryKey: ['queryResults'] },
{ queryKey: ['saved_query'] },
{ queryKey: ['saved_dashboard_query', dashboardUuid] },
{ queryKey: ['dashboards', 'availableFilters'] },
```

A Chart tile is also considered to be in loading state when data is being fetched;
Invalidate filters as well so this depending data refreshes as well;

Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/b6f8ba6d-806f-4253-8d09-11ee1c4ffbbe



