### PR TITLE
style: center and hide header if hidden title

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -24,7 +24,7 @@ export const TileBaseWrapper = styled.div<HeaderContainerProps>`
 `;
 
 export const TILE_HEADER_HEIGHT = 24;
-export const TILE_HEADER_MARGIN_BOTTOM = 12;
+const TILE_HEADER_MARGIN_BOTTOM = 12;
 
 export const HeaderContainer = styled.div<HeaderContainerProps>`
     display: flex;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -85,7 +85,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         $isEditMode={isEditMode}
                         onMouseEnter={() => setIsHovering(true)}
                         onMouseLeave={() => setIsHovering(false)}
-                        $isEmpty={isMarkdownTileTitleEmpty}
+                        $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
                     >
                         <Tooltip
                             disabled={!description}

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -6,10 +6,7 @@ import clamp from 'lodash-es/clamp';
 import { FC, HTMLAttributes, useMemo } from 'react';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import MantineIcon from '../common/MantineIcon';
-import {
-    TILE_HEADER_HEIGHT,
-    TILE_HEADER_MARGIN_BOTTOM,
-} from '../DashboardTiles/TileBase/TileBase.styles';
+import { TILE_HEADER_HEIGHT } from '../DashboardTiles/TileBase/TileBase.styles';
 import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';
 import { EmptyChart, LoadingChart } from '../SimpleChart';
 import BigNumberContextMenu from './BigNumberContextMenu';
@@ -131,9 +128,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     return validData ? (
         <BigNumberContainer
             $paddingBottom={
-                isDashboard && isTitleHidden
-                    ? TILE_HEADER_HEIGHT + TILE_HEADER_MARGIN_BOTTOM - 8
-                    : TILE_HEADER_HEIGHT
+                isDashboard && isTitleHidden ? 0 : TILE_HEADER_HEIGHT
             }
             ref={(elem) => setRef(elem)}
             {...wrapperProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7283

### Description:

Remove height of a Tile's header block if this is set as hidden -> similar approach to the way we hide the header block if the Markdown Tile's Header is empty: https://github.com/lightdash/lightdash/pull/6535

Example of a tile with hidden title that doesn't have cropped-data issues anymore:
<img width="436" alt="Screenshot 2023-10-05 at 17 55 53" src="https://github.com/lightdash/lightdash/assets/7611706/c9778e86-a12b-49f1-b606-8337269a9b6f">
