### PR TITLE
fix: size of icons in new and browse tab in navbar to 16x16

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -32,7 +32,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                     variant="default"
                     size="xs"
                     fz="sm"
-                    leftIcon={<MantineIcon icon={IconCategory}/>}
+                    leftIcon={<MantineIcon icon={IconCategory} />}
                 >
                     Browse
                 </Button>

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -32,7 +32,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                     variant="default"
                     size="xs"
                     fz="sm"
-                    leftIcon={<MantineIcon icon={IconCategory} size="lg" />}
+                    leftIcon={<MantineIcon icon={IconCategory}/>}
                 >
                     Browse
                 </Button>

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -51,9 +51,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             size="xs"
                             fz="sm"
                             leftIcon={
-                                <MantineIcon
-                                    icon={IconSquareRoundedPlus}
-                                />
+                                <MantineIcon icon={IconSquareRoundedPlus} />
                             }
                             onClick={() => setIsOpen(!isOpen)}
                         >

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -53,7 +53,6 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             leftIcon={
                                 <MantineIcon
                                     icon={IconSquareRoundedPlus}
-                                    size="lg"
                                 />
                             }
                             onClick={() => setIsOpen(!isOpen)}


### PR DESCRIPTION
Closes: #6952 

### Description:

As part of this PR, have fixed the size of icons on navbar to 16x16 in new and browse tab. Attached video for reference.

https://github.com/lightdash/lightdash/assets/20976813/2aaed9e6-cce6-4d3e-8481-7277d90dfb87


