### PR TITLE
fix: dashbaord charts disappearing during edit

### DIFF
--- a/packages/frontend/src/components/Explorer/ExportGsheets/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExportGsheets/index.tsx
@@ -20,10 +20,11 @@ import { GsheetsIcon } from '../../SchedulerModals/SchedulerModalBase/SchedulerM
 export type ExportGsheetProps = {
     getGsheetLink: () => Promise<ApiScheduledDownloadCsv>;
     asMenuItem?: boolean;
+    disabled?: boolean;
 };
 
 const ExportGsheets: FC<ExportGsheetProps> = memo(
-    ({ getGsheetLink, asMenuItem }) => {
+    ({ getGsheetLink, asMenuItem, disabled }) => {
         const { data: gdriveAuth, refetch } = useGdriveAccessToken();
         const health = useHealth();
         const hasGoogleDrive =
@@ -163,7 +164,7 @@ const ExportGsheets: FC<ExportGsheetProps> = memo(
                         )
                     }
                     text="Export Google Sheets"
-                    disabled={isExportingGoogleSheets}
+                    disabled={isExportingGoogleSheets || disabled}
                     shouldDismissPopover={false}
                     onClick={handleLoginAndExport}
                 />
@@ -176,6 +177,7 @@ const ExportGsheets: FC<ExportGsheetProps> = memo(
                 loading={isExportingGoogleSheets}
                 leftIcon={<MantineIcon icon={GsheetsIcon} />}
                 onClick={handleLoginAndExport}
+                disabled={disabled}
             >
                 Google Sheets
             </Button>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -88,7 +88,8 @@ const SavedChartsHeader: FC = () => {
     );
     const reset = useExplorerContext((context) => context.actions.reset);
 
-    const { clearIsEditingDashboardChart } = useDashboardStorage();
+    const { clearIsEditingDashboardChart, getIsEditingDashboardChart } =
+        useDashboardStorage();
 
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
@@ -486,14 +487,23 @@ const SavedChartsHeader: FC = () => {
                                         />
                                     ) : null}
                                     <Divider />
-                                    <MenuItem2
-                                        icon={<IconTrash />}
-                                        text="Delete"
-                                        intent="danger"
-                                        onClick={() =>
-                                            setIsDeleteDialogOpen(true)
-                                        }
-                                    />
+                                    <Tooltip
+                                        disabled={!getIsEditingDashboardChart()}
+                                        position="bottom"
+                                        label="This chart can be deleted from its dashboard"
+                                    >
+                                        <Box>
+                                            <MenuItem2
+                                                icon={<IconTrash />}
+                                                text="Delete"
+                                                intent="danger"
+                                                disabled={getIsEditingDashboardChart()}
+                                                onClick={() =>
+                                                    setIsDeleteDialogOpen(true)
+                                                }
+                                            />
+                                        </Box>
+                                    </Tooltip>
                                 </Menu>
                             }
                         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6962 

### Description:

Fixes a range of issues that could arise from editing charts *while* editing the dashboard they are in. The main thing this does is disables the ability to edit a chart while the dashboard is being edited. The options are disabled and there is an explanatory tooltip:

<img width="367" alt="Screenshot 2023-09-01 at 16 54 42" src="https://github.com/lightdash/lightdash/assets/1864179/8c694f59-d20c-48d6-8519-69be7e192814">

This also disables the ability to delete an in-dashboard chart from the explores page. You have to go to the dashboard to do that. I kept the option in the menu and disabled it with an explanation:

<img width="370" alt="Screenshot 2023-09-01 at 16 56 07" src="https://github.com/lightdash/lightdash/assets/1864179/39c5f99d-a751-41f1-9328-5ad5119b2593">

It could also be removed, but I thought that was a little confusing. 


