### PR TITLE
fix: add utc to cron expressions

### DIFF
--- a/packages/common/src/utils/scheduler.test.ts
+++ b/packages/common/src/utils/scheduler.test.ts
@@ -1,8 +1,4 @@
-import { SupportedDbtAdapter } from '../types/dbt';
-import { DimensionType } from '../types/field';
-import { TimeFrames } from '../types/timeFrames';
 import { getHumanReadableCronExpression } from './scheduler';
-import { timeFrameConfigs, WeekDay } from './timeFrames';
 
 describe('Scheduler utils', () => {
     describe('getHumanReadableCronExpression', () => {

--- a/packages/common/src/utils/scheduler.test.ts
+++ b/packages/common/src/utils/scheduler.test.ts
@@ -1,0 +1,43 @@
+import { SupportedDbtAdapter } from '../types/dbt';
+import { DimensionType } from '../types/field';
+import { TimeFrames } from '../types/timeFrames';
+import { getHumanReadableCronExpression } from './scheduler';
+import { timeFrameConfigs, WeekDay } from './timeFrames';
+
+describe('Scheduler utils', () => {
+    describe('getHumanReadableCronExpression', () => {
+        test('Should convert human readable cron expression with UTC', async () => {
+            expect(getHumanReadableCronExpression('* * * * *')).toEqual(
+                'every minute, every hour, every day',
+            );
+
+            expect(getHumanReadableCronExpression('0 * * * *')).toEqual(
+                'every hour, every day',
+            );
+
+            expect(getHumanReadableCronExpression('0 0 * * *')).toEqual(
+                'at 12:00 AM (UTC), every day',
+            );
+
+            expect(getHumanReadableCronExpression('0 13 * * *')).toEqual(
+                'at 01:00 PM (UTC), every day',
+            );
+
+            expect(getHumanReadableCronExpression('0 13 1 * *')).toEqual(
+                'at 01:00 PM (UTC), on day 1 of the month',
+            );
+
+            expect(getHumanReadableCronExpression('0 13 1 1 *')).toEqual(
+                'at 01:00 PM (UTC), on day 1 of the month, only in January',
+            );
+
+            expect(getHumanReadableCronExpression('0 13 1 1 1')).toEqual(
+                'at 01:00 PM (UTC), on day 1 of the month, and on Monday, only in January',
+            );
+
+            expect(getHumanReadableCronExpression('* 13 1 * *')).toEqual(
+                'every minute, between 01:00 PM (UTC) and 01:59 PM (UTC), on day 1 of the month',
+            );
+        });
+    });
+});

--- a/packages/common/src/utils/scheduler.ts
+++ b/packages/common/src/utils/scheduler.ts
@@ -5,5 +5,9 @@ export function getHumanReadableCronExpression(cronExpression: string) {
         verbose: true,
         throwExceptionOnParseError: false,
     });
-    return value[0].toLowerCase() + value.slice(1);
+    const valueWithUTC = value
+        .replaceAll(' PM', ' PM (UTC)')
+        .replaceAll(' AM', ' AM (UTC)');
+
+    return valueWithUTC[0].toLowerCase() + valueWithUTC.slice(1);
 }

--- a/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulersListItem.tsx
+++ b/packages/frontend/src/components/SchedulerModals/SchedulerModalBase/SchedulersListItem.tsx
@@ -6,9 +6,11 @@ import {
     PopoverPosition,
 } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
-import { SchedulerAndTargets } from '@lightdash/common';
-import cronstrue from 'cronstrue';
-import React, { FC } from 'react';
+import {
+    getHumanReadableCronExpression,
+    SchedulerAndTargets,
+} from '@lightdash/common';
+import { FC } from 'react';
 import {
     InfoContainer,
     PageDetailsContainer,
@@ -65,10 +67,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
             </SchedulerDetailsContainer>
             <PageDetailsContainer>
                 <UpdatedInfoLabel>
-                    {cronstrue.toString(scheduler.cron, {
-                        verbose: true,
-                        throwExceptionOnParseError: false,
-                    })}
+                    {getHumanReadableCronExpression(scheduler.cron)}
                 </UpdatedInfoLabel>
 
                 <SeparatorDot icon="dot" size={6} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6848

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Acceptance criteria:
- [x] Add `(UTC)` after the time in each of the following: 
- [x] Slack message:
Before:

<img width="434" alt="CleanShot 2023-08-22 at 19 19 49@2x" src="https://github.com/lightdash/lightdash/assets/14341285/0a06b2ce-e27b-4833-9fc6-d5c7539c9d69">

Now:

![Screenshot from 2023-09-19 09-05-29](https://github.com/lightdash/lightdash/assets/1983672/ecc5a7fc-f47b-48b6-aa50-d894340b3f51)


- [x] On chart/dashboard Scheduled Deliveries modal:

Before:

<img width="483" alt="CleanShot 2023-08-22 at 19 21 41@2x" src="https://github.com/lightdash/lightdash/assets/14341285/4574fb12-d75c-47fe-967b-c1321a81d872">

Now: 

![Screenshot from 2023-09-19 09-08-15](https://github.com/lightdash/lightdash/assets/1983672/aab86421-e8fc-4d9b-a3a2-8e9520e79655)


- [x] Email delivery:

Before: 

<img width="400" alt="CleanShot 2023-08-22 at 19 20 05@2x" src="https://github.com/lightdash/lightdash/assets/14341285/80694b50-d4c0-423c-81c1-0142d2609ab2">

Now:

![Screenshot from 2023-09-19 09-05-01](https://github.com/lightdash/lightdash/assets/1983672/ce3d35c4-ee3d-41fe-8d50-3dd70c7d3ef5)


- [x] Scheduled deliveries overview:
Before:

<img width="873" alt="CleanShot 2023-08-22 at 19 20 40@2x" src="https://github.com/lightdash/lightdash/assets/14341285/621edd10-1323-4bbc-8830-43bccbe26de1">

Now:

![image](https://github.com/lightdash/lightdash/assets/1983672/6f129219-a61e-49a9-a7cb-8afe34a14f7d)


- [x] Scheduled Jobs Run page

Does not apply 

### What problem does this solve?

<!-- Describe the problem that this feature requests solves-->
