### PR TITLE
fix: format table calculation dates

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -389,6 +389,9 @@ export function formatTableCalculationValue(
         return { compactValue, compactSuffix };
     };
     if (value === '') return '';
+    if (value instanceof Date) {
+        return formatTimestamp(value, undefined, false);
+    }
     if (valueIsNaN(value) || value === null) {
         return formatValue(value);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6852 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Note that this formatting is applied at the cell level. 
We are not inferring the table calculation overall type as each value can be different. The app still assumes table calculation is of type `number`. 

<img width="1378" alt="Screenshot 2023-09-27 at 16 50 01" src="https://github.com/lightdash/lightdash/assets/9117144/1d9821f7-43ad-4f6d-9595-ec2ab2cb5017">

