### PR TITLE
fix: parsing all references

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -211,15 +211,15 @@ describe('Compile metrics with filters', () => {
 describe('Parse dimension reference', () => {
     test('should parse dimensions', () => {
         expect(parseAllReferences('${dimension} == 1', 'table')).toStrictEqual([
-            { refName: 'dimension}', refTable: 'table' },
+            { refName: 'dimension', refTable: 'table' },
         ]);
         expect(parseAllReferences('${table.dimension}', 'table')).toStrictEqual(
-            [{ refName: 'dimension}', refTable: 'table' }],
+            [{ refName: 'dimension', refTable: 'table' }],
         );
     });
     test('should parse TABLE', () => {
         expect(parseAllReferences('${TABLE}', 'table')).toStrictEqual([
-            { refName: 'TABLE}', refTable: 'table' },
+            { refName: 'TABLE', refTable: 'table' },
         ]);
     });
     test('should not parse lightdash attribute', () => {
@@ -238,12 +238,12 @@ describe('Parse dimension reference', () => {
         expect(
             parseAllReferences('${lightdash_dimension} == 1', 'table'),
         ).toStrictEqual([
-            { refName: 'lightdash_dimension}', refTable: 'table' },
+            { refName: 'lightdash_dimension', refTable: 'table' },
         ]);
         expect(
             parseAllReferences('${dimension_lightdash} == 1', 'table'),
         ).toStrictEqual([
-            { refName: 'dimension_lightdash}', refTable: 'table' },
+            { refName: 'dimension_lightdash', refTable: 'table' },
         ]);
         expect(
             parseAllReferences(
@@ -251,7 +251,7 @@ describe('Parse dimension reference', () => {
                 'lightdash_table',
             ),
         ).toStrictEqual([
-            { refName: 'dimension}', refTable: 'lightdash_table' },
+            { refName: 'dimension', refTable: 'lightdash_table' },
         ]);
         expect(
             parseAllReferences(
@@ -259,13 +259,13 @@ describe('Parse dimension reference', () => {
                 'table_lightdash',
             ),
         ).toStrictEqual([
-            { refName: 'dimension}', refTable: 'table_lightdash' },
+            { refName: 'dimension', refTable: 'table_lightdash' },
         ]);
         expect(
             parseAllReferences('${ld_dimension} == 1', 'table'),
-        ).toStrictEqual([{ refName: 'ld_dimension}', refTable: 'table' }]);
+        ).toStrictEqual([{ refName: 'ld_dimension', refTable: 'table' }]);
         expect(
             parseAllReferences('${ld_table.ld_dimension} == 1', 'ld_table'),
-        ).toStrictEqual([{ refName: 'ld_dimension}', refTable: 'ld_table' }]);
+        ).toStrictEqual([{ refName: 'ld_dimension', refTable: 'ld_table' }]);
     });
 });

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -46,9 +46,10 @@ export const parseAllReferences = (
     raw: string,
     currentTable: string,
 ): Reference[] =>
-    (raw.match(lightdashVariablePattern) || []).map((value) =>
-        getParsedReference(value.slice(2), currentTable),
-    );
+    (raw.match(lightdashVariablePattern) || []).map((value) => {
+        const valueWithoutBrackets = value.slice(2, value.length - 1);
+        return getParsedReference(valueWithoutBrackets, currentTable);
+    });
 
 export type UncompiledExplore = {
     name: string;


### PR DESCRIPTION
Fix necessary for #7434

Problem, we didn't remove the final `}` from the reference name. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
