### PR TITLE
fix: dont allow row limit to go below 1

### DIFF
--- a/packages/frontend/src/components/LimitButton/LimitForm.tsx
+++ b/packages/frontend/src/components/LimitButton/LimitForm.tsx
@@ -43,6 +43,7 @@ const LimitForm = forwardRef<HTMLFormElement, LimitFormProps>(
                     <NumberInput
                         autoFocus
                         step={100}
+                        min={1}
                         required
                         label="Total rows:"
                         {...form.getInputProps('limit')}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7199 

### Description:

The 'total rows' input had buttons that made it easy to put it in a negative state, causing a validation error. This makes the min value for the input 1. 
