### PR TITLE
feat: 6564 dashboard links should more generically include saved filters and this should be dynamic

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -31,7 +31,7 @@ describe('Dashboard', () => {
         });
     });
 
-    it.only('Should use dashboard filters, should clear them for new dashboards', () => {
+    it('Should use dashboard filters, should clear them for new dashboards', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         // wait for the dashboard to load

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -31,10 +31,10 @@ describe('Dashboard', () => {
         });
     });
 
-    it('Should use dashboard filters, should clear them for new dashboards', () => {
+    it.only('Should use dashboard filters, should clear them for new dashboards', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
-        // wiat for the dashboard to load
+        // wait for the dashboard to load
         cy.findByText('Loading dashboards').should('not.exist');
 
         cy.contains('a', 'Jaffle dashboard').click();
@@ -59,10 +59,18 @@ describe('Dashboard', () => {
 
         cy.contains('bank_transfer').should('have.length', 0);
 
-        // Check url includes filters
-        cy.url().should('include', 'filters=');
-        cy.url().should('include', 'dimensions');
+        // Check url includes no saved filters
+        cy.url().should('not.include', 'filters=');
+        cy.url().should('not.include', 'years');
+
+        // Check url includes temp filters
+        cy.url().should('include', 'tempFilters=');
         cy.url().should('include', 'credit_card');
+
+        // Check that temp filter gets kept on reload
+        cy.reload();
+        cy.contains('Payment method is credit_card');
+        cy.contains('bank_transfer').should('have.length', 0);
 
         // Create a new dashboard
         cy.get('[data-testid="ExploreMenu/NewButton"]').click();
@@ -73,6 +81,7 @@ describe('Dashboard', () => {
 
         // Check url has no filters
         cy.url().should('not.include', 'filters=');
+        cy.url().should('not.include', 'tempFilters=');
         cy.url().should('not.include', '?');
     });
 

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -142,6 +142,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
     const [haveFiltersChanged, setHaveFiltersChanged] =
         useState<boolean>(false);
 
+    // Set filters to filters from database
     useEffect(() => {
         if (dashboard && dashboardFilters === emptyFilters) {
             setDashboardFilters(dashboard.filters);
@@ -253,7 +254,6 @@ export const DashboardProvider: React.FC = ({ children }) => {
     useMount(() => {
         const searchParams = new URLSearchParams(search);
         const tempFilterSearchParam = searchParams.get('tempFilters');
-        const filtersSearchParam = searchParams.get('filters');
         const unsavedDashboardFiltersRaw = sessionStorage.getItem(
             'unsavedDashboardFilters',
         );
@@ -271,15 +271,9 @@ export const DashboardProvider: React.FC = ({ children }) => {
                 ),
             );
         }
-        if (filtersSearchParam) {
-            setDashboardFilters(
-                convertDashboardFiltersParamToDashboardFilters(
-                    JSON.parse(filtersSearchParam),
-                ),
-            );
-        }
     });
 
+    // Updates url with temp filters
     useEffect(() => {
         const newParams = new URLSearchParams(search);
         if (
@@ -296,31 +290,11 @@ export const DashboardProvider: React.FC = ({ children }) => {
             );
         }
 
-        if (
-            dashboardFilters?.dimensions?.length === 0 &&
-            dashboardFilters?.metrics?.length === 0
-        ) {
-            newParams.delete('filters');
-        } else {
-            newParams.set(
-                'filters',
-                JSON.stringify(
-                    compressDashboardFiltersToParam(dashboardFilters),
-                ),
-            );
-        }
-
         history.replace({
             pathname,
             search: newParams.toString(),
         });
-    }, [
-        dashboardTemporaryFilters,
-        dashboardFilters,
-        history,
-        pathname,
-        search,
-    ]);
+    }, [dashboardTemporaryFilters, history, pathname, search]);
 
     const allFilters = useMemo(() => {
         return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6564 

### Description:

Don't put saved filters in the dashboard URL. Temp filters still get stored there. 

I'm going to follow this up with a bit of a cleanup of the context file.
