### PR TITLE
chore: timeout e2e tests

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -44,6 +44,7 @@ jobs:
           exit 1
 
   cli-tests:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: prepare-preview
     strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
   api-tests:
     if: needs.files-changed.outputs.backend == 'true'
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: prepare-preview
     name: API tests
@@ -74,6 +75,7 @@ jobs:
 
   app-tests:
     if: needs.files-changed.outputs.frontend == 'true'
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: prepare-preview
     container:
@@ -144,6 +146,7 @@ jobs:
 
   timezone-tests:
     if: needs.files-changed.outputs.frontend == 'true'
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: prepare-preview
     container:


### PR DESCRIPTION
For some reason there is a test that never ends and cypress doesn't kill it. Adding a timeout to the github action job.

test-frontend