### PR TITLE
feat: send pdf attachemnt with image

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -89,6 +89,7 @@
         "passport-oauth2-refresh": "^2.2.0",
         "passport-openidconnect": "^0.1.1",
         "passport-strategy": "^1.0.0",
+        "pdf-lib": "^1.17.1",
         "pg": "^8.7.1",
         "pg-connection-string": "^2.5.0",
         "puppeteer": "^18.0.5",

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -665,6 +665,7 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
         resourceType?: 'dashboard' | 'chart';
         type: 'slack' | 'email' | 'gsheets';
         format?: SchedulerFormat;
+        withPdf?: boolean;
     };
 };
 

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -189,6 +189,7 @@ export default class EmailClient {
         imageUrl: string,
         url: string,
         schedulerUrl: string,
+        pdfFile?: string,
     ) {
         return this.sendEmail({
             to: recipient,
@@ -205,6 +206,15 @@ export default class EmailClient {
                 schedulerUrl,
             },
             text: title,
+            attachments: pdfFile
+                ? [
+                      {
+                          filename: `${title}.pdf`,
+                          path: pdfFile,
+                          contentType: 'application/pdf',
+                      },
+                  ]
+                : undefined,
         });
     }
 

--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -164,7 +164,7 @@ export class SlackService {
                     const authUserUuid =
                         await this.slackAuthenticationModel.getUserUuid(teamId);
 
-                    const imageUrl = await unfurlService.unfurlImage(
+                    const { imageUrl } = await unfurlService.unfurlImage(
                         details.minimalUrl,
                         details.pageType,
                         imageId,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -826,6 +826,7 @@ export const sendEmailNotification = async (
                 schedulerTargetId: schedulerEmailTargetUuid,
                 type: 'email',
                 format,
+                withPdf: pdfFile !== undefined,
                 resourceType:
                     pageType === LightdashPage.CHART ? 'chart' : 'dashboard',
             },

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -6,7 +6,9 @@ export type SchedulerCsvOptions = {
     limit: 'table' | 'all' | number;
 };
 
-export type SchedulerImageOptions = {};
+export type SchedulerImageOptions = {
+    withPdf?: boolean;
+};
 
 export type SchedulerGsheetsOptions = {
     gdriveId: string;
@@ -175,6 +177,13 @@ export const isSchedulerCsvOptions = (
         | SchedulerGsheetsOptions,
 ): options is SchedulerCsvOptions => options && 'limit' in options;
 
+export const isSchedulerImageOptions = (
+    options:
+        | SchedulerCsvOptions
+        | SchedulerImageOptions
+        | SchedulerGsheetsOptions,
+): options is SchedulerImageOptions => options && 'withPdf' in options;
+
 export const isSchedulerGsheetsOptions = (
     options:
         | SchedulerCsvOptions
@@ -242,6 +251,7 @@ export type NotificationPayloadBase = {
             filename: string;
             localPath: string;
         }[];
+        pdfFile?: string;
     };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,6 +3716,20 @@
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz"
   integrity sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@popperjs/core@^2.11.6":
   version "2.11.6"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz"
@@ -14803,6 +14817,11 @@ packet-reader@1.0.0:
   resolved "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz"
   integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
 
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz"
@@ -15096,6 +15115,16 @@ pause@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
+
+pdf-lib@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
+  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pegjs@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: partially closes 6678 (Requires frontend)



### Description:

- [ ] If a user selects `image` as the export option, there is a toggle below the format which allows you to `Also include image as PDF attachment in email`
<img width="182" alt="image" src="https://github.com/lightdash/lightdash/assets/31848148/233474a1-7dbd-4901-b201-54a749f29871">

- [ ] by default, this toggle is `off` 
- [x] This is only for email to start with (we can open a separate issue for Slack)
- [x] add analytics

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-09-05 15-54-33](https://github.com/lightdash/lightdash/assets/1983672/4564b5fe-61ca-465f-97fa-ec0feaa004b8)
![Screenshot from 2023-09-05 15-54-47](https://github.com/lightdash/lightdash/assets/1983672/5bf4acce-e228-465c-a33e-15ab1635a72b)

Sample pdf 
[scale-to-fit.pdf](https://github.com/lightdash/lightdash/files/12524497/scale-to-fit.pdf)

