### PR TITLE
fix: fix tootlip header format

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1478,8 +1478,15 @@ const useEcharts = (
                         return '';
                     })
                     .join('');
-
-                return `${params[0].axisValueLabel}<br/><table>${tooltipRows}</table>`;
+                const tooltipHeader =
+                    params[0].dimensionNames?.[0] !== undefined
+                        ? getFormattedValue(
+                              params[0].axisValueLabel,
+                              params[0].dimensionNames[0],
+                              items,
+                          )
+                        : params[0].axisValueLabel;
+                return `${tooltipHeader}<br/><table>${tooltipRows}</table>`;
             },
         }),
         [items],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #3979
### Description:

This fix also applies formatting to non-dates (eg: currency) 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Before

![Screenshot from 2023-10-04 10-49-40](https://github.com/lightdash/lightdash/assets/1983672/df378c3d-b0fe-4a33-aee4-eaa6a8cd67a7)

![Screenshot from 2023-10-04 10-54-10](https://github.com/lightdash/lightdash/assets/1983672/aef6ffb2-f479-44ca-a1e1-7830f18a0396)

After

![Screenshot from 2023-10-04 10-56-13](https://github.com/lightdash/lightdash/assets/1983672/0a219058-896e-4d97-b60d-df1ed3b2da51)

![Screenshot from 2023-10-04 10-54-16](https://github.com/lightdash/lightdash/assets/1983672/463105bd-d675-4c2a-a93d-3722c21e2687)

