### PR TITLE
fix: tooltip hover effect on add email and add slack

### DIFF
--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulerForm.tsx
@@ -80,7 +80,10 @@ const SlackErrorContent: FC<{ slackState: SlackStates }> = ({
                 <p>No Slack integration found</p>
                 <p>
                     To create a slack scheduled delivery, you need to
-                    <Anchor href="https://docs.lightdash.com/self-host/customize-deployment/configure-a-slack-app-for-lightdash">
+                    <Anchor
+                        target="_blank"
+                        href="https://docs.lightdash.com/self-host/customize-deployment/configure-a-slack-app-for-lightdash"
+                    >
                         {' '}
                         setup Slack{' '}
                     </Anchor>
@@ -621,6 +624,7 @@ const SchedulerForm: FC<{
                                         <>
                                             <Tooltip2
                                                 interactionKind="hover"
+                                                hoverCloseDelay={500}
                                                 content={
                                                     <>
                                                         {SlackErrorContent({
@@ -655,6 +659,7 @@ const SchedulerForm: FC<{
                                                 />
                                             </Tooltip2>
                                             <Tooltip2
+                                                hoverCloseDelay={500}
                                                 interactionKind="hover"
                                                 content={
                                                     <>
@@ -666,7 +671,10 @@ const SchedulerForm: FC<{
                                                             To create an email
                                                             scheduled delivery,
                                                             you need to add
-                                                            <Anchor href="https://docs.lightdash.com/references/environmentVariables">
+                                                            <Anchor
+                                                                target="_blank"
+                                                                href="https://docs.lightdash.com/references/environmentVariables"
+                                                            >
                                                                 {' '}
                                                                 SMTP environment
                                                                 variables{' '}


### PR DESCRIPTION
Closes: #6893 

### Description:
In add schedule delivery modal, it was not possible to click on the hyperlinks in the tooltip. Have added hoverDelay of 500ms so the tooltip stays there for some time and we are able to click on the hyperlinks. Have also made it so the links open in a new tab which felt a better UX to me. Please let me know in case of feedback. Have attached video for reference.

https://github.com/lightdash/lightdash/assets/20976813/ba7141ef-e7bf-44de-ac7b-e5d76d671646


