### PR TITLE
feat: vertical legend option for pie charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -68,6 +68,16 @@ export type PieChartValueOptions = {
     showPercentage: boolean;
 };
 
+export const PieChartLegendPositions = {
+    horizontal: 'Horizontal',
+    vertical: 'Vertical',
+} as const;
+
+export type PieChartLegendPosition = keyof typeof PieChartLegendPositions;
+export const PieChartLegendPositionDefault = Object.keys(
+    PieChartLegendPositions,
+)[0] as PieChartLegendPosition;
+
 export type PieChart = {
     groupFieldIds?: string[];
     metricId?: string;
@@ -80,7 +90,7 @@ export type PieChart = {
     groupValueOptionOverrides?: Record<string, Partial<PieChartValueOptions>>;
     groupSortOverrides?: string[];
     showLegend?: boolean;
-    legend?: EchartsLegend;
+    legendPosition?: PieChartLegendPosition;
 };
 
 export type PieChartConfig = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -80,6 +80,7 @@ export type PieChart = {
     groupValueOptionOverrides?: Record<string, Partial<PieChartValueOptions>>;
     groupSortOverrides?: string[];
     showLegend?: boolean;
+    legend?: EchartsLegend;
 };
 
 export type PieChartConfig = {

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
@@ -1,11 +1,50 @@
-import { Stack, Switch } from '@mantine/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
+import {
+    Collapse,
+    SegmentedControl,
+    SimpleGrid,
+    Stack,
+    Switch,
+    Text,
+} from '@mantine/core';
+import { EchartsLegend } from '@lightdash/common';
+import startCase from 'lodash-es/startCase';
+import UnitInput from '../../common/UnitInput';
+
+enum Positions {
+    Left = 'left',
+    Right = 'right',
+    Top = 'top',
+    Bottom = 'bottom',
+}
+
+enum Units {
+    Pixels = 'px',
+    Percentage = '%',
+}
+const units = Object.values(Units);
 
 const PieChartDisplayConfig: React.FC = () => {
     const {
-        pieChartConfig: { showLegend, toggleShowLegend },
+        pieChartConfig: { validPieChartConfig, setLegend, showLegend, toggleShowLegend },
     } = useVisualizationContext();
+
+    const legendConfig = useMemo<EchartsLegend>(
+        () => ({
+            ...validPieChartConfig?.legend,
+        }),
+        [validPieChartConfig?.legend],
+    );
+
+    const handleChange = (
+        prop: string,
+        newValue: string | boolean | undefined,
+    ) => {
+        const newState = { ...legendConfig, [prop]: newValue };
+        setLegend(newState);
+        return newState;
+    };
 
     return (
         <Stack>
@@ -14,6 +53,61 @@ const PieChartDisplayConfig: React.FC = () => {
                 checked={showLegend}
                 onChange={toggleShowLegend}
             />
+            <Collapse in={legendConfig.show ?? showLegend}>
+                <Switch
+                    label="Scroll legend"
+                    mb="md"
+                    checked={validPieChartConfig?.legend?.type !== 'plain'}
+                    onChange={(e) =>
+                        handleChange(
+                            'type',
+                            e.currentTarget.checked ? 'scroll' : 'plain',
+                        )
+                    }
+                />
+                <Text fw={600}>Position</Text>
+                {[
+                    [Positions.Left, Positions.Right],
+                    [Positions.Top, Positions.Bottom],
+                ].map((positionGroup) => (
+                    <SimpleGrid
+                        cols={2}
+                        mt="xs"
+                        ml="xs"
+                        mb="md"
+                        spacing="md"
+                        key={positionGroup.join(',')}
+                    >
+                        {positionGroup.map((position) => (
+                            <UnitInput
+                                key={position}
+                                label={
+                                    <Text fw={400}>{startCase(position)} </Text>
+                                }
+                                name={position}
+                                units={units}
+                                value={legendConfig[position] ?? 'auto'}
+                                defaultValue="auto"
+                                onChange={(e) => handleChange(position, e)}
+                            />
+                        ))}
+                    </SimpleGrid>
+                ))}
+
+                <Text fw={600}>Orientation</Text>
+                <SegmentedControl
+                    name="orient"
+                    color="blue"
+                    size="sm"
+                    fullWidth
+                    value={legendConfig.orient ?? 'horizontal'}
+                    onChange={(val) => handleChange('orient', val)}
+                    data={[
+                        { label: 'Horizontal', value: 'horizontal' },
+                        { label: 'Vertical', value: 'vertical' },
+                    ]}
+                />
+            </Collapse>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
@@ -1,50 +1,20 @@
-import React, { useMemo } from 'react';
-import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import {
-    Collapse,
-    SegmentedControl,
-    SimpleGrid,
-    Stack,
-    Switch,
-    Text,
-} from '@mantine/core';
-import { EchartsLegend } from '@lightdash/common';
-import startCase from 'lodash-es/startCase';
-import UnitInput from '../../common/UnitInput';
-
-enum Positions {
-    Left = 'left',
-    Right = 'right',
-    Top = 'top',
-    Bottom = 'bottom',
-}
-
-enum Units {
-    Pixels = 'px',
-    Percentage = '%',
-}
-const units = Object.values(Units);
+    PieChartLegendPosition,
+    PieChartLegendPositions,
+} from '@lightdash/common';
+import { Collapse, SegmentedControl, Stack, Switch, Text } from '@mantine/core';
+import React from 'react';
+import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 
 const PieChartDisplayConfig: React.FC = () => {
     const {
-        pieChartConfig: { validPieChartConfig, setLegend, showLegend, toggleShowLegend },
+        pieChartConfig: {
+            showLegend,
+            toggleShowLegend,
+            legendPosition,
+            legendPositionChange,
+        },
     } = useVisualizationContext();
-
-    const legendConfig = useMemo<EchartsLegend>(
-        () => ({
-            ...validPieChartConfig?.legend,
-        }),
-        [validPieChartConfig?.legend],
-    );
-
-    const handleChange = (
-        prop: string,
-        newValue: string | boolean | undefined,
-    ) => {
-        const newState = { ...legendConfig, [prop]: newValue };
-        setLegend(newState);
-        return newState;
-    };
 
     return (
         <Stack>
@@ -53,59 +23,24 @@ const PieChartDisplayConfig: React.FC = () => {
                 checked={showLegend}
                 onChange={toggleShowLegend}
             />
-            <Collapse in={legendConfig.show ?? showLegend}>
-                <Switch
-                    label="Scroll legend"
-                    mb="md"
-                    checked={validPieChartConfig?.legend?.type !== 'plain'}
-                    onChange={(e) =>
-                        handleChange(
-                            'type',
-                            e.currentTarget.checked ? 'scroll' : 'plain',
-                        )
-                    }
-                />
-                <Text fw={600}>Position</Text>
-                {[
-                    [Positions.Left, Positions.Right],
-                    [Positions.Top, Positions.Bottom],
-                ].map((positionGroup) => (
-                    <SimpleGrid
-                        cols={2}
-                        mt="xs"
-                        ml="xs"
-                        mb="md"
-                        spacing="md"
-                        key={positionGroup.join(',')}
-                    >
-                        {positionGroup.map((position) => (
-                            <UnitInput
-                                key={position}
-                                label={
-                                    <Text fw={400}>{startCase(position)} </Text>
-                                }
-                                name={position}
-                                units={units}
-                                value={legendConfig[position] ?? 'auto'}
-                                defaultValue="auto"
-                                onChange={(e) => handleChange(position, e)}
-                            />
-                        ))}
-                    </SimpleGrid>
-                ))}
 
+            <Collapse in={showLegend}>
                 <Text fw={600}>Orientation</Text>
                 <SegmentedControl
                     name="orient"
                     color="blue"
                     size="sm"
                     fullWidth
-                    value={legendConfig.orient ?? 'horizontal'}
-                    onChange={(val) => handleChange('orient', val)}
-                    data={[
-                        { label: 'Horizontal', value: 'horizontal' },
-                        { label: 'Vertical', value: 'vertical' },
-                    ]}
+                    value={legendPosition}
+                    onChange={(val: PieChartLegendPosition) =>
+                        legendPositionChange(val)
+                    }
+                    data={Object.entries(PieChartLegendPositions).map(
+                        ([position, label]) => ({
+                            label,
+                            value: position,
+                        }),
+                    )}
                 />
             </Collapse>
         </Stack>

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -29,7 +29,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                 groupColorOverrides,
                 groupValueOptionOverrides,
                 showLegend,
-                legend,
+                legendPosition,
             },
         },
         explore,
@@ -105,12 +105,14 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
             data: seriesData,
             radius: isDonut ? ['30%', '70%'] : '70%',
             center:
-                showLegend &&
-                valueLabelDefault === 'outside' &&
-                (showValueDefault || showPercentageDefault)
-                    ? ['50%', '55%']
-                    : showLegend
-                    ? ['50%', '52%']
+                legendPosition === 'horizontal'
+                    ? showLegend &&
+                      valueLabelDefault === 'outside' &&
+                      (showValueDefault || showPercentageDefault)
+                        ? ['50%', '55%']
+                        : showLegend
+                        ? ['50%', '52%']
+                        : ['50%', '50%']
                     : ['50%', '50%'],
             tooltip: {
                 trigger: 'item',
@@ -132,18 +134,26 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         showValueDefault,
         showPercentageDefault,
         selectedMetric,
+        legendPosition,
     ]);
 
     const eChartsOption: EChartsOption = useMemo(() => {
         return {
             legend: {
                 show: showLegend,
-                orient: legend?.orient,
-                left: legend?.left,
-                right: legend?.right,
-                top: legend?.top,
-                bottom: legend?.bottom,
+                orient: legendPosition,
                 type: 'scroll',
+                ...(legendPosition === 'vertical'
+                    ? {
+                          left: 'left',
+                          top: 'middle',
+                          align: 'left',
+                      }
+                    : {
+                          left: 'center',
+                          top: 'top',
+                          align: 'auto',
+                      }),
             },
             tooltip: {
                 trigger: 'item',
@@ -151,7 +161,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
             series: [pieSeriesOption],
             animation: !isInDashboard,
         };
-    }, [showLegend, pieSeriesOption, isInDashboard, legend]);
+    }, [showLegend, pieSeriesOption, legendPosition, isInDashboard]);
 
     if (!explore || !data || data.length === 0) {
         return undefined;

--- a/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieChart.ts
@@ -29,6 +29,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                 groupColorOverrides,
                 groupValueOptionOverrides,
                 showLegend,
+                legend,
             },
         },
         explore,
@@ -137,8 +138,11 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         return {
             legend: {
                 show: showLegend,
-                orient: 'horizontal',
-                left: 'center',
+                orient: legend?.orient,
+                left: legend?.left,
+                right: legend?.right,
+                top: legend?.top,
+                bottom: legend?.bottom,
                 type: 'scroll',
             },
             tooltip: {
@@ -147,7 +151,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
             series: [pieSeriesOption],
             animation: !isInDashboard,
         };
-    }, [showLegend, pieSeriesOption, isInDashboard]);
+    }, [showLegend, pieSeriesOption, isInDashboard, legend]);
 
     if (!explore || !data || data.length === 0) {
         return undefined;

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -1,13 +1,14 @@
 import {
     ApiQueryResults,
     ECHARTS_DEFAULT_COLORS,
-    EchartsLegend,
     Explore,
     Field,
     fieldId,
     formatItemValue,
     isField,
     PieChart,
+    PieChartLegendPosition,
+    PieChartLegendPositionDefault,
     PieChartValueOptions,
     ResultRow,
     ResultValue,
@@ -68,8 +69,8 @@ type PieChartConfig = {
 
     showLegend: boolean;
     toggleShowLegend: () => void;
-
-    setLegend: (legends: EchartsLegend) => void;
+    legendPosition: PieChartLegendPosition;
+    legendPositionChange: (position: PieChartLegendPosition) => void;
 
     data: {
         name: string;
@@ -148,7 +149,9 @@ const usePieChartConfig: PieChartConfigFn = (
         pieChartConfig?.showLegend ?? true,
     );
 
-    const [legend, setLegendsConfig] = useState<EchartsLegend>({ orient: 'horizontal' });
+    const [legendPosition, setLegendPosition] = useState(
+        pieChartConfig?.legendPosition ?? PieChartLegendPositionDefault,
+    );
 
     const defaultColors = useMemo(
         () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
@@ -392,14 +395,12 @@ const usePieChartConfig: PieChartConfigFn = (
         [groupLabels],
     );
 
-    const setLegend = useCallback((legend: EchartsLegend) => {
-        setLegendsConfig((prevState) => {
-            return {
-                ...prevState,
-                ...legend,
-            };
-        });
-    }, []);
+    const handleLegendPositionChange = useCallback(
+        (position: PieChartLegendPosition) => {
+            setLegendPosition(position);
+        },
+        [],
+    );
 
     const validPieChartConfig: PieChart = useMemo(
         () => ({
@@ -425,7 +426,7 @@ const usePieChartConfig: PieChartConfigFn = (
                 groupLabels.includes(label),
             ),
             showLegend,
-            legend,
+            legendPosition,
         }),
         [
             groupFieldIds,
@@ -440,7 +441,7 @@ const usePieChartConfig: PieChartConfigFn = (
             groupValueOptionOverrides,
             groupSortOverrides,
             showLegend,
-            legend,
+            legendPosition,
         ],
     );
 
@@ -486,8 +487,8 @@ const usePieChartConfig: PieChartConfigFn = (
 
             showLegend,
             toggleShowLegend: () => setShowLegend((prev) => !prev),
-
-            setLegend,
+            legendPosition,
+            legendPositionChange: handleLegendPositionChange,
 
             data,
         }),
@@ -529,6 +530,8 @@ const usePieChartConfig: PieChartConfigFn = (
             handleGroupSortChange,
 
             showLegend,
+            legendPosition,
+            handleLegendPositionChange,
 
             data,
         ],

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -1,6 +1,7 @@
 import {
     ApiQueryResults,
     ECHARTS_DEFAULT_COLORS,
+    EchartsLegend,
     Explore,
     Field,
     fieldId,
@@ -67,6 +68,8 @@ type PieChartConfig = {
 
     showLegend: boolean;
     toggleShowLegend: () => void;
+
+    setLegend: (legends: EchartsLegend) => void;
 
     data: {
         name: string;
@@ -144,6 +147,8 @@ const usePieChartConfig: PieChartConfigFn = (
     const [showLegend, setShowLegend] = useState(
         pieChartConfig?.showLegend ?? true,
     );
+
+    const [legend, setLegendsConfig] = useState<EchartsLegend>({ orient: 'horizontal' });
 
     const defaultColors = useMemo(
         () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
@@ -387,6 +392,15 @@ const usePieChartConfig: PieChartConfigFn = (
         [groupLabels],
     );
 
+    const setLegend = useCallback((legend: EchartsLegend) => {
+        setLegendsConfig((prevState) => {
+            return {
+                ...prevState,
+                ...legend,
+            };
+        });
+    }, []);
+
     const validPieChartConfig: PieChart = useMemo(
         () => ({
             groupFieldIds,
@@ -411,6 +425,7 @@ const usePieChartConfig: PieChartConfigFn = (
                 groupLabels.includes(label),
             ),
             showLegend,
+            legend,
         }),
         [
             groupFieldIds,
@@ -425,6 +440,7 @@ const usePieChartConfig: PieChartConfigFn = (
             groupValueOptionOverrides,
             groupSortOverrides,
             showLegend,
+            legend,
         ],
     );
 
@@ -470,6 +486,8 @@ const usePieChartConfig: PieChartConfigFn = (
 
             showLegend,
             toggleShowLegend: () => setShowLegend((prev) => !prev),
+
+            setLegend,
 
             data,
         }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7091 

### Description:

Implemented a new feature allowing users to toggle between horizontal and vertical legend positions in pie chart configurations. Additionally, introduced input fields to enable precise customization of legend positions within the charts.

![Screenshot from 2023-09-22 23-47-14](https://github.com/lightdash/lightdash/assets/25580209/1d2efe1d-5a88-4533-af72-9904c4327a66)

