### PR TITLE
feat: filter inputs - operator inputs to mantine

### DIFF
--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -348,13 +348,16 @@ describe('Date tests', () => {
         );
 
         // Change date operator
-        const select = cy
-            .get('select option[label="is null"]')
-            .parent('select');
-
-        select.should('have.value', 'equals');
-        select.select('notEquals');
-        select.should('have.value', 'notEquals');
+        cy.get('[role="combobox"]').find('input[value="is"]').click();
+        cy.get('[role="listbox"]')
+            .findByRole('option', { name: 'is not' })
+            .click();
+        cy.get('[role="combobox"]')
+            .find('input[value="is"]')
+            .should('not.exist');
+        cy.get('[role="combobox"]')
+            .find('input[value="is not"]')
+            .should('exist');
 
         // Keep same date
         cy.get('.bp4-date-input input').should('have.value', todayDate);

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -1,4 +1,3 @@
-import { HTMLSelect } from '@blueprintjs/core';
 import {
     ConditionalFormattingWithConditionalOperator,
     ConditionalOperator,
@@ -9,6 +8,7 @@ import {
     ActionIcon,
     Collapse,
     Group,
+    Select,
     Stack,
     Text,
     Tooltip,
@@ -70,15 +70,13 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
 
             <Collapse in={isOpen}>
                 <Stack spacing="xs">
-                    <HTMLSelect
-                        fill
-                        onChange={(e) =>
-                            onChangeRuleOperator(
-                                e.target.value as ConditionalOperator,
-                            )
-                        }
-                        options={filterConfig.operatorOptions}
+                    <Select
                         value={rule.operator}
+                        data={filterConfig.operatorOptions}
+                        onChange={(value) => {
+                            if (!value) return;
+                            onChangeRuleOperator(value as ConditionalOperator);
+                        }}
                     />
 
                     <filterConfig.inputs

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -1,4 +1,4 @@
-import { Colors, HTMLSelect } from '@blueprintjs/core';
+import { Colors } from '@blueprintjs/core';
 import {
     createFilterRuleFromField,
     fieldId as getFieldId,
@@ -8,7 +8,7 @@ import {
     getFilterRuleWithDefaultValue,
     getFilterTypeFromItem,
 } from '@lightdash/common';
-import { ActionIcon, Box, Menu } from '@mantine/core';
+import { ActionIcon, Box, Menu, Select } from '@mantine/core';
 import { IconDots, IconX } from '@tabler/icons-react';
 import { FC, useCallback, useMemo } from 'react';
 import FieldSelect from '../FieldSelect';
@@ -88,19 +88,23 @@ const FilterRuleForm: FC<Props> = ({
                         }}
                     />
 
-                    <HTMLSelect
-                        className={!isEditMode ? 'disabled-filter' : ''}
-                        fill={false}
+                    <Select
+                        size="xs"
+                        w="130px"
+                        sx={{ flexShrink: 0 }}
                         disabled={!isEditMode}
-                        style={{ width: 150 }}
-                        onChange={(e) => {
+                        value={filterRule.operator}
+                        data={filterConfig.operatorOptions}
+                        onChange={(value) => {
+                            if (!value) return;
+
                             onChange(
                                 getFilterRuleWithDefaultValue(
                                     activeField,
                                     {
                                         ...filterRule,
-                                        operator: e.currentTarget
-                                            .value as FilterRule['operator'],
+                                        operator:
+                                            value as FilterRule['operator'],
                                     },
                                     (filterRule.values?.length || 0) > 0
                                         ? filterRule.values
@@ -108,8 +112,6 @@ const FilterRuleForm: FC<Props> = ({
                                 ),
                             );
                         }}
-                        options={filterConfig.operatorOptions}
-                        value={filterRule.operator}
                     />
 
                     <filterConfig.inputs

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -90,7 +90,7 @@ const FilterRuleForm: FC<Props> = ({
 
                     <Select
                         size="xs"
-                        w="130px"
+                        w="150px"
                         sx={{ flexShrink: 0 }}
                         disabled={!isEditMode}
                         value={filterRule.operator}


### PR DESCRIPTION
Closes: #7338 

### Description:
migrates operator inputs from blueprint to mantine

in explore:
![CleanShot 2023-10-13 at 11 06 22@2x](https://github.com/lightdash/lightdash/assets/962095/f22b2158-8335-4e08-985b-11c887054d44)

explore filters with disabled state:
![CleanShot 2023-10-13 at 11 06 15@2x](https://github.com/lightdash/lightdash/assets/962095/da533a2f-2f68-4598-9a80-52da7960f4dd)


in conditional formatting:

![CleanShot 2023-10-13 at 10 52 52@2x](https://github.com/lightdash/lightdash/assets/962095/aaf19c5a-6b75-4307-836c-2f391bdb1c80)



### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
