### PR TITLE
fix: Disables total toggle for line/area/scatter charts, only show for bar charts

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -267,7 +267,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         });
                     }}
                 />
-                {seriesGroup[0].stack && (
+                {seriesGroup[0].stack && chartValue === CartesianSeriesType.BAR && (
                     <Stack spacing="xs" mt="two">
                         <Text size="xs" fw={500}>
                             Total


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Duplicate: https://github.com/lightdash/lightdash/pull/7454

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
