### PR TITLE
docs: update max metrics

### DIFF
--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -209,8 +209,8 @@ Here are all of the properties you can customize:
 | [count](#count)                   | Aggregate     | Counts the total number of values in the dimension        |
 | [count_distinct](#count_distinct) | Aggregate     | Counts the total unique number of values in the dimension |
 | [date](#date)                     | Non-aggregate | For measures that contain dates                           |
-| [max](#max)                       | Aggregate     | Generates the maximum value within a column               |
-| [min](#min)                       | Aggregate     | Generates the minimum value within a column               |
+| [max](#max)                       | Aggregate     | Generates the maximum value within a numeric column       |
+| [min](#min)                       | Aggregate     | Generates the minimum value within a numeric column       |
 | [number](#number)                 | Non-aggregate | For measures that contain numbers                         |
 | [string](#string)                 | Non-aggregate | For measures that contain letters or special characters   |
 | [sum](#sum)                       | Aggregate     | Generates a sum of values within a column                 |
@@ -330,23 +330,29 @@ Gives you a date value from an expression.
 
 The `date` metric can be used on any valid SQL expression that gives you a date value. It can only be used on aggregations, which means either aggregate metrics *or* [custom SQL that references other metrics](#using-custom-sql-in-non-aggregate-metrics). You cannot build a `date` metric by referencing other unaggregated dimensions from your model.
 
-To be honest, `date` metrics are pretty rarely used because most SQL aggregate functions don't return dates. The only common use of this metric is if you use a `MIN` or `MAX` on a date dimension.
+**Creating a max or min date metric with `type: date`**
+
+If you want to create a metric of a maximum or minimum date, you can't use `type: max` or of `type: min` metrics because these are only compatible with numeric type fields. Instead, you can calculate a maximum or minimum date by defining a metric of `type: date` and using some custom sql, like this:
 
 ```yaml
-columns:
-  - name: date_updated
+- name: created_at_date
     meta:
+      dimension:
+        type: date
       metrics:
-        most_recent_date_updated:
+        max_created_at_date:
           type: date
-          sql: "MAX(${date_updated})"
+          sql: MAX(${created_at_date})
+  sql: ${TABLE}.updated_at
 ```
 
 ### max
 
-Max gives you the largest value in a given field. It's like SQL’s `MAX` function.
+Max gives you the largest value in a given numeric field. It's like SQL’s `MAX` function.
 
-The `max` metric can be used on any dimension or, [for custom SQL](#using-custom-SQL-in-aggregate-metrics), any valid SQL expression that gives a set of values.
+The `max` metric can be used on any numeric dimension or, [for custom SQL](#using-custom-SQL-in-aggregate-metrics), any valid SQL expression that gives a numeric value.
+
+Because `type: max` metrics only work with numerical fields, you can't use them to find a maximum date. Instead, you can use the `MAX()` function in the `sql` parameter of a metric of `type: date` to get a maximum date (you can see an [example of this in the `date` section](#date).
 
 For example, this creates a metric `max_delivery_cost` by looking at the `delivery_cost` dimension and taking the largest value it finds:
 

--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -367,9 +367,11 @@ columns:
 
 ### min
 
-Min gives you the smallest value in a given field. It's like SQL’s `MIN` function.
+Min gives you the smallest value in a given numeric field. It's like SQL’s `MIN` function.
 
-The `min` metric can be used on any dimension or, [for custom SQL](#using-custom-SQL-in-aggregate-metrics), any valid SQL expression that gives a set of values.
+The `min` metric can be used on any numeric dimension or, [for custom SQL](#using-custom-SQL-in-aggregate-metrics), any valid SQL expression that gives a numeric value.
+
+Because `type: min` metrics only work with numerical fields, you can't use them to find a minimum date. Instead, you can use the `MIN()` function in the `sql` parameter of a metric of `type: date` to get a minimum date (you can see an [example of this in the `date` section](#date).
 
 For example, this creates a metric `min_delivery_cost` by looking at the `delivery_cost` dimension and taking the smallest value it finds:
 


### PR DESCRIPTION
Include information about max metrics only working with `numeric` types

