### PR TITLE
chore: batch-query charts to then get available filters

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -735,15 +735,18 @@ export class SavedChartModel {
             );
     }
 
-    async getInfoForAvailableFilters(savedChartUuid: string): Promise<
-        {
+    async getInfoForAvailableFilters(savedChartUuids: string[]): Promise<
+        ({
             spaceUuid: Space['uuid'];
         } & Pick<SavedChart, 'uuid' | 'name' | 'tableName'> &
             Pick<Project, 'projectUuid'> &
-            Pick<Organization, 'organizationUuid'>
+            Pick<Organization, 'organizationUuid'>)[]
     > {
-        const [chart] = await this.database('saved_queries')
-            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+        const charts = await this.database('saved_queries')
+            .whereIn(
+                `${SavedChartsTableName}.saved_query_uuid`,
+                savedChartUuids,
+            )
             .select({
                 uuid: 'saved_queries.saved_query_uuid',
                 name: 'saved_queries.name',
@@ -780,9 +783,9 @@ export class SavedChartModel {
                 'projects.organization_id',
             )
             .limit(1);
-        if (chart === undefined) {
-            throw new NotFoundError('Saved query not found');
+        if (charts.length === 0) {
+            throw new NotFoundError('Saved queries not found');
         }
-        return chart;
+        return charts;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7163 

### Description:

Query all charts in batches so we can get the necessary information to get the available filters per chart.

With this: 
<img width="1908" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/2d607a86-7ce8-45ac-9c76-e4e9608b7a3c">
https://lightdash-pr-7186.onrender.com/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/43cfa66c-f99b-4d1c-82c6-5d03b6f332e7/view?filters=%7B%22dimensions%22%3A%5B%7B%22id%22%3A%22e7df7c5a-1070-439a-8300-125fe5f9b1af%22%2C%22target%22%3A%7B%22fieldId%22%3A%22orders_is_completed%22%2C%22tableName%22%3A%22orders%22%7D%2C%22values%22%3A%5Btrue%5D%2C%22operator%22%3A%22equals%22%7D%2C%7B%22id%22%3A%226d28a3a5-c01f-46d8-9f6b-74a9ab1efd99%22%2C%22target%22%3A%7B%22fieldId%22%3A%22orders_order_date_year%22%2C%22tableName%22%3A%22orders%22%7D%2C%22values%22%3A%5B5%5D%2C%22operator%22%3A%22inThePast%22%2C%22settings%22%3A%7B%22completed%22%3Atrue%2C%22unitOfTime%22%3A%22years%22%7D%7D%5D%2C%22metrics%22%3A%5B%5D%7D

Before: 
<img width="1919" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/4b6c7770-8e55-45f3-a095-23572cc0a66f">

https://lightdash-pr-7152.onrender.com/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/a4517846-bf58-47de-ba61-f3f10fb4200e/view?filters=%7B%22dimensions%22%3A%5B%7B%22id%22%3A%22e7df7c5a-1070-439a-8300-125fe5f9b1af%22%2C%22target%22%3A%7B%22fieldId%22%3A%22orders_is_completed%22%2C%22tableName%22%3A%22orders%22%7D%2C%22values%22%3A%5Btrue%5D%2C%22operator%22%3A%22equals%22%7D%2C%7B%22id%22%3A%226d28a3a5-c01f-46d8-9f6b-74a9ab1efd99%22%2C%22target%22%3A%7B%22fieldId%22%3A%22orders_order_date_year%22%2C%22tableName%22%3A%22orders%22%7D%2C%22values%22%3A%5B5%5D%2C%22operator%22%3A%22inThePast%22%2C%22settings%22%3A%7B%22completed%22%3Atrue%2C%22unitOfTime%22%3A%22years%22%7D%7D%5D%2C%22metrics%22%3A%5B%5D%7D

I've looked into 9 subsequent runs for both render environments

"With change" times: 
323ms,197ms,940ms,78ms,435ms,389ms,313ms,128ms,510ms

Average: 368ms
Median: 323ms

"Current" times: 757ms,655ms,954ms,766ms,648ms,1.06s,872ms,809ms

Average: 815.125ms
Median: 787.5ms

On average, the "with change" times are approximately 54.87% faster than the "current" times.

