### PR TITLE
fix: hide add filter button if not in edit mode

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -178,7 +178,7 @@ const FilterGroupForm: FC<Props> = ({
                     </React.Fragment>
                 ))}
             </FilterGroupItemsWrapper>
-            {!hideButtons && fields.length > 0 && (
+            {isEditMode && !hideButtons && fields.length > 0 && (
                 <Button
                     variant="light"
                     size="xs"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7500 

### Description:

Only show `Add Filter` if in Edit mode

Before: in issue ^

After:
<img width="739" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/e7314d38-8f73-4f35-84dc-77c029f6ef5b">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
