### PR TITLE
fix: admins should see all spaces when moving items

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -51,7 +51,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const location = useLocation();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const organizationUuid = user.data?.organizationUuid;
-    const { data: spaces = [] } = useSpaceSummaries(projectUuid);
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
     const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6876

### Description:

<img width="670" alt="CleanShot 2023-09-04 at 13 30 42@2x" src="https://github.com/lightdash/lightdash/assets/962095/e9e384a8-82cb-4210-adb0-ffc6d638bb6e">
<img width="459" alt="CleanShot 2023-09-04 at 13 30 54@2x" src="https://github.com/lightdash/lightdash/assets/962095/16cd64af-aef8-45ba-902b-c6615868b261">
<img width="668" alt="CleanShot 2023-09-04 at 13 30 56@2x" src="https://github.com/lightdash/lightdash/assets/962095/e3a6457c-413e-4ebc-af7d-510247ac0655">
