### PR TITLE
feat: use prism to render sql code

### DIFF
--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -1,5 +1,5 @@
-import { Callout, Code, NonIdealState, Pre, Spinner } from '@blueprintjs/core';
-import React from 'react';
+import { Callout, NonIdealState, Spinner } from '@blueprintjs/core';
+import { Prism } from '@mantine/prism';
 import { useCompiledSql } from '../hooks/useCompiledSql';
 
 export const RenderedSql = () => {
@@ -24,8 +24,8 @@ export const RenderedSql = () => {
     }
 
     return (
-        <Pre style={{ borderRadius: '0', boxShadow: 'none', overflow: 'auto' }}>
-            <Code>{data || ''}</Code>
-        </Pre>
+        <Prism m="sm" language="sql">
+            {data || ''}
+        </Prism>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7323

### Description:

Similar to how SQL code is rendered in MetricFlow, let's also use `Prism` to render the generated SQL in explore: 

<img width="1076" alt="Screenshot 2023-10-04 at 14 18 22" src="https://github.com/lightdash/lightdash/assets/7611706/d0fae74d-fb32-4c77-92e2-a0ef842e3f29">

