### PR TITLE
chore(docs): fix typo in user attributes

### DIFF
--- a/docs/docs/references/sql-variables.mdx
+++ b/docs/docs/references/sql-variables.mdx
@@ -6,6 +6,6 @@ reusable
 - `${field}` - reference a field in the current model
 - `${model.field}` - reference a field in another model
 - `${TABLE}` - reference the current table's sql reference
-- `${ lightdash.attributes.my_attr_1 }` - a user attribute called `my_attr_1`
+- `${lightdash.attributes.my_attr_1}` - a user attribute called `my_attr_1`
   - (optional) `ld` as an alias for `lightdash`
   - (optional) `attribute` or `attr` as an alias for `attributes`

--- a/docs/docs/references/user-attributes.mdx
+++ b/docs/docs/references/user-attributes.mdx
@@ -57,7 +57,7 @@ There are several places in Lightdash where you can customise behaviour based on
 
 When referencing user attributes in SQL you can use the following [SQL variables](./sql-variables.mdx):
 
-- `${lightdash.attributes.my_attr_1 }` - a user attribute called `my_attr_1`
+- `${lightdash.attributes.my_attr_1}` - a user attribute called `my_attr_1`
   - (optional) `ld` as an alias for `lightdash`
   - (optional) `attribute` or `attr` as an alias for `attributes`
 
@@ -72,7 +72,7 @@ use it in your sql like this:
 models:
   - name: my_model
     meta:
-      sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region }
+      sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}
 ```
 
 ### 2. Filtering joins with `sql_on`
@@ -92,7 +92,7 @@ models:
         - join: joined
           sql_on: >
             ${base}.id = ${joined}.id
-            AND ${joined}.sales_region = ${lightdash.attributes.sales_region }
+            AND ${joined}.sales_region = ${lightdash.attributes.sales_region}
 ```
 
 # Demo: filtering a chart based on user attributes


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

The attribute is not properly interpreted when calling it with a space before the `}`. Fixing the user attribute references in the docs