### PR TITLE
fix: ssh test connection before run query

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1161,7 +1161,10 @@ export class ProjectService {
                             metricQuery: JSON.stringify(metricQuery),
                             type: warehouseClient.credentials.type,
                         },
-                        async () => warehouseClient.runQuery(query, queryTags),
+                        async () => {
+                            await sshTunnel.testConnection();
+                            return warehouseClient.runQuery(query, queryTags);
+                        },
                     );
                     await sshTunnel.disconnect();
                     return rows;
@@ -1210,6 +1213,7 @@ export class ProjectService {
             organization_uuid: organizationUuid,
             user_uuid: user.userUuid,
         };
+        await sshTunnel.testConnection();
         const results = await warehouseClient.runQuery(sql, queryTags);
         await sshTunnel.disconnect();
         return results;
@@ -1319,6 +1323,7 @@ export class ProjectService {
             user_uuid: user.userUuid,
             project_uuid: projectUuid,
         };
+        await sshTunnel.testConnection();
         const { rows } = await warehouseClient.runQuery(query, queryTags);
         await sshTunnel.disconnect();
 

--- a/packages/warehouses/src/ssh/sshTunnel.ts
+++ b/packages/warehouses/src/ssh/sshTunnel.ts
@@ -80,8 +80,27 @@ export class SshTunnel<T extends CreateWarehouseCredentials> {
 
     disconnect = async (): Promise<void> => {
         if (this.sshConnection) {
-            console.info('Closing SSH tunnel');
             await this.sshConnection.close();
+        }
+    };
+
+    testConnection = async (): Promise<void> => {
+        const { type } = this.originalCredentials;
+        switch (type) {
+            case WarehouseTypes.POSTGRES:
+            case WarehouseTypes.REDSHIFT:
+                if (
+                    this.sshConnection &&
+                    this.originalCredentials.useSshTunnel
+                ) {
+                    const port = await this.sshConnection.connect();
+                    if (Object.keys(port.activeTunnels).length === 0) {
+                        throw new Error('No active SSH tunnels');
+                    }
+                }
+                break;
+            default:
+                break;
         }
     };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7444

### Description:


This will test connection before running a query, makes the server responsive in case one or more requests fail because of the tunnel. 

![Screenshot from 2023-10-16 16-35-42](https://github.com/lightdash/lightdash/assets/1983672/c4b6cfd3-238a-4c88-9974-f7f3ce60e1e4)

The tunnel object: 

With active connection

![Screenshot from 2023-10-16 16-28-26](https://github.com/lightdash/lightdash/assets/1983672/204fb3e4-4b3f-4a90-af14-abfa7f31c0c9)

Without active connection

![Screenshot from 2023-10-16 16-28-43](https://github.com/lightdash/lightdash/assets/1983672/43057803-2ee9-4e63-8f33-22d56a3f214b)


I was hoping this ssh library was using the event emitter interface, so I was expecting to do a `tunnel.on('close')`  to keep track of its state, but I couldn't find anything in the docs 


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
