### PR TITLE
fix: dbt error workaround for metric_time dimension

### DIFF
--- a/packages/frontend/src/api/MetricFlowAPI.ts
+++ b/packages/frontend/src/api/MetricFlowAPI.ts
@@ -39,9 +39,9 @@ export function getMetricFlowFields(
 ): Promise<GetMetricFlowFieldsResponse> {
     const query = `query GetFields($environmentId: BigInt!) {
             metricsForDimensions(environmentId: $environmentId, dimensions: [${
-                selectedFields?.dimensions.map(
-                    (dimension) => `"${dimension}"`,
-                ) ?? ''
+                selectedFields?.dimensions
+                    .filter((dimension) => dimension !== 'metric_time') // TODO: remove this when dbt stops throwing error when filtering by "metric_time"
+                    .map((dimension) => `"${dimension}"`) ?? ''
             }]) {
                 name
                 description


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Context: the dimension 'metric_time' is special and is available to all metrics.

Problem:
Dbt API throws an error when we filter metrics with the dimension `metric_time`. 

I'm introducing a workaround in the API request by excluding that dimension from the filters.
