### PR TITLE
fix: only pass onOpening and onClosing props to MultiAutoComplete

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/AutoComplete/MultiAutoComplete.tsx
@@ -127,8 +127,15 @@ const MultiAutoComplete: FC<Props> = ({
             popoverProps={{
                 minimal: true,
                 matchTargetWidth: true,
-                onClosing: () => handleOnClose(search),
-                ...popoverProps,
+                onOpening: () => {
+                    if (popoverProps?.onOpening)
+                        popoverProps?.onOpening(null as unknown as HTMLElement);
+                },
+                onClosing: () => {
+                    if (popoverProps?.onClosing)
+                        popoverProps?.onClosing(null as unknown as HTMLElement);
+                    handleOnClose(search);
+                },
             }}
             resetOnSelect
             tagRenderer={(name) => name}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7022

### Description:

Currently, users: 
* add filter to a dashboard of type string
* add operator that will trigger the MultiAutoComplete (for example `includes`)
* add value
* remove that value
* add another one. If that click happened outside of the popover, it would close the whole popover.

This was because of the `popoverProps` being spread.

Now, we only pass the necessary ones: 
`onClosing` and `onOpening`