### PR TITLE
fix: auto sorting line charts without totals

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -1404,14 +1404,19 @@ const useEcharts = (
             const xField = dimensions.find(
                 (dimension) => getItemId(dimension) === xFieldId,
             );
+            const hasTotal = validCartesianConfig?.eChartsConfig?.series?.some(
+                (s) => s.stackLabel?.show,
+            );
+            // If there is a total, we don't sort the results because we need to keep the same order on results
+            // This could still cause issues if there is a total on bar chart axis, the sorting is wrong and one of the axis is a line chart
+            if (hasTotal) return results;
 
             if (
                 xField !== undefined &&
                 results.length >= 0 &&
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                     xField.type,
-                ) &&
-                resultsData?.metricQuery.sorts.length === 0
+                )
             ) {
                 return results.sort((a, b) => {
                     if (
@@ -1436,6 +1441,7 @@ const useEcharts = (
         validCartesianConfig?.layout?.xField,
         resultsData?.metricQuery.sorts,
         explore,
+        validCartesianConfig?.eChartsConfig?.series,
     ]);
 
     const tooltip = useMemo<TooltipOption>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #7405

### Description:

> I think this might be have been a side effect of fixing https://github.com/lightdash/lightdash/issues/7076 , we removed the automatic sorting, that was causing a bug on totals. We could keep the sorting only if there are line charts, or no totals

Before:
![Screenshot from 2023-10-10 14-28-48](https://github.com/lightdash/lightdash/assets/1983672/f9f916dd-5a60-4f45-9ca1-b03022cd6bda)


Now:

![Screenshot from 2023-10-10 14-28-40](https://github.com/lightdash/lightdash/assets/1983672/56b06095-7880-47ef-8900-6933d82175ea)


However, this could still cause issues if there is a total on bar chart axis, the sorting is wrong and one of the axis is a line chart (edge case)

![Screenshot from 2023-10-10 14-30-02](https://github.com/lightdash/lightdash/assets/1983672/241a6bbc-7c1e-4f13-8611-56cd96a4304b)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
