### PR TITLE
fix: compress in express server instead

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/bcrypt": "^5.0.0",
+        "@types/compression": "^1.7.3",
         "@types/connect-flash": "^0.0.37",
         "@types/cookie-parser": "^1.4.2",
         "@types/express": "^4.17.11",
@@ -57,6 +58,7 @@
         "ajv-formats": "^2.1.0",
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",
+        "compression": "^1.7.4",
         "connect-flash": "^0.1.1",
         "connect-session-knex": "^2.1.0",
         "cookie-parser": "^1.4.5",
@@ -66,7 +68,6 @@
         "execa": "^5.0.0",
         "express": "^4.17.3",
         "express-session": "^1.17.2",
-        "express-static-gzip": "^2.1.7",
         "express-winston": "^4.2.0",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.4.6",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,7 +2,6 @@
 // eslint-disable-next-line import/order
 import otelSdk from './otel'; // must be imported first
 
-import fs from 'fs';
 import { LightdashMode, SessionUser } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
@@ -11,9 +10,9 @@ import bodyParser from 'body-parser';
 import flash from 'connect-flash';
 import connectSessionKnex from 'connect-session-knex';
 import cookieParser from 'cookie-parser';
+import compression from 'compression';
 import express, { NextFunction, Request, Response } from 'express';
 import expressSession from 'express-session';
-import expressStaticGzip from 'express-static-gzip';
 import passport from 'passport';
 import refresh from 'passport-oauth2-refresh';
 import path from 'path';
