### PR TITLE
fix: try-catch error when downloading jpeg image from pie chart

### DIFF
--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -129,35 +129,44 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
             throw new Error('Chart instance not reachable');
         }
 
-        const svgBase64 = echartsInstance.getDataURL();
-        const width = echartsInstance.getWidth();
-        const height = echartsInstance.getHeight();
+        try {
+            const svgBase64 = echartsInstance.getDataURL();
+            const width = echartsInstance.getWidth();
+            const height = echartsInstance.getHeight();
 
-        switch (type) {
-            case DownloadType.PDF:
-                downloadPdf(
-                    await base64SvgToBase64Image(svgBase64, width),
-                    width,
-                    height,
-                );
-                break;
-            case DownloadType.SVG:
-                downloadImage(svgBase64);
-                break;
-            case DownloadType.JPEG:
-                downloadImage(
-                    await base64SvgToBase64Image(svgBase64, width, 'jpeg'),
-                );
-                break;
-            case DownloadType.PNG:
-                downloadImage(await base64SvgToBase64Image(svgBase64, width));
-                break;
-            case DownloadType.JSON:
-                downloadJson(echartsInstance.getOption());
-                break;
-            default: {
-                assertUnreachable(type, `Unexpected download type: ${type}`);
+            switch (type) {
+                case DownloadType.PDF:
+                    downloadPdf(
+                        await base64SvgToBase64Image(svgBase64, width),
+                        width,
+                        height,
+                    );
+                    break;
+                case DownloadType.SVG:
+                    downloadImage(svgBase64);
+                    break;
+                case DownloadType.JPEG:
+                    downloadImage(
+                        await base64SvgToBase64Image(svgBase64, width, 'jpeg'),
+                    );
+                    break;
+                case DownloadType.PNG:
+                    downloadImage(
+                        await base64SvgToBase64Image(svgBase64, width),
+                    );
+                    break;
+                case DownloadType.JSON:
+                    downloadJson(echartsInstance.getOption());
+                    break;
+                default: {
+                    assertUnreachable(
+                        type,
+                        `Unexpected download type: ${type}`,
+                    );
+                }
             }
+        } catch (e) {
+            console.error(`Unable to download ${type} from chart ${e}`);
         }
     }, [chartRef, type]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7352

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR will not fix the issue when downloading (that requires a bit more of investigation) , this is just preventing the user from getting a white page when trying to download an image 

<!-- Even better add a screenshot / gif / loom -->
![image](https://github.com/lightdash/lightdash/assets/1983672/211435ee-3d25-47bb-be3d-11f95e9e9a65)

I believe this error might be happening on echarts library (I couldn't find an issue about this). But only happens when the label is `inside`, not when it is `outside`. This error doesn't happen even if we select outside first, and then outside. I'll create a separate PR 

[Screencast from 10-10-23 16:59:38.webm](https://github.com/lightdash/lightdash/assets/1983672/f87695cf-39c5-416b-8e40-99f7266ad4e0)


### How to test

Try to download an image from the new pie chat on jaffle shop, you should see the error on console, previously that was throwing a white page



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
