### PR TITLE
fix: change default display value for boolean filter to False

### DIFF
--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -100,7 +100,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
         case FilterType.BOOLEAN:
             switch (operator) {
                 case FilterOperator.EQUALS:
-                    return 'True / False';
+                    return 'False';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';


### PR DESCRIPTION
Closes: #7056 

### Description:

The default display value for boolean filters is True/False. The default value applied on the query is False. Change the default display value to be consistent with the backend query.
Attached video for reference.

https://github.com/lightdash/lightdash/assets/20976813/f6d7c0a7-6788-48bc-9a40-1869db37ee58


