### PR TITLE
fix: posthog analytics feature layout

### DIFF
--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -10,7 +10,7 @@ import EChartsReact from 'echarts-for-react';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { PostHogFeature } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -316,35 +316,37 @@ const UserActivity: FC = () => {
                     </Table>
                 </ActivityCard>
 
-                <PostHogFeature flag={'extended-usage-analytics'} match={true}>
-                    <ActivityCard grid="table-dashboard-views">
-                        <Description>Dashboard views (top 20)</Description>
-                        <Table withColumnBorders ta="left">
-                            <thead>
-                                <tr>
-                                    <th>Dashboard name</th>
-                                    <th>Views</th>
-                                </tr>
-                            </thead>
-                            {showTableViews(
-                                'dashboard-views',
-                                data.dashboardViews,
-                            )}
-                        </Table>
-                    </ActivityCard>
-                    <ActivityCard grid="table-chart-views">
-                        <Description>Chart views (top 20)</Description>
-                        <Table withColumnBorders ta="left">
-                            <thead>
-                                <tr>
-                                    <th>Chart name</th>
-                                    <th>Views</th>
-                                </tr>
-                            </thead>
-                            {showTableViews('chart-views', data.chartViews)}
-                        </Table>
-                    </ActivityCard>
-                </PostHogFeature>
+                {posthog.isFeatureEnabled('extended-usage-analytics') ? (
+                    <>
+                        <ActivityCard grid="table-dashboard-views">
+                            <Description>Dashboard views (top 20)</Description>
+                            <Table withColumnBorders ta="left">
+                                <thead>
+                                    <tr>
+                                        <th>Dashboard name</th>
+                                        <th>Views</th>
+                                    </tr>
+                                </thead>
+                                {showTableViews(
+                                    'dashboard-views',
+                                    data.dashboardViews,
+                                )}
+                            </Table>
+                        </ActivityCard>
+                        <ActivityCard grid="table-chart-views">
+                            <Description>Chart views (top 20)</Description>
+                            <Table withColumnBorders ta="left">
+                                <thead>
+                                    <tr>
+                                        <th>Chart name</th>
+                                        <th>Views</th>
+                                    </tr>
+                                </thead>
+                                {showTableViews('chart-views', data.chartViews)}
+                            </Table>
+                        </ActivityCard>
+                    </>
+                ) : null}
             </Container>
         </Page>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Fixes layout issue with posthog

<PosthogFeature> creates a `div`, that breaks the layout on analytics page. 

Before:

https://lightdash.slack.com/archives/C053ESBT36V/p1697186588749739?thread_ts=1696937066.677159&cid=C053ESBT36V

After:


![Screenshot from 2023-10-13 10-51-15](https://github.com/lightdash/lightdash/assets/1983672/1dc84289-056d-4725-906f-c19f30004fa2)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
