### PR TITLE
docs: Update metrics.mdx to fix date and string examples

### DIFF
--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -342,8 +342,7 @@ If you want to create a metric of a maximum or minimum date, you can't use `type
       metrics:
         max_created_at_date:
           type: date
-          sql: MAX(${created_at_date})
-  sql: ${TABLE}.updated_at
+          sql: MAX(${TABLE}.created_at_date)
 ```
 
 ### max
@@ -445,7 +444,7 @@ columns:
       metrics:
         product_name_group:
           type: string
-          sql: "GROUP_CONCAT(${product_name})"
+          sql: "GROUP_CONCAT(${TABLE}.product_name)"
 ```
 
 ## Adding your own metric descriptions


### PR DESCRIPTION
fixes `date` and `string` examples in teh docs (the custom SQL can reference metrics, but only in the format `${TABLE}.dim_name`)