### PR TITLE
chore: compress vite assets and serve them if they exist

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -66,6 +66,7 @@
         "execa": "^5.0.0",
         "express": "^4.17.3",
         "express-session": "^1.17.2",
+        "express-static-gzip": "^2.1.7",
         "express-winston": "^4.2.0",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.4.6",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,7 +1,6 @@
 // organize-imports-ignore
 // eslint-disable-next-line import/order
-import otelSdk from './otel'; // must be imported first
-
+import fs from 'fs';
 import { LightdashMode, SessionUser } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
@@ -16,6 +15,7 @@ import passport from 'passport';
 import refresh from 'passport-oauth2-refresh';
 import path from 'path';
 import reDoc from 'redoc-express';
+import otelSdk from './otel'; // must be imported first
 import apiSpec from './generated/swagger.json';
 import { analytics } from './analytics/client';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
@@ -169,6 +169,21 @@ if (
 // frontend assets - immutable because vite appends hash to filenames
 app.use(
     '/assets',
+    (req, res, next) => {
+        const gzipped = path.join(
+            __dirname,
+            '../../frontend/build/assets',
+            `${req.path}.gzip`,
+        );
+
+        // Serve gzipped file if it exists in the build folder
+        if (fs.existsSync(gzipped)) {
+            res.set('Content-Encoding', 'gzip');
+            req.url += '.gzip';
+        }
+
+        next();
+    },
     express.static(path.join(__dirname, '../../frontend/build/assets'), {
         immutable: true,
         maxAge: '1y',

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,5 +1,7 @@
 // organize-imports-ignore
 // eslint-disable-next-line import/order
+import otelSdk from './otel'; // must be imported first
+
 import fs from 'fs';
 import { LightdashMode, SessionUser } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -15,7 +17,6 @@ import passport from 'passport';
 import refresh from 'passport-oauth2-refresh';
 import path from 'path';
 import reDoc from 'redoc-express';
-import otelSdk from './otel'; // must be imported first
 import apiSpec from './generated/swagger.json';
 import { analytics } from './analytics/client';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -13,6 +13,7 @@ import connectSessionKnex from 'connect-session-knex';
 import cookieParser from 'cookie-parser';
 import express, { NextFunction, Request, Response } from 'express';
 import expressSession from 'express-session';
+import expressStaticGzip from 'express-static-gzip';
 import passport from 'passport';
 import refresh from 'passport-oauth2-refresh';
 import path from 'path';
@@ -170,24 +171,11 @@ if (
 // frontend assets - immutable because vite appends hash to filenames
 app.use(
     '/assets',
-    (req, res, next) => {
-        const gzipped = path.join(
-            __dirname,
-            '../../frontend/build/assets',
-            `${req.path}.gzip`,
-        );
-
-        // Serve gzipped file if it exists in the build folder
-        if (fs.existsSync(gzipped)) {
-            res.set('Content-Encoding', 'gzip');
-            req.url += '.gzip';
-        }
-
-        next();
-    },
-    express.static(path.join(__dirname, '../../frontend/build/assets'), {
-        immutable: true,
-        maxAge: '1y',
+    expressStaticGzip(path.join(__dirname, '../../frontend/build/assets'), {
+        serveStatic: {
+            immutable: true,
+            maxAge: '1y',
+        },
     }),
 );
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -120,6 +120,7 @@
         "type-fest": "^3.10.0",
         "vite": "^4.4.6",
         "vite-plugin-chunk-split": "^0.4.7",
+        "vite-plugin-compression2": "^0.10.4",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-svgr": "^3.2.0",
         "vite-tsconfig-paths": "^4.2.0"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -120,7 +120,7 @@
         "type-fest": "^3.10.0",
         "vite": "^4.4.6",
         "vite-plugin-chunk-split": "^0.4.7",
-        "vite-plugin-compression2": "^0.10.4",
+        "vite-plugin-compression2": "^0.10.5",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-svgr": "^3.2.0",
         "vite-tsconfig-paths": "^4.2.0"

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         },
         compression({
             include: [/\.(js)$/, /\.(css)$/],
-            filename: '[path][base].gzip',
+            // filename: '[path][base].gzip',
         }),
     ],
     css: {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import reactPlugin from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { compression } from 'vite-plugin-compression2';
 import eslintPlugin from 'vite-plugin-eslint';
 import svgrPlugin from 'vite-plugin-svgr';
 import tsconfigPathsPlugin from 'vite-tsconfig-paths';
@@ -26,6 +27,10 @@ export default defineConfig({
             apply: 'serve',
             enforce: 'post',
         },
+        compression({
+            include: [/\.(js)$/, /\.(css)$/],
+            filename: '[path][base].gzip',
+        }),
     ],
     css: {
         transformer: 'lightningcss',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -29,7 +29,6 @@ export default defineConfig({
         },
         compression({
             include: [/\.(js)$/, /\.(css)$/],
-            // filename: '[path][base].gzip',
         }),
     ],
     css: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,6 +3208,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@nolyfill/es-aggregate-error@^1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@nolyfill/es-aggregate-error/-/es-aggregate-error-1.0.21.tgz#4ded25795a5b43c78b7c553052462a7da48e4873"
+  integrity sha512-1P+7535ZSQAD/BoSmeu+xv9eOZA5oCQ3e40rO5ZVbFZBafWR+WoZJsoEwlzUDsZz9iFFIKQiMsrSsN4HbUMtTQ==
+  dependencies:
+    "@nolyfill/shared" "1.0.21"
+
+"@nolyfill/shared@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@nolyfill/shared/-/shared-1.0.21.tgz#0aeec134d6448a519dda21e122901b5f034b82f8"
+  integrity sha512-qDc/NoaFU23E0hhiDPeUrvWzTXIPE+RbvRQtRWSeHHNmCIgYI9HS1jKzNYNJxv4jvZ/1VmM3L6rNVxbj+LBMNA==
+
 "@opentelemetry/api-logs@0.39.1":
   version "0.39.1"
   resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz"
@@ -19519,11 +19531,12 @@ vite-plugin-chunk-split@^0.4.7:
     es-module-lexer "^1.0.3"
     magic-string "^0.26.3"
 
-vite-plugin-compression2@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-0.10.4.tgz#34574380dd059cd15cd35d97eed88f9dcda213ac"
-  integrity sha512-9YcESw0n1j8KxxY1NJKEcItlT0bLS+K/NKa/xPqZGEHW/qwgigIeRF/bCTUdZ/bn/mg2+PeERWgRmK8G1L0tyg==
+vite-plugin-compression2@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-0.10.5.tgz#013ed2fe8471487dca7173a971668a74e0f308fa"
+  integrity sha512-IaZUzl9pmZXSAwX3XA6LiB9S7vWK/+4P1r5hT/NlygFWjF6OXNbXJq2/jtkh4HzsxILa0+kwmihTYbJRR406Uw==
   dependencies:
+    "@nolyfill/es-aggregate-error" "^1.0.21"
     "@rollup/pluginutils" "^5.0.2"
 
 vite-plugin-eslint@^1.8.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19519,6 +19519,13 @@ vite-plugin-chunk-split@^0.4.7:
     es-module-lexer "^1.0.3"
     magic-string "^0.26.3"
 
+vite-plugin-compression2@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-0.10.4.tgz#34574380dd059cd15cd35d97eed88f9dcda213ac"
+  integrity sha512-9YcESw0n1j8KxxY1NJKEcItlT0bLS+K/NKa/xPqZGEHW/qwgigIeRF/bCTUdZ/bn/mg2+PeERWgRmK8G1L0tyg==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.2"
+
 vite-plugin-eslint@^1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9548,6 +9548,13 @@ express-session@^1.17.2:
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
 
+express-static-gzip@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/express-static-gzip/-/express-static-gzip-2.1.7.tgz#5904824a07950ba741ec3a23a21839dd04c63506"
+  integrity sha512-QOCZUC+lhPPCjIJKpQGu1Oa61Axg9Mq09Qvit8Of7kzpMuwDeMSqjjQteQS3OVw/GkENBoSBheuQDWPlngImvw==
+  dependencies:
+    serve-static "^1.14.1"
+
 express-winston@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/express-winston/-/express-winston-4.2.0.tgz"
@@ -17431,7 +17438,7 @@ serve-static@1.14.2:
     parseurl "~1.3.3"
     send "0.17.2"
 
-serve-static@1.15.0:
+serve-static@1.15.0, serve-static@^1.14.1:
   version "1.15.0"
   resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz"
   integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7097 

### Description:

Gzips `js` and `css` assets and serves them if they exist.

Utilises `vite-plugin-compression2` a package that is currently being maintained: https://github.com/nonzzz/vite-plugin-compression

Uses `express-static-gzip` to serve pre-compressed files

When this gets merged, we should test if it works on our instance first. It works locally (by running the BE + a FE build) and also in Render, but had to clear the cache on Render for it to work.  
