### PR TITLE
chore: enable js jsmap and css to be gzipped

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,7 +2,6 @@
 // eslint-disable-next-line import/order
 import otelSdk from './otel'; // must be imported first
 
-import fs from 'fs';
 import { LightdashMode, SessionUser } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
@@ -172,10 +171,13 @@ if (
 app.use(
     '/assets',
     expressStaticGzip(path.join(__dirname, '../../frontend/build/assets'), {
-        serveStatic: {
-            immutable: true,
-            maxAge: '1y',
-        },
+        index: false,
+        customCompressions: [
+            {
+                encodingName: 'gzip',
+                fileExtension: 'gzip',
+            },
+        ],
     }),
 );
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
             enforce: 'post',
         },
         compression({
-            include: [/\.(js)$/, /\.(css)$/],
+            include: [/\.(js)$/, /\.(css)$/, /\.js\.map$/],
+            filename: '[path][base].gzip',
         }),
     ],
     css: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7097 

### Description:

* gzip js, jsmap and css files
* look for these .gzip files

THis has already been tested in an alpha release, these should be the only changes required to serve all gzipped assets. 

No changes have been made to the disabling of CDN caching - only the browser can cache these assets

summary on cache + revalidation + origin server + google cloud cdn + browser caching and **with** these changes:

for example: `blueprint-vendor-xxx.js` has a `cache-control` response header of `public, max-age=0` - the  CDN sees this, holds the asset, but will revalidate it with the origin server every time it's requested because of the `max-age=0`
Since the request header also has `Cache-control: no-cache` the CDN will respect this directive and fetch a fresh copy from the origin server
Besides the origin server + CDN configuration, the browser will cache the asset
When the browser finds the asset, it immediately sees that its `max-age=0`, which will then trigger a revalidation of the cached asset
However, if it hasn't changed, it will respond with a `304`

On the 304 flow:
the browser requests the asset
The CDN responds with the `cache-control public,max-age=0` on the response header and the header: `Last-Modified: Mon, 25 Sep 2023 19:16:50 GMT`
If the requested asset hasn't been modified since the `Last-Modified` timestamp, it will use the cached asset from the client
If the asset has been modified after the time stamp, then the browser will re-validate and request the new version of the asset

example:
blueprint asset 304 not modified - has response header `cache-control`, has `last-modified` header, but **no** `cache-control` in **request** header (no need)

example 2:
* refreshed browser cache
* blueprint asset `200`  with **response** headers: `cache-control`, and `last-modified` the same
request header cache-control says: `no-cache`



