### PR TITLE
fix: header breaks returning from chart edit

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo, useEffect } from 'react';
+import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { Can } from '../../common/Authorization';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
@@ -19,12 +20,11 @@ const ExplorerHeader: FC = memo(() => {
         (context) => context.state.isValidQuery,
     );
 
+    const { getHasDashboardChanges } = useDashboardStorage();
+
     useEffect(() => {
-        const hasUnsavedDashboardChanges = JSON.parse(
-            sessionStorage.getItem('hasDashboardChanges') ?? 'false',
-        );
         const checkReload = (event: BeforeUnloadEvent) => {
-            if (hasUnsavedDashboardChanges) {
+            if (getHasDashboardChanges()) {
                 const message =
                     'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
                 event.returnValue = message;
@@ -35,7 +35,7 @@ const ExplorerHeader: FC = memo(() => {
         return () => {
             window.removeEventListener('beforeunload', checkReload);
         };
-    }, []);
+    }, [getHasDashboardChanges]);
 
     return (
         <Wrapper>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -25,6 +25,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
 import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
+import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import {
     useDuplicateChartMutation,
     useMoveChartMutation,
@@ -81,6 +82,9 @@ const SavedChartsHeader: FC = () => {
         (context) => context.state.savedChart,
     );
     const reset = useExplorerContext((context) => context.actions.reset);
+
+    const { clearIsEditingDashboardChart } = useDashboardStorage();
+
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
     const [isSaveWarningModalOpen, setIsSaveWarningModalOpen] =
@@ -527,6 +531,7 @@ const SavedChartsHeader: FC = () => {
                     opened={isMovingChart}
                     onClose={() => setIsMovingChart(false)}
                     onConfirm={() => {
+                        clearIsEditingDashboardChart();
                         history.push(
                             `/projects/${projectUuid}/saved/${savedChart.uuid}/edit`,
                         );

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -182,8 +182,6 @@ const SavedChartsHeader: FC = () => {
         history.push({
             pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardUuid}`,
         });
-        sessionStorage.removeItem('fromDashboard');
-        sessionStorage.removeItem('dashboardUuid');
     };
 
     const handleCancelClick = () => {
@@ -529,8 +527,6 @@ const SavedChartsHeader: FC = () => {
                     opened={isMovingChart}
                     onClose={() => setIsMovingChart(false)}
                     onConfirm={() => {
-                        sessionStorage.removeItem('fromDashboard');
-                        sessionStorage.removeItem('dashboardUuid');
                         history.push(
                             `/projects/${projectUuid}/saved/${savedChart.uuid}/edit`,
                         );

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -15,6 +15,7 @@ import {
 import { IconInfoCircle, IconTool } from '@tabler/icons-react';
 import { FC, memo, useEffect, useMemo } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProjects } from '../../hooks/useProjects';
 import { ReactComponent as Logo } from '../../svgs/logo-icon.svg';
@@ -86,8 +87,6 @@ const DashboardExplorerBanner: FC<{
                                 savedQueryUuid ? 'view' : 'edit'
                             }`,
                         );
-                        sessionStorage.removeItem('fromDashboard');
-                        sessionStorage.removeItem('dashboardUuid');
                     }}
                     size="xs"
                     ml="md"
@@ -106,6 +105,13 @@ const NavBar = memo(() => {
     const { data: projects } = useProjects();
     const { activeProjectUuid, isLoading: isLoadingActiveProject } =
         useActiveProjectUuid({ refetchOnMount: true });
+    const {
+        getIsEditingDashboardChart,
+        getEditingDashboardInfo,
+        clearDashboardStorage,
+    } = useDashboardStorage();
+
+    const dashboardInfo = getEditingDashboardInfo();
 
     const homeUrl = activeProjectUuid
         ? `/projects/${activeProjectUuid}/home`
@@ -116,26 +122,19 @@ const NavBar = memo(() => {
             project.projectUuid === activeProjectUuid &&
             project.type === ProjectType.PREVIEW,
     );
-    const fromDashboard = sessionStorage.getItem('fromDashboard');
-    const dashboardUuid = sessionStorage.getItem('dashboardUuid');
 
     useEffect(() => {
-        const clearDashboardStorage = () => {
-            if (fromDashboard) {
-                sessionStorage.clear();
-            }
-        };
         window.addEventListener('unload', clearDashboardStorage);
         return () =>
             window.removeEventListener('unload', clearDashboardStorage);
-    }, [fromDashboard]);
+    }, [clearDashboardStorage]);
 
-    if (fromDashboard && dashboardUuid) {
+    if (getIsEditingDashboardChart()) {
         return (
             <DashboardExplorerBanner
-                dashboardName={fromDashboard}
+                dashboardName={dashboardInfo.name || ''}
                 projectUuid={projectUuid}
-                dashboardUuid={dashboardUuid}
+                dashboardUuid={dashboardInfo.dashboardUuid || ''}
             />
         );
     }

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -2,6 +2,39 @@ import { DashboardFilters, DashboardTile } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 
 const useDashboardStorage = () => {
+    const getIsEditingDashboardChart = useCallback(() => {
+        return (
+            !!sessionStorage.getItem('fromDashboard') ||
+            !!sessionStorage.getItem('dashboardUuid')
+        );
+    }, []);
+
+    const clearIsEditingDashboardChart = useCallback(() => {
+        sessionStorage.removeItem('fromDashboard');
+        sessionStorage.removeItem('dashboardUuid');
+    }, []);
+
+    const getEditingDashboardInfo = useCallback(() => {
+        return {
+            name: sessionStorage.getItem('fromDashboard'),
+            dashboardUuid: sessionStorage.getItem('dashboardUuid'),
+        };
+    }, []);
+
+    const getHasDashboardChanges = useCallback(() => {
+        return JSON.parse(
+            sessionStorage.getItem('getHasDashboardChanges') ?? 'false',
+        );
+    }, []);
+
+    const clearDashboardStorage = useCallback(() => {
+        sessionStorage.removeItem('fromDashboard');
+        sessionStorage.removeItem('dashboardUuid');
+        sessionStorage.removeItem('unsavedDashboardTiles');
+        sessionStorage.removeItem('unsavedDashboardFilters');
+        sessionStorage.removeItem('hasDashboardChanges');
+    }, []);
+
     const storeDashboard = useCallback(
         (
             dashboardTiles: DashboardTile[],
@@ -37,8 +70,20 @@ const useDashboardStorage = () => {
     return useMemo(() => {
         return {
             storeDashboard: storeDashboard,
+            clearDashboardStorage: clearDashboardStorage,
+            getEditingDashboardInfo: getEditingDashboardInfo,
+            getIsEditingDashboardChart: getIsEditingDashboardChart,
+            clearIsEditingDashboardChart: clearIsEditingDashboardChart,
+            getHasDashboardChanges: getHasDashboardChanges,
         };
-    }, [storeDashboard]);
+    }, [
+        storeDashboard,
+        clearDashboardStorage,
+        getEditingDashboardInfo,
+        getIsEditingDashboardChart,
+        clearIsEditingDashboardChart,
+        getHasDashboardChanges,
+    ]);
 };
 
 export default useDashboardStorage;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -38,6 +38,7 @@ import {
     useMoveDashboardMutation,
     useUpdateDashboard,
 } from '../hooks/dashboard/useDashboard';
+import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import useSavedQueryWithDashboardFilters from '../hooks/dashboard/useSavedQueryWithDashboardFilters';
 import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
@@ -140,6 +141,8 @@ const Dashboard: FC = () => {
     }>();
     const { data: spaces } = useSpaceSummaries(projectUuid);
 
+    const { clearIsEditingDashboardChart } = useDashboardStorage();
+
     const {
         dashboard,
         dashboardError,
@@ -186,7 +189,14 @@ const Dashboard: FC = () => {
 
     const { tiles: savedTiles } = dashboard || {};
     useEffect(() => {
+        // TODO: The logic in this useEffect isn't right. It's checking if
+        // there are saved tiles, then checking for unsaved tiles,
+        // then replacing the saved tiles with the unsaved ones if they exist.
         if (savedTiles) {
+            // TODO: maybe this should move in the future, but it makes
+            // some sense here since this useEffect is essentially handling
+            // sessions storage
+            clearIsEditingDashboardChart();
             const unsavedDashboardTilesRaw = sessionStorage.getItem(
                 'unsavedDashboardTiles',
             );
@@ -205,7 +215,12 @@ const Dashboard: FC = () => {
             setDashboardTiles(unsavedDashboardTiles || savedTiles);
             setHaveTilesChanged(!!unsavedDashboardTiles);
         }
-    }, [setHaveTilesChanged, setDashboardTiles, savedTiles]);
+    }, [
+        setHaveTilesChanged,
+        setDashboardTiles,
+        savedTiles,
+        clearIsEditingDashboardChart,
+    ]);
 
     useEffect(() => {
         if (isSuccess) {

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -7,6 +7,7 @@ import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplore } from '../hooks/useExplore';
 import {
     useExplorerRoute,
@@ -26,6 +27,8 @@ const ExplorerWithUrlParams = memo(() => {
     );
     const { data } = useExplore(tableId);
 
+    const { getIsEditingDashboardChart } = useDashboardStorage();
+
     const clearQuery = useExplorerContext(
         (context) => context.actions.clearQuery,
     );
@@ -37,7 +40,7 @@ const ExplorerWithUrlParams = memo(() => {
             sidebar={<ExploreSideBar />}
             withFullHeight
             withPaddedContent
-            hasBanner={!!sessionStorage.getItem('fromDashboard')}
+            hasBanner={getIsEditingDashboardChart()}
         >
             <Explorer />
         </Page>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6865 

### Description:

Going back to a dashboard from editing a chart in that dashboard was breaking the header. The special header for editing charts would stay around forever. This change moves more of the interaction with sessionStorage into a hook, then uses that hook to read and clear storage items used for the header. The clear now happens in a useEffect on the dashboard page instead of before the re-direct. 

There is more to be done as far as moving things into the hook, but this fixes the header problem. 
