### PR TITLE
fix: query generation with empty value on string and number filters

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -41,7 +41,7 @@ export const renderStringFilterSql = (
     switch (filter.operator) {
         case FilterOperator.EQUALS:
             return !escapedFilterValues || escapedFilterValues.length === 0
-                ? 'false'
+                ? 'true'
                 : `(${dimensionSql}) IN (${escapedFilterValues
                       .map((v) => `${stringQuoteChar}${v}${stringQuoteChar}`)
                       .join(',')})`;
@@ -92,7 +92,7 @@ export const renderNumberFilterSql = (
     switch (filter.operator) {
         case FilterOperator.EQUALS:
             return !filter.values || filter.values.length === 0
-                ? 'false'
+                ? 'true'
                 : `(${dimensionSql}) IN (${filter.values.join(',')})`;
         case FilterOperator.NOT_EQUALS:
             return !filter.values || filter.values.length === 0


### PR DESCRIPTION
Closes: #7064 

### Description:

When using string filters and not having any value in the criteria, the query generated used to have a where clause (false) as mentioned in the referenced issue. Have changed it to have a where clause as (true) so it does not impact rest of the query. Have made similar change for number type filters as the issue was also persistent in that case as well (not mentioned on the original issue). Please let me know in case this was not needed.

Attached video for reference.

https://github.com/lightdash/lightdash/assets/20976813/497ef34e-4275-416e-8f1d-1d54263a29f5
