### PR TITLE
fix: auto refresh on renaming a space from spaces page

### DIFF
--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -142,6 +142,11 @@ export const useUpdateMutation = (projectUuid: string, spaceUuid: string) => {
         {
             mutationKey: ['space_update', projectUuid],
             onSuccess: async (data) => {
+                await queryClient.invalidateQueries([
+                    'projects',
+                    projectUuid,
+                    'spaces',
+                ]);
                 await queryClient.refetchQueries(['spaces', projectUuid]);
                 queryClient.setQueryData(
                     ['space', projectUuid, spaceUuid],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7491 

### Description:

Updating the space name did not auto refresh on spaces page. Please see attached video for the fix:

https://github.com/lightdash/lightdash/assets/20976813/62167e96-99b2-4a42-a2aa-3fce330ed96a


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
