### PR TITLE
chore: reduce query to get available filters

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4070,7 +4070,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.778.4",
+        "version": "0.783.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4070,7 +4070,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.776.1",
+        "version": "0.778.4",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -10,9 +10,11 @@ import {
     getChartType,
     isFormat,
     NotFoundError,
+    Project,
     SavedChart,
     SessionUser,
     SortField,
+    Space,
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
@@ -732,18 +734,17 @@ export class SavedChartModel {
             );
     }
 
-    async getInfoForAvailableFilters(savedChartUuid: string): Promise<{
-        uuid: string;
-        name: string;
-        spaceUuid: string;
-        tableName: string;
-        projectUuid: string;
-    }> {
+    async getInfoForAvailableFilters(savedChartUuid: string): Promise<
+        {
+            spaceUuid: Space['uuid'];
+        } & Pick<SavedChart, 'uuid' | 'name' | 'tableName'> &
+            Pick<Project, 'projectUuid'>
+    > {
         const [chart] = await this.database('saved_queries')
             .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
             .select({
                 uuid: 'saved_queries.saved_query_uuid',
-                name: 'saved_queries.name',
+                name: 'saved_queries.names',
                 spaceUuid: 'spaces.space_uuid',
                 tableName: 'saved_queries_versions.explore_name',
                 projectUuid: 'projects.project_uuid',

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -720,7 +720,6 @@ export class SavedChartModel {
                 'organizations.organization_id',
                 'projects.organization_id',
             )
-
             .leftJoin(
                 PinnedChartTableName,
                 `${PinnedChartTableName}.saved_chart_uuid`,
@@ -731,5 +730,50 @@ export class SavedChartModel {
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.pinned_list_uuid`,
             );
+    }
+
+    async getInfoForAvailableFilters(savedChartUuid: string): Promise<{
+        uuid: string;
+        name: string;
+        spaceUuid: string;
+        tableName: string;
+        projectUuid: string;
+    }> {
+        const [chart] = await this.database('saved_queries')
+            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+            .select({
+                uuid: 'saved_queries.saved_query_uuid',
+                name: 'saved_queries.name',
+                spaceUuid: 'spaces.space_uuid',
+                tableName: 'saved_queries_versions.explore_name',
+                projectUuid: 'projects.project_uuid',
+            })
+            .leftJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(SpaceTableName, function spaceJoin() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${DashboardsTableName}.space_id`,
+                ).orOn(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                );
+            })
+            .innerJoin(
+                'saved_queries_versions',
+                `${SavedChartsTableName}.saved_query_id`,
+                'saved_queries_versions.saved_query_id',
+            )
+            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .limit(1);
+        if (chart === undefined) {
+            throw new NotFoundError('Saved query not found');
+        }
+        return chart;
     }
 }

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -10,6 +10,7 @@ import {
     getChartType,
     isFormat,
     NotFoundError,
+    Organization,
     Project,
     SavedChart,
     SessionUser,
@@ -738,16 +739,18 @@ export class SavedChartModel {
         {
             spaceUuid: Space['uuid'];
         } & Pick<SavedChart, 'uuid' | 'name' | 'tableName'> &
-            Pick<Project, 'projectUuid'>
+            Pick<Project, 'projectUuid'> &
+            Pick<Organization, 'organizationUuid'>
     > {
         const [chart] = await this.database('saved_queries')
             .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
             .select({
                 uuid: 'saved_queries.saved_query_uuid',
-                name: 'saved_queries.names',
+                name: 'saved_queries.name',
                 spaceUuid: 'spaces.space_uuid',
                 tableName: 'saved_queries_versions.explore_name',
                 projectUuid: 'projects.project_uuid',
+                organizationUuid: 'organizations.organization_uuid',
             })
             .leftJoin(
                 DashboardsTableName,
@@ -771,6 +774,11 @@ export class SavedChartModel {
                 'saved_queries_versions.saved_query_id',
             )
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .leftJoin(
+                OrganizationTableName,
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
             .limit(1);
         if (chart === undefined) {
             throw new NotFoundError('Saved query not found');

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -655,18 +655,6 @@ export class SavedChartModel {
         }
     }
 
-    async getSummaryWithExploreName(
-        savedChartUuid: string,
-    ): Promise<ChartSummary & { tableName: string }> {
-        const [chart] = await this.getChartSummaryQueryWithExploreName()
-            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
-            .limit(1);
-        if (chart === undefined) {
-            throw new NotFoundError('Saved query not found');
-        }
-        return chart;
-    }
-
     async find(filters: {
         projectUuid?: string;
         spaceUuids?: string[];
@@ -729,61 +717,6 @@ export class SavedChartModel {
                     `${SavedChartsTableName}.space_id`,
                 );
             })
-            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
-            .leftJoin(
-                OrganizationTableName,
-                'organizations.organization_id',
-                'projects.organization_id',
-            )
-            .leftJoin(
-                PinnedChartTableName,
-                `${PinnedChartTableName}.saved_chart_uuid`,
-                `${SavedChartsTableName}.saved_query_uuid`,
-            )
-            .leftJoin(
-                PinnedListTableName,
-                `${PinnedListTableName}.pinned_list_uuid`,
-                `${PinnedChartTableName}.pinned_list_uuid`,
-            );
-    }
-
-    private getChartSummaryQueryWithExploreName() {
-        return this.database('saved_queries')
-            .select({
-                uuid: 'saved_queries.saved_query_uuid',
-                name: 'saved_queries.name',
-                description: 'saved_queries.description',
-                tableName: 'saved_queries_versions.explore_name',
-                spaceUuid: 'spaces.space_uuid',
-                spaceName: 'spaces.name',
-                projectUuid: 'projects.project_uuid',
-                organizationUuid: 'organizations.organization_uuid',
-                pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
-                chartKind: 'saved_queries.last_version_chart_kind',
-                dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
-                dashboardName: `${DashboardsTableName}.name`,
-            })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
-            .innerJoin(SpaceTableName, function spaceJoin() {
-                this.on(
-                    `${SpaceTableName}.space_id`,
-                    '=',
-                    `${DashboardsTableName}.space_id`,
-                ).orOn(
-                    `${SpaceTableName}.space_id`,
-                    '=',
-                    `${SavedChartsTableName}.space_id`,
-                );
-            })
-            .innerJoin(
-                'saved_queries_versions',
-                `${SavedChartsTableName}.saved_query_id`,
-                'saved_queries_versions.saved_query_id',
-            )
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
             .leftJoin(
                 OrganizationTableName,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -655,6 +655,18 @@ export class SavedChartModel {
         }
     }
 
+    async getSummaryWithExploreName(
+        savedChartUuid: string,
+    ): Promise<ChartSummary & { tableName: string }> {
+        const [chart] = await this.getChartSummaryQueryWithExploreName()
+            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+            .limit(1);
+        if (chart === undefined) {
+            throw new NotFoundError('Saved query not found');
+        }
+        return chart;
+    }
+
     async find(filters: {
         projectUuid?: string;
         spaceUuids?: string[];
@@ -717,6 +729,61 @@ export class SavedChartModel {
                     `${SavedChartsTableName}.space_id`,
                 );
             })
+            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .leftJoin(
+                OrganizationTableName,
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .leftJoin(
+                PinnedChartTableName,
+                `${PinnedChartTableName}.saved_chart_uuid`,
+                `${SavedChartsTableName}.saved_query_uuid`,
+            )
+            .leftJoin(
+                PinnedListTableName,
+                `${PinnedListTableName}.pinned_list_uuid`,
+                `${PinnedChartTableName}.pinned_list_uuid`,
+            );
+    }
+
+    private getChartSummaryQueryWithExploreName() {
+        return this.database('saved_queries')
+            .select({
+                uuid: 'saved_queries.saved_query_uuid',
+                name: 'saved_queries.name',
+                description: 'saved_queries.description',
+                tableName: 'saved_queries_versions.explore_name',
+                spaceUuid: 'spaces.space_uuid',
+                spaceName: 'spaces.name',
+                projectUuid: 'projects.project_uuid',
+                organizationUuid: 'organizations.organization_uuid',
+                pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
+                chartKind: 'saved_queries.last_version_chart_kind',
+                dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
+                dashboardName: `${DashboardsTableName}.name`,
+            })
+            .leftJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(SpaceTableName, function spaceJoin() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${DashboardsTableName}.space_id`,
+                ).orOn(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                );
+            })
+            .innerJoin(
+                'saved_queries_versions',
+                `${SavedChartsTableName}.saved_query_id`,
+                'saved_queries_versions.saved_query_id',
+            )
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
             .leftJoin(
                 OrganizationTableName,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1901,7 +1901,7 @@ export class ProjectService {
             const endTime4 = Date.now();
             console.log(
                 `getSummaryWithExploreName for chart ${savedChartUuid} took ${
-                    startTime4 - endTime4
+                    endTime4 - startTime4
                 } ms`,
             );
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1864,14 +1864,22 @@ export class ProjectService {
             const startTime1 = Date.now();
             const savedChart2 = await this.savedChartModel.get(savedChartUuid);
             const endTime1 = Date.now();
-            console.log(`get took ${endTime1 - startTime1} ms`);
+            console.log(
+                `get for chart ${savedChartUuid} took ${
+                    endTime1 - startTime1
+                } ms`,
+            );
 
             const startTime2 = Date.now();
             const savedChart3 = await this.savedChartModel.getSummary(
                 savedChartUuid,
             );
             const endTime2 = Date.now();
-            console.log(`getSummary took ${endTime2 - startTime2} ms`);
+            console.log(
+                `getSummary for chart ${savedChartUuid} took ${
+                    endTime2 - startTime2
+                } ms`,
+            );
 
             const startTime3 = Date.now();
             const savedChart =
@@ -1880,7 +1888,21 @@ export class ProjectService {
                 );
             const endTime3 = Date.now();
             console.log(
-                `getInfoForAvailableFilters took ${endTime3 - startTime3} ms`,
+                `getInfoForAvailableFilters for chart ${savedChartUuid} took ${
+                    endTime3 - startTime3
+                } ms`,
+            );
+
+            const startTime4 = Date.now();
+            const savedChart4 =
+                await this.savedChartModel.getSummaryWithExploreName(
+                    savedChartUuid,
+                );
+            const endTime4 = Date.now();
+            console.log(
+                `getSummaryWithExploreName for chart ${savedChartUuid} took ${
+                    startTime4 - endTime4
+                } ms`,
             );
 
             if (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1859,51 +1859,10 @@ export class ProjectService {
             description: 'Gets all filters available for a single query',
         });
         try {
-            console.log(`for chart ${savedChartUuid}`);
-
-            const startTime1 = Date.now();
-            const savedChart2 = await this.savedChartModel.get(savedChartUuid);
-            const endTime1 = Date.now();
-            console.log(
-                `get for chart ${savedChartUuid} took ${
-                    endTime1 - startTime1
-                } ms`,
-            );
-
-            const startTime2 = Date.now();
-            const savedChart3 = await this.savedChartModel.getSummary(
-                savedChartUuid,
-            );
-            const endTime2 = Date.now();
-            console.log(
-                `getSummary for chart ${savedChartUuid} took ${
-                    endTime2 - startTime2
-                } ms`,
-            );
-
-            const startTime3 = Date.now();
             const savedChart =
                 await this.savedChartModel.getInfoForAvailableFilters(
                     savedChartUuid,
                 );
-            const endTime3 = Date.now();
-            console.log(
-                `getInfoForAvailableFilters for chart ${savedChartUuid} took ${
-                    endTime3 - startTime3
-                } ms`,
-            );
-
-            const startTime4 = Date.now();
-            const savedChart4 =
-                await this.savedChartModel.getSummaryWithExploreName(
-                    savedChartUuid,
-                );
-            const endTime4 = Date.now();
-            console.log(
-                `getSummaryWithExploreName for chart ${savedChartUuid} took ${
-                    endTime4 - startTime4
-                } ms`,
-            );
 
             if (
                 user.ability.cannot('view', subject('SavedChart', savedChart))

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1859,19 +1859,32 @@ export class ProjectService {
             description: 'Gets all filters available for a single query',
         });
         try {
+            console.log(`for chart ${savedChartUuid}`);
+
+            const startTime1 = Date.now();
+            const savedChart2 = await this.savedChartModel.get(savedChartUuid);
+            const endTime1 = Date.now();
+            console.log(`get took ${endTime1 - startTime1} ms`);
+
+            const startTime2 = Date.now();
+            const savedChart3 = await this.savedChartModel.getSummary(
+                savedChartUuid,
+            );
+            const endTime2 = Date.now();
+            console.log(`getSummary took ${endTime2 - startTime2} ms`);
+
+            const startTime3 = Date.now();
             const savedChart =
                 await this.savedChartModel.getInfoForAvailableFilters(
                     savedChartUuid,
                 );
+            const endTime3 = Date.now();
+            console.log(
+                `getInfoForAvailableFilters took ${endTime3 - startTime3} ms`,
+            );
 
             if (
-                user.ability.cannot(
-                    'view',
-                    subject('SavedChart', {
-                        ...savedChart,
-                        organizationUuid: user.organizationUuid,
-                    }),
-                )
+                user.ability.cannot('view', subject('SavedChart', savedChart))
             ) {
                 throw new ForbiddenError();
             }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1859,10 +1859,19 @@ export class ProjectService {
             description: 'Gets all filters available for a single query',
         });
         try {
-            const savedChart = await this.savedChartModel.get(savedChartUuid);
+            const savedChart =
+                await this.savedChartModel.getInfoForAvailableFilters(
+                    savedChartUuid,
+                );
 
             if (
-                user.ability.cannot('view', subject('SavedChart', savedChart))
+                user.ability.cannot(
+                    'view',
+                    subject('SavedChart', {
+                        ...savedChart,
+                        organizationUuid: user.organizationUuid,
+                    }),
+                )
             ) {
                 throw new ForbiddenError();
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #7058 

### Description:

`availableFilters` was getting the whole chart from the chart model when all info that is necessary is:

 ```
uuid: string;
name: string;
spaceUuid: string;
tableName: string;
projectUuid: string;
```

Sentry `/availableFilters` duration:  https://lightdash.sentry.io/performance/summary/spans/projectService.getAvailableFiltersForSavedQuery:ca6069760127bd19/?project=5959292&statsPeriod=30d&transaction=POST+%2Fapi%2Fv1%2Fdashboards%2FavailableFilters


