### PR TITLE
fix: reference lines uuid

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -146,6 +146,7 @@ export type MarkLineData = {
     yAxis?: string;
     xAxis?: string;
     name: string;
+    value: string;
     lineStyle?: {
         color: string;
     };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -62,7 +62,8 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                     if (selectedSeries === undefined) return;
 
                     const dataWithAxis = {
-                        name: lineId,
+                        name: updateLabel || 'Reference line',
+                        value: lineId,
                         lineStyle: { color: updateColor },
                         label: updateLabel ? { formatter: updateLabel } : {},
                         xAxis: undefined,
@@ -73,7 +74,11 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
 
                     const updatedReferenceLines: ReferenceLineField[] =
                         referenceLines.map((line) => {
-                            if (line.data.name === lineId)
+                            // Check both .value and .name for backwards compatibility
+                            if (
+                                line.data.value === lineId ||
+                                line.data.name === lineId
+                            )
                                 return { fieldId: fieldId, data: dataWithAxis };
                             else return line;
                         });
@@ -93,7 +98,8 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
     const addReferenceLine = useCallback(() => {
         const newReferenceLine: ReferenceLineField = {
             data: {
-                name: uuidv4(),
+                name: 'Reference line',
+                value: uuidv4(),
             },
         };
         setReferenceLines([...referenceLines, newReferenceLine]);
@@ -109,7 +115,9 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                         ...serie.markLine,
                         data:
                             serie.markLine?.data.filter(
-                                (data) => data.name !== markLineId,
+                                (data) =>
+                                    data.value !== markLineId &&
+                                    data.name !== markLineId,
                             ) || [],
                     },
                 };
@@ -118,7 +126,11 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
             updateSeries(series);
 
             setReferenceLines(
-                referenceLines.filter((line) => line.data.name !== markLineId),
+                referenceLines.filter(
+                    (line) =>
+                        line.data.value !== markLineId &&
+                        line.data.name !== markLineId,
+                ),
             );
         },
         [
@@ -136,7 +148,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                 referenceLines.map((line, index) => {
                     return (
                         <ReferenceLine
-                            key={line.data.name}
+                            key={line.data.value}
                             index={index + 1}
                             isDefaultOpen={referenceLines.length <= 1}
                             items={items}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #7421

### Description:

Instead of using `name` to store the `uuid` we use echarts' value: 

![image](https://github.com/lightdash/lightdash/assets/1983672/ab5a45ba-59c0-4030-947b-8e1b29d540eb)

I kept some .name filtering for backwards compatibility (so you can edit or remove "old" reference lines) 

<!-- Add a description of the changes proposed in the pull request. -->
Before: 

![image](https://github.com/lightdash/lightdash/assets/1983672/1e9130bb-db55-4c2c-b911-aded9d197f50)


Now: 
Without label 
![Screenshot from 2023-10-12 10-15-19](https://github.com/lightdash/lightdash/assets/1983672/5bc654c0-9507-49c4-92d1-6fb2dab1ee36)

With label 

![Screenshot from 2023-10-12 10-15-53](https://github.com/lightdash/lightdash/assets/1983672/9369cf66-cf78-4723-bb59-89469c717998)

<!-- Even better add a screenshot / gif / loom -->


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
