### PR TITLE
fix: show pivot table results

### DIFF
--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -50,5 +50,6 @@ export type PivotData = {
     rowTotals?: TotalValue[][];
     columnTotals?: TotalValue[][];
     cellsCount: number;
+    rowsCount: number;
     pivotConfig: PivotConfig;
 };

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -161,7 +161,7 @@ const ResultsCard: FC = memo(() => {
                 )
             }
         >
-            {/* <ExplorerResults /> */}
+            <ExplorerResults />
         </CollapsableCard>
     );
 });

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -161,7 +161,7 @@ const ResultsCard: FC = memo(() => {
                 )
             }
         >
-            <ExplorerResults />
+            {/* <ExplorerResults /> */}
         </CollapsableCard>
     );
 });

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,8 +1,9 @@
 import { NonIdealState } from '@blueprintjs/core';
-import { Box } from '@mantine/core';
+import { Box, Flex } from '@mantine/core';
 import { FC } from 'react';
 import PivotTable from '../common/PivotTable';
 import Table from '../common/Table';
+import { ResultCount } from '../common/Table/TablePagination';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import { LoadingChart } from '../SimpleChart';
 import CellContextMenu from './CellContextMenu';
@@ -63,10 +64,13 @@ const SimpleTable: FC<SimpleTableProps> = ({
             />
         );
     } else if (pivotTableData.loading || pivotTableData.data) {
-        console.log({ pivotTableData });
-
         return (
-            <Box p="xs" pb="xl" miw="100%" h="100%">
+            <Box
+                p="xs"
+                pb={showResultsTotal ? 'xxl' : 'xl'}
+                miw="100%"
+                h="100%"
+            >
                 {pivotTableData.data ? (
                     <>
                         <PivotTable
@@ -77,13 +81,13 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             getField={getField}
                             hideRowNumbers={hideRowNumbers}
                         />
-                        <>
-                            {pivotTableData.data.dataValues.length === 0
-                                ? null
-                                : pivotTableData.data.dataValues.length === 1
-                                ? '1 result'
-                                : `${pivotTableData.data.dataValues.length} results`}
-                        </>
+                        {showResultsTotal && (
+                            <Flex justify="flex-end" pt="xxs" align="center">
+                                <ResultCount
+                                    count={pivotTableData.data.rowsCount}
+                                />
+                            </Flex>
+                        )}
                     </>
                 ) : (
                     <LoadingChart />

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -63,17 +63,28 @@ const SimpleTable: FC<SimpleTableProps> = ({
             />
         );
     } else if (pivotTableData.loading || pivotTableData.data) {
+        console.log({ pivotTableData });
+
         return (
             <Box p="xs" pb="xl" miw="100%" h="100%">
                 {pivotTableData.data ? (
-                    <PivotTable
-                        className={className}
-                        data={pivotTableData.data}
-                        conditionalFormattings={conditionalFormattings}
-                        getFieldLabel={getFieldLabel}
-                        getField={getField}
-                        hideRowNumbers={hideRowNumbers}
-                    />
+                    <>
+                        <PivotTable
+                            className={className}
+                            data={pivotTableData.data}
+                            conditionalFormattings={conditionalFormattings}
+                            getFieldLabel={getFieldLabel}
+                            getField={getField}
+                            hideRowNumbers={hideRowNumbers}
+                        />
+                        <>
+                            {pivotTableData.data.dataValues.length === 0
+                                ? null
+                                : pivotTableData.data.dataValues.length === 1
+                                ? '1 result'
+                                : `${pivotTableData.data.dataValues.length} results`}
+                        </>
+                    </>
                 ) : (
                     <LoadingChart />
                 )}

--- a/packages/frontend/src/components/common/Table/TablePagination/index.tsx
+++ b/packages/frontend/src/components/common/Table/TablePagination/index.tsx
@@ -8,13 +8,11 @@ interface ResultCountProps {
     count: number;
 }
 
-const ResultCount: FC<ResultCountProps> = ({ count }) => {
-    return (
-        <PageCount>
-            {count === 0 ? null : count === 1 ? '1 result' : `${count} results`}
-        </PageCount>
-    );
-};
+export const ResultCount: FC<ResultCountProps> = ({ count }) => (
+    <PageCount>
+        {count === 0 ? null : count === 1 ? '1 result' : `${count} results`}
+    </PageCount>
+);
 
 const TablePagination = () => {
     const { table, data, pagination } = useTableContext();

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.test.ts
@@ -83,6 +83,7 @@ describe('Should pivot data', () => {
 
             rowTotalFields: undefined,
             rowTotals: undefined,
+            rowsCount: 1,
             columnTotalFields: undefined,
             columnTotals: undefined,
 
@@ -162,6 +163,7 @@ describe('Should pivot data', () => {
             pivotConfig,
             titleFields: [[{ fieldId: 'page', direction: 'index' }]],
             cellsCount: 3,
+            rowsCount: 3,
         };
         const result = pivotQueryResults({
             pivotConfig,
@@ -224,6 +226,7 @@ describe('Should pivot data', () => {
             },
             titleFields: [[{ fieldId: 'page', direction: 'header' }]],
             cellsCount: 4,
+            rowsCount: 2,
         };
         const result = pivotQueryResults({
             pivotConfig,
@@ -333,6 +336,7 @@ describe('Should pivot data', () => {
             columnTotals: undefined,
             rowTotals: undefined,
             cellsCount: 5,
+            rowsCount: 3,
         };
         const result = pivotQueryResults({
             pivotConfig,
@@ -473,6 +477,7 @@ describe('Should pivot data', () => {
             columnTotals: undefined,
             rowTotals: [[8], [17], [14], [13], [11], [1]],
             cellsCount: 5,
+            rowsCount: 6,
         };
         const result = pivotQueryResults({
             pivotConfig,

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -571,7 +571,7 @@ export const pivotQueryResults = ({
         dataValues[0].length +
         (pivotConfig.rowTotals && rowTotals ? rowTotals[0].length : 0);
 
-    const rowsCount = dataValues?.length || 0;
+    const rowsCount = dataValues.length || 0;
 
     return {
         titleFields,

--- a/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
+++ b/packages/frontend/src/hooks/pivotTable/pivotQueryResults.ts
@@ -571,6 +571,8 @@ export const pivotQueryResults = ({
         dataValues[0].length +
         (pivotConfig.rowTotals && rowTotals ? rowTotals[0].length : 0);
 
+    const rowsCount = dataValues?.length || 0;
+
     return {
         titleFields,
 
@@ -587,6 +589,7 @@ export const pivotQueryResults = ({
         rowTotals,
         columnTotals,
         cellsCount,
+        rowsCount,
         pivotConfig,
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7149 

### Description:

Check if `show number of results` is set on the config for a pivot table and display its results

With it turned on
<img width="1392" alt="Screenshot 2023-09-29 at 10 49 34" src="https://github.com/lightdash/lightdash/assets/7611706/d86d8502-4c7e-4a9f-a1ac-9f169f5ef260">

With it turned off
<img width="1392" alt="Screenshot 2023-09-29 at 10 49 43" src="https://github.com/lightdash/lightdash/assets/7611706/d32b30b3-88a2-43bd-9d4c-949fbdf25c91">
