### PR TITLE
fix: add default suffix to metricflow time dimensions

### DIFF
--- a/packages/frontend/src/features/metricFlow/utils/convertMetricFlowFieldsToExplore.ts
+++ b/packages/frontend/src/features/metricFlow/utils/convertMetricFlowFieldsToExplore.ts
@@ -20,13 +20,14 @@ export default function convertMetricFlowFieldsToExplore(
 ) {
     const dimensionsMap = metricFlowFields.dimensions.reduce(
         (acc, { name, description, type }) => {
+            const isTimeDimension = type === MetricFlowDimensionType.TIME;
             const dimension: CompiledDimension = {
                 fieldType: FieldType.DIMENSION,
-                type:
-                    type === MetricFlowDimensionType.TIME
-                        ? DimensionType.TIMESTAMP
-                        : DimensionType.STRING,
-                name,
+                type: isTimeDimension
+                    ? DimensionType.TIMESTAMP
+                    : DimensionType.STRING,
+                // Note: time columns in results are suffixed with '__day' by default
+                name: isTimeDimension ? `${name}__day` : name,
                 description,
                 label: friendlyName(name),
                 table: tableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6971 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

**Problem:**
If we group by a time dimension without specifying a grain we expected the results columns to match but that's not the case.

eg: for the following query
```
mutation {
  createQuery(
    environmentId: "204496"
    metrics: [{ name: "revenue"}]
    groupBy: [{ name: "order_id__ordered_at"}]
  ) {
    queryId
  }
}
```
I expect the columns:  ‘revenue’ and ‘order_id__ordered_at’  but we get:  ‘revenue’ and ‘order_id__ordered_at__day’ ( note the grain suffix )
This causes problems because there is a mismatch between the dimension name (aka ID ) the user selected and what was returned.

We had to implement a workaround by renaming all the time dimensions we receive from dbt.
`isTimeDimension ? `${name}__day` : name`
This works well because the API accepts the name with the grain suffix.
```
mutation {
  createQuery(
    environmentId: "204496"
    metrics: [{ name: "revenue"}]
    groupBy: [{ name: "order_id__ordered_at__day"}]
  ) {
    queryId
  }
}
```
But this is not in the docs so I’m unsure if it is intentional and if they are going to remove support for it.
