### PR TITLE
fix: csv export dashboard filters

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
+import { Explore } from '../types/explore';
 import {
     Dimension,
     DimensionType,
@@ -16,6 +17,7 @@ import {
 import {
     DashboardFieldTarget,
     DashboardFilterRule,
+    DashboardFilters,
     DateFilterRule,
     FilterGroup,
     FilterGroupItem,
@@ -27,6 +29,7 @@ import {
     isFilterGroup,
     UnitOfTime,
 } from '../types/filter';
+import { MetricQuery } from '../types/metricQuery';
 import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 import { formatDate } from './formatting';
@@ -376,3 +379,94 @@ export const getFilterRulesByFieldType = (
             metrics: [],
         },
     );
+
+// TODO: reuse this function in useDashboardFiltersForExplore
+const getDashboardFiltersForTile = (
+    explore: Explore,
+    tileUuid: string,
+    dashboardFilters: DashboardFilters,
+): DashboardFilters => {
+    const overrideTileFilters = (rules: DashboardFilterRule[]) =>
+        rules
+            .filter((rule) => !rule.disabled)
+            .map((filter) => {
+                const tileConfig = filter.tileTargets?.[tileUuid];
+
+                // If the config is false, we remove this filter
+                if (tileConfig === false) {
+                    return null;
+                }
+
+                // If the tile isn't in the tileTarget overrides,
+                // we return the filter and don't treat this tile
+                // differently.
+                if (tileConfig === undefined) {
+                    return filter;
+                }
+
+                return {
+                    ...filter,
+                    target: {
+                        fieldId: tileConfig.fieldId,
+                        tableName: tileConfig.tableName,
+                    },
+                };
+            })
+            .filter((f): f is DashboardFilterRule => f !== null)
+            .filter((f) =>
+                Object.keys(explore.tables).includes(f.target.tableName),
+            );
+
+    return {
+        dimensions: overrideTileFilters(dashboardFilters.dimensions),
+        metrics: overrideTileFilters(dashboardFilters.metrics),
+    };
+};
+
+export const addDashboardFiltersToMetricQuery = (
+    explore: Explore,
+    metricQuery: MetricQuery,
+    tileUuid: string | undefined,
+    dashboardFilters: DashboardFilters | undefined,
+): MetricQuery => {
+    const dashboardFiltersForTile =
+        tileUuid && dashboardFilters
+            ? getDashboardFiltersForTile(explore, tileUuid, dashboardFilters)
+            : undefined;
+
+    const dimensionFilters: FilterGroup | undefined =
+        dashboardFiltersForTile && dashboardFiltersForTile.dimensions.length > 0
+            ? {
+                  id: 'yes',
+                  and: [
+                      ...(metricQuery.filters.dimensions
+                          ? [metricQuery.filters.dimensions]
+                          : []),
+                      ...dashboardFiltersForTile.dimensions,
+                  ],
+              }
+            : metricQuery.filters.dimensions;
+
+    const metricFilters: FilterGroup | undefined =
+        dashboardFiltersForTile && dashboardFiltersForTile.metrics.length > 0
+            ? {
+                  id: 'yes',
+                  and: [
+                      ...(metricQuery.filters.metrics
+                          ? [metricQuery.filters.metrics]
+                          : []),
+                      ...dashboardFiltersForTile.metrics,
+                  ],
+              }
+            : metricQuery.filters.metrics;
+
+    return dashboardFiltersForTile
+        ? {
+              ...metricQuery,
+              filters: {
+                  dimensions: dimensionFilters,
+                  metrics: metricFilters,
+              },
+          }
+        : metricQuery;
+};

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -1,9 +1,9 @@
 import {
-    DashboardFilterRule,
     DashboardFilters,
     Explore,
+    getDashboardFilterRulesForTile,
 } from '@lightdash/common';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 
 const useDashboardFiltersForExplore = (
@@ -18,50 +18,19 @@ const useDashboardFiltersForExplore = (
         [explore],
     );
 
-    const overrideTileFilters = useCallback(
-        (rules: DashboardFilterRule[]) =>
-            rules
-                .filter((rule) => !rule.disabled)
-                .map((filter) => {
-                    const tileConfig = filter.tileTargets?.[tileUuid];
-
-                    // If the config is false, we remove this filter
-                    if (tileConfig === false) {
-                        return null;
-                    }
-
-                    // If the tile isn't in the tileTarget overrides,
-                    // we return the filter and don't treat this tile
-                    // differently.
-                    if (tileConfig === undefined) {
-                        return filter;
-                    }
-
-                    return {
-                        ...filter,
-                        target: {
-                            fieldId: tileConfig.fieldId,
-                            tableName: tileConfig.tableName,
-                        },
-                    };
-                })
-                .filter((f): f is DashboardFilterRule => f !== null)
-                .filter((f) => tables.includes(f.target.tableName)),
-        [tables, tileUuid],
-    );
-
-    return useMemo(() => {
-        return {
-            dimensions: overrideTileFilters([
+    return useMemo(
+        () => ({
+            dimensions: getDashboardFilterRulesForTile(tileUuid, tables, [
                 ...dashboardFilters.dimensions,
                 ...(dashboardTemporaryFilters?.dimensions ?? []),
             ]),
-            metrics: overrideTileFilters([
+            metrics: getDashboardFilterRulesForTile(tileUuid, tables, [
                 ...dashboardFilters.metrics,
                 ...(dashboardTemporaryFilters?.metrics ?? []),
             ]),
-        };
-    }, [dashboardFilters, dashboardTemporaryFilters, overrideTileFilters]);
+        }),
+        [tileUuid, tables, dashboardFilters, dashboardTemporaryFilters],
+    );
 };
 
 export default useDashboardFiltersForExplore;


### PR DESCRIPTION
Closes: #7068 

### Description:

OG chart:
<img width="1481" alt="CleanShot 2023-09-26 at 20 23 35@2x" src="https://github.com/lightdash/lightdash/assets/962095/b7ad53c3-3d84-4e57-8a1a-fd42dd1fc90e">

dashboard with chart + dashboard filter:
<img width="1244" alt="CleanShot 2023-09-26 at 20 23 17@2x" src="https://github.com/lightdash/lightdash/assets/962095/920c277d-b83d-4ef7-8280-8c611d166f4e">

old buggy csv:
<img width="351" alt="CleanShot 2023-09-26 at 20 22 59@2x" src="https://github.com/lightdash/lightdash/assets/962095/f54e69e7-d351-44ac-952d-87fda341ba1c">

new fixed csv:
<img width="463" alt="CleanShot 2023-09-26 at 20 22 51@2x" src="https://github.com/lightdash/lightdash/assets/962095/8471b012-9a6c-4a58-a8c4-ba5fb5368a6b">
