### PR TITLE
style: render semantic layer table label from dimension label

### DIFF
--- a/packages/frontend/src/features/metricFlow/components/MetricFlowFieldList.tsx
+++ b/packages/frontend/src/features/metricFlow/components/MetricFlowFieldList.tsx
@@ -1,7 +1,7 @@
-import { friendlyName } from '@lightdash/common';
-import { NavLink } from '@mantine/core';
+import { Group, NavLink, Text } from '@mantine/core';
 import React, { FC } from 'react';
 import { GetMetricFlowFieldsResponse } from '../../../api/MetricFlowAPI';
+import { convertDimensionNameToLabels } from '../utils/convertDimensionNameToLabels';
 import MetricFlowFieldIcon from './MetricFlowFieldIcon';
 
 type Props = {
@@ -20,16 +20,30 @@ const MetricFlowFieldList: FC<Props> = ({
 }) => {
     return (
         <>
-            {fields?.map((field) => (
-                <NavLink
-                    key={field.name}
-                    active={selectedFields.includes(field.name)}
-                    icon={<MetricFlowFieldIcon type={field.type} size="lg" />}
-                    label={friendlyName(field.name)}
-                    description={field.description}
-                    onClick={() => onClick(field.name)}
-                />
-            ))}
+            {fields?.map((field) => {
+                const labels = convertDimensionNameToLabels(field.name);
+                return (
+                    <NavLink
+                        key={field.name}
+                        active={selectedFields.includes(field.name)}
+                        icon={
+                            <MetricFlowFieldIcon type={field.type} size="lg" />
+                        }
+                        label={
+                            <Group spacing="xxs">
+                                {labels.tableLabel ? (
+                                    <Text fw={400} color="gray.6">
+                                        {labels.tableLabel}
+                                    </Text>
+                                ) : null}
+                                {labels.dimensionLabel}
+                            </Group>
+                        }
+                        description={field.description}
+                        onClick={() => onClick(field.name)}
+                    />
+                );
+            })}
         </>
     );
 };

--- a/packages/frontend/src/features/metricFlow/utils/convertDimensionNameToLabels.ts
+++ b/packages/frontend/src/features/metricFlow/utils/convertDimensionNameToLabels.ts
@@ -1,0 +1,16 @@
+import { friendlyName } from '@lightdash/common';
+
+export function convertDimensionNameToLabels(name: string) {
+    const nameParts = name.split('__');
+    const tableLabel = nameParts.length > 1 ? friendlyName(nameParts[0]) : null;
+    const dimensionLabel = friendlyName(
+        nameParts[nameParts.length - 1].replace(
+            new RegExp(`^${tableLabel}`, 'i'),
+            '',
+        ), // remove duplicate table label
+    );
+    return {
+        dimensionLabel,
+        tableLabel,
+    };
+}

--- a/packages/frontend/src/features/metricFlow/utils/convertMetricFlowFieldsToExplore.ts
+++ b/packages/frontend/src/features/metricFlow/utils/convertMetricFlowFieldsToExplore.ts
@@ -13,6 +13,7 @@ import {
     GetMetricFlowFieldsResponse,
     MetricFlowDimensionType,
 } from '../../../api/MetricFlowAPI';
+import { convertDimensionNameToLabels } from './convertDimensionNameToLabels';
 
 export default function convertMetricFlowFieldsToExplore(
     tableName: string,
@@ -21,6 +22,7 @@ export default function convertMetricFlowFieldsToExplore(
     const dimensionsMap = metricFlowFields.dimensions.reduce(
         (acc, { name, description, type }) => {
             const isTimeDimension = type === MetricFlowDimensionType.TIME;
+            const labels = convertDimensionNameToLabels(name);
             const dimension: CompiledDimension = {
                 fieldType: FieldType.DIMENSION,
                 type: isTimeDimension
@@ -29,9 +31,9 @@ export default function convertMetricFlowFieldsToExplore(
                 // Note: time columns in results are suffixed with '__day' by default
                 name: isTimeDimension ? `${name}__day` : name,
                 description,
-                label: friendlyName(name),
+                label: labels.dimensionLabel,
                 table: tableName,
-                tableLabel: '',
+                tableLabel: labels.tableLabel ?? '',
                 sql: '',
                 compiledSql: '',
                 tablesReferences: [tableName],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7329<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

The initial idea was to group them by "table" and have a tree. 
This will involve quite a bit of work and needs design. 

I opted to make the labels cleaner for now.

Before:
<img width="1670" alt="Screenshot 2023-10-09 at 17 49 06" src="https://github.com/lightdash/lightdash/assets/9117144/dd63cf9d-e8d2-4314-a0be-9f17dcf9faa4">


After:

 
<img width="1670" alt="Screenshot 2023-10-09 at 17 48 36" src="https://github.com/lightdash/lightdash/assets/9117144/31baff9a-6ee4-42e1-9302-06e2fbca445f">

