### PR TITLE
fix: fix total label on stacked chart

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1400,7 +1400,8 @@ const useEcharts = (
                 results.length >= 0 &&
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                     xField.type,
-                )
+                ) &&
+                resultsData?.metricQuery.sorts.length === 0
             ) {
                 return results.sort((a, b) => {
                     if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7076

### What was the issue: 

It took me a while to understand this issue, but it was really easy to replicate: 

- If you select a chart and select a date as X axis
- But then you sort by "another" dimension
- Then in the code we check if fthe `field` matches the sort : `alreadySorted` 
- If not, then we run a  `results.sort` 
- This method was messing with the results, the series was not matching the results
- This was causing that all results were displayed in the wrong place. 


### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before:

X: axis Month
Sort by: quarter

![Screenshot from 2023-10-04 09-15-25](https://github.com/lightdash/lightdash/assets/1983672/45601a90-a0d9-4dbf-8216-b823e40b9b06)


After:

![Screenshot from 2023-10-04 09-22-43](https://github.com/lightdash/lightdash/assets/1983672/72662997-3d94-4f01-82ef-12fdc33890c9)

