### PR TITLE
fix: make delete action consistent on settings page

### DIFF
--- a/packages/e2e/cypress/e2e/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/invites.cy.ts
@@ -47,8 +47,8 @@ describe('Settings - Invites', () => {
         cy.contains('User management').click();
         cy.get('table')
             .contains('tr', 'demo+marygreen@lightdash.com')
-            .find('.tabler-icon-trash', { force: true })
-            .click();
+            .find('.tabler-icon-trash')
+            .click({ force: true });
         cy.findByText('Are you sure you want to delete this user ?')
             .parents('.mantine-Modal-root')
             .findByText('Delete')

--- a/packages/e2e/cypress/e2e/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/invites.cy.ts
@@ -47,7 +47,7 @@ describe('Settings - Invites', () => {
         cy.contains('User management').click();
         cy.get('table')
             .contains('tr', 'demo+marygreen@lightdash.com')
-            .find('.tabler-icon-trash')
+            .find('.tabler-icon-trash', { force: true })
             .click();
         cy.findByText('Are you sure you want to delete this user ?')
             .parents('.mantine-Modal-root')

--- a/packages/e2e/cypress/e2e/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/settings/invites.cy.ts
@@ -47,7 +47,7 @@ describe('Settings - Invites', () => {
         cy.contains('User management').click();
         cy.get('table')
             .contains('tr', 'demo+marygreen@lightdash.com')
-            .contains('td', 'Delete')
+            .find('.tabler-icon-trash')
             .click();
         cy.findByText('Are you sure you want to delete this user ?')
             .parents('.mantine-Modal-root')

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -1,8 +1,6 @@
 import {
-    Button,
     ButtonGroup,
     Classes,
-    Dialog,
     Intent,
     NonIdealState,
     Spinner,
@@ -16,7 +14,7 @@ import {
     ProjectMemberProfile,
     ProjectMemberRole,
 } from '@lightdash/common';
-import { Stack } from '@mantine/core';
+import { Button, Group, Stack, Modal, Title, Text } from '@mantine/core';
 import { FC, useMemo, useState } from 'react';
 import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
 import {
@@ -36,6 +34,8 @@ import {
     UserInfo,
     UserName,
 } from './ProjectAccess.styles';
+import { IconKey, IconTrash } from '@tabler/icons-react';
+import MantineIcon from '../common/MantineIcon';
 
 const UserListItem: FC<{
     user: OrganizationMemberProfile | ProjectMemberProfile;
@@ -104,40 +104,45 @@ const UserListItem: FC<{
                         )}
                         {onDelete && (
                             <Button
-                                icon="delete"
-                                intent="danger"
-                                outlined
+                                variant="outline"
+                                size="xs"
+                                color="red"
+                                px="xs"
                                 onClick={() => setIsDeleteDialogOpen(true)}
-                                text="Delete"
-                            />
+                            >
+                                <MantineIcon icon={IconTrash} />
+                            </Button>
                         )}
                     </ButtonGroup>
                 </SectionWrapper>
             </ItemContent>
-            <Dialog
-                isOpen={isDeleteDialogOpen}
-                icon="key"
+            <Modal
+                opened={isDeleteDialogOpen}
                 onClose={() => setIsDeleteDialogOpen(false)}
-                title="Revoke project access"
-                lazy
-            >
-                <div className={Classes.DIALOG_BODY}>
-                    <p>
-                        Are you sure you want to revoke project access this user{' '}
+                title={
+                    <Group spacing="xs">
+                        <MantineIcon
+                            size="lg"
+                            icon={IconKey}
+                            color="red"
+                        />
+                        <Title order={4}>Revoke project access</Title>
+                    </Group>
+                }
+            >   
+                <Text pb="md">
+                    Are you sure you want to revoke project access for this user{' '}
                         {email} ?
-                    </p>
-                </div>
-                <div className={Classes.DIALOG_FOOTER}>
-                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <Button onClick={() => setIsDeleteDialogOpen(false)}>
-                            Cancel
-                        </Button>
-                        <Button intent="danger" onClick={onDelete}>
-                            Delete
-                        </Button>
-                    </div>
-                </div>
-            </Dialog>
+                </Text>
+                <Group spacing="xs" position="right">
+                    <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+                        Cancel
+                    </Button>
+                    <Button color="red" onClick={onDelete}>
+                        Delete
+                    </Button>
+                </Group>
+            </Modal>
         </SettingsCard>
     );
 };

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -14,7 +14,8 @@ import {
     ProjectMemberProfile,
     ProjectMemberRole,
 } from '@lightdash/common';
-import { Button, Group, Stack, Modal, Title, Text } from '@mantine/core';
+import { Button, Group, Modal, Stack, Text, Title } from '@mantine/core';
+import { IconKey, IconTrash } from '@tabler/icons-react';
 import { FC, useMemo, useState } from 'react';
 import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
 import {
@@ -24,6 +25,7 @@ import {
 } from '../../hooks/useProjectAccess';
 import { useApp } from '../../providers/AppProvider';
 import { useAbilityContext } from '../common/Authorization';
+import MantineIcon from '../common/MantineIcon';
 import { SettingsCard } from '../common/Settings/SettingsCard';
 import {
     ItemContent,
@@ -34,8 +36,6 @@ import {
     UserInfo,
     UserName,
 } from './ProjectAccess.styles';
-import { IconKey, IconTrash } from '@tabler/icons-react';
-import MantineIcon from '../common/MantineIcon';
 
 const UserListItem: FC<{
     user: OrganizationMemberProfile | ProjectMemberProfile;
@@ -121,21 +121,20 @@ const UserListItem: FC<{
                 onClose={() => setIsDeleteDialogOpen(false)}
                 title={
                     <Group spacing="xs">
-                        <MantineIcon
-                            size="lg"
-                            icon={IconKey}
-                            color="red"
-                        />
+                        <MantineIcon size="lg" icon={IconKey} color="red" />
                         <Title order={4}>Revoke project access</Title>
                     </Group>
                 }
-            >   
+            >
                 <Text pb="md">
                     Are you sure you want to revoke project access for this user{' '}
-                        {email} ?
+                    {email} ?
                 </Text>
                 <Group spacing="xs" position="right">
-                    <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+                    <Button
+                        variant="outline"
+                        onClick={() => setIsDeleteDialogOpen(false)}
+                    >
                         Cancel
                     </Button>
                     <Button color="red" onClick={onDelete}>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -9,6 +9,7 @@ import {
     Text,
     Title,
 } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
 import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import {
@@ -16,7 +17,6 @@ import {
     useDeleteAccessToken,
 } from '../../../hooks/useAccessToken';
 import MantineIcon from '../../common/MantineIcon';
-import { IconTrash } from '@tabler/icons-react';
 
 const TokenItem: FC<{
     token: ApiPersonalAccessTokenResponse;

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -15,6 +15,8 @@ import {
     useAccessToken,
     useDeleteAccessToken,
 } from '../../../hooks/useAccessToken';
+import MantineIcon from '../../common/MantineIcon';
+import { IconTrash } from '@tabler/icons-react';
 
 const TokenItem: FC<{
     token: ApiPersonalAccessTokenResponse;
@@ -36,12 +38,13 @@ const TokenItem: FC<{
                 </td>
                 <td width="1%">
                     <Button
+                        px="xs"
                         variant="outline"
                         size="xs"
                         color="red"
                         onClick={() => setTokenToDelete(token)}
                     >
-                        Delete
+                        <MantineIcon icon={IconTrash} />
                     </Button>
                 </td>
             </tr>

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -78,7 +78,7 @@ const ProjectListItem: FC<ProjectListItemProps> = ({
                         })}
                     >
                         <Button
-                            leftIcon={<MantineIcon icon={IconTrash} />}
+                            px="xs"
                             size="xs"
                             variant="outline"
                             color="red"
@@ -86,7 +86,7 @@ const ProjectListItem: FC<ProjectListItemProps> = ({
                                 onDelete(projectUuid);
                             }}
                         >
-                            Delete
+                            <MantineIcon icon={IconTrash} />
                         </Button>
                     </Can>
                 </Group>

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -80,11 +80,11 @@ const SlackSettingsPanel: FC = () => {
                                 Reinstall
                             </Button>
                             <Button
-                                leftIcon={<MantineIcon icon={IconTrash} />}
+                                px="xs"
                                 color="red"
                                 onClick={() => deleteSlack(undefined)}
                             >
-                                Remove
+                                <MantineIcon icon={IconTrash} />
                             </Button>
                         </Group>
 

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -193,8 +193,8 @@ const UserListItem: FC<{
                                     onClick={() => setIsDeleteDialogOpen(true)}
                                     disabled={disabled}
                                     color="red"
-                                >         
-                                    <MantineIcon icon={IconTrash} />        
+                                >
+                                    <MantineIcon icon={IconTrash} />
                                 </Button>
                             </Group>
                             <Modal

--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -20,9 +20,9 @@ import {
 } from '@mantine/core';
 import {
     IconAlertCircle,
-    IconCircleX,
     IconHelp,
     IconInfoCircle,
+    IconTrash,
 } from '@tabler/icons-react';
 import { capitalize } from 'lodash-es';
 import { FC, useState } from 'react';
@@ -188,15 +188,13 @@ const UserListItem: FC<{
                         <td>
                             <Group position="right">
                                 <Button
-                                    leftIcon={
-                                        <MantineIcon icon={IconCircleX} />
-                                    }
+                                    px="xs"
                                     variant="outline"
                                     onClick={() => setIsDeleteDialogOpen(true)}
                                     disabled={disabled}
                                     color="red"
-                                >
-                                    Delete
+                                >         
+                                    <MantineIcon icon={IconTrash} />        
                                 </Button>
                             </Group>
                             <Modal


### PR DESCRIPTION
Closes: #6515 

### Description:

This PR makes the delete icon consistent across the tabs specified in the issue. Attached screenshot for the same. Have also made couple of additional fixes not part of the original issue.

- There seemed to be a typo in the Revoke project access modal. The word 'for' seemed to be missing. Have added that. 
- In the same file, to add the trash icon I used the mantine button. There were already button being used from blueprint. So migrated the buttons to mantine. This broke the UI of the modal using these buttons, so migrated it to mantine as well. (I saw in some issues that there was a plan to migrate to mantine so made this change. Apologies if this is not needed).

Attaching screenshots:
User management panel:
![User](https://github.com/lightdash/lightdash/assets/20976813/f5fb7637-873d-4f74-9be5-516983dd4eab)


All projects panel:
![Project management](https://github.com/lightdash/lightdash/assets/20976813/90ddb27f-5d1c-4a1b-b927-fcebf437e485)

Slack Integration:
![Slack](https://github.com/lightdash/lightdash/assets/20976813/e44e2f3c-be57-4784-9eb8-249bd69aa119)

Personal access token:
![Access token](https://github.com/lightdash/lightdash/assets/20976813/4cce23ae-23c6-4d86-8317-056b083a3fe7)

Projects access panel:
![ProjectAccess](https://github.com/lightdash/lightdash/assets/20976813/f84fd7bf-a44c-49fb-b707-bbe4e1ea93e8)



Screenshot for the Project access modal (Before):
![Project access Old Modal](https://github.com/lightdash/lightdash/assets/20976813/63fa8cc6-16e8-4b1b-9f07-df9171a292b9)

Screenshot for the Project access modal (After):
![Project access new Modal](https://github.com/lightdash/lightdash/assets/20976813/9d078ff9-ef2e-49dc-9626-1bfa44adf56a)



