### PR TITLE
feat: add a validation function to TagInput

### DIFF
--- a/packages/frontend/src/components/common/TagInput/TagInput.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInput.tsx
@@ -76,8 +76,11 @@ export interface TagInputProps
 
     splitChars?: string[];
 
-    /** Called for validation when add tags */
+    /** Used for validation when adding tags */
     validationRegex?: RegExp;
+
+    /** Called for validation when adding tags */
+    validationFunction?: (data: string) => boolean;
 
     /** Called when validationRegex reject tags */
     onValidationReject?: (data: string[]) => void;
@@ -200,6 +203,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
             maxTags,
             splitChars,
             validationRegex,
+            validationFunction,
             searchValue,
             defaultSearchValue,
             onValidationReject,
@@ -279,9 +283,16 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
                 );
             }
 
-            const rejectedTags = tags.filter(
-                (tag) => !validationRegex!.test(tag),
-            );
+            const rejectedTags = tags.filter((tag) => {
+                if (validationFunction) {
+                    return (
+                        !validationRegex!.test(tag) ||
+                        (validationFunction ? !validationFunction(tag) : true)
+                    );
+                }
+
+                return !validationRegex!.test(tag);
+            });
 
             if (maxTags && maxTags >= 0) {
                 const remainingLimit = Math.max(maxTags - _value.length, 0);
@@ -447,6 +458,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
                 disabled={disabled}
                 // @ts-ignore
                 autoComplete="off"
+                data-1p-ignore
                 {...rest}
             />
         );


### PR DESCRIPTION
### Description:

Add a validationFunction to TagInput. It already has a way to pass a regex, but it's a common pattern to pass a function for validation. For example, we use validateEmail and others in a number of places. 

- If neither validationRegex nor validationFunction is set, any value is allowed
- If only one of them is set, rejections are based on that one
- If both are set, new values must pass both tests

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
