### PR TITLE
fix: tile name not showing up for charts in dashes

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -18,9 +18,7 @@ import {
     useMantineTheme,
 } from '@mantine/core';
 import { FC, useCallback, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { FilterActions } from '.';
-import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import FieldAutoComplete from '../../common/Filters/FieldAutoComplete';
 import MantineIcon from '../../common/MantineIcon';
 import { getChartIcon } from '../../common/ResourceIcon';
@@ -49,11 +47,6 @@ const TileFilterConfiguration: FC<Props> = ({
     onToggleAll,
 }) => {
     const theme = useMantineTheme();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
-
-    const { data: savedCharts } = useChartSummaries(projectUuid, {
-        refetchOnMount: false,
-    });
 
     const sortTilesByFieldMatch = useCallback(
         (
@@ -124,11 +117,7 @@ const TileFilterConfiguration: FC<Props> = ({
             let tileLabel = '';
             if (tile) {
                 if (tileWithoutTitle && isChartTileType) {
-                    const relatedChart = savedCharts?.find(
-                        (chart) =>
-                            chart.uuid === tile.properties.savedChartUuid,
-                    );
-                    tileLabel = relatedChart?.name || '';
+                    tileLabel = tile.properties.chartName || '';
                 } else if (tile.properties.title) {
                     tileLabel = tile.properties.title;
                 }
@@ -148,14 +137,7 @@ const TileFilterConfiguration: FC<Props> = ({
                 selectedFilter,
             };
         });
-    }, [
-        filterRule,
-        field,
-        savedCharts,
-        sortFieldsByMatch,
-        sortedTileWithFilters,
-        tiles,
-    ]);
+    }, [filterRule, field, sortFieldsByMatch, sortedTileWithFilters, tiles]);
 
     const isAllChecked = tileTargetList.every(({ checked }) => checked);
     const isIndeterminate =

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -139,6 +139,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
             properties: {
                 belongsToDashboard: true,
                 savedChartUuid: (await mutateAsync(newChartInDashboard)).uuid,
+                chartName: newChartInDashboard.name,
             },
             ...getDefaultChartTileSize(savedData.chartConfig?.type),
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6878 

### Description:

Chart names were not showing up in the tile selector for filters. Two things caused this. First,  we were fetching the project charts to get the names, which don't include charts in dashboards. Second, we were not creating the tiles with a name. This fixes both of those issues.
