### PR TITLE
feat: Show the dbt profile and target when compiling with the CLI

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -81,6 +81,10 @@ export const compile = async (options: CompileHandlerOptions) => {
         profileName,
         targetName: options.target,
     });
+
+    GlobalState.debug(`> Compiling with profile ${profileName}`);
+    GlobalState.debug(`> Compiling with target ${target}`);
+
     const credentials = await warehouseCredentialsFromDbtTarget(target);
     const warehouseClient = warehouseClientFromCredentials({
         ...credentials,


### PR DESCRIPTION
### Description:
I have an issue to compile a dbt project with the Lightdash CLI. I am still investigating the root cause. But, I would like to make sure the CLI uses the passed dbt profile and target by showing the logs. 
