### PR TITLE
fix: space inherit project permission

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -348,17 +348,23 @@ export class SpaceModel {
                 `${OrganizationMembershipsTableName}.user_id`,
                 `${UserTableName}.user_id`,
             )
-            .leftJoin(
-                ProjectMembershipsTableName,
-                `${UserTableName}.user_id`,
-                `${ProjectMembershipsTableName}.user_id`,
-            )
+            .leftJoin(ProjectMembershipsTableName, function () {
+                this.on(
+                    `${UserTableName}.user_id`,
+                    '=',
+                    `${ProjectMembershipsTableName}.user_id`,
+                ).andOn(
+                    `${SpaceTableName}.project_id`,
+                    '=',
+                    `${ProjectMembershipsTableName}.project_id`,
+                );
+            })
             .select<
                 {
                     user_uuid: string;
                     first_name: string;
                     last_name: string;
-                    project_role: ProjectMemberRole;
+                    project_role: ProjectMemberRole | null;
                     organization_role: OrganizationMemberRole;
                 }[]
             >([


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7108 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

When checking for space access we were joining the project membership table so we can show the user project role. 
We were joining just with the user_uuid so there was a possibility it was returning the role for that user in a different project.

Fix: join project membership table with user id and project id.
