### PR TITLE
fix: editing an in-dashboard chart loses the chart

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -6,6 +6,7 @@ import { useLocalStorage } from '@mantine/hooks';
 import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import MantineIcon from '../common/MantineIcon';
 import AddChartTilesModal from './TileForms/AddChartTilesModal';
@@ -30,6 +31,18 @@ const AddTileButton: FC<Props> = ({
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
+
+    const {
+        dashboardTiles,
+        dashboardFilters,
+        haveTilesChanged,
+        haveFiltersChanged,
+        dashboard,
+    } = useDashboardContext();
+
+    const { storeDashboard } = useDashboardStorage();
+    const history = useHistory();
+
     const onAddTile = useCallback(
         (tile: Dashboard['tiles'][number]) => {
             onAddTiles([tile]);
@@ -39,14 +52,6 @@ const AddTileButton: FC<Props> = ({
     const { projectUuid } = useParams<{
         projectUuid: string;
     }>();
-    const {
-        dashboard,
-        dashboardTiles,
-        dashboardFilters,
-        haveTilesChanged,
-        haveFiltersChanged,
-    } = useDashboardContext();
-    const history = useHistory();
 
     return (
         <>
@@ -78,36 +83,13 @@ const AddTileButton: FC<Props> = ({
                                         </Group>
                                     }
                                     onClick={() => {
-                                        sessionStorage.setItem(
-                                            'fromDashboard',
-                                            dashboard?.name ?? '',
-                                        );
-                                        sessionStorage.setItem(
-                                            'dashboardUuid',
-                                            dashboard?.uuid ?? '',
-                                        );
-                                        sessionStorage.setItem(
-                                            'unsavedDashboardTiles',
-                                            JSON.stringify(dashboardTiles),
-                                        );
-                                        if (
-                                            dashboardFilters.dimensions.length >
-                                                0 ||
-                                            dashboardFilters.metrics.length > 0
-                                        ) {
-                                            sessionStorage.setItem(
-                                                'unsavedDashboardFilters',
-                                                JSON.stringify(
-                                                    dashboardFilters,
-                                                ),
-                                            );
-                                        }
-                                        sessionStorage.setItem(
-                                            'hasDashboardChanges',
-                                            JSON.stringify(
-                                                haveTilesChanged ||
-                                                    haveFiltersChanged,
-                                            ),
+                                        storeDashboard(
+                                            dashboardTiles,
+                                            dashboardFilters,
+                                            haveTilesChanged,
+                                            haveFiltersChanged,
+                                            dashboard?.uuid,
+                                            dashboard?.name,
                                         );
                                         history.push(
                                             `/projects/${projectUuid}/tables`,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -29,13 +29,14 @@ import {
 } from '@lightdash/common';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import { useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Text } from '@mantine/core';
 import { IconFolders } from '@tabler/icons-react';
 import { downloadCsv } from '../../api/csv';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import useSavedQueryWithDashboardFilters from '../../hooks/dashboard/useSavedQueryWithDashboardFilters';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
 import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
@@ -265,6 +266,7 @@ interface DashboardChartTileMainProps
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { showToastSuccess } = useToaster();
     const { track } = useTracking();
+    const history = useHistory();
     const {
         tile: {
             uuid: tileUuid,
@@ -283,8 +285,19 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { data: explore, isLoading: isLoadingExplore } = useExplore(
         savedQuery?.tableName,
     );
-    const { addDimensionDashboardFilter, setDashboardTiles } =
-        useDashboardContext();
+
+    const {
+        addDimensionDashboardFilter,
+        setDashboardTiles,
+        dashboardTiles,
+        dashboardFilters: filtersFromCOntext,
+        haveTilesChanged,
+        haveFiltersChanged,
+        dashboard,
+    } = useDashboardContext();
+
+    const { storeDashboard } = useDashboardStorage();
+
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
         left: number;
@@ -493,10 +506,22 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                 'manage',
                                 'SavedChart',
                             ) && (
-                                <LinkMenuItem
+                                <MenuItem2
                                     icon="document-open"
                                     text="Edit chart"
-                                    href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
+                                    onClick={() => {
+                                        storeDashboard(
+                                            dashboardTiles,
+                                            filtersFromCOntext,
+                                            haveTilesChanged,
+                                            haveFiltersChanged,
+                                            dashboard?.uuid,
+                                            dashboard?.name,
+                                        );
+                                        history.push(
+                                            `/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`,
+                                        );
+                                    }}
                                 />
                             )}
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -29,7 +29,7 @@ import {
 } from '@lightdash/common';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Text } from '@mantine/core';
@@ -266,7 +266,6 @@ interface DashboardChartTileMainProps
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { showToastSuccess } = useToaster();
     const { track } = useTracking();
-    const history = useHistory();
     const {
         tile: {
             uuid: tileUuid,
@@ -506,7 +505,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                 'manage',
                                 'SavedChart',
                             ) && (
-                                <MenuItem2
+                                <LinkMenuItem
                                     icon="document-open"
                                     text="Edit chart"
                                     onClick={() => {
@@ -518,10 +517,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                             dashboard?.uuid,
                                             dashboard?.name,
                                         );
-                                        history.push(
-                                            `/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`,
-                                        );
                                     }}
+                                    href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
                                 />
                             )}
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -269,7 +269,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const {
         tile: {
             uuid: tileUuid,
-            properties: { savedChartUuid, hideTitle, title },
+            properties: {
+                savedChartUuid,
+                hideTitle,
+                title,
+                belongsToDashboard,
+            },
         },
         isEditMode,
     } = props;
@@ -509,14 +514,16 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                     icon="document-open"
                                     text="Edit chart"
                                     onClick={() => {
-                                        storeDashboard(
-                                            dashboardTiles,
-                                            filtersFromCOntext,
-                                            haveTilesChanged,
-                                            haveFiltersChanged,
-                                            dashboard?.uuid,
-                                            dashboard?.name,
-                                        );
+                                        if (belongsToDashboard) {
+                                            storeDashboard(
+                                                dashboardTiles,
+                                                filtersFromCOntext,
+                                                haveTilesChanged,
+                                                haveFiltersChanged,
+                                                dashboard?.uuid,
+                                                dashboard?.name,
+                                            );
+                                        }
                                     }}
                                     href={`/projects/${projectUuid}/saved/${savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
                                 />

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -1,0 +1,44 @@
+import { DashboardFilters, DashboardTile } from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+
+const useDashboardStorage = () => {
+    const storeDashboard = useCallback(
+        (
+            dashboardTiles: DashboardTile[],
+            dashboardFilters: DashboardFilters,
+            haveTilesChanged: boolean,
+            haveFiltersChanged: boolean,
+            dashboardUuid?: string,
+            dashboardName?: string,
+        ) => {
+            sessionStorage.setItem('fromDashboard', dashboardName ?? '');
+            sessionStorage.setItem('dashboardUuid', dashboardUuid ?? '');
+            sessionStorage.setItem(
+                'unsavedDashboardTiles',
+                JSON.stringify(dashboardTiles),
+            );
+            if (
+                dashboardFilters.dimensions.length > 0 ||
+                dashboardFilters.metrics.length > 0
+            ) {
+                sessionStorage.setItem(
+                    'unsavedDashboardFilters',
+                    JSON.stringify(dashboardFilters),
+                );
+            }
+            sessionStorage.setItem(
+                'hasDashboardChanges',
+                JSON.stringify(haveTilesChanged || haveFiltersChanged),
+            );
+        },
+        [],
+    );
+
+    return useMemo(() => {
+        return {
+            storeDashboard: storeDashboard,
+        };
+    }, [storeDashboard]);
+};
+
+export default useDashboardStorage;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6853 

### Description:

NOTE to reviewers: There are a number of issues with charts in dashboards and I am starting with a targeted fix for this one. Things won't work perfectly with just this review but they will be better. This introduces a hook for managing these temp charts which will have more functionality with in next few reviews. 

Editing a chart in a dashboard was causing the chart to be lost. This was happening when the dashboard hadn't been saved yet. The draft state of the dashboard wasn't getting passed back to the edit experience. 

In this review I created a hook for storing the dashboard between pages and reused that hook where necessary. In the next few reviews I plan to move more of the interaction with session storage into the hook. 

Also note if you want to test it out, there is a feature flag. In the console:
`localStorage.setItem('enable-create-chart-in-dashboard', true)`
