### PR TITLE
fix: disable move-to-space option for viewers

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -478,6 +478,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         }
     }, [savedQueryWithDashboardFilters]);
 
+    const userCanManageChart = user.data?.ability?.can('manage', 'SavedChart');
+
     return (
         <>
             <GlobalTileStyles />
@@ -518,10 +520,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                             label="Finish editing dashboard to use these actions"
                         >
                             <Box>
-                                {user.data?.ability?.can(
-                                    'manage',
-                                    'SavedChart',
-                                ) && (
+                                {userCanManageChart && (
                                     <LinkMenuItem
                                         icon="document-open"
                                         text="Edit chart"
@@ -574,14 +573,17 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                         />
                                     )}
 
-                                {savedQueryWithDashboardFilters?.dashboardUuid && (
-                                    <MenuItem2
-                                        icon={<IconFolders size={16} />}
-                                        text="Move to space"
-                                        onClick={() => setIsMovingChart(true)}
-                                        disabled={isEditMode}
-                                    />
-                                )}
+                                {savedQueryWithDashboardFilters?.dashboardUuid &&
+                                    userCanManageChart && (
+                                        <MenuItem2
+                                            icon={<IconFolders size={16} />}
+                                            text="Move to space"
+                                            onClick={() =>
+                                                setIsMovingChart(true)
+                                            }
+                                            disabled={isEditMode}
+                                        />
+                                    )}
                             </Box>
                         </Tooltip>
                     )


### PR DESCRIPTION
### Description:

Viewers and Interactive viewers were seeing the 'Move to space' button on charts in dashboards. It errored out when they tried, but this makes it so they won't see the button. 
