### PR TITLE
feat: joined table fields can now omit fields used in the SQL

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -907,17 +907,6 @@ export const joinedExploreWithSubsetOfFields: UncompiledExplore = {
     ],
 };
 
-export const joinedExploreWithSubsetOfFieldsCausingError: UncompiledExplore = {
-    ...exploreReferenceInJoin,
-    joinedTables: [
-        {
-            table: 'b',
-            sqlOn: '${a.dim1} = ${b.dim1}',
-            fields: ['dim2'], // not possible because it dim1 is also needed for the join sql
-        },
-    ],
-};
-
 export const compiledJoinedExploreWithSubsetOfFields: Explore = {
     ...exploreReferenceInJoinCompiled,
     tables: {
@@ -932,6 +921,40 @@ export const compiledJoinedExploreWithSubsetOfFields: Explore = {
         },
     },
 };
+
+export const joinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields: UncompiledExplore =
+    {
+        ...exploreReferenceInJoin,
+        joinedTables: [
+            {
+                table: 'b',
+                sqlOn: '${a.dim1} = ${b.dim1}',
+                fields: ['dim2'], // doesn't include "dim1" that is required for join SQL
+            },
+        ],
+    };
+
+export const compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields: Explore =
+    {
+        ...exploreReferenceInJoinCompiled,
+        tables: {
+            ...exploreReferenceInJoinCompiled.tables,
+            b: {
+                ...exploreReferenceInJoinCompiled.tables.b,
+                dimensions: {
+                    dim1: {
+                        ...exploreReferenceInJoinCompiled.tables.b.dimensions
+                            .dim1,
+                        hidden: true,
+                    },
+                    dim2: {
+                        ...exploreReferenceInJoinCompiled.tables.b.dimensions
+                            .dim2,
+                    },
+                },
+            },
+        },
+    };
 
 export const exploreWithMetricNumber: UncompiledExplore = {
     ...exploreBase,

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -6,6 +6,7 @@ import {
     compiledJoinedExploreOverridingJoinAlias,
     compiledJoinedExploreOverridingJoinLabel,
     compiledJoinedExploreWithSubsetOfFields,
+    compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     compiledSimpleJoinedExplore,
     exploreCircularDimensionReference,
     exploreCircularDimensionShortReference,
@@ -31,7 +32,7 @@ import {
     joinedExploreOverridingJoinAlias,
     joinedExploreOverridingJoinLabel,
     joinedExploreWithSubsetOfFields,
-    joinedExploreWithSubsetOfFieldsCausingError,
+    joinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     simpleJoinedExplore,
     tablesWithMetricsWithFilters,
     warehouseClientMock,
@@ -139,12 +140,14 @@ describe('Explores with a base table and joined table', () => {
             compiler.compileExplore(joinedExploreWithSubsetOfFields),
         ).toStrictEqual(compiledJoinedExploreWithSubsetOfFields);
     });
-    test('should throw error if referenced field is removed from join', () => {
-        expect(() =>
+    test('should compile with a subset of fields selected on join what dont include the fields in the join SQL', () => {
+        expect(
             compiler.compileExplore(
-                joinedExploreWithSubsetOfFieldsCausingError,
+                joinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
             ),
-        ).toThrowError(CompileError);
+        ).toStrictEqual(
+            compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
+        );
     });
 });
 

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,7 +11,6 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
-    fieldId,
     friendlyName,
     isNonAggregateMetric,
     Metric,
@@ -182,7 +181,6 @@ export class ExploreCompiler {
             },
             { [baseTable]: tables[baseTable] },
         );
-        console.log('includedTables', includedTables);
 
         const compiledTables: Record<string, CompiledTable> = aliases.reduce(
             (prev, tableName) => ({

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -132,8 +132,7 @@ export class ExploreCompiler {
                         dimensions: Object.keys(tableDimensions).reduce<
                             Record<string, Dimension>
                         >((acc, dimensionKey) => {
-                            const dimension =
-                                tables[join.table].dimensions[dimensionKey];
+                            const dimension = tableDimensions[dimensionKey];
                             const isRequired =
                                 requiredDimensionsForJoin.includes(
                                     dimensionKey,
@@ -141,11 +140,8 @@ export class ExploreCompiler {
                             const isVisible =
                                 join.fields === undefined ||
                                 join.fields.includes(dimensionKey) ||
-                                (tableDimensions[dimensionKey].group !==
-                                    undefined &&
-                                    join.fields.includes(
-                                        tableDimensions[dimensionKey].group!,
-                                    ));
+                                (dimension.group !== undefined &&
+                                    join.fields.includes(dimension.group));
 
                             if (isRequired || isVisible) {
                                 acc[dimensionKey] = {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,6 +11,7 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
+    fieldId,
     friendlyName,
     isNonAggregateMetric,
     Metric,
@@ -112,6 +113,15 @@ export class ExploreCompiler {
                     join.label ||
                     (join.alias && friendlyName(join.alias)) ||
                     tables[join.table].label;
+                const requiredDimensionsForJoin = parseAllReferences(
+                    join.sqlOn,
+                    join.table,
+                ).reduce<string[]>((acc, reference) => {
+                    if (reference.refTable === join.table) {
+                        acc.push(reference.refName);
+                    }
+                    return acc;
+                }, []);
 
                 const tableDimensions = tables[join.table].dimensions;
                 return {
@@ -120,29 +130,34 @@ export class ExploreCompiler {
                         ...tables[join.table],
                         name: joinTableName,
                         label: joinTableLabel,
-                        dimensions: Object.keys(tableDimensions)
-                            .filter(
-                                (d) =>
-                                    join.fields === undefined ||
-                                    join.fields.includes(d) ||
-                                    (tableDimensions[d].group !== undefined &&
-                                        join.fields.includes(
-                                            tableDimensions[d].group!,
-                                        )),
-                            )
-                            .reduce<Record<string, Dimension>>(
-                                (prevDimensions, dimensionKey) => ({
-                                    ...prevDimensions,
-                                    [dimensionKey]: {
-                                        ...tables[join.table].dimensions[
-                                            dimensionKey
-                                        ],
-                                        table: joinTableName,
-                                        tableLabel: joinTableLabel,
-                                    },
-                                }),
-                                {},
-                            ),
+                        dimensions: Object.keys(tableDimensions).reduce<
+                            Record<string, Dimension>
+                        >((acc, dimensionKey) => {
+                            const dimension =
+                                tables[join.table].dimensions[dimensionKey];
+                            const isRequired =
+                                requiredDimensionsForJoin.includes(
+                                    dimensionKey,
+                                );
+                            const isVisible =
+                                join.fields === undefined ||
+                                join.fields.includes(dimensionKey) ||
+                                (tableDimensions[dimensionKey].group !==
+                                    undefined &&
+                                    join.fields.includes(
+                                        tableDimensions[dimensionKey].group!,
+                                    ));
+
+                            if (isRequired || isVisible) {
+                                acc[dimensionKey] = {
+                                    ...dimension,
+                                    hidden: !isVisible,
+                                    table: joinTableName,
+                                    tableLabel: joinTableLabel,
+                                };
+                            }
+                            return acc;
+                        }, {}),
                         metrics: Object.keys(tables[join.table].metrics)
                             .filter(
                                 (d) =>
@@ -167,6 +182,7 @@ export class ExploreCompiler {
             },
             { [baseTable]: tables[baseTable] },
         );
+        console.log('includedTables', includedTables);
 
         const compiledTables: Record<string, CompiledTable> = aliases.reduce(
             (prev, tableName) => ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7434<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

example yml
```
  - name: orders
    meta:
      joins:
        - join: customers
          sql_on: ${customers.customer_id} = ${orders.customer_id}
          fields: [first_name, last_name] # we don't need to include 'customer_id' anymore
```

Query using join table, customer id is used in the join but not available in the sidebar.

<img width="1387" alt="Screenshot 2023-10-17 at 16 40 39" src="https://github.com/lightdash/lightdash/assets/9117144/16358713-b889-402f-a7cc-b21a975e79f5">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
