### PR TITLE
chore: add metrics to screenshot method

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -338,7 +338,7 @@ export class UnfurlService {
                         await page.setViewport(viewport);
                     }
                     await page.on('requestfailed', (request) => {
-                        Logger.error(
+                        Logger.warn(
                             `Headless browser request error - method: ${request.method()}, url: ${request.url()}, text: ${
                                 request.failure()?.errorText
                             }`,
@@ -347,7 +347,7 @@ export class UnfurlService {
                     await page.on('console', (msg) => {
                         const type = msg.type();
                         if (type === 'error') {
-                            Logger.error(
+                            Logger.warn(
                                 `Headless browser console error - file: ${
                                     msg.location().url
                                 }, text ${msg.text()} `,
@@ -430,7 +430,7 @@ export class UnfurlService {
                     chartCounter.addCallback(async (result) => {
                         result.observe(chartRequests, {
                             errors: chartRequestErrors,
-                            timeout: timeout,
+                            timeout,
                         });
                     });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -435,8 +435,8 @@ export class UnfurlService {
                     });
 
                     span.setAttributes({
-                        'page.width': box?.width || 0,
-                        'page.height': box?.height || 0,
+                        'page.width': box?.width,
+                        'page.height': box?.height,
                         'chart.requests.total': chartRequests,
                         'chart.requests.error': chartRequestErrors,
                         'page.metrics.task_duration': pageMetrics.TaskDuration,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7041

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

While debugging

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-09-18 13-39-09](https://github.com/lightdash/lightdash/assets/1983672/bca5cc88-0fee-40bb-bfea-922aa5003559)

Now: 
![image](https://github.com/lightdash/lightdash/assets/1983672/1696f27d-c5a9-463f-a100-6ced935ace0c)


### Acceptance critiera

- [x] we're notified when a dashboard or chart that was sent in a scheduled delivery had an error
- [x] If it's a dashboard, we know how many charts were broken
- [ ] For any chart that is broken, we know information about that chart (e.g. chart type, is it pivoted, number of rows, etc.)
- [x] We know what error was trigger for each chart that did not load correctly (e.g. downtime, server crashed because of memory limit, etc.)
- [x] "charts with errors" also include errors that are caused by internal project errors (e.g. metric no longer exists)
- [ ] It's easy to differentiate between internal project errors (i.e. validation errors) and _**us**_ errors (e.g. downtime, server crashed) - maybe there's a column or something which lets us easily filter between the two
- [x] There is an easy way for us to monitor these errors and be notified when they happen

To complete the rest of the acceptance criteria we'll have to release and test these metrics first. 