### PR TITLE
chore: add sentry logging for getting chart results and warehouse query

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1180,6 +1180,8 @@ export class ProjectService {
                         {
                             query,
                             queryTags,
+                            context,
+                            metricQuery: JSON.stringify(metricQuery),
                             type: warehouseClient.credentials.type,
                         },
                         async () => warehouseClient.runQuery(query, queryTags),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1016,7 +1016,7 @@ export class ProjectService {
         const rows = await wrapSentryTransaction(
             'getResultsForChartWithWarehouseQuery',
             {
-                user,
+                userUuid: user.userUuid,
                 chartUuid,
             },
             async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7106 

### Description:

Adds 2 Sentry Transactions: 

`getResultsForChartWithWarehouseQuery`: The total time for a saved chart result

`runWarehouseQuery`: The total time for a warehouse query

This would benefit observability, specially when encapsulating multiple warehouse requests at a time into one Sentry transaction so it's easier to calculate how much time between Lightdash DB and Warehouse client operations

