### PR TITLE
fix: user attribute default value

### DIFF
--- a/packages/backend/src/models/UserAttributesModel.ts
+++ b/packages/backend/src/models/UserAttributesModel.ts
@@ -83,7 +83,6 @@ export class UserAttributesModel {
             {},
         );
 
-        console.log('allValues', filters.userUuid, allValues);
         return allValues;
     }
 

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, UserAttribute } from '@lightdash/common';
+import { ForbiddenError } from '@lightdash/common';
 import {
     assertValidDimensionRequiredAttribute,
     buildQuery,
@@ -56,7 +56,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -67,7 +66,6 @@ describe('Query builder', () => {
                 explore: EXPLORE_BIGQUERY,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: bigqueryClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL_BIGQUERY);
     });
@@ -78,7 +76,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_TWO_TABLES_SQL);
     });
@@ -89,7 +86,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_TABLE_REFERENCE_SQL);
     });
@@ -100,7 +96,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_SQL);
     });
@@ -111,7 +106,6 @@ describe('Query builder', () => {
                 explore: EXPLORE_JOIN_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_JOIN_CHAIN_SQL);
     });
@@ -122,7 +116,6 @@ describe('Query builder', () => {
                 explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL);
     });
@@ -133,7 +126,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL);
     });
@@ -144,7 +136,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_DISABLED_FILTER_SQL);
     });
@@ -156,7 +147,6 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL);
     });
@@ -167,7 +157,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL);
     });
@@ -178,7 +167,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -189,7 +177,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_SQL);
     });
@@ -201,7 +188,6 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(
             METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM_SQL,
@@ -214,7 +200,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_METRIC_FILTERS_SQL);
     });
@@ -225,7 +210,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL);
     });
@@ -236,7 +220,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_FILTER_SQL);
     });
@@ -247,7 +230,6 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL);
     });
@@ -259,36 +241,20 @@ describe('Query builder', () => {
                     explore: EXPLORE_WITH_SQL_FILTER,
                     compiledMetricQuery: METRIC_QUERY,
                     warehouseClient: warehouseClientMock,
-                    userUuid: 'user-uuid',
-                    userAttributes: [],
+                    userAttributes: {},
                 }).query,
         ).toThrowError(ForbiddenError);
     });
 
     test('Should replace user attributes from sql filter', () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'country',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: null,
-                users: [
-                    {
-                        userUuid: 'user-uuid',
-                        email: '',
-                        value: 'EU',
-                    },
-                ],
-            },
-        ];
         expect(
             buildQuery({
                 explore: EXPLORE_WITH_SQL_FILTER,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
-                userUuid: 'user-uuid',
-                userAttributes,
+                userAttributes: {
+                    country: 'EU',
+                },
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_SQL_FILTER);
     });
