### PR TITLE
docs: remove google sheets related info from scheduled deliveries

### DIFF
--- a/docs/docs/guides/how-to-create-scheduled-deliveries.mdx
+++ b/docs/docs/guides/how-to-create-scheduled-deliveries.mdx
@@ -43,36 +43,12 @@ If you click on `create new`, you'll be brought to a configuration screen for yo
 
 - **Name**: this is the name of your scheduled delivery. 
 - **Frequency**: this is how often your scheduled delivery will be sent. You can make this hourly, daily, weekly, monthly, or custom - each frequency has its own options. For example, with a monthly schedule, you set the day of the month and the time that you want your scheduled delivery to be sent. The custom frequency lets you write out your own custom Cron expression if you need something more specific than our standard options. All times for the scheduler are in UTC.
-- **Format**: either `Image`, `CSV` or `Google Sheets`. `Image` sends an image of the content (chart or dashboard) to your chosen destination. `CSV` sends a downloadable .csv file of the results table from your chart, or if you're sending a dashboard, it sends a single message with multiple .csv files for the results tables from each of your charts.
+- **Format**: either `Image` or `CSV`. `Image` sends an image of the content (chart or dashboard) to your chosen destination. `CSV` sends a downloadable .csv file of the results table from your chart, or if you're sending a dashboard, it sends a single message with multiple .csv files for the results tables from each of your charts.
     - **For CSV formats**: you can set the `values` to either be `raw` (we remove the formatting applied dates, numbers, or other fields in Lightdash) or `formatted` (the way the values appear in your table in Lightdash is how they'll appear in the .csv). You can also adjust the `limit` and specify the number of rows that you want to be delivered in your .csv. `Results in table` will deliver the number of results that are currently in the results table for your charts. You can also set a custom number of rows to be delivered using `custom`, or set all results to be delivered so there's no maximum row limit for each chart using `all results`. 
     - **Limit on CSV format**: We limit CSV downloads to 100,000 cells by default, so if you are trying to download more cells, your file will get truncated.
 - **Send to**: here, you can pick if you want to send your scheduled delivery to Slack, email, or both. You can add as many Slack channels and email addresses as you'd like to here. You can send a scheduled delivery to a person in Slack using `@persons-name` or to a channel using `#channel-name`.
 
 Once you've set up all of your delivery options, you can click `create new` to create your new scheduled delivery.
-
-## Uploading data to Google Sheets
-
-This option requires [Google SSO](https://docs.lightdash.com/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash#google) to be configured on the server. 
-
-If you want to enable this option on self hosting, visit [Google Sheet integration](https://docs.lightdash.com/self-host/customize-deployment/configure-a-slack-app-for-lightdash) to find how to configure Lightdash. 
-
-You can configure a scheduled delivery for `charts` or `dashboards` to upload data to an existing spreadhseet in Google Sheets. 
-
-First selec the format `Google Sheets` then click on `+ Add to Google Sheets`.
-
-If this is the first time you upload a Google Sheet, you will see an authentication popup where you can select your Google account to have access to your files. 
-
-Once you're logged in, you can select the file you want to write into. 
-
-<img src={GsheetDelivery} width="500" height="515" style={{display: "block", margin: "0 auto 20px auto"}}/>
-
-If you are uploading data from a chart, the data will be uploaded to the first tab in your selected Google Spreadsheet and it will overwrite all the content. 
-
-If you are uploading data from a dashboard, we will create as many tabs as charts in your dashboard.
-
-Aditionally, for both `charts` and `dashboards` we will create a `metadata` tab in the Google spreadsheet with the information about the type and additionally how many tabs were uploaded if a dashboard was selected 
-
-<img src={GsheetMetadata} width="845" height="515" style={{display: "block", margin: "0 auto 20px auto"}}/>
 
 ## Editing and deleting your scheduled deliveries
 


### PR DESCRIPTION
Most content will be used in separate section

Relates to: #6945 & #6946 