### PR TITLE
fix: turn off stacking if no pivot dimensions

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -32,6 +32,7 @@ const VisualizationCardOptions: FC = memo(() => {
         resultsData,
         cartesianConfig,
         setPivotDimensions,
+        pivotDimensions,
         cartesianConfig: { setStacking },
     } = useVisualizationContext();
     const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
@@ -85,6 +86,7 @@ const VisualizationCardOptions: FC = memo(() => {
                         };
 
                     case CartesianSeriesType.BAR:
+                        if (!pivotDimensions) setStacking(false);
                         return cartesianFlipAxis
                             ? {
                                   text: 'Horizontal bar chart',
@@ -147,11 +149,12 @@ const VisualizationCardOptions: FC = memo(() => {
             }
         }
     }, [
-        isChartTypeTheSameForAllSeries,
-        cartesianFlipAxis,
-        cartesianType,
         chartType,
+        isChartTypeTheSameForAllSeries,
+        cartesianType,
         setStacking,
+        pivotDimensions,
+        cartesianFlipAxis,
     ]);
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7229

### Description:

Screen recording: 

Turn off stacking if moving from chart type AREA to something else, with no pivot dimensions.
Example:
* Create bar chart
* Change to Area
* Change back to bar

Screen recording with fix:

https://github.com/lightdash/lightdash/assets/7611706/a0f9d3a2-89cd-4824-b851-e6921a8be296



