### PR TITLE
fix: dead tiles when charts are deleted

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useSavedQueryWithDashboardFilters.ts
+++ b/packages/frontend/src/hooks/dashboard/useSavedQueryWithDashboardFilters.ts
@@ -32,16 +32,12 @@ const useSavedQueryWithDashboardFilters = (
     );
 
     const isLoadingOrFetching =
-        isLoadingSavedQuery ||
-        isFetchingSavedQuery ||
-        isLoadingExplore ||
-        !savedQuery ||
-        !explore;
+        isLoadingSavedQuery || isFetchingSavedQuery || isLoadingExplore;
 
     const dashboardFilters = useDashboardFiltersForExplore(tileUuid, explore);
 
     const savedQueryWithDashboardFilters = useMemo(() => {
-        if (isLoadingOrFetching) return undefined;
+        if (isLoadingOrFetching || !savedQuery) return undefined;
 
         return {
             ...savedQuery,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7400 

### Description:

We were showing a loading state when there was no data for a chart. The result was a chart that had been deleted would show the loading state forever and the tile was un-deletable. 

To test:

1. Create a chart 
2. Add it to a dashboard
3. Delete the chart 
4. Go back to the dashboard

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
