### PR TITLE
test: add more coverage to dashboard test on filters

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -60,7 +60,7 @@ describe('Dashboard', () => {
         cy.contains('bank_transfer').should('have.length', 0);
     });
 
-    it('Should create dashboard with tiles', () => {
+    it('Should create dashboard with saved chart + charts within dashboard + filters + tile targets', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         cy.contains('Create dashboard').click();
@@ -68,6 +68,7 @@ describe('Dashboard', () => {
         cy.findByLabelText('Dashboard description').type('Description');
         cy.findByText('Create').click();
 
+        // Add Saved Chart
         cy.findAllByText('Add tile').click({ multiple: true });
         cy.findByText('Saved chart').click();
         cy.findByRole('dialog').findByPlaceholderText('Search...').click();
@@ -75,35 +76,136 @@ describe('Dashboard', () => {
         cy.findByRole('dialog').get('.mantine-MultiSelect-input').click(); // Close dropdown
         cy.findByText('Add').click();
 
+        // Create chart within dashboard
         cy.findAllByText('Add tile').click({ multiple: true });
         cy.findByText('New chart').click();
         cy.findByText('You are creating this chart from within "Title"').should(
             'exist',
         );
-        cy.findByText('Orders').click();
-        cy.findByText('Status').click();
-        cy.findByText('Average order size').click();
+        cy.findByText('Payments').click();
+        cy.findByText('Payment method').click();
+        cy.findByText('Unique payment count').click();
         cy.findByText('Save chart').click();
-        cy.get('input#chart-name').type('Average order size per status');
+        cy.get('input#chart-name').type(
+            `What's the number of unique payments per payment method?`,
+        );
         cy.findByText('Save').click();
         cy.findByText(
-            'Success! Average order size per status was added to Title',
+            `Success! What's the number of unique payments per payment method? was added to Title`,
         ).should('exist');
 
+        // Wait to be redirected to dashboard
+        cy.url().should('include', '/dashboards');
+
+        // Add filter Payment method is credit_card and apply
+        cy.contains('Add filter').click();
+        cy.get('#field-autocomplete').click().type('payment method{enter}');
+        cy.get('label.mantine-Switch-track').click();
+        cy.findByPlaceholderText('Start typing to filter results').type(
+            'credit_card{enter}{esc}',
+        );
+        cy.contains('button', 'Apply').click();
+
+        // Filter should be applied and no other payment methods should be visible in the charts
+        cy.contains('bank_transfer').should('have.length', 0);
+
+        // Create another chart within dashboard
         cy.findAllByText('Add tile').click({ multiple: true });
+        cy.findByText('New chart').click();
+        cy.findByText('You are creating this chart from within "Title"').should(
+            'exist',
+        );
+        cy.findByText('Payments').click();
+        cy.findByText('Payment method').click();
+        cy.findByText('Total revenue').click();
+        cy.findByText('Save chart').click();
+        cy.get('input#chart-name').type(
+            `What's the total revenue per payment method?`,
+        );
+        cy.findByText('Save').click();
+        cy.findByText(
+            `Success! What's the total revenue per payment method? was added to Title`,
+        ).should('exist');
+
+        // Wait to be redirected to dashboard
+        cy.url().should('include', '/dashboards');
+
+        // Filter payment method should be already applied
+        cy.contains('bank_transfer').should('have.length', 0);
+
+        // Check tile targets are correct and all charts have that filter applied
+        cy.contains('Payment method is credit_card').click();
+        cy.findAllByRole('tab').eq(1).click();
+        cy.get('.mantine-Checkbox-body').should('have.length', 4); // 3 checkboxes for the 3 charts + `select all` checkbox
+        cy.get('.mantine-Checkbox-body').each(($el) => {
+            cy.wrap($el).find('input[checked]').should('have.length', 1);
+        });
+
+        // Remove filter from first chart - saved chart
+        cy.get('.mantine-Checkbox-body').eq(1).click();
+        cy.contains('button', 'Apply').click();
+
+        // Saved chart should have no filter applied
+        cy.get('.react-grid-item').first().should('contain', 'bank_transfer');
+        cy.contains('bank_transfer').should('have.length', 1);
+
+        // Create new chart within dashboard, but reference another explore
+        cy.findAllByText('Add tile').click({ multiple: true });
+        cy.findByText('New chart').click();
+        cy.findByText('You are creating this chart from within "Title"').should(
+            'exist',
+        );
+        cy.findByText('Stg payments').click();
+        cy.findByText('Payment method').click();
+        cy.findByText('Amount').click();
+        cy.findByText('Save chart').click();
+        cy.get('input#chart-name').type(
+            `Stg Payments (payment method x amount)?`,
+        );
+        cy.findByText('Save').click();
+        cy.findByText(
+            `Success! Stg Payments (payment method x amount)? was added to Title`,
+        ).should('exist');
+
+        // Wait to be redirected to dashboard
+        cy.url().should('include', '/dashboards');
+
+        // Open filter popover  and check that all charts have the filter applied except for the new one (which is referencing another explore)
+        cy.contains('Payment method is credit_card').click();
+        cy.findAllByRole('tab').eq(1).click();
+        cy.get('.mantine-Checkbox-body').should('have.length', 5); // 4 checkboxes for the 4 charts + `select all` checkbox
+
+        // Enable filter for the new chart
+        cy.get('.mantine-Checkbox-body').eq(4).click();
+        cy.get('.mantine-Checkbox-body')
+            .eq(4)
+            .within(() => {
+                cy.get('input').should('be.checked');
+            });
+        cy.get('.mantine-Checkbox-body')
+            .eq(4)
+            .parent()
+            .parent()
+            .siblings()
+            .first()
+            .within(() => {
+                cy.get('input').should(
+                    'have.value',
+                    'Stg payments Payment method',
+                );
+            });
+        cy.contains('button', 'Apply').click();
+
+        // Saved chart should have the filter applied and only see credit_card bar
+        cy.get('.react-grid-item')
+            .last()
+            .should('not.contain', 'bank_transfer');
+
+        // Add Markdown tile
+        cy.findAllByText('Add tile').click();
         cy.findByText('Markdown').click();
         cy.findByLabelText('Title').type('Title');
         cy.get('textarea').type('Content');
-        cy.findByText('Add').click();
-
-        cy.findAllByText('Add tile').click({ multiple: true });
-        cy.findByText('Loom video').click();
-
-        cy.findByLabelText('Title *').type('Title');
-        cy.findByLabelText('Loom url *').type(
-            'https://www.loom.com/share/12345',
-        );
-        cy.findByText('Add').click();
 
         cy.findByText('Save').click();
 

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -206,6 +206,7 @@ describe('Dashboard', () => {
         cy.findByText('Markdown').click();
         cy.findByLabelText('Title').type('Title');
         cy.get('textarea').type('Content');
+        cy.findByText('Add').click();
 
         cy.findByText('Save').click();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Adds e2e test coverage for dashboards when the user:
* Adds a saved chart
* Creates charts within dashboards
* Adds a filter
* Customises the tile targets
* Adds a field from another explore in the tile target

