### PR TITLE
fix: incorrectly created shared space when private selected

### DIFF
--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -135,6 +135,11 @@ const SpaceModal: FC<ActionModalProps> = ({
                                         <SimpleButton
                                             text="Back"
                                             onClick={(ev) => {
+                                                form.setValue(
+                                                    'access',
+                                                    undefined,
+                                                );
+                                                console.log(form.getValues());
                                                 setModalStep(
                                                     CreateModalStep.SET_NAME,
                                                 );

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -139,7 +139,6 @@ const SpaceModal: FC<ActionModalProps> = ({
                                                     'access',
                                                     undefined,
                                                 );
-                                                console.log(form.getValues());
                                                 setModalStep(
                                                     CreateModalStep.SET_NAME,
                                                 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7475<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Reset value of form when clicking the 'Back' button

<!-- Even better add a screenshot / gif / loom -->
Before - 
https://www.loom.com/share/5f899005f3da435483ec2c8fbaeb331c
After - 
https://www.loom.com/share/1ea55c65f28f4d998d24fdc77fd8af51

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
