### PR TITLE
fix: filter input year and year month timezone issue

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -92,17 +92,23 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     onClose: () =>
                                         popoverProps?.onClose?.(null as any),
                                 }}
-                                value={rule.values ? rule.values[0] : null}
+                                value={
+                                    rule.values
+                                        ? parseDate(
+                                              formatDate(
+                                                  rule.values[0],
+                                                  TimeFrames.MONTH,
+                                              ),
+                                              TimeFrames.MONTH,
+                                          )
+                                        : null
+                                }
                                 onChange={(value: Date) => {
-                                    // converts to utc to remove timezone offset from date to avoid issues with datepicker
-                                    const date = moment(value)
-                                        .utc(true)
-                                        .toDate()
-                                        .toISOString();
-
                                     onChange({
                                         ...rule,
-                                        values: [date],
+                                        values: [
+                                            formatDate(value, TimeFrames.MONTH),
+                                        ],
                                     });
                                 }}
                             />
@@ -121,17 +127,26 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     onClose: () =>
                                         popoverProps?.onClose?.(null as any),
                                 }}
-                                value={rule.values ? rule.values[0] : null}
-                                onChange={(value: Date) => {
-                                    // converts to utc to remove timezone offset from date to avoid issues with datepicker
-                                    const date = moment(value)
-                                        .utc(true)
-                                        .toDate()
-                                        .toISOString();
-
+                                value={
+                                    rule.values
+                                        ? parseDate(
+                                              formatDate(
+                                                  rule.values[0],
+                                                  TimeFrames.YEAR,
+                                              ),
+                                              TimeFrames.YEAR,
+                                          )
+                                        : null
+                                }
+                                onChange={(newDate: Date) => {
                                     onChange({
                                         ...rule,
-                                        values: [date],
+                                        values: [
+                                            formatDate(
+                                                newDate,
+                                                TimeFrames.YEAR,
+                                            ),
+                                        ],
                                     });
                                 }}
                             />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -93,7 +93,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onClose?.(null as any),
                                 }}
                                 value={
-                                    rule.values
+                                    rule.values && rule.values[0]
                                         ? parseDate(
                                               formatDate(
                                                   rule.values[0],
@@ -128,7 +128,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onClose?.(null as any),
                                 }}
                                 value={
-                                    rule.values
+                                    rule.values && rule.values[0]
                                         ? parseDate(
                                               formatDate(
                                                   rule.values[0],

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -94,13 +94,15 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 }}
                                 value={rule.values ? rule.values[0] : null}
                                 onChange={(value: Date) => {
+                                    // converts to utc to remove timezone offset from date to avoid issues with datepicker
+                                    const date = moment(value)
+                                        .utc(true)
+                                        .toDate()
+                                        .toISOString();
+
                                     onChange({
                                         ...rule,
-                                        values: [
-                                            moment(value)
-                                                .startOf('month')
-                                                .toDate(),
-                                        ],
+                                        values: [date],
                                     });
                                 }}
                             />
@@ -121,13 +123,15 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 }}
                                 value={rule.values ? rule.values[0] : null}
                                 onChange={(value: Date) => {
+                                    // converts to utc to remove timezone offset from date to avoid issues with datepicker
+                                    const date = moment(value)
+                                        .utc(true)
+                                        .toDate()
+                                        .toISOString();
+
                                     onChange({
                                         ...rule,
-                                        values: [
-                                            moment(value)
-                                                .startOf('year')
-                                                .toDate(),
-                                        ],
+                                        values: [date],
                                     });
                                 }}
                             />

--- a/packages/frontend/src/components/common/MonthAndYearInput.tsx
+++ b/packages/frontend/src/components/common/MonthAndYearInput.tsx
@@ -17,6 +17,8 @@ const MonthAndYearInput: FC<Props> = ({ value, onChange, ...props }) => {
         <MonthPickerInput
             sx={{ width: '100%' }}
             size="xs"
+            minDate={moment().year(1000).toDate()}
+            maxDate={moment().year(9999).toDate()}
             onClick={toggle}
             {...props}
             popoverProps={{


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6902

I was able to reproduce this with selecting timezone that is ahead of local timezone

my locale: gmt+4:00
overriden: gmt+5:30

### Description:

![CleanShot 2023-08-28 at 19 11 54@2x](https://github.com/lightdash/lightdash/assets/962095/0d9d6da8-e646-4320-afb9-9834603a0eaa)
![CleanShot 2023-08-28 at 19 11 17@2x](https://github.com/lightdash/lightdash/assets/962095/df92d728-0198-4aa4-93b3-2e53086cbd4a)
