### PR TITLE
fix: clear filters when creating new dashboard

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -31,7 +31,7 @@ describe('Dashboard', () => {
         });
     });
 
-    it.only('Should use dashboard filters, should clear them for new dashboards', () => {
+    it('Should use dashboard filters, should clear them for new dashboards', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         // wiat for the dashboard to load

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -31,7 +31,7 @@ describe('Dashboard', () => {
         });
     });
 
-    it('Should use dashboard filters', () => {
+    it.only('Should use dashboard filters, should clear them for new dashboards', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         // wiat for the dashboard to load
@@ -58,6 +58,22 @@ describe('Dashboard', () => {
         cy.contains('button', 'Apply').click();
 
         cy.contains('bank_transfer').should('have.length', 0);
+
+        // Check url includes filters
+        cy.url().should('include', 'filters=');
+        cy.url().should('include', 'dimensions');
+        cy.url().should('include', 'credit_card');
+
+        // Create a new dashboard
+        cy.get('[data-testid="ExploreMenu/NewButton"]').click();
+        cy.get('[data-testid="ExploreMenu/NewDashboardButton"]').click();
+
+        cy.findByLabelText('Name your dashboard *').type('Title');
+        cy.findByText('Create').click();
+
+        // Check url has no filters
+        cy.url().should('not.include', 'filters=');
+        cy.url().should('not.include', '?');
     });
 
     it('Should create dashboard with saved chart + charts within dashboard + filters + tile targets', () => {

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -161,12 +161,24 @@ const Routes: FC = () => {
                                         </TrackPage>
                                     </Route>
 
-                                    <Route path="/projects/:projectUuid/dashboards/:dashboardUuid/:mode?">
-                                        <NavBar />
-                                        <TrackPage name={PageName.DASHBOARD}>
-                                            <Dashboard />
-                                        </TrackPage>
-                                    </Route>
+                                    <Route
+                                        path="/projects/:projectUuid/dashboards/:dashboardUuid/:mode?"
+                                        render={(props) => (
+                                            <>
+                                                <NavBar />
+                                                <TrackPage
+                                                    name={PageName.DASHBOARD}
+                                                >
+                                                    <Dashboard
+                                                        key={
+                                                            props.match.params
+                                                                .dashboardUuid
+                                                        }
+                                                    />
+                                                </TrackPage>
+                                            </>
+                                        )}
+                                    />
 
                                     <Route path="/projects/:projectUuid/dashboards">
                                         <NavBar />

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -54,6 +54,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 <MantineIcon icon={IconSquareRoundedPlus} />
                             }
                             onClick={() => setIsOpen(!isOpen)}
+                            data-testid="ExploreMenu/NewButton"
                         >
                             New
                         </Button>
@@ -96,6 +97,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 description="Arrange multiple charts into a single view."
                                 onClick={() => setIsCreateDashboardOpen(true)}
                                 icon={IconLayoutDashboard}
+                                data-testid="ExploreMenu/NewDashboardButton"
                             />
                         </Can>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7116 

### Description:

The problem was:
- When creating a new dashboard from an existing dashboard, the page never remounted, leaving all of the state from the  dashboard context.

This fix:
- Forces a re-mount of the dashboard by keying the page to the dashboard uuid. This clears the filters, but is also probably the right thing to do for other state. 
