### PR TITLE
fix: avoid filtering out hidden columns and set visibility on table provider

### DIFF
--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -69,6 +69,18 @@ const rowColumn: TableColumn = {
     },
 };
 
+const calculateColumnVisibility = (columns: Props['columns']) =>
+    columns.reduce(
+        (acc, c) => ({
+            ...acc,
+            ...(c.id && {
+                [c.id]:
+                    c.meta && 'isVisible' in c.meta ? c.meta?.isVisible : true,
+            }),
+        }),
+        {},
+    );
+
 export const TableProvider: FC<Props> = ({
     hideRowNumbers,
     showColumnCalculation,
@@ -78,6 +90,11 @@ export const TableProvider: FC<Props> = ({
     const { showToastSuccess } = useToaster();
     const { data, columns, columnOrder, pagination } = rest;
     const [columnVisibility, setColumnVisibility] = useState({});
+
+    useEffect(() => {
+        setColumnVisibility(calculateColumnVisibility(columns));
+    }, [columns]);
+
     const [tempColumnOrder, setTempColumnOrder] = useState<ColumnOrderState>([
         ROW_NUMBER_COLUMN_ID,
         ...(columnOrder || []),

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -39,6 +39,7 @@ export type TableColumn = ColumnDef<ResultRow, ResultRow[0]> & {
         className?: string;
         style?: CSSProperties;
         frozen?: boolean;
+        isVisible?: boolean;
     };
 };
 

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -54,7 +54,7 @@ const getDataAndColumns = ({
                 | typeof itemsMap[number]
                 | undefined;
 
-            if (!isColumnVisible(itemId) || !columnOrder.includes(itemId)) {
+            if (!columnOrder.includes(itemId)) {
                 return acc;
             }
             const headerOverride = getFieldLabelOverride(itemId);
@@ -100,6 +100,7 @@ const getDataAndColumns = ({
                             : null,
                     meta: {
                         item,
+                        isVisible: isColumnVisible(itemId),
                         frozen: isColumnFrozen(itemId),
                     },
                 },

--- a/packages/frontend/src/types/table-core.d.ts
+++ b/packages/frontend/src/types/table-core.d.ts
@@ -14,6 +14,7 @@ declare module '@tanstack/table-core' {
         className?: string;
         style?: CSSProperties;
         frozen?: boolean;
+        isVisible?: boolean;
         onHeaderClick?: MouseEventHandler<HTMLTableHeaderCellElement>;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7009

### Description:

We currently filter out hidden columns from `getDataAndColumns` util. The result of this util is then utilised in `TableProvider`. 
However, some cells might require information about other columns, regardless of their visibility. 

(read bug 7009)

This ensures all columns are provided, but then looped through to set if visible or not on `TableProvider` using `setColumnVisibility`

Screen recording: 

on explorer

https://github.com/lightdash/lightdash/assets/7611706/6019389b-0533-470b-b815-4d7ad4088fc7

on dashboards

https://github.com/lightdash/lightdash/assets/7611706/ddcd7b7b-364e-4890-82f0-7cefdaf4b348



