### PR TITLE
fix: fix total stack mixed chart

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1147,6 +1147,12 @@ const getStackTotalRows = (
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
 ): [unknown, unknown, number][] => {
+    const isNonStackable = series.some(
+        (s) =>
+            s.type === CartesianSeriesType.LINE ||
+            s.type === CartesianSeriesType.SCATTER,
+    );
+    if (isNonStackable) return [];
     return rows.map((row) => {
         const total = calculateStackTotal(
             row,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:#6588


### The issue:

When there was a mixed chart (lines + barchart) and the bar was stacked, the total was using the line value to calculate the total.

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Before
<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-10-05 11-33-10](https://github.com/lightdash/lightdash/assets/1983672/58fa9ee4-fbaf-4225-a3b4-58e44f42012b)


After:



[Screencast from 05-10-23 13:16:39.webm](https://github.com/lightdash/lightdash/assets/1983672/1406a271-8eb8-422c-a3da-f5b699435809)
