### PR TITLE
fix: the deprecated GitHub Actions' outputs manner

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -240,7 +240,10 @@ export const startPreviewHandler = async (
         const url = await projectUrl(previewProject);
         console.error(`Project updated on ${url}`);
         if (process.env.CI === 'true') {
-            console.info(`::set-output name=url::${url}`);
+            console.info(`url="${url}" >> "$GITHUB_OUTPUT"`);
+            console.info(
+                `project_uuid="${previewProject.projectUuid}" >> "$GITHUB_OUTPUT"`,
+            );
         }
     } else {
         const config = await getConfig();
@@ -288,7 +291,10 @@ export const startPreviewHandler = async (
 
         console.error(`New project created on ${url}`);
         if (process.env.CI === 'true') {
-            console.info(`::set-output name=url::${url}`);
+            console.info(`url="${url}" >> "$GITHUB_OUTPUT"`);
+            console.info(
+                `project_uuid="${project.projectUuid}" >> "$GITHUB_OUTPUT"`,
+            );
         }
     }
 };


### PR DESCRIPTION
### Description:
First, GitHub changed the manner to set output in GitHub Actions. So, we have to follow the current one.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Second, it would be good to give another way to get the project UUID deployed by the Lightdash CLI, because GitHub Actions might disallow us to put files in `${HOME}/.config/lightdash`. I haven't identified the root cause of failures on GitHub Actions to validate a preview project which was launched just before executing a `lightdash validate` command. The preview project was created. However, a `lightdash validate` command sequencially executed just after the creation was failed due to the lack of informatio of a project UUID.

```
      # Validate the lightdash project
      - id: validate-lightdash-project
        name: "Validate Lightdash project"
        env:
          LIGHTDASH_URL: "${{ inputs.lightdash_url }}"
          LIGHTDASH_API_KEY: "${{ steps.get-token.outputs.lightdash_api_key }}"
        run: |
          # Start the preview project
          lightdash start-preview \
              --name "${{ inputs.lightdash_preview_project_name }}" \
              --project-dir "${{ github.workspace }}" \
              --profiles-dir "${{ github.workspace }}" \
              --profile "${{ inputs.dbt_profile }}" \
              --target "${{ inputs.dbt_target }}" \
              --selector "${{ inputs.dbt_selector }}" \
              --vars "$(cat "${{ github.workspace }}/${{ inputs.dbt_vars_path }}")" \
              --verbose
          # Validate the preview project
          # The project UUID is set to the preview project by default.
          lightdash validate \
              --project-dir "${{ github.workspace }}" \
              --profiles-dir "${{ github.workspace }}" \
              --profile "${{ inputs.dbt_profile }}" \
              --target "${{ inputs.dbt_target }}" \
              --selector "${{ inputs.dbt_selector }}" \
              --vars "$(cat "${{ github.workspace }}/${{ inputs.dbt_vars_path }}")" \
              --verbose

...

No project specified, select a project to validate using --project <projectUuid> or create a preview environment using lightdash start-preview or configure your default project using lightdash config set-project
```