### PR TITLE
feat: filter inputs tag input to mantine

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -54,7 +54,7 @@ describe('Dashboard', () => {
             .click()
             .type('payment method{downArrow}{enter}');
         cy.findByPlaceholderText('Start typing to filter results').type(
-            'credit_card{enter}',
+            'credit_card{enter}{esc}',
         );
         cy.findAllByRole('tab').eq(0).click();
         cy.contains('button', 'Apply').click();
@@ -129,9 +129,10 @@ describe('Dashboard', () => {
         cy.findByTestId('FilterConfiguration/FieldSelect')
             .click()
             .type('payment method{downArrow}{enter}');
-        cy.get('label.mantine-Switch-track').click();
+        // using force click here because this is a mantine switch and the actual checkbox is hidden
+        cy.findByLabelText('Provide default value').click({ force: true });
         cy.findByPlaceholderText('Start typing to filter results').type(
-            'credit_card{enter}',
+            'credit_card{enter}{esc}',
         );
         cy.contains('button', 'Apply').click();
 

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -54,7 +54,7 @@ describe('Dashboard', () => {
             .click()
             .type('payment method{downArrow}{enter}');
         cy.findByPlaceholderText('Start typing to filter results').type(
-            'credit_card{enter}{esc}',
+            'credit_card{enter}',
         );
         cy.findAllByRole('tab').eq(0).click();
         cy.contains('button', 'Apply').click();
@@ -131,7 +131,7 @@ describe('Dashboard', () => {
             .type('payment method{downArrow}{enter}');
         cy.get('label.mantine-Switch-track').click();
         cy.findByPlaceholderText('Start typing to filter results').type(
-            'credit_card{enter}{esc}',
+            'credit_card{enter}',
         );
         cy.contains('button', 'Apply').click();
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -29,6 +29,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     filterType,
     rule,
     disabled,
+    popoverProps,
     onChange,
 }: React.PropsWithChildren<FilterInputsProps<T>>) => {
     const { getField } = useFiltersContext();
@@ -64,6 +65,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             placeholder={placeholder}
                             values={(rule.values || []).filter(isString)}
                             suggestions={suggestions || []}
+                            popoverProps={popoverProps}
                             onChange={(values) =>
                                 onChange({
                                     ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -1,3 +1,4 @@
+import { Popover2Props } from '@blueprintjs/popover2';
 import {
     assertUnreachable,
     ConditionalRule,
@@ -20,6 +21,7 @@ export type FilterInputsProps<T extends ConditionalRule> = {
     rule: T;
     onChange: (value: T) => void;
     disabled?: boolean;
+    popoverProps?: Popover2Props;
 };
 
 const DefaultFilterInputs = <T extends ConditionalRule>({

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -86,7 +86,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             allowDuplicates={false}
                             validationRegex={
                                 filterType === FilterType.NUMBER
-                                    ? /^\d+$/
+                                    ? /^-?\d+(\.\d+)?$/
                                     : undefined
                             }
                             value={rule.values?.map(String)}

--- a/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.styles.ts
+++ b/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.styles.ts
@@ -1,0 +1,82 @@
+import { createStyles, getSize, MantineNumberSize, rem } from '@mantine/core';
+
+interface DefaultLabelStyles {
+    radius: MantineNumberSize;
+    disabled: boolean;
+    readOnly: boolean;
+}
+
+export const sizes = {
+    xs: rem(16),
+    sm: rem(22),
+    md: rem(26),
+    lg: rem(30),
+    xl: rem(36),
+};
+
+const fontSizes = {
+    xs: rem(10),
+    sm: rem(12),
+    md: rem(14),
+    lg: rem(16),
+    xl: rem(18),
+};
+
+export default createStyles(
+    (
+        theme,
+        { disabled, radius, readOnly }: DefaultLabelStyles,
+        { size, variant },
+    ) => ({
+        defaultValue: {
+            display: 'flex',
+            alignItems: 'center',
+            backgroundColor: disabled
+                ? theme.colorScheme === 'dark'
+                    ? theme.colors.dark[5]
+                    : theme.colors.gray[3]
+                : theme.colorScheme === 'dark'
+                ? theme.colors.dark[7]
+                : variant === 'filled'
+                ? theme.white
+                : theme.colors.gray[1],
+            color: disabled
+                ? theme.colorScheme === 'dark'
+                    ? theme.colors.dark[1]
+                    : theme.colors.gray[7]
+                : theme.colorScheme === 'dark'
+                ? theme.colors.dark[0]
+                : theme.colors.gray[7],
+            height: getSize({ size, sizes }),
+            paddingLeft: `calc(${getSize({
+                size,
+                sizes: theme.spacing,
+            })} / 1.5)`,
+            paddingRight:
+                disabled || readOnly
+                    ? getSize({ size, sizes: theme.spacing })
+                    : 0,
+            fontWeight: 500,
+            fontSize: getSize({ size, sizes: fontSizes }),
+            borderRadius: getSize({ size: radius, sizes: theme.radius }),
+            cursor: disabled ? 'not-allowed' : 'default',
+            userSelect: 'none',
+            maxWidth: `calc(100% - ${rem(20)})`,
+        },
+
+        defaultValueRemove: {
+            color:
+                theme.colorScheme === 'dark'
+                    ? theme.colors.dark[0]
+                    : theme.colors.gray[7],
+            marginLeft: `calc(${getSize({ size, sizes: theme.spacing })} / 6)`,
+        },
+
+        defaultValueLabel: {
+            display: 'block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+        },
+    }),
+);

--- a/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
+++ b/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
@@ -1,0 +1,74 @@
+import {
+    CloseButton,
+    DefaultProps,
+    MantineNumberSize,
+    MantineSize,
+    Selectors,
+} from '@mantine/core';
+import React from 'react';
+import useStyles from './DefaultValue.styles';
+
+export type DefaultValueStylesNames = Selectors<typeof useStyles>;
+
+export interface TagInputValueProps
+    extends DefaultProps<DefaultValueStylesNames>,
+        React.ComponentPropsWithoutRef<'div'> {
+    label: string;
+    onRemove(): void;
+    disabled: boolean;
+    size: MantineSize;
+    radius: MantineNumberSize;
+    variant: string;
+    readOnly: boolean;
+}
+
+const buttonSizes: Record<MantineSize, MantineNumberSize> = {
+    xs: 16,
+    sm: 22,
+    md: 24,
+    lg: 26,
+    xl: 30,
+};
+
+export function DefaultValue({
+    label,
+    classNames,
+    styles,
+    className,
+    onRemove,
+    disabled,
+    size,
+    radius = 'sm',
+    variant,
+    unstyled,
+    readOnly,
+    ...others
+}: TagInputValueProps) {
+    const { classes, cx } = useStyles(
+        { disabled, readOnly, radius },
+        { classNames, styles, name: 'TagInput', size, variant, unstyled },
+    );
+
+    return (
+        <div className={cx(classes.defaultValue, className)} {...others}>
+            <span className={classes.defaultValueLabel}>{label}</span>
+
+            {!disabled && !readOnly && (
+                <CloseButton
+                    aria-hidden
+                    onMouseDown={onRemove}
+                    size={buttonSizes[size]}
+                    radius={2}
+                    color="blue"
+                    variant="transparent"
+                    iconSize="70%"
+                    className={classes.defaultValueRemove}
+                    tabIndex={-1}
+                    unstyled={unstyled}
+                />
+            )}
+        </div>
+    );
+}
+
+DefaultValue.displayName = '@mantine/core/TagInput/DefaultValue';

--- a/packages/frontend/src/components/common/TagInput/TagInput.styles.ts
+++ b/packages/frontend/src/components/common/TagInput/TagInput.styles.ts
@@ -1,0 +1,83 @@
+import { INPUT_SIZES } from '@mantine/core';
+import { createStyles, getSize, rem } from '@mantine/styles';
+import { sizes as DEFAULT_VALUE_SIZES } from './DefaultValue/DefaultValue.styles';
+
+interface TagInputStyles {
+    invalid: boolean;
+}
+
+export type InputFieldPosition = 'inside' | 'top' | 'bottom';
+
+export default createStyles(
+    (theme, { invalid }: TagInputStyles, { size, variant }) => ({
+        wrapper: {
+            position: 'relative',
+        },
+
+        values: {
+            minHeight: `calc(${getSize({ size, sizes: INPUT_SIZES })} - ${rem(
+                2,
+            )})`,
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            marginLeft:
+                variant === 'unstyled'
+                    ? rem(0)
+                    : `calc(-${theme.spacing.xs} / 2)`,
+            boxSizing: 'border-box',
+            width: '100%',
+
+            '&[data-clearable]': {
+                marginRight: getSize({ size, sizes: INPUT_SIZES }),
+            },
+        },
+
+        value: {
+            margin: `calc(${theme.spacing.xs} / 2 - ${rem(2)}) calc(${
+                theme.spacing.xs
+            } / 2)`,
+        },
+
+        tagInput: {
+            ...theme.fn.fontStyles(),
+            flex: 1,
+            width: rem(60),
+            backgroundColor: 'transparent',
+            border: 0,
+            outline: 0,
+            fontSize: getSize({ size, sizes: theme.fontSizes }),
+            padding: 0,
+            margin: `calc(${theme.spacing.xs}px / 2)`,
+            appearance: 'none',
+            color: 'inherit',
+            lineHeight: `calc(${getSize({ size, sizes: INPUT_SIZES })} - ${rem(
+                2,
+            )})`,
+            maxHeight: getSize({ size, sizes: DEFAULT_VALUE_SIZES }),
+
+            '&::placeholder': {
+                color: invalid
+                    ? theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7]
+                    : theme.colorScheme === 'dark'
+                    ? theme.colors.dark[3]
+                    : theme.colors.gray[5],
+            },
+
+            '&:disabled': {
+                cursor: 'not-allowed',
+            },
+        },
+
+        tagInputEmpty: {
+            width: '100%',
+        },
+        tagInputContainer: {
+            display: 'flex',
+            alignItems: 'center',
+            '&:not(:disabled)': {
+                cursor: 'pointer',
+            },
+        },
+    }),
+);

--- a/packages/frontend/src/components/common/TagInput/TagInput.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInput.tsx
@@ -99,6 +99,9 @@ export interface TagInputProps
 
     /** Called when search changes */
     onSearchChange?: (value: string) => void;
+
+    /** Add on blur */
+    addOnBlur?: boolean;
 }
 
 function splitTags(splitChars: string[] | undefined, value: string) {
@@ -204,6 +207,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
             allowDuplicates,
             inputFieldPosition,
             clearButtonProps,
+            addOnBlur = true,
             ...others
         } = useComponentDefaultProps('TagInput', defaultProps, props);
 
@@ -263,16 +267,6 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
             }
         };
 
-        const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-            if (typeof onBlur === 'function') {
-                onBlur(event);
-            }
-
-            if (clearInputOnBlur) {
-                setSearchValue('');
-            }
-        };
-
         const handleAddTags = (newTags: string[]): boolean => {
             let tags = newTags;
             if (readOnly) {
@@ -311,6 +305,21 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
 
             setSearchValue('');
             return false;
+        };
+
+        const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+            if (addOnBlur && _searchValue !== '') {
+                handleAddTags([_searchValue]);
+                setSearchValue('');
+            }
+
+            if (typeof onBlur === 'function') {
+                onBlur(event);
+            }
+
+            if (clearInputOnBlur) {
+                setSearchValue('');
+            }
         };
 
         const handleInputKeydown = (

--- a/packages/frontend/src/components/common/TagInput/TagInput.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInput.tsx
@@ -1,0 +1,497 @@
+import { extractSystemStyles, Input } from '@mantine/core';
+import {
+    BaseSelectProps,
+    BaseSelectStylesNames,
+} from '@mantine/core/lib/Select/types';
+import { useId, useMergedRef, useUncontrolled } from '@mantine/hooks';
+import {
+    DefaultProps,
+    MantineSize,
+    Selectors,
+    useComponentDefaultProps,
+} from '@mantine/styles';
+import uniq from 'lodash/uniq';
+import React, { forwardRef, useRef, useState } from 'react';
+import {
+    DefaultValue,
+    DefaultValueStylesNames,
+} from './DefaultValue/DefaultValue';
+import useStyles, { InputFieldPosition } from './TagInput.styles';
+import { getTagInputRightSectionProps } from './TagInputRightSection/get-taginput-right-section-props';
+
+export type TagInputStylesNames =
+    | DefaultValueStylesNames
+    | Exclude<Selectors<typeof useStyles>, 'tagInputEmpty'>
+    | Exclude<
+          BaseSelectStylesNames,
+          | 'selected'
+          | 'item'
+          | 'nothingFound'
+          | 'separator'
+          | 'separatorLabel'
+          | 'itemsWrapper'
+          | 'dropdown'
+      >;
+export interface TagInputProps
+    extends DefaultProps<TagInputStylesNames>,
+        BaseSelectProps {
+    /** Input size */
+    size?: MantineSize;
+
+    /** Properties spread to root element */
+    wrapperProps?: Record<string, any>;
+
+    /** Controlled input value */
+    value?: string[];
+
+    /** Uncontrolled input defaultValue */
+    defaultValue?: string[];
+
+    /** Controlled input onChange handler */
+    onChange?(value: string[]): void;
+
+    /** Component used to render values */
+    valueComponent?: React.FC<any>;
+
+    /** Allow to clear item */
+    clearable?: boolean;
+
+    /** Clear input field value on blur */
+    clearInputOnBlur?: boolean;
+
+    /** Called each time search query changes */
+    onChangeInput?(query: string): void;
+
+    /** Get input ref */
+    elementRef?: React.ForwardedRef<HTMLInputElement>;
+
+    /** Limit amount of tags */
+    maxTags?: number;
+
+    /** Component used to render right section */
+    rightSection?: React.ReactNode;
+
+    /** Called to split after onPaste  */
+    pasteSplit?: (data: any) => string[];
+
+    /** Allow to paste item */
+    addOnPaste?: boolean;
+
+    /** Called for validation when add tags */
+    validationRegex?: RegExp;
+
+    /** Called when validationRegex reject tags */
+    onValidationReject?: (data: string[]) => void;
+
+    /** Allow to only unique */
+    onlyUnique?: boolean;
+
+    /** Input Tag position */
+    inputFieldPosition?: InputFieldPosition;
+
+    /** Props added to clear button */
+    clearButtonProps?: React.ComponentPropsWithoutRef<'button'>;
+}
+
+const separators = [',', ';', '\\(', '\\)', '\\*', '/', ':', '\\?', '\n', '\r'];
+
+const defaultPasteSplit = (data: string): string[] => {
+    return data.split(new RegExp(separators.join('|'))).map((d) => d.trim());
+};
+
+const getClipboardData = (e: React.ClipboardEvent): string => {
+    if (e.clipboardData) {
+        return e.clipboardData.getData('text/plain');
+    }
+
+    return '';
+};
+
+const defaultProps: Partial<TagInputProps> = {
+    size: 'sm',
+    valueComponent: DefaultValue,
+    disabled: false,
+    addOnPaste: true,
+    onlyUnique: false,
+    pasteSplit: defaultPasteSplit,
+    validationRegex: /.*/,
+    onValidationReject: () => {},
+    inputFieldPosition: 'inside',
+};
+
+export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
+    (props, ref) => {
+        const {
+            className,
+            style,
+            required,
+            label,
+            description,
+            size,
+            error,
+            classNames,
+            styles,
+            wrapperProps,
+            value,
+            defaultValue,
+            onChange,
+            valueComponent: Value,
+            id,
+            onFocus,
+            onBlur,
+            placeholder,
+            clearable,
+            variant,
+            disabled,
+            radius,
+            icon,
+            rightSection,
+            rightSectionWidth,
+            sx,
+            name,
+            errorProps,
+            labelProps,
+            descriptionProps,
+            form,
+            onKeyDown,
+            unstyled,
+            inputContainer,
+            inputWrapperOrder,
+            readOnly,
+            withAsterisk,
+            clearInputOnBlur = false,
+            onChangeInput,
+            maxTags,
+            addOnPaste,
+            pasteSplit,
+            validationRegex,
+            onValidationReject,
+            onlyUnique,
+            inputFieldPosition,
+            clearButtonProps,
+            ...others
+        } = useComponentDefaultProps('TagInput', defaultProps, props);
+
+        const { classes, cx, theme } = useStyles(
+            { invalid: !!error },
+            { name: 'TagInput', classNames, styles, size, variant, unstyled },
+        );
+        const { systemStyles, rest } = extractSystemStyles(others);
+
+        const inputRef = useRef<HTMLInputElement>();
+        const wrapperRef = useRef<HTMLDivElement>();
+        const uuid = useId(id);
+        const [inputValue, setInputValue] = useState('');
+        const [IMEOpen, setIMEOpen] = useState(false);
+
+        const [_value, setValue] = useUncontrolled({
+            value,
+            defaultValue,
+            finalValue: [],
+            onChange,
+        });
+
+        const valuesOverflow = useRef(!!maxTags && maxTags < _value.length);
+
+        const handleValueRemove = (_index: number) => {
+            if (!readOnly) {
+                const newValue = _value.filter((_, index) => index !== _index);
+                setValue(newValue);
+
+                if (!!maxTags && newValue.length < maxTags) {
+                    valuesOverflow.current = false;
+                }
+            }
+        };
+
+        const handleInputChange = (
+            event: React.ChangeEvent<HTMLInputElement>,
+        ) => {
+            if (typeof onChangeInput === 'function') {
+                onChangeInput(event.currentTarget.value);
+            }
+
+            setInputValue(event.currentTarget.value);
+        };
+
+        const handleInputFocus = (
+            event: React.FocusEvent<HTMLInputElement>,
+        ) => {
+            if (typeof onFocus === 'function') {
+                onFocus(event);
+            }
+        };
+
+        const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+            if (typeof onBlur === 'function') {
+                onBlur(event);
+            }
+
+            if (clearInputOnBlur) {
+                setInputValue('');
+            }
+        };
+
+        const handleAddTags = (newTags: string[]): boolean => {
+            let tags = newTags;
+            if (readOnly) {
+                return false;
+            }
+            if (onlyUnique) {
+                tags = uniq(tags);
+                tags = tags.filter((tag) =>
+                    _value.every((currentTag) => currentTag !== tag),
+                );
+            }
+
+            const rejectedTags = tags.filter(
+                (tag) => !validationRegex!.test(tag),
+            );
+
+            if (maxTags && maxTags >= 0) {
+                const remainingLimit = Math.max(maxTags - _value.length, 0);
+                tags = tags.slice(0, remainingLimit);
+            }
+
+            if (onValidationReject && rejectedTags.length > 0) {
+                onValidationReject(rejectedTags);
+            }
+
+            if (rejectedTags.length > 0) {
+                return false;
+            }
+
+            if (tags.length > 0) {
+                const newValue = _value.concat(tags);
+                setValue(newValue);
+                setInputValue('');
+                return true;
+            }
+
+            setInputValue('');
+            return false;
+        };
+
+        const handleInputKeydown = (
+            event: React.KeyboardEvent<HTMLInputElement>,
+        ) => {
+            if (IMEOpen) {
+                return;
+            }
+
+            if (readOnly) {
+                return;
+            }
+
+            switch (event.key) {
+                case 'Enter': {
+                    if (inputValue) {
+                        event.preventDefault();
+
+                        handleAddTags([inputValue]);
+                        if (maxTags && _value.length === maxTags - 1) {
+                            valuesOverflow.current = true;
+                            inputRef.current?.blur();
+                            return;
+                        }
+                        inputRef.current?.focus();
+                    }
+
+                    break;
+                }
+
+                case 'Backspace': {
+                    if (_value.length > 0 && inputValue.length === 0) {
+                        setValue(_value.slice(0, -1));
+                    }
+
+                    break;
+                }
+            }
+        };
+
+        const selectedItems = _value
+            .map((val) => {
+                const selectedItem = {
+                    value: val,
+                    label: val,
+                };
+                return selectedItem;
+            })
+            .filter((val) => !!val)
+            .map((item, index) => {
+                const Component = Value!;
+
+                return (
+                    <Component
+                        {...item}
+                        variant={variant}
+                        disabled={disabled}
+                        className={classes.value}
+                        onRemove={() => {
+                            handleValueRemove(index);
+                        }}
+                        key={`${item.value}-${index}`}
+                        size={size}
+                        styles={styles}
+                        classNames={classNames}
+                        radius={radius}
+                        readOnly={readOnly}
+                    />
+                );
+            });
+
+        const handleClear = (): void => {
+            setInputValue('');
+            setValue([]);
+            inputRef.current?.focus();
+            valuesOverflow.current = false;
+        };
+
+        const handlePaste = (e: React.ClipboardEvent): void => {
+            if (!addOnPaste) {
+                return;
+            }
+
+            e.preventDefault();
+            const data = getClipboardData(e);
+            const tags = pasteSplit(data);
+            handleAddTags(tags);
+        };
+
+        const inputElement = (
+            <input
+                ref={useMergedRef(ref, inputRef)}
+                type="text"
+                id={uuid}
+                className={cx(classes.tagInput, {
+                    [classes.tagInputEmpty]: _value.length === 0,
+                })}
+                onKeyDown={handleInputKeydown}
+                value={inputValue}
+                onChange={handleInputChange}
+                onFocus={handleInputFocus}
+                onCompositionStart={() => setIMEOpen(true)}
+                onCompositionEnd={() => setIMEOpen(false)}
+                onBlur={handleInputBlur}
+                readOnly={valuesOverflow.current || readOnly}
+                placeholder={_value.length === 0 ? placeholder : undefined}
+                disabled={disabled}
+                autoComplete="off"
+                {...rest}
+            />
+        );
+
+        return (
+            <Input.Wrapper
+                required={required}
+                id={uuid}
+                label={label}
+                error={error}
+                description={description}
+                size={size}
+                className={className}
+                style={style}
+                classNames={classNames}
+                styles={styles}
+                __staticSelector="TagInput"
+                sx={sx}
+                errorProps={errorProps}
+                descriptionProps={descriptionProps}
+                labelProps={labelProps}
+                inputContainer={inputContainer}
+                inputWrapperOrder={inputWrapperOrder}
+                unstyled={unstyled}
+                withAsterisk={withAsterisk}
+                variant={variant}
+                {...systemStyles}
+                {...wrapperProps}
+            >
+                <div
+                    className={classes.wrapper}
+                    aria-haspopup="listbox"
+                    aria-owns={`${uuid}-items`}
+                    aria-controls={uuid}
+                    tabIndex={-1}
+                    ref={wrapperRef}
+                >
+                    {inputFieldPosition === 'top' && (
+                        <div className={classes.values} id={`${uuid}-items`}>
+                            {selectedItems}
+                        </div>
+                    )}
+                    <Input<'div'>
+                        __staticSelector="TagInput"
+                        style={{ overflow: 'hidden' }}
+                        component="div"
+                        multiline
+                        size={size}
+                        variant={variant}
+                        disabled={disabled}
+                        error={error}
+                        required={required}
+                        radius={radius}
+                        icon={icon}
+                        unstyled={unstyled}
+                        onMouseDown={(event) => {
+                            event.preventDefault();
+                            if (!disabled && !valuesOverflow.current) {
+                                inputRef.current?.focus();
+                            }
+                        }}
+                        classNames={{
+                            ...classNames,
+                            input: cx(
+                                classes.tagInputContainer,
+                                classNames?.input,
+                            ),
+                        }}
+                        onPaste={handlePaste}
+                        {...getTagInputRightSectionProps({
+                            theme,
+                            rightSection,
+                            rightSectionWidth,
+                            styles,
+                            size,
+                            shouldClear: clearable && _value.length > 0,
+                            onClear: handleClear,
+                            error,
+                            disabled,
+                            clearButtonProps,
+                            readOnly,
+                        })}
+                    >
+                        {inputFieldPosition === 'inside' && (
+                            <div
+                                className={classes.values}
+                                id={`${uuid}-items`}
+                            >
+                                {selectedItems}
+                                {inputElement}
+                            </div>
+                        )}
+                        {(inputFieldPosition === 'bottom' ||
+                            inputFieldPosition === 'top') && (
+                            <>{inputElement}</>
+                        )}
+                    </Input>
+                    {inputFieldPosition === 'bottom' && (
+                        <div className={classes.values} id={`${uuid}-items`}>
+                            {selectedItems}
+                        </div>
+                    )}
+                </div>
+
+                <input
+                    type="hidden"
+                    name={name}
+                    value={_value.join(',')}
+                    form={form}
+                    disabled={disabled}
+                />
+            </Input.Wrapper>
+        );
+    },
+);
+
+TagInput.displayName = '@mantine/core/TagInput';

--- a/packages/frontend/src/components/common/TagInput/TagInputRightSection/TagInputRightSection.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInputRightSection/TagInputRightSection.tsx
@@ -1,0 +1,34 @@
+import { CloseButton } from '@mantine/core';
+import { MantineSize } from '@mantine/styles';
+import React from 'react';
+
+export interface TagInputRightSectionProps {
+    shouldClear: boolean;
+    clearButtonProps?: React.ComponentPropsWithoutRef<'button'>;
+    onClear?: () => void;
+    size: MantineSize;
+    error?: any;
+    // eslint-disable-next-line react/no-unused-prop-types
+    disabled?: boolean;
+}
+
+export function TagInputRightSection({
+    shouldClear,
+    clearButtonProps,
+    onClear,
+    size,
+}: TagInputRightSectionProps) {
+    return shouldClear ? (
+        <CloseButton
+            {...clearButtonProps}
+            variant="transparent"
+            onClick={onClear}
+            size={size}
+            onMouseDown={(event) => event.preventDefault()}
+        />
+    ) : (
+        <></>
+    );
+}
+
+TagInputRightSection.displayName = '@mantine/core/TagInputRightSection';

--- a/packages/frontend/src/components/common/TagInput/TagInputRightSection/get-taginput-right-section-props.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInputRightSection/get-taginput-right-section-props.tsx
@@ -1,0 +1,42 @@
+import { MantineTheme } from '@mantine/styles';
+import React from 'react';
+import {
+    TagInputRightSection,
+    TagInputRightSectionProps,
+} from './TagInputRightSection';
+
+interface GetRightSectionProps extends TagInputRightSectionProps {
+    rightSection?: React.ReactNode;
+    rightSectionWidth?: string | number;
+    styles: Record<string, any>;
+    theme: MantineTheme;
+    readOnly: boolean;
+}
+
+export function getTagInputRightSectionProps({
+    styles,
+    rightSection,
+    rightSectionWidth,
+    theme,
+    ...props
+}: GetRightSectionProps) {
+    if (rightSection) {
+        return { rightSection, rightSectionWidth, styles };
+    }
+
+    const _styles = typeof styles === 'function' ? styles(theme) : styles;
+
+    return {
+        rightSection: !props.readOnly &&
+            !(props.disabled && props.shouldClear) && (
+                <TagInputRightSection {...props} />
+            ),
+        styles: {
+            ..._styles,
+            rightSection: {
+                ..._styles?.rightSection,
+                pointerEvents: props.shouldClear ? undefined : 'none',
+            },
+        },
+    };
+}


### PR DESCRIPTION
Closes: #7317 

### Description:

This is a TagInput component that I am introducing to mantine v6 since we are stuck on v6.

Why are we stuck on mantine v6:
- mantine v7 depends on react 18
- upgrading to react 18 breaks blueprint
- blueprint is the problem
- but we should also migrate v6 mantine to v7 because of the breaking changes

---

TagInput Code comes from three sources but **it must be removed with Mantine v7!!!**
- PR that was going to introduce TagInput to Mantine v6.1 https://github.com/mantinedev/mantine/pull/3674
- TagInput from v7 https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/components/TagsInput/TagsInput.tsx#L93
- me


new tag input:
![CleanShot 2023-10-12 at 18 15 46@2x](https://github.com/lightdash/lightdash/assets/962095/f67209a4-4ea5-4913-b5fe-6b41ea5f1a23)

overflow:
![CleanShot 2023-10-12 at 18 15 27@2x](https://github.com/lightdash/lightdash/assets/962095/c8428436-0eef-43de-83fd-26ca56208cf1)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
