### PR TITLE
fix: disable animations in minimal dashboards

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -66,13 +66,14 @@ export const getReactGridLayoutConfig = (
     isResizable: isEditMode,
 });
 
-export const RESPONSIVE_GRID_LAYOUT_PROPS = {
+export const getResponsiveGridLayoutProps = (enableAnimation = true) => ({
     draggableCancel: '.non-draggable',
-    useCSSTransforms: false,
+    useCSSTransforms: enableAnimation,
+    measureBeforeMount: !enableAnimation,
     breakpoints: { lg: 1200, md: 996, sm: 768 },
     cols: { lg: 36, md: 30, sm: 18 },
     rowHeight: 50,
-};
+});
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -530,7 +531,7 @@ const Dashboard: FC = () => {
                 )}
 
                 <ResponsiveGridLayout
-                    {...RESPONSIVE_GRID_LAYOUT_PROPS}
+                    {...getResponsiveGridLayoutProps()}
                     onDragStop={handleUpdateTiles}
                     onResizeStop={handleUpdateTiles}
                     layouts={layouts}

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -10,7 +10,7 @@ import { useDashboardQuery } from '../hooks/dashboard/useDashboard';
 import { DashboardProvider } from '../providers/DashboardProvider';
 import {
     getReactGridLayoutConfig,
-    RESPONSIVE_GRID_LAYOUT_PROPS,
+    getResponsiveGridLayoutProps,
 } from './Dashboard';
 
 import '../styles/react-grid.css';
@@ -46,7 +46,7 @@ const MinimalDashboard: FC = () => {
     return (
         <DashboardProvider>
             <ResponsiveGridLayout
-                {...RESPONSIVE_GRID_LAYOUT_PROPS}
+                {...getResponsiveGridLayoutProps(false)}
                 layouts={layouts}
             >
                 {dashboard.tiles.map((tile) => (


### PR DESCRIPTION
### Description:

this PR work is related to: https://github.com/lightdash/lightdash/issues/6932
As it's been impossible for me to reproduce this issue, I am not going to close the original ticket and will continue investigating on it today.

From the latest image in the customer thread, I can see a tile positioned over another tile, in the middle of an animation.

That makes me suspicious that headless browser resources are not enough to do a complex layout animations. React Grid Layout does a lot of calculations and mounts with an animation, which is unnecessary for minimal web pages (screenshot pages) and consumes a lot of resources.

See the before-and-after in the video:

https://github.com/lightdash/lightdash/assets/962095/34806a44-9d88-4c45-b67d-f131d2bf42ae

