### PR TITLE
fix: explore filters add filter button should be disabled in view mode

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -178,7 +178,8 @@ const FilterGroupForm: FC<Props> = ({
                     </React.Fragment>
                 ))}
             </FilterGroupItemsWrapper>
-            {!hideButtons && fields.length > 0 && (
+
+            {isEditMode && !hideButtons && fields.length > 0 && (
                 <Button
                     variant="light"
                     size="xs"


### PR DESCRIPTION
Closes: #7500 

### Description:
--- 
**edit mode:**
![CleanShot 2023-10-17 at 15 22 52@2x](https://github.com/lightdash/lightdash/assets/962095/169c0605-e16b-4520-8357-fdb861851522)

---

**view mode:**
![CleanShot 2023-10-17 at 15 22 59@2x](https://github.com/lightdash/lightdash/assets/962095/f37a4d6f-dbed-49a0-ae9b-a59b5075b7ce)

---

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
