### PR TITLE
fix: Disables `total` toggle for line charts.

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -267,7 +267,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         });
                     }}
                 />
-                {seriesGroup[0].stack && (
+                {seriesGroup[0].stack && chartValue !== CartesianSeriesType.LINE && (
                     <Stack spacing="xs" mt="two">
                         <Text size="xs" fw={500}>
                             Total


### PR DESCRIPTION
Closes: #7408 

### Description:
Hides the total toggle if its a line chart.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
