### PR TITLE
fix: fix unfurl data visualization on tables

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -450,7 +450,7 @@ export class UnfurlService {
                         'page.metrics.heap_size': pageMetrics.JSHeapUsedSize,
                         'page.metrics.total_size': pageMetrics.JSHeapTotalSize,
                         'page.type': lightdashPage,
-                        url: url,
+                        url,
                         chartType: chartType || 'undefined',
                         organization_uuid: organizationUuid || 'undefined',
                         'page.metrics.event_listeners':
@@ -468,7 +468,7 @@ export class UnfurlService {
                     span.recordException(e);
                     span.setAttributes({
                         'page.type': lightdashPage,
-                        url: url,
+                        url,
                         chartType: chartType || 'undefined',
                         organization_uuid: organizationUuid || 'undefined',
                     });

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -39,6 +39,7 @@ const taskDurationHistogram = meter.createHistogram<{
 const chartCounter = meter.createObservableUpDownCounter<{
     errors: number;
     timeout: boolean;
+    organization_uuid: string;
 }>('screenshot.chart.count', {
     description: 'Total number of chart requests on an unfurl job',
     valueType: ValueType.INT,
@@ -239,6 +240,7 @@ export class UnfurlService {
             url,
             lightdashPage,
             details?.chartType,
+            details?.organizationUuid,
         );
 
         let imageUrl;
@@ -297,6 +299,7 @@ export class UnfurlService {
         url: string,
         lightdashPage: LightdashPage,
         chartType?: string,
+        organizationUuid?: string,
     ): Promise<Buffer | undefined> {
         if (this.lightdashConfig.headlessBrowser?.host === undefined) {
             Logger.error(
@@ -415,7 +418,7 @@ export class UnfurlService {
                     const path = `/tmp/${imageId}.png`;
                     const selector =
                         lightdashPage === LightdashPage.EXPLORE
-                            ? `.echarts-for-react, [data-testid="visualization"]`
+                            ? `[data-testid="visualization"]`
                             : 'body';
 
                     const element = await page.waitForSelector(selector, {
@@ -434,6 +437,7 @@ export class UnfurlService {
                         result.observe(chartRequests, {
                             errors: chartRequestErrors,
                             timeout,
+                            organization_uuid: organizationUuid || 'undefined',
                         });
                     });
 
@@ -445,6 +449,10 @@ export class UnfurlService {
                         'page.metrics.task_duration': pageMetrics.TaskDuration,
                         'page.metrics.heap_size': pageMetrics.JSHeapUsedSize,
                         'page.metrics.total_size': pageMetrics.JSHeapTotalSize,
+                        'page.type': lightdashPage,
+                        url: url,
+                        chartType: chartType || 'undefined',
+                        organization_uuid: organizationUuid || 'undefined',
                         'page.metrics.event_listeners':
                             pageMetrics.JSEventListeners,
                         timeout,
@@ -458,6 +466,12 @@ export class UnfurlService {
                     Sentry.captureException(e);
                     hasError = true;
                     span.recordException(e);
+                    span.setAttributes({
+                        'page.type': lightdashPage,
+                        url: url,
+                        chartType: chartType || 'undefined',
+                        organization_uuid: organizationUuid || 'undefined',
+                    });
                     span.setStatus({
                         code: SpanStatusCode.ERROR,
                     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7363

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Previously we were filtering the element on `explore` by .echarts-for-react, this doesn't work for table viz or big value.


I also added some extra span details like orgUuid

![Screenshot from 2023-10-06 09-39-12](https://github.com/lightdash/lightdash/assets/1983672/6c41eff8-a734-4984-974e-f906f7ac50fd)
