### PR TITLE
feat: add --name to preview

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -102,12 +102,12 @@ export const previewHandler = async (
     );
 
     const previewProject = await getPreviewProject(name);
-    if (previewProject) {        
+    if (previewProject) {
         GlobalState.debug(`> Preview with the same name already running`);
         spinner.fail();
         throw new Error('Preview with the same name already running.');
     }
-    
+
     let project: Project | undefined;
 
     const config = await getConfig();

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -87,11 +87,22 @@ export const previewHandler = async (
 ): Promise<void> => {
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
-    const name = uniqueNamesGenerator({
-        length: 2,
-        separator: ' ',
-        dictionaries: [adjectives, animals],
-    });
+    let name = options?.name;
+    if (name === undefined) {
+        name = uniqueNamesGenerator({
+            length: 2,
+            separator: ' ',
+            dictionaries: [adjectives, animals],
+        });
+    }
+
+    const previewProject = await getPreviewProject(name);
+    if (previewProject) {
+        throw new Error(
+            'Preview with the same name already running.'
+        );
+    }
+
     console.error('');
     const spinner = GlobalState.startSpinner(
         `  Setting up preview environment`,

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -98,9 +98,7 @@ export const previewHandler = async (
 
     const previewProject = await getPreviewProject(name);
     if (previewProject) {
-        throw new Error(
-            'Preview with the same name already running.'
-        );
+        throw new Error('Preview with the same name already running.');
     }
 
     console.error('');

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -96,15 +96,18 @@ export const previewHandler = async (
         });
     }
 
-    const previewProject = await getPreviewProject(name);
-    if (previewProject) {
-        throw new Error('Preview with the same name already running.');
-    }
-
     console.error('');
     const spinner = GlobalState.startSpinner(
         `  Setting up preview environment`,
     );
+
+    const previewProject = await getPreviewProject(name);
+    if (previewProject) {        
+        GlobalState.debug(`> Preview with the same name already running`);
+        spinner.fail();
+        throw new Error('Preview with the same name already running.');
+    }
+    
     let project: Project | undefined;
 
     const config = await getConfig();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -282,6 +282,10 @@ program
     .command('preview')
     .description('Compile Lightdash resources')
     .option(
+        '--name <preview name>',
+        'Custom name for preview. If a name is not provided, a unique randomly generated name will created.'
+    )
+    .option(
         '--project-dir <path>',
         'The directory of the dbt project',
         defaultProjectDir,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -283,7 +283,7 @@ program
     .description('Compile Lightdash resources')
     .option(
         '--name <preview name>',
-        'Custom name for preview. If a name is not provided, a unique randomly generated name will created.',
+        'Custom name for the preview. If a name is not provided, a unique, randomly generated name will be created.',
     )
     .option(
         '--project-dir <path>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -283,7 +283,7 @@ program
     .description('Compile Lightdash resources')
     .option(
         '--name <preview name>',
-        'Custom name for preview. If a name is not provided, a unique randomly generated name will created.'
+        'Custom name for preview. If a name is not provided, a unique randomly generated name will created.',
     )
     .option(
         '--project-dir <path>',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5041 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Added custom preview name through `--name`
- Enforced a single `lightdash preview` with the same name running at the same time

Creating preview - 
![image](https://github.com/lightdash/lightdash/assets/79533543/57e6415c-bff2-46e7-8683-b0c670452d78)

Creating preview with the same name as existing preview -
![image](https://github.com/lightdash/lightdash/assets/79533543/635a4bbf-f706-4de5-9d27-6ed4e2630103)

Aside - It seems that `preview` and `start-preview` can be merged into a single command with a `--live` option that runs `preview`  

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
