### PR TITLE
docs: register user API

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3152,88 +3152,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___':
-        {
-            dataType: 'refAlias',
-            type: { ref: 'RawRuleOf_T_', validators: {} },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_':
-        {
-            dataType: 'refAlias',
-            type: {
-                ref: 'DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_',
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    RawRuleOf_T_: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    LightdashUserWithAbilityRules: {
-        dataType: 'refObject',
-        properties: {
-            userUuid: { dataType: 'string', required: true },
-            email: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
-                required: true,
-            },
-            firstName: { dataType: 'string', required: true },
-            lastName: { dataType: 'string', required: true },
-            organizationUuid: { dataType: 'string' },
-            organizationName: { dataType: 'string' },
-            organizationCreatedAt: { dataType: 'datetime' },
-            isTrackingAnonymized: { dataType: 'boolean', required: true },
-            isMarketingOptedIn: { dataType: 'boolean', required: true },
-            isSetupComplete: { dataType: 'boolean', required: true },
-            role: { ref: 'OrganizationMemberRole' },
-            isActive: { dataType: 'boolean', required: true },
-            abilityRules: {
-                dataType: 'array',
-                array: { dataType: 'refAlias', ref: 'RawRuleOf_T_' },
-                required: true,
-            },
-        },
-        additionalProperties: false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGetAuthenticatedUserResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    ref: 'LightdashUserWithAbilityRules',
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LightdashUser: {
         dataType: 'refObject',
         properties: {
@@ -3255,6 +3173,18 @@ const models: TsoaRoute.Models = {
             isActive: { dataType: 'boolean', required: true },
         },
         additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetAuthenticatedUserResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'LightdashUser', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiRegisterUserResponse: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3618,95 +3618,6 @@
                     }
                 ]
             },
-            "DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___": {
-                "$ref": "#/components/schemas/RawRuleOf_T_"
-            },
-            "DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_": {
-                "$ref": "#/components/schemas/DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___"
-            },
-            "RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_": {
-                "$ref": "#/components/schemas/DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_"
-            },
-            "RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_": {
-                "$ref": "#/components/schemas/RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_"
-            },
-            "RawRuleOf_T_": {
-                "$ref": "#/components/schemas/RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_"
-            },
-            "LightdashUserWithAbilityRules": {
-                "properties": {
-                    "userUuid": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
-                    "organizationName": {
-                        "type": "string"
-                    },
-                    "organizationCreatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "isTrackingAnonymized": {
-                        "type": "boolean"
-                    },
-                    "isMarketingOptedIn": {
-                        "type": "boolean"
-                    },
-                    "isSetupComplete": {
-                        "type": "boolean"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/OrganizationMemberRole"
-                    },
-                    "isActive": {
-                        "type": "boolean"
-                    },
-                    "abilityRules": {
-                        "items": {
-                            "$ref": "#/components/schemas/RawRuleOf_T_"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "userUuid",
-                    "firstName",
-                    "lastName",
-                    "isTrackingAnonymized",
-                    "isMarketingOptedIn",
-                    "isSetupComplete",
-                    "isActive",
-                    "abilityRules"
-                ],
-                "type": "object",
-                "additionalProperties": false
-            },
-            "ApiGetAuthenticatedUserResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/LightdashUserWithAbilityRules"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object",
-                "description": "Shows the authenticated user"
-            },
             "LightdashUser": {
                 "properties": {
                     "userUuid": {
@@ -3758,6 +3669,21 @@
                 ],
                 "type": "object",
                 "additionalProperties": false
+            },
+            "ApiGetAuthenticatedUserResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/LightdashUser"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "Shows the authenticated user"
             },
             "ApiRegisterUserResponse": {
                 "properties": {
@@ -4192,7 +4118,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.757.1",
+        "version": "0.759.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -88,7 +88,7 @@ export type ApiUserAllowedOrganizationsResponse = {
  */
 export type ApiGetAuthenticatedUserResponse = {
     status: 'ok';
-    results: LightdashUserWithAbilityRules;
+    results: LightdashUser;
 };
 
 export type ApiRegisterUserResponse = {


### PR DESCRIPTION
Error when generating API docs:
```
4:12:35 PM: $ docusaurus build
4:12:36 PM: [INFO] [en] Creating an optimized production build...
4:12:37 PM: [REDOCUSAURUS_PLUGIN] errors while bundling spec ../packages/backend/src/generated/swagger.json
4:12:37 PM: [1] ../packages/backend/src/generated/swagger.json:3676:34 at #/components/schemas/LightdashUserWithAbilityRules/properties/abilityRules/items
4:12:37 PM: Can't resolve $ref
4:12:37 PM: 3674 | },
4:12:37 PM: 3675 | abilityRules: {
4:12:37 PM: 3676 |     items: {
4:12:37 PM: 3677 |         $ref: #/components/schemas/RawRuleOf_T_
4:12:37 PM: 3678 |     },
4:12:37 PM: 3679 |     type: array
4:12:37 PM: 3680 | }
4:12:37 PM: Error was generated by the bundler rule.
4:12:37 PM: [2] ../packages/backend/src/generated/swagger.json:3621:144 at #/components/schemas/DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___
4:12:37 PM: Can't resolve $ref
4:12:37 PM: 3619 |     ]
4:12:37 PM: 3620 | },
4:12:37 PM: 3621 | DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAbilityTypes_T-at-uniquesymbol_.string___: {
4:12:37 PM: 3622 |     $ref: #/components/schemas/RawRuleOf_T_
4:12:37 PM: 3623 | },
4:12:37 PM: 3624 | DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_: {
4:12:37 PM: 3625 |     $ref: #/components/schemas/DefineRule_ToAbilityTypes_T-at-uniquesymbol_.T-at-uniquesymbol.ClaimRawRule_Extract_ToAb...<22 chars>
4:12:37 PM: Error was generated by the bundler rule.
4:12:37 PM: [3] ../packages/backend/src/generated/swagger.json:8:20 at #/components/schemas/DefineRule_ToAbilityTypes_T_.Generics_T_%5Bconditions%5D_
4:12:37 PM: Can't resolve $ref
4:12:37 PM:    6 | requestBodies: {},
4:12:37 PM:    7 | responses: {},
4:12:37 PM:    8 | schemas: {
4:12:37 PM:    9 |     ApiErrorPayload: {
4:12:37 PM:    … |     < 4168 more lines >
4:12:37 PM: 4178 | },
4:12:37 PM: 4179 | securitySchemes: {
4:12:37 PM: 4180 |     session_cookie: {
4:12:37 PM: Error was generated by the bundler rule.
4:12:37 PM: [4] ../packages/backend/src/generated/swagger.json:8:20 at #/components/schemas/RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_
4:12:37 PM: Can't resolve $ref
4:12:37 PM:    6 | requestBodies: {},
4:12:37 PM:    7 | responses: {},
4:12:37 PM:    8 | schemas: {
4:12:37 PM:    9 |     ApiErrorPayload: {
4:12:37 PM:    … |     < 4168 more lines >
4:12:37 PM: 4178 | },
4:12:37 PM: 4179 | securitySchemes: {
4:12:37 PM: 4180 |     session_cookie: {
4:12:37 PM: Error was generated by the bundler rule.
4:12:37 PM: [5] ../packages/backend/src/generated/swagger.json:8:20 at #/components/schemas/RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_
4:12:37 PM: Can't resolve $ref
4:12:37 PM:    6 | requestBodies: {},
4:12:37 PM:    7 | responses: {},
4:12:37 PM:    8 | schemas: {
4:12:37 PM:    9 |     ApiErrorPayload: {
4:12:37 PM:    … |     < 4168 more lines >
4:12:37 PM: 4178 | },
4:12:37 PM: 4179 | securitySchemes: {
4:12:37 PM: 4180 |     session_cookie: {
4:12:37 PM: Error was generated by the bundler rule.
4:12:37 PM: [6] ../packages/backend/src/generated/swagger.json:3633:29 at #/components/schemas/RawRuleOf_T_
4:12:37 PM: Can't resolve $ref
4:12:37 PM: 3631 |     $ref: #/components/schemas/RawRule_ToAbilityTypes_Generics_T_%5Babilities%5D_.Generics_T_%5Bconditions%5D_
4:12:37 PM: 3632 | },
4:12:37 PM: 3633 | RawRuleOf_T_: {
4:12:37 PM: 3634 |     $ref: #/components/schemas/RawRuleFrom_Generics_T_%5Babilities%5D.Generics_T_%5Bconditions%5D_
4:12:37 PM: 3635 | },
4:12:37 PM: 3636 | LightdashUserWithAbilityRules: {
4:12:37 PM: 3637 |     properties: {                         
```



`tsoa` can generate invalid swagger json. 

In this case, it didn't generate correctly the types from the @casl lib. 
I updated the return type to be more generic and not have those types for now. 