### PR TITLE
fix: Revert "Revert "feat: dashboard filters apply to new charts (#70…

### DIFF
--- a/packages/common/src/types/filter.test.ts
+++ b/packages/common/src/types/filter.test.ts
@@ -1,0 +1,279 @@
+import { ConditionalOperator } from './conditionalRule';
+import {
+    compressDashboardFiltersToParam,
+    convertDashboardFiltersParamToDashboardFilters,
+} from './filter';
+
+describe('compress and uncompress dashboard filters', () => {
+    describe('compressDashboardFiltersToParam', () => {
+        const DUMMY_DIMENSION = {
+            id: 'filter-id',
+            label: 'A label',
+            operator: ConditionalOperator.EQUALS,
+            target: {
+                fieldId: 'payments_payment_method',
+                tableName: 'payments',
+            },
+            tileTargets: {},
+            disabled: false,
+            values: ['credit_card'],
+        };
+        it('should create no tile targets when there are no overrides', async () => {
+            expect(
+                compressDashboardFiltersToParam({
+                    dimensions: [DUMMY_DIMENSION],
+                    metrics: [],
+                }),
+            ).toEqual({
+                dimensions: [
+                    {
+                        id: 'filter-id',
+                        label: 'A label',
+                        operator: 'equals',
+                        target: {
+                            fieldId: 'payments_payment_method',
+                            tableName: 'payments',
+                        },
+                        tileTargets: [],
+                        disabled: false,
+                        values: ['credit_card'],
+                    },
+                ],
+                metrics: [],
+            });
+        });
+        it('should set tile target to "false" when tile is disabled', async () => {
+            expect(
+                compressDashboardFiltersToParam({
+                    dimensions: [
+                        {
+                            ...DUMMY_DIMENSION,
+                            tileTargets: { 'chart-id-no-filter': false },
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual([{ 'chart-id-no-filter': false }]);
+        });
+        it('should set tile target overrides when filter fields dont match tile fields', async () => {
+            expect(
+                compressDashboardFiltersToParam({
+                    dimensions: [
+                        {
+                            ...DUMMY_DIMENSION,
+                            tileTargets: {
+                                'chart-id-modified-filter': {
+                                    fieldId: 'a_different_field',
+                                    tableName: 'a_different_table',
+                                },
+                            },
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual([
+                {
+                    'chart-id-modified-filter': {
+                        fieldId: 'a_different_field',
+                        tableName: 'a_different_table',
+                    },
+                },
+            ]);
+        });
+        it('should NOT set tile targets when filter fields DO match tile fields', async () => {
+            expect(
+                compressDashboardFiltersToParam({
+                    dimensions: [
+                        {
+                            ...DUMMY_DIMENSION,
+                            tileTargets: {
+                                'chart-id': {
+                                    fieldId: 'payments_payment_method',
+                                    tableName: 'payments',
+                                },
+                            },
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual([]);
+        });
+        it('should handle disabled, override and default cases together', async () => {
+            const compressedFilters = compressDashboardFiltersToParam({
+                dimensions: [
+                    {
+                        ...DUMMY_DIMENSION,
+                        tileTargets: {
+                            'chart-id': {
+                                fieldId: 'payments_payment_method',
+                                tableName: 'payments',
+                            },
+                            'chart-id-no-filter': false,
+                            'chart-id-modified-filter': {
+                                fieldId: 'a_different_field',
+                                tableName: 'a_different_table',
+                            },
+                            'chart-id-no-filter2': false,
+                        },
+                    },
+                ],
+                metrics: [
+                    {
+                        ...DUMMY_DIMENSION,
+                        tileTargets: {
+                            'metric-chart-id': {
+                                fieldId: 'payments_payment_method',
+                                tableName: 'payments',
+                            },
+                            'metric-chart-id-no-filter': false,
+                            'metric-chart-id-modified-filter': {
+                                fieldId: 'a_different_field',
+                                tableName: 'a_different_table',
+                            },
+                            'metric-chart-id-no-filter2': false,
+                        },
+                    },
+                ],
+            });
+
+            expect(compressedFilters.dimensions[0].tileTargets).toEqual([
+                { 'chart-id-no-filter': false },
+                {
+                    'chart-id-modified-filter': {
+                        fieldId: 'a_different_field',
+                        tableName: 'a_different_table',
+                    },
+                },
+                { 'chart-id-no-filter2': false },
+            ]);
+            expect(compressedFilters.metrics[0].tileTargets).toEqual([
+                { 'metric-chart-id-no-filter': false },
+                {
+                    'metric-chart-id-modified-filter': {
+                        fieldId: 'a_different_field',
+                        tableName: 'a_different_table',
+                    },
+                },
+                { 'metric-chart-id-no-filter2': false },
+            ]);
+        });
+    });
+    describe('convertDashboardFiltersParamToDashboardFilters', () => {
+        const DUMMY_URL_FILTER = {
+            id: 'url-dimension',
+            label: 'a label',
+            operator: ConditionalOperator.EQUALS,
+            target: {
+                fieldId: 'payments_payment_method',
+                tableName: 'payments',
+            },
+            tileTargets: [],
+            disabled: false,
+            values: ['credit_card'],
+        };
+        it('should convert filters with no tile targets', async () => {
+            expect(
+                convertDashboardFiltersParamToDashboardFilters({
+                    dimensions: [DUMMY_URL_FILTER],
+                    metrics: [],
+                }),
+            ).toEqual({
+                dimensions: [
+                    {
+                        id: 'url-dimension',
+                        label: 'a label',
+                        operator: 'equals',
+                        target: {
+                            fieldId: 'payments_payment_method',
+                            tableName: 'payments',
+                        },
+                        tileTargets: {},
+                        disabled: false,
+                        values: ['credit_card'],
+                    },
+                ],
+                metrics: [],
+            });
+        });
+        it('should have modified tile targets when target modified', async () => {
+            expect(
+                convertDashboardFiltersParamToDashboardFilters({
+                    dimensions: [
+                        {
+                            ...DUMMY_URL_FILTER,
+                            tileTargets: [
+                                {
+                                    'chart-id-modified-filter': {
+                                        fieldId: 'other-field',
+                                        tableName: 'other-table',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual({
+                'chart-id-modified-filter': {
+                    fieldId: 'other-field',
+                    tableName: 'other-table',
+                },
+            });
+        });
+        it('should have disabled tile targets when target is "false"', async () => {
+            expect(
+                convertDashboardFiltersParamToDashboardFilters({
+                    dimensions: [
+                        {
+                            ...DUMMY_URL_FILTER,
+                            tileTargets: [{ 'chart-id-no-filter': false }],
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual({ 'chart-id-no-filter': false });
+        });
+        it('should omit tile target string (for back-compat)', async () => {
+            expect(
+                convertDashboardFiltersParamToDashboardFilters({
+                    dimensions: [
+                        {
+                            ...DUMMY_URL_FILTER,
+                            tileTargets: ['an-id'],
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual({});
+        });
+        it('should handle normal, modified and disabled tile targets', async () => {
+            expect(
+                convertDashboardFiltersParamToDashboardFilters({
+                    dimensions: [
+                        {
+                            ...DUMMY_URL_FILTER,
+                            tileTargets: [
+                                'an-id',
+                                { 'chart-id-no-filter': false },
+                                'another-id',
+                                {
+                                    'chart-id-modified-filter': {
+                                        fieldId: 'other-field',
+                                        tableName: 'other-table',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    metrics: [],
+                }).dimensions[0].tileTargets,
+            ).toEqual({
+                'chart-id-no-filter': false,
+                'chart-id-modified-filter': {
+                    fieldId: 'other-field',
+                    tableName: 'other-table',
+                },
+            });
+        });
+    });
+});

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -66,13 +66,6 @@ interface Props {
     onSave: (value: DashboardFilterRule) => void;
 }
 
-const getExactFilter = (
-    filters: FilterableField[],
-    selectedField: FilterableField,
-) => {
-    return filters.find(matchFieldExact(selectedField));
-};
-
 const getDefaultFilter = (
     filters: FilterableField[],
     selectedField: FilterableField,
@@ -191,7 +184,7 @@ const FilterConfiguration: FC<Props> = ({
                         return draftState;
 
                     case FilterActions.REMOVE:
-                        delete draftState.tileTargets[tileUuid];
+                        draftState.tileTargets[tileUuid] = false;
                         return draftState;
 
                     default:
@@ -219,6 +212,12 @@ const FilterConfiguration: FC<Props> = ({
                     if (!draftState || !selectedField) return;
 
                     draftState.tileTargets = {};
+                    Object.entries(availableTileFilters).forEach(
+                        ([tileUuid]) => {
+                            if (!draftState.tileTargets) return;
+                            draftState.tileTargets[tileUuid] = false;
+                        },
+                    );
                     return draftState;
                 });
 
@@ -226,29 +225,7 @@ const FilterConfiguration: FC<Props> = ({
             } else {
                 const newFilterRule = produce(draftFilterRule, (draftState) => {
                     if (!draftState || !selectedField) return;
-
-                    Object.entries(availableTileFilters).forEach(
-                        ([tileUuid, filters]) => {
-                            if (!filters) return;
-
-                            const filterableField = getExactFilter(
-                                filters,
-                                selectedField,
-                            );
-
-                            if (!filterableField) return;
-
-                            if (!draftState.tileTargets) {
-                                draftState.tileTargets = {};
-                            }
-
-                            draftState.tileTargets[tileUuid] = {
-                                fieldId: fieldId(filterableField),
-                                tableName: filterableField.table,
-                            };
-                        },
-                    );
-
+                    draftState.tileTargets = {};
                     return draftState;
                 });
 

--- a/packages/frontend/src/components/common/Filters/configs.ts
+++ b/packages/frontend/src/components/common/Filters/configs.ts
@@ -239,6 +239,7 @@ export const getFilterRuleTables = (
             (tables, tileTarget) => {
                 const targetField = filterableFields.find(
                     (f) =>
+                        tileTarget !== false &&
                         f.table === tileTarget.tableName &&
                         getItemId(f) === tileTarget.fieldId,
                 );

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -22,16 +22,23 @@ const useDashboardFiltersForExplore = (
         (rules: DashboardFilterRule[]) =>
             rules
                 .filter((rule) => !rule.disabled)
-                .filter((f) => f.tileTargets?.[tileUuid] ?? true)
                 .map((filter) => {
-                    const { tileTargets, ...rest } = filter;
-                    if (!tileTargets) return filter;
+                    const tileConfig = filter.tileTargets?.[tileUuid];
 
-                    const tileConfig = tileTargets[tileUuid];
-                    if (!tileConfig) return null;
+                    // If the config is false, we remove this filter
+                    if (tileConfig === false) {
+                        return null;
+                    }
+
+                    // If the tile isn't in the tileTarget overrides,
+                    // we return the filter and don't treat this tile
+                    // differently.
+                    if (tileConfig === undefined) {
+                        return filter;
+                    }
 
                     return {
-                        ...rest,
+                        ...filter,
                         target: {
                             fieldId: tileConfig.fieldId,
                             tableName: tileConfig.tableName,


### PR DESCRIPTION
…32)" (#7222)"

This reverts commit 00bf0e5021587043238996bdb57c641b82bbc506.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

We reverted this change, but it turns out it's ok. This puts it back.