@@ -296,46 +262,30 @@ describe('Query builder', () => {
 
 describe('replaceUserAttributes', () => {
     it('method with no user attribute should return same sqlFilter', async () => {
-        expect(replaceUserAttributes('${dimension} > 1', [])).toEqual(
+        expect(replaceUserAttributes('${dimension} > 1', {})).toEqual(
             '${dimension} > 1',
         );
-        expect(replaceUserAttributes('${table.dimension} = 1', [])).toEqual(
+        expect(replaceUserAttributes('${table.dimension} = 1', {})).toEqual(
             '${table.dimension} = 1',
         );
         expect(
-            replaceUserAttributes('${dimension} = ${TABLE}.dimension', []),
+            replaceUserAttributes('${dimension} = ${TABLE}.dimension', {}),
         ).toEqual('${dimension} = ${TABLE}.dimension');
     });
 
     it('method with missing user attribute should throw error', async () => {
         expect(() =>
-            replaceUserAttributes('${lightdash.attribute.test} > 1', []),
+            replaceUserAttributes('${lightdash.attribute.test} > 1', {}),
         ).toThrowError(ForbiddenError);
 
         expect(() =>
-            replaceUserAttributes('${ld.attr.test} > 1', []),
+            replaceUserAttributes('${ld.attr.test} > 1', {}),
         ).toThrowError(ForbiddenError);
     });
 
     it('method should replace sqlFilter with user attribute', async () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'test',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: null,
-                users: [
-                    {
-                        userUuid: '',
-                        email: '',
-                        value: '1',
-                    },
-                ],
-            },
-        ];
+        const userAttributes = { test: '1' };
         const expected = "'1' > 1";
-
         expect(
             replaceUserAttributes(
                 '${lightdash.attribute.test} > 1',
@@ -349,36 +299,7 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should replace sqlFilter with multiple user attributes', async () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'test',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: null,
-                users: [
-                    {
-                        userUuid: '',
-                        email: '',
-                        value: '1',
-                    },
-                ],
-            },
-            {
-                uuid: '',
-                name: 'another',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: null,
-                users: [
-                    {
-                        userUuid: '',
-                        email: '',
-                        value: '2',
-                    },
-                ],
-            },
-        ];
+        const userAttributes = { test: '1', another: '2' };
         const sqlFilter =
             '${dimension} IS NOT NULL OR (${lightdash.attribute.test} > 1 AND ${lightdash.attribute.another} = 2)';
         const expected = "${dimension} IS NOT NULL OR ('1' > 1 AND '2' = 2)";
@@ -388,22 +309,7 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should replace sqlFilter using short aliases', async () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'test',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: null,
-                users: [
-                    {
-                        userUuid: '',
-                        email: '',
-                        value: '1',
-                    },
-                ],
-            },
-        ];
+        const userAttributes = { test: '1', another: '2' };
         const expected = "'1' > 1";
         expect(
             replaceUserAttributes('${ld.attribute.test} > 1', userAttributes),
@@ -424,74 +330,17 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should not replace any invalid attribute', async () => {
-        expect(replaceUserAttributes('${lightdash.foo.test} > 1', [])).toEqual(
+        expect(replaceUserAttributes('${lightdash.foo.test} > 1', {})).toEqual(
             '${lightdash.foo.test} > 1',
         );
-    });
-
-    it('method should replace sqlFilter with user value before default', async () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'test',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: 'default_value',
-                users: [
-                    {
-                        userUuid: '',
-                        email: '',
-                        value: '1',
-                    },
-                ],
-            },
-        ];
-        const expected = "'1' > 1";
-
-        expect(
-            replaceUserAttributes(
-                '${lightdash.attribute.test} > 1',
-                userAttributes,
-            ),
-        ).toEqual(expected);
-
-        expect(
-            replaceUserAttributes('${ld.attr.test} > 1', userAttributes),
-        ).toEqual(expected);
-    });
-
-    it('method should replace sqlFilter with default value if user value is not available', async () => {
-        const userAttributes: UserAttribute[] = [
-            {
-                uuid: '',
-                name: 'test',
-                createdAt: new Date(),
-                organizationUuid: '',
-                attributeDefault: 'default_value',
-                users: [],
-            },
-        ];
-        const expected = "'default_value' > 1";
-
-        expect(
-            replaceUserAttributes(
-                '${lightdash.attribute.test} > 1',
-                userAttributes,
-            ),
-        ).toEqual(expected);
-
-        expect(
-            replaceUserAttributes('${ld.attr.test} > 1', userAttributes),
-        ).toEqual(expected);
     });
 });
 
 describe('assertValidDimensionRequiredAttribute', () => {
     it('should not throw errors if no user attributes are required', async () => {
         const result = assertValidDimensionRequiredAttribute(
-            'user-uuid',
             COMPILED_DIMENSION,
-            [],
+            {},
             '',
         );
 
@@ -501,43 +350,26 @@ describe('assertValidDimensionRequiredAttribute', () => {
     it('should throw errors if required attributes are required and user attributes are missing', async () => {
         expect(() =>
             assertValidDimensionRequiredAttribute(
-                'user-uuid',
                 {
                     ...COMPILED_DIMENSION,
                     requiredAttributes: {
                         is_admin: 'true',
                     },
                 },
-                [],
+                {},
                 '',
             ),
         ).toThrowError(ForbiddenError);
 
         expect(() =>
             assertValidDimensionRequiredAttribute(
-                'user-uuid',
                 {
                     ...COMPILED_DIMENSION,
                     requiredAttributes: {
                         is_admin: 'true',
                     },
                 },
-                [
-                    {
-                        uuid: '',
-                        name: 'is_admin',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: null,
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-                                email: '',
-                                value: 'false',
-                            },
-                        ],
-                    },
-                ],
+                { is_admin: 'false' },
                 '',
             ),
         ).toThrowError(ForbiddenError);
@@ -545,29 +377,13 @@ describe('assertValidDimensionRequiredAttribute', () => {
 
     it('should not throw errors if required attributes are required and user attributes exist', async () => {
         const result = assertValidDimensionRequiredAttribute(
-            'user-uuid',
             {
                 ...COMPILED_DIMENSION,
                 requiredAttributes: {
                     is_admin: 'true',
                 },
             },
-            [
-                {
-                    uuid: '',
-                    name: 'is_admin',
-                    createdAt: new Date(),
-                    organizationUuid: '',
-                    attributeDefault: null,
-                    users: [
-                        {
-                            userUuid: 'user-uuid',
-                            email: '',
-                            value: 'true',
-                        },
-                    ],
-                },
-            ],
+            { is_admin: 'true' },
             '',
         );
 

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -20,7 +20,6 @@ import {
     parseAllReferences,
     renderFilterRuleSql,
     SupportedDbtAdapter,
-    UserAttribute,
     WarehouseClient,
 } from '@lightdash/common';
 import { hasUserAttribute } from './services/UserAttributesService/UserAttributeUtils';
@@ -54,7 +53,7 @@ const getMetricFromId = (
 
 export const replaceUserAttributes = (
     sqlFilter: string,
-    userAttributes: UserAttribute[],
+    userAttributes: Record<string, string | null>,
     stringQuoteChar: string = "'",
     filter: string = 'sql_filter',
 ): string => {
@@ -66,57 +65,38 @@ export const replaceUserAttributes = (
         return sqlFilter;
     }
 
-    const sq = sqlAttributes.reduce<string>((acc, sqlAttribute) => {
+    return sqlAttributes.reduce<string>((acc, sqlAttribute) => {
         const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
-        const userAttribute = userAttributes.find(
-            (ua) => ua.name === attribute,
-        );
+        const userValue: string | null | undefined = userAttributes[attribute];
 
-        if (userAttribute === undefined) {
+        if (userValue === undefined) {
             throw new ForbiddenError(
                 `Missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
             );
         }
-        if (
-            userAttribute.users.length !== 1 &&
-            userAttribute.attributeDefault === null
-        ) {
+        if (userValue === null) {
             throw new ForbiddenError(
                 `Invalid or missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
             );
         }
 
-        const userValue =
-            userAttribute.users.length > 0
-                ? userAttribute.users[0].value
-                : userAttribute.attributeDefault;
         return acc.replace(
             sqlAttribute,
             `${stringQuoteChar}${userValue}${stringQuoteChar}`,
         );
     }, sqlFilter);
-
-    return sq;
 };
 
 export const assertValidDimensionRequiredAttribute = (
-    userUuid: string,
     dimension: CompiledDimension,
-    userAttributes: UserAttribute[],
+    userAttributes: Record<string, string | null>,
     field: string,
 ) => {
     // Throw error if user does not have the right requiredAttribute for this dimension
     if (dimension.requiredAttributes)
         Object.entries(dimension.requiredAttributes).map((attribute) => {
             const [attributeName, value] = attribute;
-            if (
-                !hasUserAttribute(
-                    userUuid,
-                    userAttributes,
-                    attributeName,
-                    value,
-                )
-            ) {
+            if (!hasUserAttribute(userAttributes, attributeName, value)) {
                 throw new ForbiddenError(
                     `Invalid or missing user attribute "${attribute}" on ${field}`,
                 );
@@ -128,10 +108,8 @@ export const assertValidDimensionRequiredAttribute = (
 export type BuildQueryProps = {
     explore: Explore;
     compiledMetricQuery: CompiledMetricQuery;
-
     warehouseClient: WarehouseClient;
-    userUuid: string;
-    userAttributes?: UserAttribute[];
+    userAttributes?: Record<string, string | null>;
 };
 
 const getJoinType = (type: DbtModelJoinType = 'left') => {
@@ -153,8 +131,7 @@ export const buildQuery = ({
     explore,
     compiledMetricQuery,
     warehouseClient,
-    userUuid, // used to check permissions on user attributes
-    userAttributes = [],
+    userAttributes = {},
 }: BuildQueryProps): { query: string; hasExampleMetric: boolean } => {
     let hasExampleMetric: boolean = false;
     const adapterType: SupportedDbtAdapter = warehouseClient.getAdapterType();
@@ -172,7 +149,6 @@ export const buildQuery = ({
         const dimension = getDimensionFromId(field, explore);
 
         assertValidDimensionRequiredAttribute(
-            userUuid,
             dimension,
             userAttributes,
             `dimension: "${field}"`,
@@ -201,7 +177,6 @@ export const buildQuery = ({
             const dimension = getDimensionFromId(dimensionId, explore);
 
             assertValidDimensionRequiredAttribute(
-                userUuid,
                 dimension,
                 userAttributes,
                 `custom metric: "${metric.name}"`,

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import {
     DashboardSearchResult,
     ForbiddenError,
-    getDimensions,
     SavedChartSearchResult,
     SearchResults,
     SessionUser,
@@ -99,16 +98,13 @@ export class SearchService {
         let filteredFields = results.fields;
         if (dimensionsHaveUserAttributes) {
             // Do not make user attribute query if not needed
-            const userAttributes = await this.userAttributesModel.find({
-                organizationUuid,
-                userUuid: user.userUuid,
-            });
+            const userAttributes =
+                await this.userAttributesModel.getAttributeValuesForOrgMember({
+                    organizationUuid,
+                    userUuid: user.userUuid,
+                });
             filteredFields = results.fields.filter((field) =>
-                hasUserAttributes(
-                    user.userUuid,
-                    field.requiredAttributes,
-                    userAttributes,
-                ),
+                hasUserAttributes(field.requiredAttributes, userAttributes),
             );
         }
 

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -1,4 +1,4 @@
-import { hasUserAttribute } from './UserAttributeUtils';
+import { hasUserAttribute, hasUserAttributes } from './UserAttributeUtils';
 
 describe('hasUserAttribute', () => {
     test('should be false if attribute is not present', () => {
@@ -20,6 +20,36 @@ describe('hasUserAttribute', () => {
     test('should be false if attribute value match a different user', () => {
         expect(hasUserAttribute({ test: null }, 'test', '1')).toStrictEqual(
             false,
+        );
+    });
+});
+describe('hasUserAttributes', () => {
+    test('should be true if there are no required attributes', () => {
+        expect(hasUserAttributes(undefined, { test: '1' })).toStrictEqual(true);
+        expect(hasUserAttributes({}, { test: '1' })).toStrictEqual(true);
+    });
+    test('should be false if required attributes are not present', () => {
+        expect(
+            hasUserAttributes({ another: '1' }, { test: '1' }),
+        ).toStrictEqual(false);
+    });
+    test('should be false if required attribute values does not match', () => {
+        expect(hasUserAttributes({ test: '2' }, { test: '1' })).toStrictEqual(
+            false,
+        );
+        expect(hasUserAttributes({ test: '1' }, { test: null })).toStrictEqual(
+            false,
+        );
+        expect(
+            hasUserAttributes(
+                { test: '2', another: '1' },
+                { test: '1', another: '1' },
+            ),
+        ).toStrictEqual(false);
+    });
+    test('should be true if required attribute value match', () => {
+        expect(hasUserAttributes({ test: '1' }, { test: '1' })).toStrictEqual(
+            true,
         );
     });
 });

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -2,156 +2,24 @@ import { hasUserAttribute } from './UserAttributeUtils';
 
 describe('hasUserAttribute', () => {
     test('should be false if attribute is not present', () => {
-        expect(
-            hasUserAttribute(
-                'user-uuid',
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: null,
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-                                email: '',
-                                value: '1',
-                            },
-                        ],
-                    },
-                ],
-                'another',
-                '1',
-            ),
-        ).toStrictEqual(false);
+        expect(hasUserAttribute({ test: '1' }, 'another', '1')).toStrictEqual(
+            false,
+        );
     });
     test('should be false if attribute value does not match', () => {
-        expect(
-            hasUserAttribute(
-                'user-uuid',
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: null,
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-                                email: '',
-                                value: '1',
-                            },
-                        ],
-                    },
-                ],
-                'test',
-                '2',
-            ),
-        ).toStrictEqual(false);
-    });
-
-    test('should be false if attribute value does not match even if attributeDefault is present', () => {
-        expect(
-            hasUserAttribute(
-                'user-uuid',
-
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: '2',
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-                                email: '',
-                                value: '1',
-                            },
-                        ],
-                    },
-                ],
-                'test',
-                '2',
-            ),
-        ).toStrictEqual(false);
+        expect(hasUserAttribute({ test: '1' }, 'test', '2')).toStrictEqual(
+            false,
+        );
     });
     test('should be true if attribute value match user', () => {
-        expect(
-            hasUserAttribute(
-                'user-uuid',
-
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: null,
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-
-                                email: '',
-                                value: '1',
-                            },
-                        ],
-                    },
-                ],
-                'test',
-                '1',
-            ),
-        ).toStrictEqual(true);
-    });
-
-    test('should be true if user does not have value and attributeDefault matches', () => {
-        expect(
-            hasUserAttribute(
-                'user-uuid',
-
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: '1',
-                        users: [],
-                    },
-                ],
-                'test',
-                '1',
-            ),
-        ).toStrictEqual(true);
+        expect(hasUserAttribute({ test: '1' }, 'test', '1')).toStrictEqual(
+            true,
+        );
     });
 
     test('should be false if attribute value match a different user', () => {
-        expect(
-            hasUserAttribute(
-                'another-user-uuid',
-
-                [
-                    {
-                        uuid: '',
-                        name: 'test',
-                        createdAt: new Date(),
-                        organizationUuid: '',
-                        attributeDefault: null,
-                        users: [
-                            {
-                                userUuid: 'user-uuid',
-
-                                email: '',
-                                value: '1',
-                            },
-                        ],
-                    },
-                ],
-                'test',
-                '1',
-            ),
-        ).toStrictEqual(false);
+        expect(hasUserAttribute({ test: null }, 'test', '1')).toStrictEqual(
+            false,
+        );
     });
 });

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -1,41 +1,22 @@
-import { Explore, UserAttribute } from '@lightdash/common';
+import { Explore } from '@lightdash/common';
 
 export const hasUserAttribute = (
-    userUuid: string,
-    userAttributes: UserAttribute[],
+    userAttributes: Record<string, string | null>,
     attributeName: string,
     value: string,
-) =>
-    userAttributes.some((ua) => {
-        if (ua.name === attributeName) {
-            // If user does not have attributes, we will check default value
-            const userAttribute = ua.users.find((u) => u.userUuid === userUuid);
-            if (userAttribute) return userAttribute.value === value;
-            return ua.attributeDefault === value;
-        }
-        return false;
-    });
+) => userAttributes[attributeName] === value;
 
 export const hasUserAttributes = (
-    userUuid: string,
     requiredAttributes: Record<string, string> | undefined,
-    userAttributes: UserAttribute[],
+    userAttributes: Record<string, string | null>,
 ): boolean => {
     if (requiredAttributes === undefined) return true; // No required attributes
 
     // Check all required attributes conditions for dimension
-    const hasAttributes = Object.entries(requiredAttributes).map(
-        (attribute) => {
-            const [attributeName, value] = attribute;
-            return hasUserAttribute(
-                userUuid,
-                userAttributes,
-                attributeName,
-                value,
-            );
-        },
-    );
-    return hasAttributes.every((attribute) => attribute === true);
+    return Object.entries(requiredAttributes).every((attribute) => {
+        const [attributeName, value] = attribute;
+        return hasUserAttribute(userAttributes, attributeName, value);
+    });
 };
 
 export const exploreHasFilteredAttribute = (explore: Explore) =>
@@ -46,8 +27,7 @@ export const exploreHasFilteredAttribute = (explore: Explore) =>
     );
 export const filterDimensionsFromExplore = (
     explore: Explore,
-    userUuid: string,
-    userAttributes: UserAttribute[],
+    userAttributes: Record<string, string | null>,
 ): Explore => ({
     ...explore,
     tables: Object.entries(explore.tables).reduce((at, exploreTable) => {
@@ -62,7 +42,6 @@ export const filterDimensionsFromExplore = (
 
                         if (
                             hasUserAttributes(
-                                userUuid,
                                 dimension.requiredAttributes,
                                 userAttributes,
                             )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7227 <!-- reference the related issue e.g. #150 -->

## Context on what was wrong:

**Wrong sql filters**
The following code intended to fetch values for specific user uuids and for attributes with default values.
```javascript
        // packages/backend/src/models/UserAttributesModel.ts
        if (filters.userUuid) {
            query
                .where(`users.user_uuid`, filters.userUuid)
                .orWhereNotNull(`attribute_default`); 
        }
```
The problem is that it is a `OR` condition so it was returning values for all users where the attribute had a default value.

**Assumptions** 

The logic that builds the query assumed the user attributes argument only had information for 1 user.
```
        const userValue =
            userAttribute.users.length > 0
                ? userAttribute.users[0].value
                : userAttribute.attributeDefault;
```
The problem is that argument had more users values ( see first problem above ).



## Fixes:

- New method to fetch attribute values for a specific user
  - this method abstract the default logic and returns a `key/value` object
- Remove assumptions and default logic from the rest of the app

## Tests:

Table yml
<img width="601" alt="Screenshot 2023-09-26 at 16 51 03" src="https://github.com/lightdash/lightdash/assets/9117144/db81ca5e-0d26-471e-84ec-db97b52913b2">


### Case where there is **no** default value:

<img width="658" alt="Screenshot 2023-09-26 at 16 54 21" src="https://github.com/lightdash/lightdash/assets/9117144/15ebee45-296f-43a0-b620-d9cdd86a3778">

Admin query

<img width="1117" alt="Screenshot 2023-09-26 at 16 54 32" src="https://github.com/lightdash/lightdash/assets/9117144/bd996e16-97cb-498d-87e0-fb99a4b2b55e">

Viewer query

<img width="819" alt="Screenshot 2023-09-26 at 16 54 50" src="https://github.com/lightdash/lightdash/assets/9117144/1279c011-2dfd-496e-9825-c7e1f1920fd7">

### Case where there is a default value:

<img width="645" alt="Screenshot 2023-09-26 at 16 50 31" src="https://github.com/lightdash/lightdash/assets/9117144/e7ff380c-1af2-4798-8da6-30bf6dd9bbf9">

Admin query

<img width="1114" alt="Screenshot 2023-09-26 at 16 50 41" src="https://github.com/lightdash/lightdash/assets/9117144/d55a3b69-a598-409f-8706-a8bb72f8cb80">

Viewer query

<img width="811" alt="Screenshot 2023-09-26 at 16 50 48" src="https://github.com/lightdash/lightdash/assets/9117144/eeb84383-95da-4207-a1a6-74b4978f580c">
