### PR TITLE
docs: fix typo in CLI authentication behind proxy

### DIFF
--- a/docs/docs/guides/cli/cli-authentication.mdx
+++ b/docs/docs/guides/cli/cli-authentication.mdx
@@ -49,7 +49,7 @@ You can use the following environment variables to authenticate yourself on each
 Example:
 
   ```shell
-  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://{{ lightdash_domain }}" LIGHTDASH_PROXY_AUTHENTICATION="Bearer <JWT_TOKEN>" lightdash preview
+  LIGHTDASH_API_KEY=946fedb74003405646867dcacf1ad345 LIGHTDASH_URL="https://{{ lightdash_domain }}" LIGHTDASH_PROXY_AUTHORIZATION="Bearer <JWT_TOKEN>" lightdash preview
   ```
 
 Where `{{ lightdash_domain }}` is your domain. For Lightdash Cloud users use `https://app.lightdash.cloud`

--- a/docs/docs/guides/cli/cli-authentication.mdx
+++ b/docs/docs/guides/cli/cli-authentication.mdx
@@ -44,7 +44,7 @@ You can use the following environment variables to authenticate yourself on each
 
 - **LIGHTDASH_API_KEY** a personal access token you can generate in the app under the user settings
 - **LIGHTDASH_URL** address for your running Lightdash instance
-- **LIGHTDASH_PROXY_AUTHENTICATION** if your Lightdash instance is behind a proxy like (Cloud IAP)[https://cloud.google.com/iap] you can set here `Proxy-Authentication` header value
+- **LIGHTDASH_PROXY_AUTHORIZATION** if your Lightdash instance is behind a proxy like [Cloud IAP](https://cloud.google.com/iap) you can set here `Proxy-Authentication` header value
 
 Example:
 


### PR DESCRIPTION
### Description:

Fixes a typo in the documentation when running Lightdash behind an authenticating proxy (https://docs.lightdash.com/guides/cli/cli-authentication/, option 3).

The variable used in [packages/cli/src/handlers/login.ts](https://github.com/lightdash/lightdash/blob/main/packages/cli/src/handlers/login.ts#L126) is `LIGHTDASH_PROXY_AUTHORIZATION`. 

