### PR TITLE
fix: fix total legend with multiple series

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1092,7 +1092,7 @@ const calculateStackTotal = (
 ) => {
     return series.reduce<number>((acc, s) => {
         const hash = flipAxis ? s.encode?.x : s.encode?.y;
-        const legendName = s.encode?.seriesName.split('.')[2];
+        const legendName = s.dimensions?.[1]?.displayName;
         let selected = true;
         for (const key in selectedLegendNames) {
             if (legendName === key) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6588

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

[Screencast from 04-09-23 11:44:39.webm](https://github.com/lightdash/lightdash/assets/1983672/cd0dfd2f-4a63-4763-b631-e37511e1cdc1)


What was happening: 

Before we were simply checking the `group/pivot` of the series (eg: shipped, completed) but when you have multiple sries, the pivot appears multiple times. so that didn't work. 

Now I'm checking the  full serie display name against the selected legend

![Screenshot from 2023-09-04 11-44-33](https://github.com/lightdash/lightdash/assets/1983672/7c7c45ea-f731-40fe-b123-3ffa058edfba)

