### PR TITLE
chore: scheduler send now

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
@@ -1,0 +1,68 @@
+import { Box, Button, Group } from '@mantine/core';
+import { IconChevronLeft, IconSend } from '@tabler/icons-react';
+import React from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+interface FooterProps {
+    confirmText?: string;
+    onBack?: () => void;
+    onSendNow?: () => void;
+    onCancel?: () => void;
+    onConfirm?: () => void;
+    loading?: boolean;
+}
+
+const SchedulersModalFooter = ({
+    confirmText = 'Confirm',
+    onBack,
+    onCancel,
+    onSendNow,
+    onConfirm,
+    loading,
+}: FooterProps) => {
+    return (
+        <Group
+            position="apart"
+            sx={(theme) => ({
+                position: 'sticky',
+                backgroundColor: 'white',
+                borderTop: `1px solid ${theme.colors.gray[4]}`,
+                bottom: 0,
+                padding: theme.spacing.md,
+            })}
+        >
+            {!!onBack ? (
+                <Button
+                    onClick={onBack}
+                    variant="subtle"
+                    leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                >
+                    Back
+                </Button>
+            ) : (
+                <Box />
+            )}
+            <Group>
+                {!!onCancel && (
+                    <Button onClick={onCancel} variant="outline">
+                        Cancel
+                    </Button>
+                )}
+                {!!onSendNow && (
+                    <Button
+                        variant="light"
+                        leftIcon={<MantineIcon icon={IconSend} />}
+                        onClick={onSendNow}
+                    >
+                        Send now
+                    </Button>
+                )}
+                <Button type="submit" loading={loading} onClick={onConfirm}>
+                    {confirmText}
+                </Button>
+            </Group>
+        </Group>
+    );
+};
+
+export default SchedulersModalFooter;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7386 

### Description:

> **NOTE**: to test these changes, turn the feature flag on by pasting and running this in the console: `localStorage.setItem('scheduler-modal-2', true)`

Add 'Send now' to the new scheduled deliveries form. This also includes moving footer code to its own file. The footer doesn't change, the main changes here are:

- Add the send now handler
- Validate before sending
- Add types to form transformation

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
