### PR TITLE
fix: opening dashboard links in popup in a new tab

### DIFF
--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -26,6 +26,7 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
                             <Anchor
                                 href={`${window.location.origin}/projects/${projectUuid}/dashboards/${uuid}/view/`}
                                 target="_blank"
+                                onClick={(e) => e.stopPropagation()}
                             >
                                 {name}
                             </Anchor>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#7023](https://github.com/lightdash/lightdash/issues/7023)

### Description:
The dashboard link was bubbling out the click event to the chart link, which was making the chart open in the same tab. 
I added a stop propagation to the event, so that the dashboard link opens up in a new tab

[Screencast from 2023-09-07 01-47-11.webm](https://github.com/lightdash/lightdash/assets/37402791/5b8a4745-8ef5-476e-bb3b-86625164bc0e)
