### PR TITLE
chore: scheduled deliveries modal in mantine

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerModal2.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal2.tsx
@@ -1,22 +1,47 @@
-import { Code, Modal, Text } from '@mantine/core';
+import { Group, Modal, Text } from '@mantine/core';
+import { IconSend } from '@tabler/icons-react';
 import React, { FC } from 'react';
-import SchedulersModalContent from './SchedulerModalContent';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SchedulerModalContent2 from './SchedulerModalContent2';
 
 // TODO: rename when replacement is complete
 const SchedulersModal2: FC<
-    Omit<React.ComponentProps<typeof SchedulersModalContent>, 'onClose'> & {
+    Omit<React.ComponentProps<typeof SchedulerModalContent2>, 'onClose'> & {
         name: string;
         onClose?: () => void;
     }
-> = ({ isOpen, onClose = () => {} }) => {
+> = ({
+    resourceUuid,
+    schedulersQuery,
+    createMutation,
+    isOpen,
+    isChart,
+    onClose = () => {},
+}) => {
     return (
-        <Modal opened={isOpen} onClose={onClose}>
-            <Text mb="xl">
-                This feature isn't ready yet. Paste this in your browser console
-                to use Scheduled Deliveries:
-            </Text>
-
-            <Code>localStorage.clear('scheduler-modal-2')</Code>
+        <Modal
+            opened={isOpen}
+            onClose={onClose}
+            size="lg"
+            title={
+                <Group spacing="xs">
+                    <MantineIcon icon={IconSend} size="lg" color="gray.7" />
+                    <Text fw={600}>Scheduled deliveries</Text>
+                </Group>
+            }
+            styles={(theme) => ({
+                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
+                body: { backgroundColor: theme.colors.gray[2] },
+            })}
+        >
+            <SchedulerModalContent2
+                resourceUuid={resourceUuid}
+                schedulersQuery={schedulersQuery}
+                createMutation={createMutation}
+                onClose={onClose}
+                isOpen={isOpen}
+                isChart={isChart}
+            />
         </Modal>
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -68,7 +68,7 @@ const ListStateContent: FC<{
     );
 };
 
-const CreateStateContent: FC<{
+export const CreateStateContent: FC<{
     resourceUuid: string;
     createMutation: UseMutationResult<
         SchedulerAndTargets,
@@ -145,7 +145,7 @@ const CreateStateContent: FC<{
     );
 };
 
-const UpdateStateContent: FC<{
+export const UpdateStateContent: FC<{
     schedulerUuid: string;
     onBack: () => void;
 }> = ({ schedulerUuid, onBack }) => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent2.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent2.tsx
@@ -1,0 +1,139 @@
+import { DialogProps } from '@blueprintjs/core';
+import {
+    ApiError,
+    CreateSchedulerAndTargetsWithoutIds,
+    SchedulerAndTargets,
+} from '@lightdash/common';
+import { Box, Button, Group } from '@mantine/core';
+import { FC, useEffect, useState } from 'react';
+import {
+    UseMutationResult,
+    UseQueryResult,
+} from 'react-query/types/react/types';
+import { useHistory, useLocation } from 'react-router-dom';
+import { getSchedulerUuidFromUrlParams } from '../utils';
+import SchedulersList from './SchedulersList';
+
+import {
+    CreateStateContent,
+    UpdateStateContent,
+} from './SchedulerModalContent';
+
+enum States {
+    LIST,
+    CREATE,
+    EDIT,
+}
+
+const ListStateContent: FC<{
+    schedulersQuery: UseQueryResult<SchedulerAndTargets[], ApiError>;
+    onClose: () => void;
+    onConfirm: () => void;
+    onEdit: (schedulerUuid: string) => void;
+}> = ({ schedulersQuery, onClose, onConfirm, onEdit }) => {
+    return (
+        <>
+            <Box py="sm" mih={220}>
+                <SchedulersList
+                    schedulersQuery={schedulersQuery}
+                    onEdit={onEdit}
+                />
+            </Box>
+            <Group
+                spacing="xs"
+                position="right"
+                // TODO: this css is basically a sticky-footer setup for Mantine modals.
+                // It should be shared somewhere else.
+                sx={(theme) => ({
+                    position: 'sticky',
+                    backgroundColor: 'white',
+                    border: `1px solid ${theme.colors.gray[4]}`,
+                    bottom: 0,
+                    margin: `-${theme.spacing.md}`,
+                    padding: theme.spacing.md,
+                })}
+            >
+                <Button onClick={onClose} variant="outline">
+                    Cancel
+                </Button>
+                <Button onClick={onConfirm} type="submit">
+                    Create new
+                </Button>
+            </Group>
+        </>
+    );
+};
+
+interface Props extends DialogProps {
+    resourceUuid: string;
+    schedulersQuery: UseQueryResult<SchedulerAndTargets[], ApiError>;
+    createMutation: UseMutationResult<
+        SchedulerAndTargets,
+        ApiError,
+        { resourceUuid: string; data: CreateSchedulerAndTargetsWithoutIds }
+    >;
+    onClose: () => void;
+    isChart: boolean;
+}
+
+const SchedulerModalContent2: FC<Omit<Props, 'name'>> = ({
+    resourceUuid,
+    schedulersQuery,
+    createMutation,
+    isChart,
+    onClose = () => {},
+}) => {
+    const [state, setState] = useState<States>(States.LIST);
+    const [schedulerUuid, setSchedulerUuid] = useState<string | undefined>();
+    const history = useHistory();
+    const { search, pathname } = useLocation();
+
+    useEffect(() => {
+        const schedulerUuidFromUrlParams =
+            getSchedulerUuidFromUrlParams(search);
+        if (schedulerUuidFromUrlParams) {
+            setState(States.EDIT);
+            setSchedulerUuid(schedulerUuidFromUrlParams);
+
+            // remove from url param after modal is open
+            const newParams = new URLSearchParams(search);
+            newParams.delete('scheduler_uuid');
+            history.replace({
+                pathname,
+                search: newParams.toString(),
+            });
+        }
+    }, [history, pathname, search]);
+
+    return (
+        <>
+            {state === States.LIST && (
+                <ListStateContent
+                    schedulersQuery={schedulersQuery}
+                    onClose={onClose}
+                    onConfirm={() => setState(States.CREATE)}
+                    onEdit={(schedulerUuidToUpdate) => {
+                        setState(States.EDIT);
+                        setSchedulerUuid(schedulerUuidToUpdate);
+                    }}
+                />
+            )}
+            {state === States.CREATE && (
+                <CreateStateContent
+                    resourceUuid={resourceUuid}
+                    createMutation={createMutation}
+                    isChart={isChart}
+                    onBack={() => setState(States.LIST)}
+                />
+            )}
+            {state === States.EDIT && schedulerUuid && (
+                <UpdateStateContent
+                    schedulerUuid={schedulerUuid}
+                    onBack={() => setState(States.LIST)}
+                />
+            )}
+        </>
+    );
+};
+
+export default SchedulerModalContent2;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7324 

### Description:

> **NOTE**: to test these changes, turn the feature flag on by pasting and running this in the console: `localStorage.setItem('scheduler-modal-2', true)`

Moves the modal for scheduled deliveries and the scheduled deliveries list to mantine. Not the list items. A couple notes for reviewers:
- SchedulerModalContent2 is a partial re-implementation of SchedulerModalContent. In coming reviews I will move the rest of the content over
- The CSS for making a sticky footer in Mantine isn't great and it's inline. I will move it somewhere shared when I need it again. Also, I was having trouble with it, so I time-boxed it and this is what I got. If someone has a better idea or pattern I'm all ears 😄 

Here's the new view:
<img width="641" alt="Screenshot 2023-10-05 at 13 19 26" src="https://github.com/lightdash/lightdash/assets/1864179/7a0c1999-a4e7-4258-a63d-01e6a1a2840d">

With nothing in the list:
<img width="633" alt="Screenshot 2023-10-05 at 13 06 32" src="https://github.com/lightdash/lightdash/assets/1864179/54f0eb20-6ed5-42ed-b6dd-3904c44a4b99">
