### PR TITLE
chore: remove small dashboard header icon

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -5,7 +5,6 @@ import {
     ActionIcon,
     Box,
     Button,
-    Flex,
     Popover,
     Stack,
     Text,
@@ -147,16 +146,11 @@ const DashboardHeader = ({
                                         {dashboardDescription}
                                     </Text>
                                 )}
-                                <Flex align="center" gap="xxs">
-                                    <MantineIcon
-                                        icon={IconPencil}
-                                        color="gray.6"
-                                    />
-                                    <UpdatedInfo
-                                        updatedAt={dashboardUpdatedAt}
-                                        user={dashboardUpdatedByUser}
-                                    />
-                                </Flex>
+
+                                <UpdatedInfo
+                                    updatedAt={dashboardUpdatedAt}
+                                    user={dashboardUpdatedByUser}
+                                />
 
                                 <ViewInfo
                                     views={dashboardViews}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

add a `Pencil icon` on the left of the dashboard popover last-updated section that doesn't make sense 

this is without:
<img width="339" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/f03b6191-e1dc-4404-adcc-d216daf3fee6">

