### PR TITLE
fix: keep add charts dialog open on click outside

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -121,6 +121,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                 </Flex>
             }
             withCloseButton
+            closeOnClickOutside={false}
         >
             <Stack spacing="md">
                 <form


### PR DESCRIPTION
### Description:

Keep the add chart dialog open on click outside. 

The dashboard add charts dialog is currently set to close on click outside. But the dropdown to choose charts stays open even after you select one, covering the 'Add' button. The result is a kind of frustrating experience where you have to pick a chart, then be careful to click on a small exposed part of the dialog to close the dropdown so you can click Add. If you click outside the dialog, it closes without adding your selected charts. 

This just keeps the dialog open on click outside, giving the user more space to click the dropdown closed and also making them make an explicit choice whether to add or cancel. 
