### PR TITLE
fix: add loader on hover of information icon on chart list item

### DIFF
--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -13,14 +13,18 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
         resourceItemId,
     );
     return (
-        <>  
-            { relatedDashboards ?
-            <Text fw={600} fz="xs" color="gray.6">
-                Used in {relatedDashboards?.length ?? 0} dashboard
-                {relatedDashboards?.length === 1 ? '' : 's'}
-                {relatedDashboards && relatedDashboards.length > 0 ? ':' : ''}
-            </Text> : <Loader color="gray" size="xs"/>
-}
+        <>
+            {relatedDashboards ? (
+                <Text fw={600} fz="xs" color="gray.6">
+                    Used in {relatedDashboards?.length ?? 0} dashboard
+                    {relatedDashboards?.length === 1 ? '' : 's'}
+                    {relatedDashboards && relatedDashboards.length > 0
+                        ? ':'
+                        : ''}
+                </Text>
+            ) : (
+                <Loader color="gray" size="xs" />
+            )}
             {!!relatedDashboards?.length && (
                 <List size="xs">
                     {relatedDashboards.map(({ uuid, name }) => (

--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -1,4 +1,4 @@
-import { Anchor, List, Text } from '@mantine/core';
+import { Anchor, List, Loader, Text } from '@mantine/core';
 import { FC } from 'react';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
 
@@ -13,12 +13,14 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
         resourceItemId,
     );
     return (
-        <>
+        <>  
+            { relatedDashboards ?
             <Text fw={600} fz="xs" color="gray.6">
                 Used in {relatedDashboards?.length ?? 0} dashboard
                 {relatedDashboards?.length === 1 ? '' : 's'}
                 {relatedDashboards && relatedDashboards.length > 0 ? ':' : ''}
-            </Text>
+            </Text> : <Loader color="gray" size="xs"/>
+}
             {!!relatedDashboards?.length && (
                 <List size="xs">
                     {relatedDashboards.map(({ uuid, name }) => (


### PR DESCRIPTION
Closes: #6735 

### Description:

There is a slight lag when we hover on the information icon in dashboard list item (specially if we have a very slow network). Have added a loader on this so the user don't get confused.

Attaching video for reference.

https://github.com/lightdash/lightdash/assets/20976813/77341cb0-6893-40f9-b506-9a21fc414dc6

