### PR TITLE
fix: Disables total toggle for line/area/scatter charts, only show for bar charts.

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -267,24 +267,26 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         });
                     }}
                 />
-                {seriesGroup[0].stack && chartValue === CartesianSeriesType.BAR && (
-                    <Stack spacing="xs" mt="two">
-                        <Text size="xs" fw={500}>
-                            Total
-                        </Text>
-                        <Switch
-                            size="xs"
-                            checked={seriesGroup[0].stackLabel?.show}
-                            onChange={() => {
-                                updateAllGroupedSeries(fieldKey, {
-                                    stackLabel: {
-                                        show: !seriesGroup[0].stackLabel?.show,
-                                    },
-                                });
-                            }}
-                        />
-                    </Stack>
-                )}
+                {seriesGroup[0].stack &&
+                    chartValue === CartesianSeriesType.BAR && (
+                        <Stack spacing="xs" mt="two">
+                            <Text size="xs" fw={500}>
+                                Total
+                            </Text>
+                            <Switch
+                                size="xs"
+                                checked={seriesGroup[0].stackLabel?.show}
+                                onChange={() => {
+                                    updateAllGroupedSeries(fieldKey, {
+                                        stackLabel: {
+                                            show: !seriesGroup[0].stackLabel
+                                                ?.show,
+                                        },
+                                    });
+                                }}
+                            />
+                        </Stack>
+                    )}
             </Group>
             {(chartValue === CartesianSeriesType.LINE ||
                 chartValue === CartesianSeriesType.AREA) && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7408 

### Description:
Showing the total toggle only for BAR charts.
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
