### PR TITLE
fix: save temp filters when adding dashboard chart

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -28,6 +28,7 @@ const AddTileButton: FC<Props> = ({
     const {
         dashboardTiles,
         dashboardFilters,
+        dashboardTemporaryFilters,
         haveTilesChanged,
         haveFiltersChanged,
         dashboard,
@@ -77,6 +78,7 @@ const AddTileButton: FC<Props> = ({
                                 storeDashboard(
                                     dashboardTiles,
                                     dashboardFilters,
+                                    dashboardTemporaryFilters,
                                     haveTilesChanged,
                                     haveFiltersChanged,
                                     dashboard?.uuid,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -302,7 +302,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         addDimensionDashboardFilter,
         setDashboardTiles,
         dashboardTiles,
-        dashboardFilters: filtersFromCOntext,
+        dashboardFilters: filtersFromContext,
+        dashboardTemporaryFilters: tempFiltersFromContext,
         haveTilesChanged,
         haveFiltersChanged,
         dashboard,
@@ -529,7 +530,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                             if (belongsToDashboard) {
                                                 storeDashboard(
                                                     dashboardTiles,
-                                                    filtersFromCOntext,
+                                                    filtersFromContext,
+                                                    tempFiltersFromContext,
                                                     haveTilesChanged,
                                                     haveFiltersChanged,
                                                     dashboard?.uuid,

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -32,6 +32,7 @@ const useDashboardStorage = () => {
         sessionStorage.removeItem('dashboardUuid');
         sessionStorage.removeItem('unsavedDashboardTiles');
         sessionStorage.removeItem('unsavedDashboardFilters');
+        sessionStorage.removeItem('unsavedDashboardTemporaryFilters');
         sessionStorage.removeItem('hasDashboardChanges');
     }, []);
 
@@ -39,6 +40,7 @@ const useDashboardStorage = () => {
         (
             dashboardTiles: DashboardTile[],
             dashboardFilters: DashboardFilters,
+            dashboardTemporaryFilters: DashboardFilters,
             haveTilesChanged: boolean,
             haveFiltersChanged: boolean,
             dashboardUuid?: string,
@@ -57,6 +59,15 @@ const useDashboardStorage = () => {
                 sessionStorage.setItem(
                     'unsavedDashboardFilters',
                     JSON.stringify(dashboardFilters),
+                );
+            }
+            if (
+                dashboardTemporaryFilters.dimensions.length > 0 ||
+                dashboardTemporaryFilters.metrics.length > 0
+            ) {
+                sessionStorage.setItem(
+                    'unsavedDashboardTemporaryFilters',
+                    JSON.stringify(dashboardTemporaryFilters),
                 );
             }
             sessionStorage.setItem(

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -257,12 +257,21 @@ export const DashboardProvider: React.FC = ({ children }) => {
         const unsavedDashboardFiltersRaw = sessionStorage.getItem(
             'unsavedDashboardFilters',
         );
+        const unsavedDashboardTemporaryFiltersRaw = sessionStorage.getItem(
+            'unsavedDashboardTemporaryFilters',
+        );
         sessionStorage.removeItem('unsavedDashboardFilters');
         if (unsavedDashboardFiltersRaw) {
             const unsavedDashboardFilters = JSON.parse(
                 unsavedDashboardFiltersRaw,
             );
             setDashboardFilters(unsavedDashboardFilters);
+        }
+        if (unsavedDashboardTemporaryFiltersRaw) {
+            const unsavedDashboardTemporaryFilters = JSON.parse(
+                unsavedDashboardTemporaryFiltersRaw,
+            );
+            setDashboardTemporaryFilters(unsavedDashboardTemporaryFilters);
         }
         if (tempFilterSearchParam) {
             setDashboardTemporaryFilters(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7264 

### Description:

Saves dashboard filters when adding a new temp chart. 

This is a draft for now. I think it works, but it needs a bit more test. 
