### PR TITLE
fix: allow interactive viewers to export dashboard

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -59,6 +59,7 @@ type DashboardHeaderProps = {
     dashboardViews: number;
     dashboardFirstViewedAt: Date | string | null;
     dashboardUpdatedByUser?: UpdatedByUser;
+    organizationUuid?: string;
     hasDashboardChanged: boolean;
     isEditMode: boolean;
     isSaving: boolean;
@@ -81,6 +82,7 @@ const DashboardHeader = ({
     dashboardFirstViewedAt,
     dashboardUpdatedAt,
     dashboardUpdatedByUser,
+    organizationUuid,
     hasDashboardChanged,
     isEditMode,
     isSaving,
@@ -93,7 +95,7 @@ const DashboardHeader = ({
     onExport,
 }: DashboardHeaderProps) => {
     const { search } = useLocation();
-    const { projectUuid, dashboardUuid, organizationUuid } = useParams<{
+    const { projectUuid, dashboardUuid } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
         organizationUuid: string;
@@ -129,6 +131,7 @@ const DashboardHeader = ({
         'manage',
         subject('ExportCsv', { organizationUuid, projectUuid }),
     );
+
     const isOneAtLeastFetching = isFetching > 0;
 
     return (
@@ -236,7 +239,7 @@ const DashboardHeader = ({
                 </PageActionsContainer>
             ) : (
                 <PageActionsContainer>
-                    {!!userCanExportData && (
+                    {userCanExportData && (
                         <Button
                             size="xs"
                             loading={isOneAtLeastFetching}
@@ -247,7 +250,7 @@ const DashboardHeader = ({
                         </Button>
                     )}
 
-                    {!!userCanManageDashboard && (
+                    {userCanManageDashboard && (
                         <Tooltip
                             label="Edit dashboard"
                             withinPortal
@@ -266,7 +269,7 @@ const DashboardHeader = ({
                         </Tooltip>
                     )}
 
-                    {!!userCanExportData && (
+                    {userCanExportData && (
                         <ShareLinkButton url={`${window.location.href}`} />
                     )}
 
@@ -345,14 +348,15 @@ const DashboardHeader = ({
                                         />
                                     </>
                                 )}
-                                {!!userCanExportData && (
+                                {(userCanExportData ||
+                                    userCanManageDashboard) && (
                                     <MenuItem2
                                         icon={<IconUpload />}
                                         text="Export dashboard"
                                         onClick={onExport}
                                     />
                                 )}
-                                {!!userCanManageDashboard && (
+                                {userCanManageDashboard && (
                                     <>
                                         <Divider />
                                         <MenuItem2
@@ -366,7 +370,7 @@ const DashboardHeader = ({
                             </Menu>
                         }
                     >
-                        {!!userCanExportData && (
+                        {userCanExportData && (
                             <ActionIcon variant="default">
                                 <MantineIcon icon={IconDots} />
                             </ActionIcon>

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -123,6 +123,9 @@ const DashboardHeader = ({
         'Dashboard',
     );
 
+    // Proxy for 'Interactive Viewer'
+    const userCanExportData = user.data?.ability.can('manage', 'ExportCsv');
+
     const isOneAtLeastFetching = isFetching > 0;
 
     return (
@@ -228,123 +231,143 @@ const DashboardHeader = ({
                         Cancel
                     </Button>
                 </PageActionsContainer>
-            ) : userCanManageDashboard ? (
+            ) : (
                 <PageActionsContainer>
-                    <Button
-                        size="xs"
-                        loading={isOneAtLeastFetching}
-                        leftIcon={<MantineIcon icon={IconRefresh} />}
-                        onClick={invalidateDashboardRelatedQueries}
-                    >
-                        Refresh
-                    </Button>
-
-                    <Tooltip
-                        label="Edit dashboard"
-                        withinPortal
-                        position="bottom"
-                    >
-                        <ActionIcon
-                            variant="default"
-                            onClick={() => {
-                                history.replace(
-                                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
-                                );
-                            }}
+                    {!!userCanExportData && (
+                        <Button
+                            size="xs"
+                            loading={isOneAtLeastFetching}
+                            leftIcon={<MantineIcon icon={IconRefresh} />}
+                            onClick={invalidateDashboardRelatedQueries}
                         >
-                            <MantineIcon icon={IconPencil} />
-                        </ActionIcon>
-                    </Tooltip>
+                            Refresh
+                        </Button>
+                    )}
 
-                    <ShareLinkButton url={`${window.location.href}`} />
+                    {!!userCanManageDashboard && (
+                        <Tooltip
+                            label="Edit dashboard"
+                            withinPortal
+                            position="bottom"
+                        >
+                            <ActionIcon
+                                variant="default"
+                                onClick={() => {
+                                    history.replace(
+                                        `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                                    );
+                                }}
+                            >
+                                <MantineIcon icon={IconPencil} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+
+                    {!!userCanExportData && (
+                        <ShareLinkButton url={`${window.location.href}`} />
+                    )}
 
                     <Popover2
                         placement="bottom"
                         content={
                             <Menu>
-                                <MenuItem2
-                                    icon={<IconCopy />}
-                                    text="Duplicate"
-                                    onClick={onDuplicate}
-                                />
+                                {!!userCanManageDashboard && (
+                                    <>
+                                        <MenuItem2
+                                            icon={<IconCopy />}
+                                            text="Duplicate"
+                                            onClick={onDuplicate}
+                                        />
 
-                                <MenuItem2
-                                    icon={<IconFolders />}
-                                    text="Move to space"
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                    }}
-                                >
-                                    {spaces?.map((spaceToMove) => {
-                                        const isDisabled =
-                                            dashboardSpaceUuid ===
-                                            spaceToMove.uuid;
-                                        return (
+                                        <MenuItem2
+                                            icon={<IconFolders />}
+                                            text="Move to space"
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                            }}
+                                        >
+                                            {spaces?.map((spaceToMove) => {
+                                                const isDisabled =
+                                                    dashboardSpaceUuid ===
+                                                    spaceToMove.uuid;
+                                                return (
+                                                    <MenuItem2
+                                                        key={spaceToMove.uuid}
+                                                        text={spaceToMove.name}
+                                                        icon={
+                                                            isDisabled ? (
+                                                                <IconCheck />
+                                                            ) : undefined
+                                                        }
+                                                        className={
+                                                            isDisabled
+                                                                ? 'bp4-disabled'
+                                                                : ''
+                                                        }
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            e.stopPropagation();
+                                                            if (
+                                                                dashboardSpaceUuid !==
+                                                                spaceToMove.uuid
+                                                            ) {
+                                                                onMoveToSpace(
+                                                                    spaceToMove.uuid,
+                                                                );
+                                                            }
+                                                        }}
+                                                    />
+                                                );
+                                            })}
+                                            <Divider />
                                             <MenuItem2
-                                                key={spaceToMove.uuid}
-                                                text={spaceToMove.name}
-                                                icon={
-                                                    isDisabled ? (
-                                                        <IconCheck />
-                                                    ) : undefined
-                                                }
-                                                className={
-                                                    isDisabled
-                                                        ? 'bp4-disabled'
-                                                        : ''
-                                                }
+                                                icon={<IconPlus />}
+                                                text="Create new"
                                                 onClick={(e) => {
                                                     e.preventDefault();
                                                     e.stopPropagation();
-                                                    if (
-                                                        dashboardSpaceUuid !==
-                                                        spaceToMove.uuid
-                                                    ) {
-                                                        onMoveToSpace(
-                                                            spaceToMove.uuid,
-                                                        );
-                                                    }
+                                                    setIsCreatingNewSpace(true);
                                                 }}
                                             />
-                                        );
-                                    })}
-                                    <Divider />
+                                        </MenuItem2>
+                                        <MenuItem2
+                                            icon={<IconSend />}
+                                            text="Scheduled deliveries"
+                                            onClick={() => {
+                                                toggleScheduledDeliveriesModal(
+                                                    true,
+                                                );
+                                            }}
+                                        />
+                                    </>
+                                )}
+                                {!!userCanExportData && (
                                     <MenuItem2
-                                        icon={<IconPlus />}
-                                        text="Create new"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            setIsCreatingNewSpace(true);
-                                        }}
+                                        icon={<IconUpload />}
+                                        text="Export dashboard"
+                                        onClick={onExport}
                                     />
-                                </MenuItem2>
-                                <MenuItem2
-                                    icon={<IconSend />}
-                                    text="Scheduled deliveries"
-                                    onClick={() => {
-                                        toggleScheduledDeliveriesModal(true);
-                                    }}
-                                />
-                                <MenuItem2
-                                    icon={<IconUpload />}
-                                    text="Export dashboard"
-                                    onClick={onExport}
-                                />
-                                <Divider />
-                                <MenuItem2
-                                    icon={<IconTrash />}
-                                    text="Delete"
-                                    intent="danger"
-                                    onClick={onDelete}
-                                />
+                                )}
+                                {!!userCanManageDashboard && (
+                                    <>
+                                        <Divider />
+                                        <MenuItem2
+                                            icon={<IconTrash />}
+                                            text="Delete"
+                                            intent="danger"
+                                            onClick={onDelete}
+                                        />
+                                    </>
+                                )}
                             </Menu>
                         }
                     >
-                        <ActionIcon variant="default">
-                            <MantineIcon icon={IconDots} />
-                        </ActionIcon>
+                        {!!userCanExportData && (
+                            <ActionIcon variant="default">
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        )}
                     </Popover2>
 
                     {isCreatingNewSpace && (
@@ -371,7 +394,7 @@ const DashboardHeader = ({
                         />
                     )}
                 </PageActionsContainer>
-            ) : null}
+            )}
         </PageHeader>
     );
 };

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,5 +1,6 @@
 import { Classes, Divider, Menu } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { subject } from '@casl/ability';
 import { Dashboard, SpaceSummary, UpdatedByUser } from '@lightdash/common';
 import {
     ActionIcon,
@@ -92,9 +93,10 @@ const DashboardHeader = ({
     onExport,
 }: DashboardHeaderProps) => {
     const { search } = useLocation();
-    const { projectUuid, dashboardUuid } = useParams<{
+    const { projectUuid, dashboardUuid, organizationUuid } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
+        organizationUuid: string;
     }>();
     const { isFetching, invalidateDashboardRelatedQueries } =
         useDashboardRefresh();
@@ -123,9 +125,10 @@ const DashboardHeader = ({
         'Dashboard',
     );
 
-    // Proxy for 'Interactive Viewer'
-    const userCanExportData = user.data?.ability.can('manage', 'ExportCsv');
-
+    const userCanExportData = user.data?.ability.can(
+        'manage',
+        subject('ExportCsv', { organizationUuid, projectUuid }),
+    );
     const isOneAtLeastFetching = isFetching > 0;
 
     return (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -40,6 +40,7 @@ import {
 } from '../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import useSavedQueryWithDashboardFilters from '../hooks/dashboard/useSavedQueryWithDashboardFilters';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import {
@@ -157,6 +158,8 @@ const Dashboard: FC = () => {
         setDashboardFilters,
         setDashboardTemporaryFilters,
     } = useDashboardContext();
+
+    const { data: organization } = useOrganization();
     const hasTemporaryFilters = useMemo(
         () =>
             dashboardTemporaryFilters.dimensions.length > 0 ||
@@ -489,6 +492,7 @@ const Dashboard: FC = () => {
                         dashboardSpaceUuid={dashboard.spaceUuid}
                         dashboardViews={dashboard.views}
                         dashboardFirstViewedAt={dashboard.firstViewedAt}
+                        organizationUuid={organization?.organizationUuid}
                         isEditMode={isEditMode}
                         isSaving={isSaving}
                         hasDashboardChanged={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7196

### Description:

Allows interactive viewers to export dashboards. As well as see the refresh and link buttons. 

Note: we don't have a super-clear way of describing in code the difference between and interactive viewer and a viewer. I'm using whether or not they can export csv as a proxy for being an interactive viewer. Tested with viewer, interactive viewer, and editor permissions.
