### PR TITLE
feat: rename CSV files

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -46,6 +46,7 @@ describe('Csv service', () => {
             metricQuery,
             itemMap,
             false,
+            'explore',
             {},
             [],
         );
@@ -77,6 +78,7 @@ $4.00,value_4,2020-03-16
             metricQuery,
             itemMap,
             true,
+            'explore',
             {},
             [],
         );

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import moment from 'moment';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import {
     dashboardModel,
@@ -159,5 +160,37 @@ $4.00,value_4,2020-03-16
         ]);
 
         expect(csv).toEqual([undefined, 'value_1', '2020-03-16']);
+    });
+
+    it('Should generate csv file ids', async () => {
+        const time = moment('2023-09-07 12:13:45.123');
+        const timestamp = time.format('YYYY-MM-DD-HH-mm-ss-SSSS');
+
+        expect(timestamp).toEqual(`2023-09-07-12-13-45-1230`);
+
+        expect(CsvService.generateFileId('payment', time)).toEqual(
+            `csv-payment-${timestamp}.csv`,
+        );
+        expect(CsvService.generateFileId('MyTable', time)).toEqual(
+            `csv-mytable-${timestamp}.csv`,
+        );
+        expect(CsvService.generateFileId('my table', time)).toEqual(
+            `csv-my_table-${timestamp}.csv`,
+        );
+        expect(CsvService.generateFileId('table!', time)).toEqual(
+            `csv-table_-${timestamp}.csv`,
+        );
+        expect(
+            CsvService.generateFileId('this is a chart title', time),
+        ).toEqual(`csv-this_is_a_chart_title-${timestamp}.csv`);
+        expect(
+            CsvService.generateFileId('another table (for testing)', time),
+        ).toEqual(`csv-another_table_for_testing_-${timestamp}.csv`);
+        expect(CsvService.generateFileId('weird chars *!"()_-', time)).toEqual(
+            `csv-weird_chars_-${timestamp}.csv`,
+        );
+
+        // Test without time
+        expect(CsvService.generateFileId('payment')).toContain(`csv-payment-`);
     });
 });

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -181,6 +181,19 @@ export class CsvService {
         });
     }
 
+    static generateFileId(
+        fileName: string,
+        time: moment.Moment = moment(),
+    ): string {
+        const timestamp = time.format('YYYY-MM-DD-HH-mm-ss-SSSS');
+        const sanitizedFileName = fileName
+            .toLowerCase()
+            .replace(/[^a-z0-9]/gi, '_') // Replace non-alphanumeric characters with underscores
+            .replace(/_{2,}/g, '_'); // Replace multiple underscores with a single one
+        const fileId = `csv-${sanitizedFileName}-${timestamp}.csv`;
+        return fileId;
+    }
+
     static async writeRowsToFile(
         rows: Record<string, any>[],
         onlyRaw: boolean,
@@ -201,12 +214,7 @@ export class CsvService {
             `writeRowsToFile with ${rows.length} rows and ${selectedFieldIds.length} columns`,
         );
 
-        const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss-SSSS');
-        const sanitizedFileName = fileName
-            .toLowerCase()
-            .replace(/[^a-z0-9]/gi, '_') // Replace non-alphanumeric characters with underscores
-            .replace(/_{2,}/g, '_'); // Replace multiple underscores with a single one
-        const fileId = `csv-${sanitizedFileName}-${timestamp}.csv`;
+        const fileId = CsvService.generateFileId(fileName);
         const writeStream = fs.createWriteStream(`/tmp/${fileId}`);
 
         const sortedFieldIds = Object.keys(rows[0])

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -187,6 +187,7 @@ export class CsvService {
         metricQuery: MetricQuery,
         itemMap: Record<string, Field | TableCalculation>,
         showTableNames: boolean,
+        fileName: string,
         customLabels: Record<string, string> = {},
         columnOrder: string[] = [],
     ): Promise<string> {
@@ -200,7 +201,12 @@ export class CsvService {
             `writeRowsToFile with ${rows.length} rows and ${selectedFieldIds.length} columns`,
         );
 
-        const fileId = `csv-${nanoid()}.csv`;
+        const timestamp = new Date().getTime();
+        const sanitizedFileName = fileName
+            .toLowerCase()
+            .replace(/[^a-z0-9]/gi, '_')
+            .replace(/_{2,}/g, '_');
+        const fileId = `csv-${sanitizedFileName}-${timestamp}.csv`;
         const writeStream = fs.createWriteStream(`/tmp/${fileId}`);
 
         const sortedFieldIds = Object.keys(rows[0])
@@ -363,6 +369,7 @@ export class CsvService {
             metricQuery,
             itemMap,
             isTableChartConfig(config) ? config.showTableNames ?? false : true,
+            chart.name,
             getCustomLabelsFromTableConfig(config),
             chart.tableConfig.columnOrder,
         );
@@ -622,6 +629,7 @@ export class CsvService {
                 metricQuery,
                 itemMap,
                 showTableNames,
+                exploreId,
                 customLabels,
                 columnOrder || [],
             );

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -204,8 +204,8 @@ export class CsvService {
         const timestamp = new Date().getTime();
         const sanitizedFileName = fileName
             .toLowerCase()
-            .replace(/[^a-z0-9]/gi, '_')
-            .replace(/_{2,}/g, '_');
+            .replace(/[^a-z0-9]/gi, '_') // Replace non-alphanumeric characters with underscores
+            .replace(/_{2,}/g, '_'); // Replace multiple underscores with a single one
         const fileId = `csv-${sanitizedFileName}-${timestamp}.csv`;
         const writeStream = fs.createWriteStream(`/tmp/${fileId}`);
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -201,7 +201,7 @@ export class CsvService {
             `writeRowsToFile with ${rows.length} rows and ${selectedFieldIds.length} columns`,
         );
 
-        const timestamp = new Date().getTime();
+        const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss-SSSS');
         const sanitizedFileName = fileName
             .toLowerCase()
             .replace(/[^a-z0-9]/gi, '_') // Replace non-alphanumeric characters with underscores


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4758

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- [x] If I export a file from a saved chart, the file should have the name like `csv-NameOfChart_export-timestamp.csv`

Exporting `Which customers have not recently ordered an item?` chart : 

> csv-which_customers_have_not_recently_ordered_an_item_-2023-09-06-11-36-24-6970.csv


- [x] If I export a .file from an unsaved chart, the .file should have the name like `csv-NameOfTable_export-timestamp.csv`

Exporting `payments` unsaved chart or results:

> csv-payments-2023-09-06-11-36-24-6970.csv

- [x] This behaviour should also apply to exports included in scheduled deliveries