### PR TITLE
fix: autocomplete for joined tables with alias

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1245,13 +1245,13 @@ export class ProjectService {
             );
         }
 
-        const explore = await this.projectModel.getExploreFromCache(
+        const explore = await this.projectModel.findExploreByTableName(
             projectUuid,
             table,
         );
 
-        if (isExploreError(explore)) {
-            throw new NotExistsError(`Explore does not exist.`);
+        if (!explore || isExploreError(explore)) {
+            throw new NotExistsError(`Explore does not exist or has errors`);
         }
 
         const field = findFieldByIdInExplore(explore, fieldId);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7007 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Note: There is an edge case where we return the wrong explore because join table aliases are not unique
eg:
```
  - name: payments
    meta:
      joins:
        - join: users
          alias: users_alias
          sql_on: ${users.user_id} = ${payments.order_id}
          
  - name: orders
    meta:
      joins:
        - join: customer
          alias: users_alias
          sql_on: ${users_alias.customer_id} = ${payments.order_id}
```
In this case, autocomplete for the field `users_alias.name` will always get results from table `users` and never from `customers`.

Preview autocomplete working with joined tables with alias:

```
  - name: payments
    meta:
      joins:
        - join: orders
          sql_on: ${orders.order_id} = ${payments.order_id}
        - join: customers
          alias: customers_payments_limited
          sql_on: ${customers_payments_limited.customer_id} = ${orders.customer_id}
          fields: [customer_id, first_name, last_name]
        - join: customers
          alias: customers_payments
          sql_on: ${customers_payments.customer_id} = ${orders.customer_id}
          fields: [customer_id, first_name]
```

https://github.com/lightdash/lightdash/assets/9117144/61e74db8-943f-4dd0-9099-c3a0599ddc8b

