### PR TITLE
feat: Keep run query enabled in explore even when underlying metrics/dimensions have not been modified

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -17,11 +17,8 @@ export const RefreshButton = memo(() => {
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,
     );
-    const hasUnfetchedChanges = useExplorerContext(
-        (context) => context.hasUnfetchedChanges,
-    );
 
-    const canRunQuery = !isLoading && isValidQuery && hasUnfetchedChanges;
+    const canRunQuery = !isLoading && isValidQuery;
 
     const { track } = useTracking();
 
@@ -36,13 +33,7 @@ export const RefreshButton = memo(() => {
 
     return (
         <Tooltip2
-            content={
-                !hasUnfetchedChanges ? (
-                    'You need to make some changes before running a query'
-                ) : (
-                    <KeyCombo combo="mod+enter" />
-                )
-            }
+            content={<KeyCombo combo="mod+enter" />}
             position="bottom"
             disabled={isLoading || !isValidQuery}
         >

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -22,7 +22,6 @@ import {
 } from '@lightdash/common';
 import produce from 'immer';
 import cloneDeep from 'lodash-es/cloneDeep';
-import isEqual from 'lodash-es/isEqual';
 import { FC, useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useHistory } from 'react-router-dom';
 import { createContext, useContextSelector } from 'use-context-selector';
@@ -188,7 +187,6 @@ export interface ExplorerState extends ExplorerReduceState {
 export interface ExplorerContext {
     state: ExplorerState;
     queryResults: ReturnType<typeof useQueryResults>;
-    hasUnfetchedChanges: boolean;
     actions: {
         clearExplore: () => void;
         clearQuery: () => void;
@@ -1212,13 +1210,6 @@ export const ExplorerProvider: FC<{
         unsavedChartVersion.metricQuery,
     ]);
 
-    const hasUnfetchedChanges = useMemo(() => {
-        return !isEqual(
-            state.unsavedChartVersion.metricQuery,
-            state.previouslyFetchedState,
-        );
-    }, [state.unsavedChartVersion.metricQuery, state.previouslyFetchedState]);
-
     useEffect(() => {
         if (!state.shouldFetchResults) return;
 
@@ -1328,10 +1319,9 @@ export const ExplorerProvider: FC<{
         () => ({
             state,
             queryResults,
-            hasUnfetchedChanges,
             actions,
         }),
-        [actions, queryResults, state, hasUnfetchedChanges],
+        [actions, queryResults, state],
     );
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };


### PR DESCRIPTION
Closes:  #7161 
### Description:

As per the issue description, we have to keep the run query button enabled in explore view even when underlying metrics/dimensions have not been modified. Have made the suggested change.
