### PR TITLE
fix: fix default tooltip format

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -104,6 +104,9 @@ models:
       - name: order_date
         description: Date (UTC) that the order was placed
         meta:
+          dimension: 
+            type: date
+            time_intervals: ['DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR'] 
           metrics:
             date_of_first_order:
               type: min

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -7,7 +7,6 @@ import {
     ECHARTS_DEFAULT_COLORS,
     Field,
     findItem,
-    formatDate,
     formatItemValue,
     formatTableCalculationValue,
     formatValue,
@@ -1509,9 +1508,10 @@ const useEcharts = (
                         const date = (params[0].data as Record<string, any>)[
                             dimensionId
                         ]; // get full timestamp from data
-                        const dateFormatted = formatDate(
+                        const dateFormatted = getFormattedValue(
                             date,
-                            field.timeInterval,
+                            dimensionId,
+                            items,
                             false,
                         );
                         return `${dateFormatted}<br/><table>${tooltipRows}</table>`;

--- a/packages/frontend/src/hooks/echarts/useEcharts.ts
+++ b/packages/frontend/src/hooks/echarts/useEcharts.ts
@@ -33,6 +33,7 @@ import {
     Series,
     TableCalculation,
     timeFrameConfigs,
+    TimeFrames,
 } from '@lightdash/common';
 import {
     DefaultLabelFormatterCallbackParams,
@@ -1491,15 +1492,30 @@ const useEcharts = (
                         return '';
                     })
                     .join('');
-                const tooltipHeader =
-                    params[0].dimensionNames?.[0] !== undefined
-                        ? getFormattedValue(
-                              params[0].axisValueLabel,
-                              params[0].dimensionNames[0],
-                              items,
-                          )
-                        : params[0].axisValueLabel;
-                return `${tooltipHeader}<br/><table>${tooltipRows}</table>`;
+
+                const dimensionId = params[0].dimensionNames?.[0];
+
+                if (dimensionId !== undefined) {
+                    const field = items.find(
+                        (item) => getItemId(item) === dimensionId,
+                    );
+                    const isQuarter = isDimension(field)
+                        ? field.timeInterval === TimeFrames.QUARTER
+                        : false;
+                    const hasFormat = isField(field)
+                        ? field.format !== undefined
+                        : false;
+
+                    if (isQuarter || hasFormat) {
+                        const tooltipHeader = getFormattedValue(
+                            params[0].axisValueLabel,
+                            dimensionId,
+                            items,
+                        );
+                        return `${tooltipHeader}<br/><table>${tooltipRows}</table>`;
+                    }
+                }
+                return `${params[0].axisValueLabel}<br/><table>${tooltipRows}</table>`;
             },
         }),
         [items],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7422

This fix https://github.com/lightdash/lightdash/pull/7307 introduced a new issue on `non-formatted` timestamps 

I am only formatting if the time interval is quarter (original issue) or the field is formatted 

Before


![Screenshot from 2023-10-11 08-52-05](https://github.com/lightdash/lightdash/assets/1983672/10eaae97-11ac-4333-b3b7-62a18a40cd34)


Now:


![Screenshot from 2023-10-11 09-50-45](https://github.com/lightdash/lightdash/assets/1983672/2bdc9a65-79a8-4472-8fcb-ea5f209c8af6)


![Screenshot from 2023-10-11 09-52-34](https://github.com/lightdash/lightdash/assets/1983672/07b3f5e3-6cba-40d1-ad4a-8646a239bc08)

![Screenshot from 2023-10-11 10-03-55](https://github.com/lightdash/lightdash/assets/1983672/e832c700-671e-45ba-9d45-64b938df6398)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
