### PR TITLE
fix: keep tooltip trigger axis if line series with no symbol

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -170,7 +170,7 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
                         type: 'highlight',
                         seriesIndex: params.seriesIndex,
                     });
-                }, 200);
+                }, 100);
             }
         },
         [chartRef],

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -36,6 +36,7 @@ import {
 } from '@lightdash/common';
 import {
     DefaultLabelFormatterCallbackParams,
+    LineSeriesOption,
     TooltipComponentFormatterCallback,
     TooltipComponentOption,
 } from 'echarts';
@@ -65,6 +66,9 @@ type TooltipOption = Omit<TooltipComponentOption, 'formatter'> & {
               TooltipFormatterParams | TooltipFormatterParams[]
           >;
 };
+
+export const isLineSeriesOption = (obj: unknown): obj is LineSeriesOption =>
+    typeof obj === 'object' && obj !== null && 'showSymbol' in obj;
 
 const getLabelFromField = (
     fields: Array<Field | TableCalculation>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7285 

### Description:

in: https://github.com/apache/echarts/issues/14563 we can see that there's issues when triggering the tooltip with `trigger: 'item'` + `showSymbol: false`

This PRs checks if the hovered item has that property set to `false` and then will not set the option to change the trigger to `item` if that matches.


Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/1574f73e-38cc-4b0b-a84a-87a6d1b293d9


