### PR TITLE
fix: set activeItem null if undefined

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/AutoComplete.tsx
+++ b/packages/frontend/src/components/ReactHookForm/AutoComplete.tsx
@@ -162,7 +162,6 @@ const ControlledSuggest: FC<{
         },
         [groupBy, suggestProps?.createNewItemRenderer],
     );
-    console.log(activeItem);
 
     return (
         <Suggest2<Item>

--- a/packages/frontend/src/components/ReactHookForm/AutoComplete.tsx
+++ b/packages/frontend/src/components/ReactHookForm/AutoComplete.tsx
@@ -128,7 +128,7 @@ const ControlledSuggest: FC<{
     groupBy,
     ...props
 }) => {
-    const activeItem = items.find((item) => item.value === field.value);
+    const activeItem = items.find((item) => item.value === field.value) ?? null; // Note: Avoid displaying first item as selected by default when activeItem is undefined
     const onItemSelect = useCallback(
         (item: Item) => {
             field.onChange(item.value);
@@ -162,6 +162,7 @@ const ControlledSuggest: FC<{
         },
         [groupBy, suggestProps?.createNewItemRenderer],
     );
+    console.log(activeItem);
 
     return (
         <Suggest2<Item>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7287

### Description:

When `activeItem` is `undefined` on the Autocomplete, we should return `null` to indicate no item is active: https://blueprintjs.com/docs/#select/suggest

screen recording:

https://github.com/lightdash/lightdash/assets/7611706/5660de79-1911-49d5-924a-6616fd7e9a2a


