### PR TITLE
chore: refactor auser attribute method

### DIFF
--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -56,6 +56,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -66,6 +67,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_BIGQUERY,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: bigqueryClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL_BIGQUERY);
     });
@@ -76,6 +78,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_TWO_TABLES_SQL);
     });
@@ -86,6 +89,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_TABLE_REFERENCE_SQL);
     });
@@ -96,6 +100,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_SQL);
     });
@@ -106,6 +111,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_JOIN_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_JOIN_CHAIN_SQL);
     });
@@ -116,6 +122,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL);
     });
@@ -126,6 +133,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL);
     });
@@ -136,6 +144,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_DISABLED_FILTER_SQL);
     });
@@ -147,6 +156,7 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL);
     });
@@ -157,6 +167,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL);
     });
@@ -167,6 +178,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -177,6 +189,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_SQL);
     });
@@ -188,6 +201,7 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(
             METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM_SQL,
@@ -200,6 +214,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_METRIC_FILTERS_SQL);
     });
@@ -210,6 +225,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL);
     });
@@ -220,6 +236,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_FILTER_SQL);
     });
@@ -230,6 +247,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL);
     });
@@ -241,6 +259,7 @@ describe('Query builder', () => {
                     explore: EXPLORE_WITH_SQL_FILTER,
                     compiledMetricQuery: METRIC_QUERY,
                     warehouseClient: warehouseClientMock,
+                    userUuid: 'user-uuid',
                     userAttributes: [],
                 }).query,
         ).toThrowError(ForbiddenError);

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -256,7 +256,7 @@ describe('Query builder', () => {
                 attributeDefault: null,
                 users: [
                     {
-                        userUuid: '',
+                        userUuid: 'user-uuid',
                         email: '',
                         value: 'EU',
                     },
@@ -268,6 +268,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_WITH_SQL_FILTER,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
+                userUuid: 'user-uuid',
                 userAttributes,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_SQL_FILTER);
@@ -469,6 +470,7 @@ describe('replaceUserAttributes', () => {
 describe('assertValidDimensionRequiredAttribute', () => {
     it('should not throw errors if no user attributes are required', async () => {
         const result = assertValidDimensionRequiredAttribute(
+            'user-uuid',
             COMPILED_DIMENSION,
             [],
             '',
@@ -480,6 +482,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
     it('should throw errors if required attributes are required and user attributes are missing', async () => {
         expect(() =>
             assertValidDimensionRequiredAttribute(
+                'user-uuid',
                 {
                     ...COMPILED_DIMENSION,
                     requiredAttributes: {
@@ -493,6 +496,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
 
         expect(() =>
             assertValidDimensionRequiredAttribute(
+                'user-uuid',
                 {
                     ...COMPILED_DIMENSION,
                     requiredAttributes: {
@@ -508,7 +512,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
                         attributeDefault: null,
                         users: [
                             {
-                                userUuid: '',
+                                userUuid: 'user-uuid',
                                 email: '',
                                 value: 'false',
                             },
@@ -522,6 +526,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
 
     it('should not throw errors if required attributes are required and user attributes exist', async () => {
         const result = assertValidDimensionRequiredAttribute(
+            'user-uuid',
             {
                 ...COMPILED_DIMENSION,
                 requiredAttributes: {
@@ -537,7 +542,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
                     attributeDefault: null,
                     users: [
                         {
-                            userUuid: '',
+                            userUuid: 'user-uuid',
                             email: '',
                             value: 'true',
                         },

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -130,7 +130,7 @@ export type BuildQueryProps = {
     compiledMetricQuery: CompiledMetricQuery;
 
     warehouseClient: WarehouseClient;
-    userUuid?: string;
+    userUuid: string;
     userAttributes?: UserAttribute[];
 };
 
@@ -171,13 +171,8 @@ export const buildQuery = ({
         const alias = field;
         const dimension = getDimensionFromId(field, explore);
 
-        if (userUuid === undefined && userAttributes.length > 0) {
-            throw new Error(
-                `Missing userUuid with userAttributes on buildQuery for dimension ${dimension.name}`,
-            );
-        }
         assertValidDimensionRequiredAttribute(
-            userUuid!,
+            userUuid,
             dimension,
             userAttributes,
             `dimension: "${field}"`,
@@ -204,14 +199,9 @@ export const buildQuery = ({
 
             const dimensionId = getCustomMetricDimensionId(metric);
             const dimension = getDimensionFromId(dimensionId, explore);
-            if (userUuid === undefined && userAttributes.length > 0) {
-                throw new Error(
-                    `Missing userUuid with userAttributes on buildQuery for dimension ${dimension.name}`,
-                );
-            }
 
             assertValidDimensionRequiredAttribute(
-                userUuid!,
+                userUuid,
                 dimension,
                 userAttributes,
                 `custom metric: "${metric.name}"`,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -700,6 +700,7 @@ export class ProjectService {
         metricQuery: MetricQuery,
         explore: Explore,
         warehouseClient: WarehouseClient,
+        userUuid: string,
         userAttributes: UserAttribute[],
     ): Promise<{ query: string; hasExampleMetric: boolean }> {
         const compiledMetricQuery = compileMetricQuery({
@@ -711,6 +712,7 @@ export class ProjectService {
             explore,
             compiledMetricQuery,
             warehouseClient,
+            userUuid,
             userAttributes,
         });
     }
@@ -744,6 +746,7 @@ export class ProjectService {
             metricQuery,
             explore,
             warehouseClient,
+            user.userUuid,
             userAttributes,
         );
         await sshTunnel.disconnect();
@@ -1086,6 +1089,7 @@ export class ProjectService {
                             metricQueryWithLimit,
                             explore,
                             warehouseClient,
+                            user.userUuid,
                             userAttributes,
                         );
 
@@ -1312,6 +1316,7 @@ export class ProjectService {
             metricQuery,
             explore,
             warehouseClient,
+            user.userUuid,
             userAttributes,
         );
 
@@ -1736,7 +1741,11 @@ export class ProjectService {
                 userUuid: user.userUuid,
             });
 
-            return filterDimensionsFromExplore(explore, userAttributes);
+            return filterDimensionsFromExplore(
+                explore,
+                user.userUuid,
+                userAttributes,
+            );
         } finally {
             span?.finish();
         }

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -104,7 +104,11 @@ export class SearchService {
                 userUuid: user.userUuid,
             });
             filteredFields = results.fields.filter((field) =>
-                hasUserAttributes(field.requiredAttributes, userAttributes),
+                hasUserAttributes(
+                    user.userUuid,
+                    field.requiredAttributes,
+                    userAttributes,
+                ),
             );
         }
 

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -4,6 +4,7 @@ describe('hasUserAttribute', () => {
     test('should be false if attribute is not present', () => {
         expect(
             hasUserAttribute(
+                'user-uuid',
                 [
                     {
                         uuid: '',
@@ -13,7 +14,7 @@ describe('hasUserAttribute', () => {
                         attributeDefault: null,
                         users: [
                             {
-                                userUuid: '',
+                                userUuid: 'user-uuid',
                                 email: '',
                                 value: '1',
                             },
@@ -28,6 +29,7 @@ describe('hasUserAttribute', () => {
     test('should be false if attribute value does not match', () => {
         expect(
             hasUserAttribute(
+                'user-uuid',
                 [
                     {
                         uuid: '',
@@ -37,7 +39,7 @@ describe('hasUserAttribute', () => {
                         attributeDefault: null,
                         users: [
                             {
-                                userUuid: '',
+                                userUuid: 'user-uuid',
                                 email: '',
                                 value: '1',
                             },
@@ -53,6 +55,8 @@ describe('hasUserAttribute', () => {
     test('should be false if attribute value does not match even if attributeDefault is present', () => {
         expect(
             hasUserAttribute(
+                'user-uuid',
+
                 [
                     {
                         uuid: '',
@@ -62,7 +66,7 @@ describe('hasUserAttribute', () => {
                         attributeDefault: '2',
                         users: [
                             {
-                                userUuid: '',
+                                userUuid: 'user-uuid',
                                 email: '',
                                 value: '1',
                             },
@@ -77,6 +81,8 @@ describe('hasUserAttribute', () => {
     test('should be true if attribute value match user', () => {
         expect(
             hasUserAttribute(
+                'user-uuid',
+
                 [
                     {
                         uuid: '',
@@ -86,7 +92,8 @@ describe('hasUserAttribute', () => {
                         attributeDefault: null,
                         users: [
                             {
-                                userUuid: '',
+                                userUuid: 'user-uuid',
+
                                 email: '',
                                 value: '1',
                             },
@@ -102,6 +109,8 @@ describe('hasUserAttribute', () => {
     test('should be true if user does not have value and attributeDefault matches', () => {
         expect(
             hasUserAttribute(
+                'user-uuid',
+
                 [
                     {
                         uuid: '',
@@ -116,5 +125,33 @@ describe('hasUserAttribute', () => {
                 '1',
             ),
         ).toStrictEqual(true);
+    });
+
+    test('should be false if attribute value match a different user', () => {
+        expect(
+            hasUserAttribute(
+                'another-user-uuid',
+
+                [
+                    {
+                        uuid: '',
+                        name: 'test',
+                        createdAt: new Date(),
+                        organizationUuid: '',
+                        attributeDefault: null,
+                        users: [
+                            {
+                                userUuid: 'user-uuid',
+
+                                email: '',
+                                value: '1',
+                            },
+                        ],
+                    },
+                ],
+                'test',
+                '1',
+            ),
+        ).toStrictEqual(false);
     });
 });

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -1,6 +1,7 @@
 import { Explore, UserAttribute } from '@lightdash/common';
 
 export const hasUserAttribute = (
+    userUuid: string,
     userAttributes: UserAttribute[],
     attributeName: string,
     value: string,
@@ -8,13 +9,15 @@ export const hasUserAttribute = (
     userAttributes.some((ua) => {
         if (ua.name === attributeName) {
             // If user does not have attributes, we will check default value
-            if (ua.users.length === 0) return ua.attributeDefault === value;
-            return ua.users.some((u) => u.value === value);
+            const userAttribute = ua.users.find((u) => u.userUuid === userUuid);
+            if (userAttribute) return userAttribute.value === value;
+            return ua.attributeDefault === value;
         }
         return false;
     });
 
 export const hasUserAttributes = (
+    userUuid: string,
     requiredAttributes: Record<string, string> | undefined,
     userAttributes: UserAttribute[],
 ): boolean => {
@@ -24,7 +27,12 @@ export const hasUserAttributes = (
     const hasAttributes = Object.entries(requiredAttributes).map(
         (attribute) => {
             const [attributeName, value] = attribute;
-            return hasUserAttribute(userAttributes, attributeName, value);
+            return hasUserAttribute(
+                userUuid,
+                userAttributes,
+                attributeName,
+                value,
+            );
         },
     );
     return hasAttributes.every((attribute) => attribute === true);
@@ -38,6 +46,7 @@ export const exploreHasFilteredAttribute = (explore: Explore) =>
     );
 export const filterDimensionsFromExplore = (
     explore: Explore,
+    userUuid: string,
     userAttributes: UserAttribute[],
 ): Explore => ({
     ...explore,
@@ -53,6 +62,7 @@ export const filterDimensionsFromExplore = (
 
                         if (
                             hasUserAttributes(
+                                userUuid,
                                 dimension.requiredAttributes,
                                 userAttributes,
                             )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7049

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Motivation: 

when checking user attributes, we filter from db user attributes by `userUuid` which means attributes we were passing to the `hasUserAttribute` only contain the user.

But this is confusing, not very untuitive, and could cause bugs in the future. So I refactored to also check the uuid on the `hasUserAttribute` method. 

This means we'll have to cascade the userUuid in some methods like `buidlQuery`