@@ -171,11 +170,10 @@ if (
 // frontend assets - immutable because vite appends hash to filenames
 app.use(
     '/assets',
-    expressStaticGzip(path.join(__dirname, '../../frontend/build/assets'), {
-        serveStatic: {
-            immutable: true,
-            maxAge: '1y',
-        },
+    compression(), // Apply compression only to the assets route
+    express.static(path.join(__dirname, '../../frontend/build/assets'), {
+        immutable: true,
+        maxAge: '1y',
     }),
 );
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -120,7 +120,6 @@
         "type-fest": "^3.10.0",
         "vite": "^4.4.6",
         "vite-plugin-chunk-split": "^0.4.7",
-        "vite-plugin-compression2": "^0.10.5",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-svgr": "^3.2.0",
         "vite-tsconfig-paths": "^4.2.0"

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import reactPlugin from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-import { compression } from 'vite-plugin-compression2';
 import eslintPlugin from 'vite-plugin-eslint';
 import svgrPlugin from 'vite-plugin-svgr';
 import tsconfigPathsPlugin from 'vite-tsconfig-paths';
@@ -27,9 +26,6 @@ export default defineConfig({
             apply: 'serve',
             enforce: 'post',
         },
-        compression({
-            include: [/\.(js)$/, /\.(css)$/],
-        }),
     ],
     css: {
         transformer: 'lightningcss',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,18 +3208,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nolyfill/es-aggregate-error@^1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@nolyfill/es-aggregate-error/-/es-aggregate-error-1.0.21.tgz#4ded25795a5b43c78b7c553052462a7da48e4873"
-  integrity sha512-1P+7535ZSQAD/BoSmeu+xv9eOZA5oCQ3e40rO5ZVbFZBafWR+WoZJsoEwlzUDsZz9iFFIKQiMsrSsN4HbUMtTQ==
-  dependencies:
-    "@nolyfill/shared" "1.0.21"
-
-"@nolyfill/shared@1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@nolyfill/shared/-/shared-1.0.21.tgz#0aeec134d6448a519dda21e122901b5f034b82f8"
-  integrity sha512-qDc/NoaFU23E0hhiDPeUrvWzTXIPE+RbvRQtRWSeHHNmCIgYI9HS1jKzNYNJxv4jvZ/1VmM3L6rNVxbj+LBMNA==
-
 "@opentelemetry/api-logs@0.39.1":
   version "0.39.1"
   resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz"
@@ -4708,6 +4696,13 @@
   resolved "https://registry.npmjs.org/@types/columnify/-/columnify-1.5.1.tgz"
   integrity sha512-pXWQTEvwcO7GAwFvSvaMOIktLcJ2ajIAUyMR93KDZZVWN2G7uieEDBPJskEmXb0Qv8JMPHhaRA52azCPfiFmQA==
 
+"@types/compression@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.3.tgz#2dd34648fc3b71c95aacd63b3098b2192da33929"
+  integrity sha512-rKquEGjebqizyHNMOpaE/4FdYR5VQiWFeesqYfvJU0seSEyB4625UGhNOO/qIkH10S3wftiV7oefc8WdLZ/gCQ==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect-flash@^0.0.37":
   version "0.0.37"
   resolved "https://registry.npmjs.org/@types/connect-flash/-/connect-flash-0.0.37.tgz"
@@ -5871,7 +5866,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-accepts@~1.3.8:
+accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -6972,6 +6967,11 @@ bull@^4.7.0:
     semver "^7.3.2"
     uuid "^8.3.0"
 
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
@@ -7588,12 +7588,25 @@ component-type@^1.2.1:
   resolved "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz"
   integrity sha1-ikeQFwAjjk/DIml3EjAibyS0Fak=
 
-compressible@^2.0.12:
+compressible@^2.0.12, compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz"
   integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
   dependencies:
     mime-db ">= 1.43.0 < 2"
+
+compression@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -9547,13 +9560,6 @@ express-session@^1.17.2:
     parseurl "~1.3.3"
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
-
-express-static-gzip@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/express-static-gzip/-/express-static-gzip-2.1.7.tgz#5904824a07950ba741ec3a23a21839dd04c63506"
-  integrity sha512-QOCZUC+lhPPCjIJKpQGu1Oa61Axg9Mq09Qvit8Of7kzpMuwDeMSqjjQteQS3OVw/GkENBoSBheuQDWPlngImvw==
-  dependencies:
-    serve-static "^1.14.1"
 
 express-winston@^4.2.0:
   version "4.2.0"
@@ -17255,15 +17261,15 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex-test@^1.0.0:
   version "1.0.0"
@@ -17438,7 +17444,7 @@ serve-static@1.14.2:
     parseurl "~1.3.3"
     send "0.17.2"
 
-serve-static@1.15.0, serve-static@^1.14.1:
+serve-static@1.15.0:
   version "1.15.0"
   resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz"
   integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
@@ -19537,14 +19543,6 @@ vite-plugin-chunk-split@^0.4.7:
   dependencies:
     es-module-lexer "^1.0.3"
     magic-string "^0.26.3"
-
-vite-plugin-compression2@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-0.10.5.tgz#013ed2fe8471487dca7173a971668a74e0f308fa"
-  integrity sha512-IaZUzl9pmZXSAwX3XA6LiB9S7vWK/+4P1r5hT/NlygFWjF6OXNbXJq2/jtkh4HzsxILa0+kwmihTYbJRR406Uw==
-  dependencies:
-    "@nolyfill/es-aggregate-error" "^1.0.21"
-    "@rollup/pluginutils" "^5.0.2"
 
 vite-plugin-eslint@^1.8.1:
   version "1.8.1"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7097

### Description:

After work done on: https://github.com/lightdash/lightdash/pull/7200, I've noticed that some assets were randomly not being served with the gzipped file generated with vite compression plugin. 
This is because some of these asset response headers were missing 2 headers:
```
- `Vary: Accept-Encoding`
- `Content-Encoding: gzip`
```

For example: 
<img width="661" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/4751eedd-318d-4899-9029-082ca32b347a">
in here ^ only the first asset is served gzipped, and the others aren't, even though these are available. 

This could be related to: https://github.com/tkoenig89/express-static-gzip/issues/22 where there are multiple assets being requested at once. 

Since this could be a config issue (with google cloud CDN), I would like to test one thing instead: compressing the assets with the `express`'s `compression` middleware. 

**NOTE**
THis should only be done to test if the issue is with the pre-compressed assets or the cdn. This is not an optimal solution
