### PR TITLE
feat: do not include timezone on raw timeframes

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -115,7 +115,9 @@ const getTimeFormat = (
             timeFormat = 'HH:mm:ss:SSS';
             break;
     }
-    return `YYYY-MM-DD, ${timeFormat} (Z)`;
+    return `YYYY-MM-DD, ${timeFormat} ${
+        timeInterval !== TimeFrames.RAW ? '(Z)' : ''
+    }`;
 };
 
 export function formatTimestamp(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7010

### Description:

Remove Timezone from `RAW` timestamps formatting. At least visually Users don't get confused with an irrelevant timezone on `ntz`s

![Screenshot 2023-09-05 at 17 13 46](https://github.com/lightdash/lightdash/assets/7611706/6795681a-f739-4fc4-b0d1-59c3845254d5)

I think all makes sense 👍 
