### PR TITLE
fix: should not go to editing a dashboard after saving or cancelling

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -229,7 +229,7 @@ const Dashboard: FC = () => {
             setHaveFiltersChanged(false);
             setDashboardTemporaryFilters({ dimensions: [], metrics: [] });
             reset();
-            history.push(
+            history.replace(
                 `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
             );
         }
@@ -341,7 +341,7 @@ const Dashboard: FC = () => {
         setHaveTilesChanged(false);
         if (dashboard) setDashboardFilters(dashboard.filters);
         setHaveFiltersChanged(false);
-        history.push(
+        history.replace(
             `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
         );
     }, [


### PR DESCRIPTION


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7124 
### Description:
Changed history.push() to history.replace() to avoid going back to edit mode

[Screencast from 2023-09-19 23-16-40.webm](https://github.com/lightdash/lightdash/assets/37402791/8ed16591-25ca-453c-aec0-4812834b3e71)

