### PR TITLE
fix: dashboard crash on refresh

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -96,8 +96,8 @@ const DashboardHeader = ({
         projectUuid: string;
         dashboardUuid: string;
     }>();
-    const { isOneAtLeastFetching, invalidateDashboardRelatedQueries } =
-        useDashboardRefresh(dashboardUuid);
+    const { isFetching, invalidateDashboardRelatedQueries } =
+        useDashboardRefresh();
     const history = useHistory();
     const { track } = useTracking();
     const [isUpdating, setIsUpdating] = useState(false);
@@ -122,6 +122,8 @@ const DashboardHeader = ({
         'manage',
         'Dashboard',
     );
+
+    const isOneAtLeastFetching = isFetching > 0;
 
     return (
         <PageHeader h="auto">

--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.tsx
@@ -1,24 +1,27 @@
-import { useQueries, useQueryClient } from 'react-query';
+import { useIsFetching, useQueryClient } from 'react-query';
 
-export const useDashboardRefresh = (dashboardUuid: string) => {
+export const useDashboardRefresh = () => {
     const queryClient = useQueryClient();
 
-    const queriesToRefresh = [
-        { queryKey: ['queryResults'] },
-        { queryKey: ['saved_query'] },
-        { queryKey: ['saved_dashboard_query', dashboardUuid] },
-        { queryKey: ['dashboards', 'availableFilters'] },
+    const queryKeysToRefresh = [
+        'savedChartResults',
+        'saved_query',
+        'saved_dashboard_query',
+        'dashboards',
     ];
 
-    const queries = useQueries(queriesToRefresh);
-
-    const isOneAtLeastFetching = queries.some((query) => query.isFetching);
+    const isFetching = useIsFetching();
 
     const invalidateDashboardRelatedQueries = () => {
-        queriesToRefresh.forEach((query) => {
-            queryClient.invalidateQueries(query.queryKey);
+        queryKeysToRefresh.map((key) => {
+            return queryClient.invalidateQueries({
+                queryKey: [key],
+            });
         });
     };
 
-    return { invalidateDashboardRelatedQueries, isOneAtLeastFetching };
+    return {
+        invalidateDashboardRelatedQueries,
+        isFetching,
+    };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6905 

### Description:

There was an issue with the refresh button setup where it was calling `useQueries` on the default client with existing query strings and no query functions, essentially creating a new cache for those functions. There was a race condition that caused the page to break with an unknown error when one of those was called.

This changes the pattern to just invalidate those queries in the existing client. 

This also changes the `queryResults` key to `savedChartResults`. `queryResults` doesn't exist. 

One caveat here is that the loading state on the button will now show whenever something is getting fetched on the page, not just from the refresh button. We could potentially pare that down, but I didn't figure out how to scope `isFetching` to just these queries. It will take a little more work. And it wasn't clear to me that that would be better anyway--it's possible the button should be disabled whenever a fetch is happening. 
