### PR TITLE
chore: disable echarts animation if on a dashboard

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -53,6 +53,7 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
                 return (
                     <SimpleChart
                         className={className}
+                        isInDashboard={!!isDashboard}
                         $shouldExpand
                         data-testid={props['data-testid']}
                         {...props}

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -64,6 +64,7 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
                     <SimplePieChart
                         className={className}
                         tileUuid={tileUuid}
+                        isInDashboard={!!isDashboard}
                         $shouldExpand
                         data-testid={props['data-testid']}
                         {...props}

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -70,6 +70,7 @@ const isSeriesClickEvent = (e: EchartClickEvent): e is EchartSeriesClickEvent =>
     e.componentType === 'series';
 
 type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
+    isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
     'data-testid'?: string;
@@ -91,7 +92,10 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
         setSelectedLegendsUpdated(selectedLegends);
     }, [selectedLegends]);
 
-    const eChartsOptions = useEcharts(selectedLegendsUpdated);
+    const eChartsOptions = useEcharts(
+        selectedLegendsUpdated,
+        props.isInDashboard,
+    );
 
     useEffect(() => {
         const listener = () => {

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -30,6 +30,7 @@ const LoadingChart = () => (
 );
 
 type SimplePieChartProps = Omit<EChartsReactProps, 'option'> & {
+    isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
     tileUuid?: string;
@@ -40,7 +41,7 @@ const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
     const { chartRef, isLoading } = useVisualizationContext();
-    const pieChartOptions = useEchartsPieConfig();
+    const pieChartOptions = useEchartsPieConfig(props.isInDashboard);
     const [isOpen, { open, close }] = useDisclosure();
     const [menuProps, setMenuProps] = useState<{
         position: PieChartContextMenuProps['menuPosition'];

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1193,7 +1193,10 @@ const getStackTotalSeries = (
     );
 };
 
-const useEcharts = (validCartesianConfigLegend?: LegendValues) => {
+const useEcharts = (
+    validCartesianConfigLegend?: LegendValues,
+    isInDashboard?: boolean,
+) => {
     const context = useVisualizationContext();
 
     const {
@@ -1408,6 +1411,7 @@ const useEcharts = (validCartesianConfigLegend?: LegendValues) => {
             yAxis: axis.yAxis,
             useUTC: true,
             series: stackedSeries,
+            animation: !isInDashboard,
             legend: mergeLegendSettings(
                 validCartesianConfig?.eChartsConfig.legend,
                 validCartesianConfigLegend,
@@ -1435,13 +1439,16 @@ const useEcharts = (validCartesianConfigLegend?: LegendValues) => {
             color: colors,
         }),
         [
-            axis,
-            colors,
-            series,
+            axis.xAxis,
+            axis.yAxis,
             stackedSeries,
-            validCartesianConfig,
-            sortedResults,
+            isInDashboard,
+            validCartesianConfig?.eChartsConfig.legend,
+            validCartesianConfig?.eChartsConfig.grid,
             validCartesianConfigLegend,
+            series,
+            sortedResults,
+            colors,
         ],
     );
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -12,7 +12,7 @@ export type PieSeriesDataPoint = NonNullable<
     };
 };
 
-const useEchartsPieConfig = () => {
+const useEchartsPieConfig = (isInDashboard: boolean) => {
     const context = useVisualizationContext();
     const {
         pieChartConfig: {
@@ -145,8 +145,9 @@ const useEchartsPieConfig = () => {
                 trigger: 'item',
             },
             series: [pieSeriesOption],
+            animation: !isInDashboard,
         };
-    }, [showLegend, pieSeriesOption]);
+    }, [showLegend, pieSeriesOption, isInDashboard]);
 
     if (!explore || !data || data.length === 0) {
         return undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7093 

### Description:

Disable `animation` for echarts in dashboards.

Screen recording:

https://github.com/lightdash/lightdash/assets/7611706/4269c893-9161-4ed3-9da4-19edb3f8dd92

Screen recording with pie chart:

https://github.com/lightdash/lightdash/assets/7611706/8feda3c7-c75d-4bdf-a56e-40b40d23a9f2

Screen recording for minimal:

https://github.com/lightdash/lightdash/assets/7611706/acd40b2b-2e56-4f9f-8377-9050fd27907a

Screen recording of individual chart animation still working:

https://github.com/lightdash/lightdash/assets/7611706/acbe1ab9-fe80-4f95-96d1-bee1f9dd8b25



NOTE: animation still works when viewing individual charts
