### PR TITLE
chore: runs tests in default browser

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          browser: chrome
           project: ./packages/e2e
           spec: packages/e2e/cypress/cli/**/*
           config: 'baseUrl=${{needs.prepare-preview.outputs.url}}'


### PR DESCRIPTION
Github action that runs CLI tests is failing with following error:

```
Running:  cli.cy.ts                                                                       (1 of 1)
read ECONNRESET
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20)
Test run failed, code 1
More information might be available above
Cypress module has returned the following error message:
Could not find Cypress test run results
Error: Could not find Cypress test run results
```
Error seems related to chrome so I'm removing that config since it shouldn't matter for CLI tests.