### PR TITLE
fix: allow vertical big number resizing

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -28,6 +28,10 @@ interface SimpleStatisticsProps extends HTMLAttributes<HTMLDivElement> {
 const BOX_MIN_WIDTH = 150;
 const BOX_MAX_WIDTH = 1000;
 
+const BOX_MIN_HEIGHT = 25;
+//TODO: Decide what value is good for max height
+const BOX_MAX_HEIGHT = 1000;
+
 const VALUE_SIZE_MIN = 24;
 const VALUE_SIZE_MAX = 64;
 
@@ -41,12 +45,19 @@ const calculateFontSize = (
     fontSizeMin: number,
     fontSizeMax: number,
     boundWidth: number,
-) =>
-    Math.floor(
-        fontSizeMin +
-            ((fontSizeMax - fontSizeMin) * (boundWidth - BOX_MIN_WIDTH)) /
-                (BOX_MAX_WIDTH - BOX_MIN_WIDTH),
-    );
+    boundHeight: number,
+) => {
+    const widthScale = (boundWidth - BOX_MIN_WIDTH) / (BOX_MAX_WIDTH - BOX_MIN_WIDTH);
+    const heightScale = (boundHeight - BOX_MIN_HEIGHT) / (BOX_MAX_HEIGHT - BOX_MIN_HEIGHT);
+
+    const scalingFactor = Math.min(widthScale, heightScale)
+
+    // assert : 0 <= scalingFactor <= 1
+
+    const fontSize = Math.floor(fontSizeMin + ((fontSizeMax - fontSizeMin) * scalingFactor))
+
+    return fontSize;
+}
 
 const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     minimal = false,
@@ -82,22 +93,31 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             BOX_MAX_WIDTH,
         );
 
+        const boundHeight = clamp(
+            observerElementSize?.height || 0,
+            BOX_MIN_HEIGHT,
+            BOX_MAX_HEIGHT,
+        )
+
         const valueSize = calculateFontSize(
             VALUE_SIZE_MIN,
             VALUE_SIZE_MAX,
             boundWidth,
+            boundHeight,
         );
 
         const labelSize = calculateFontSize(
             LABEL_SIZE_MIN,
             LABEL_SIZE_MAX,
             boundWidth,
+            boundHeight,
         );
 
         const comparisonValueSize = calculateFontSize(
             COMPARISON_VALUE_SIZE_MIN,
             COMPARISON_VALUE_SIZE_MAX,
             boundWidth,
+            boundHeight,
         );
 
         return {

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -29,7 +29,6 @@ const BOX_MIN_WIDTH = 150;
 const BOX_MAX_WIDTH = 1000;
 
 const BOX_MIN_HEIGHT = 25;
-//TODO: Decide what value is good for max height
 const BOX_MAX_HEIGHT = 1000;
 
 const VALUE_SIZE_MIN = 24;

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -47,17 +47,21 @@ const calculateFontSize = (
     boundWidth: number,
     boundHeight: number,
 ) => {
-    const widthScale = (boundWidth - BOX_MIN_WIDTH) / (BOX_MAX_WIDTH - BOX_MIN_WIDTH);
-    const heightScale = (boundHeight - BOX_MIN_HEIGHT) / (BOX_MAX_HEIGHT - BOX_MIN_HEIGHT);
+    const widthScale =
+        (boundWidth - BOX_MIN_WIDTH) / (BOX_MAX_WIDTH - BOX_MIN_WIDTH);
+    const heightScale =
+        (boundHeight - BOX_MIN_HEIGHT) / (BOX_MAX_HEIGHT - BOX_MIN_HEIGHT);
 
-    const scalingFactor = Math.min(widthScale, heightScale)
+    const scalingFactor = Math.min(widthScale, heightScale);
 
     // assert : 0 <= scalingFactor <= 1
 
-    const fontSize = Math.floor(fontSizeMin + ((fontSizeMax - fontSizeMin) * scalingFactor))
+    const fontSize = Math.floor(
+        fontSizeMin + (fontSizeMax - fontSizeMin) * scalingFactor,
+    );
 
     return fontSize;
-}
+};
 
 const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     minimal = false,
@@ -97,7 +101,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             observerElementSize?.height || 0,
             BOX_MIN_HEIGHT,
             BOX_MAX_HEIGHT,
-        )
+        );
 
         const valueSize = calculateFontSize(
             VALUE_SIZE_MIN,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6608 <!-- reference the related issue e.g. #150 -->

Good morning :)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Added a vertical scaling factor. Currently taking the minimum of both for scaling and it seems to me that it works, but let me know if a different behavior is required.

> Resize the viz to a reasonable extent when the panel shrinks. The other charts do this.

Done.
> Indicate when there is a viz that is hidden by the panel being too small.

Requires some design decisions. 
Let me know what you all think :)

<!-- Even better add a screenshot / gif / loom -->

Before :
https://www.loom.com/share/316e17f69b40447fb78fdd649a52ba7a

After : 
https://www.loom.com/share/d95ada8f5cc345d399bb71a426926fa3

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
