### PR TITLE
chore: add customization tab to scheduler modal

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm2.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm2.tsx
@@ -20,6 +20,7 @@ import {
     SegmentedControl,
     Space,
     Stack,
+    Tabs,
     Text,
     TextInput,
 } from '@mantine/core';
@@ -33,6 +34,7 @@ import {
     IconMail,
     IconSettings,
 } from '@tabler/icons-react';
+import MDEditor, { commands } from '@uiw/react-md-editor';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { TagInput } from '../../../components/common/TagInput/TagInput';
 import { hasRequiredScopes } from '../../../components/UserSettings/SlackSettingsPanel';
@@ -245,312 +247,364 @@ const SchedulerForm2: FC<{
 
     return (
         <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
-            <Stack
-                sx={(theme) => ({
-                    backgroundColor: theme.white,
-                    paddingRight: theme.spacing.xl,
-                })}
-                spacing="xl"
-                py="sm"
-                px="md"
-            >
-                <TextInput
-                    label="Delivery name"
-                    placeholder="Name your delivery"
-                    required
-                    {...form.getInputProps('name')}
-                />
-                <Input.Wrapper label="Delivery frequency">
-                    {/* TODO: Cron inputs */}
-                    <TextInput
-                        disabled
-                        placeholder="Always Monday at 9am for now"
-                        mt={3}
-                    ></TextInput>
-                </Input.Wrapper>
-                <Stack spacing={0}>
-                    <Input.Label mb="xxs"> Format </Input.Label>
-                    <Group spacing="xs" noWrap>
-                        <SegmentedControl
-                            data={[
-                                { label: '.csv', value: SchedulerFormat.CSV },
-                                {
-                                    label: 'Image',
-                                    value: SchedulerFormat.IMAGE,
-                                    disabled: isImageDisabled,
-                                },
-                            ]}
-                            w="50%"
-                            mb="xs"
-                            {...form.getInputProps('format')}
+            <Tabs defaultValue="setup">
+                <Tabs.List mt="sm" mb={0}>
+                    <Tabs.Tab value="setup" ml="md">
+                        Setup
+                    </Tabs.Tab>
+                    <Tabs.Tab value="customization">Customization</Tabs.Tab>
+                </Tabs.List>
+                <Tabs.Panel value="setup" mt="md">
+                    <Stack
+                        sx={(theme) => ({
+                            backgroundColor: theme.white,
+                            paddingRight: theme.spacing.xl,
+                        })}
+                        spacing="xl"
+                        px="md"
+                    >
+                        <TextInput
+                            label="Delivery name"
+                            placeholder="Name your delivery"
+                            required
+                            {...form.getInputProps('name')}
                         />
-                        {isImageDisabled && (
-                            <Text
-                                size="xs"
-                                color="gray.6"
-                                w={185}
-                                sx={{ alignSelf: 'start' }}
-                            >
-                                You must enable the
-                                <Anchor href="https://docs.lightdash.com/self-host/customize-deployment/enable-headless-browser-for-lightdash">
-                                    {' '}
-                                    headless browser{' '}
-                                </Anchor>
-                                to send images
-                            </Text>
-                        )}
-                    </Group>
-                    <Space h="xxs" />
-                    {form.getInputProps('format').value ===
-                    SchedulerFormat.IMAGE ? (
-                        <Checkbox
-                            h={26}
-                            label="Also include image as PDF attachment"
-                            labelPosition="left"
-                            {...form.getInputProps('options.withPdf', {
-                                type: 'checkbox',
-                            })}
-                        />
-                    ) : (
-                        <Stack spacing="xs">
-                            <Button
-                                variant="subtle"
-                                compact
-                                sx={{
-                                    alignSelf: 'start',
-                                }}
-                                leftIcon={<MantineIcon icon={IconSettings} />}
-                                rightIcon={
-                                    <MantineIcon
-                                        icon={
-                                            showFormatting
-                                                ? IconChevronUp
-                                                : IconChevronDown
-                                        }
-                                    />
-                                }
-                                onClick={() => setShowFormatting((old) => !old)}
-                            >
-                                Formatting options
-                            </Button>
-                            <Collapse in={showFormatting} pl="md">
-                                <Group align="start" spacing="xxl">
-                                    <Radio.Group
-                                        label="Values"
-                                        {...form.getInputProps(
-                                            'options.formatted',
-                                        )}
+                        <Input.Wrapper label="Delivery frequency">
+                            {/* TODO: Cron inputs */}
+                            <TextInput
+                                disabled
+                                placeholder="Always Monday at 9am for now"
+                                mt={3}
+                            ></TextInput>
+                        </Input.Wrapper>
+                        <Stack spacing={0}>
+                            <Input.Label mb="xxs"> Format </Input.Label>
+                            <Group spacing="xs" noWrap>
+                                <SegmentedControl
+                                    data={[
+                                        {
+                                            label: '.csv',
+                                            value: SchedulerFormat.CSV,
+                                        },
+                                        {
+                                            label: 'Image',
+                                            value: SchedulerFormat.IMAGE,
+                                            disabled: isImageDisabled,
+                                        },
+                                    ]}
+                                    w="50%"
+                                    mb="xs"
+                                    {...form.getInputProps('format')}
+                                />
+                                {isImageDisabled && (
+                                    <Text
+                                        size="xs"
+                                        color="gray.6"
+                                        w="30%"
+                                        sx={{ alignSelf: 'start' }}
                                     >
-                                        <Stack spacing="xxs" pt="xs">
-                                            <Radio
-                                                label="Formatted"
-                                                value={Values.FORMATTED}
-                                            />
-                                            <Radio
-                                                label="Raw"
-                                                value={Values.RAW}
-                                            />
-                                        </Stack>
-                                    </Radio.Group>
-                                    <Stack spacing="xs">
-                                        <Radio.Group
-                                            label="Limit"
-                                            {...form.getInputProps(
-                                                'options.limit',
-                                            )}
-                                        >
-                                            <Stack spacing="xxs" pt="xs">
-                                                <Radio
-                                                    label="Results in Table"
-                                                    value={Limit.TABLE}
-                                                />
-                                                <Radio
-                                                    label="All Results"
-                                                    value={Limit.ALL}
-                                                />
-                                                <Radio
-                                                    label="Custom..."
-                                                    value={Limit.CUSTOM}
-                                                />
-                                            </Stack>
-                                        </Radio.Group>
-                                        {limit === Limit.CUSTOM && (
-                                            <NumberInput
-                                                w={150}
-                                                min={1}
-                                                precision={0}
-                                                required
-                                                {...form.getInputProps(
-                                                    'options.customLimit',
-                                                )}
-                                            />
-                                        )}
-
-                                        {(form.values?.options?.limit ===
-                                            Limit.ALL ||
-                                            form.values?.options?.limit ===
-                                                Limit.CUSTOM) && (
-                                            <i>
-                                                Results are limited to{' '}
-                                                {Number(
-                                                    health.data?.query
-                                                        .csvCellsLimit ||
-                                                        100000,
-                                                ).toLocaleString()}{' '}
-                                                cells for each file
-                                            </i>
-                                        )}
-                                    </Stack>
-                                </Group>
-                            </Collapse>
-                        </Stack>
-                    )}
-                </Stack>
-
-                <Input.Wrapper
-                    label="Destinations"
-                    description={
-                        showDestinationLabel ? 'No destination(s) selected' : ''
-                    }
-                >
-                    <Stack mt="sm">
-                        <Group noWrap>
-                            <MantineIcon
-                                icon={IconMail}
-                                size="xl"
-                                color="gray.7"
-                            />
-                            <HoverCard
-                                disabled={!isAddEmailDisabled}
-                                width={300}
-                                position="bottom-start"
-                                shadow="md"
-                            >
-                                <HoverCard.Target>
-                                    <Box w="100%">
-                                        <TagInput
-                                            clearable
-                                            error={emailValidationError || null}
-                                            placeholder="Enter email addresses"
-                                            disabled={isAddEmailDisabled}
-                                            value={form.values?.emailTargets}
-                                            allowDuplicates={false}
-                                            splitChars={[',', ' ']}
-                                            validationFunction={validateEmail}
-                                            onBlur={() =>
-                                                setEmailValidationError(
-                                                    undefined,
-                                                )
-                                            }
-                                            onValidationReject={(val) =>
-                                                setEmailValidationError(
-                                                    `'${val}' doesn't appear to be an email address`,
-                                                )
-                                            }
-                                            onChange={(val) => {
-                                                setEmailValidationError(
-                                                    undefined,
-                                                );
-                                                form.setFieldValue(
-                                                    'emailTargets',
-                                                    val,
-                                                );
-                                            }}
-                                        />
-                                    </Box>
-                                </HoverCard.Target>
-                                <HoverCard.Dropdown>
-                                    <>
-                                        <Text pb="sm">
-                                            No Email integration found
-                                        </Text>
-                                        <Text>
-                                            To create an email scheduled
-                                            delivery, you need to add
-                                            <Anchor
-                                                target="_blank"
-                                                href="https://docs.lightdash.com/references/environmentVariables"
-                                            >
-                                                {' '}
-                                                SMTP environment variables{' '}
-                                            </Anchor>
-                                            for your Lightdash instance
-                                        </Text>
-                                    </>
-                                </HoverCard.Dropdown>
-                            </HoverCard>
-                        </Group>
-                        <Stack spacing="sm">
-                            <Group noWrap>
-                                <SlackIcon style={{ margin: '5px 2px' }} />
-                                <HoverCard
-                                    disabled={!isAddSlackDisabled}
-                                    width={300}
-                                    position="bottom-start"
-                                    shadow="md"
-                                >
-                                    <HoverCard.Target>
-                                        <Box w="100%">
-                                            <MultiSelect
-                                                placeholder="Search slack channels"
-                                                data={slackChannels}
-                                                searchable
-                                                creatable
-                                                rightSection={
-                                                    slackChannelsQuery.isLoading ?? (
-                                                        <Loader size="sm" />
-                                                    )
-                                                }
-                                                disabled={isAddSlackDisabled}
-                                                getCreateLabel={(query) =>
-                                                    `Send to private channel #${query}`
-                                                }
-                                                onCreate={(newItem) => {
-                                                    setPrivateChannels(
-                                                        (current) => [
-                                                            ...current,
-                                                            {
-                                                                label: newItem,
-                                                                value: newItem,
-                                                                group: 'Private channels',
-                                                            },
-                                                        ],
-                                                    );
-                                                    return newItem;
-                                                }}
-                                                onChange={(val) => {
-                                                    form.setFieldValue(
-                                                        'slackTargets',
-                                                        val,
-                                                    );
-                                                }}
-                                            />
-                                        </Box>
-                                    </HoverCard.Target>
-                                    <HoverCard.Dropdown>
-                                        <SlackErrorContent
-                                            slackState={slackState}
-                                        />
-                                    </HoverCard.Dropdown>
-                                </HoverCard>
+                                        You must enable the
+                                        <Anchor href="https://docs.lightdash.com/self-host/customize-deployment/enable-headless-browser-for-lightdash">
+                                            {' '}
+                                            headless browser{' '}
+                                        </Anchor>
+                                        to send images
+                                    </Text>
+                                )}
                             </Group>
-                            {!isAddSlackDisabled && (
-                                <Text size="xs" color="gray.6" ml="3xl">
-                                    If delivering to a private Slack channel,
-                                    please type the name of the channel in the
-                                    input box exactly as it appears in Slack.
-                                    Also ensure you invite the Lightdash
-                                    Slackbot into that channel.
-                                </Text>
+                            <Space h="xxs" />
+                            {form.getInputProps('format').value ===
+                            SchedulerFormat.IMAGE ? (
+                                <Checkbox
+                                    h={26}
+                                    label="Also include image as PDF attachment"
+                                    labelPosition="left"
+                                    {...form.getInputProps('options.withPdf', {
+                                        type: 'checkbox',
+                                    })}
+                                />
+                            ) : (
+                                <Stack spacing="xs">
+                                    <Button
+                                        variant="subtle"
+                                        compact
+                                        sx={{
+                                            alignSelf: 'start',
+                                        }}
+                                        leftIcon={
+                                            <MantineIcon icon={IconSettings} />
+                                        }
+                                        rightIcon={
+                                            <MantineIcon
+                                                icon={
+                                                    showFormatting
+                                                        ? IconChevronUp
+                                                        : IconChevronDown
+                                                }
+                                            />
+                                        }
+                                        onClick={() =>
+                                            setShowFormatting((old) => !old)
+                                        }
+                                    >
+                                        Formatting options
+                                    </Button>
+                                    <Collapse in={showFormatting} pl="md">
+                                        <Group align="start" spacing="xxl">
+                                            <Radio.Group
+                                                label="Values"
+                                                {...form.getInputProps(
+                                                    'options.formatted',
+                                                )}
+                                            >
+                                                <Stack spacing="xxs" pt="xs">
+                                                    <Radio
+                                                        label="Formatted"
+                                                        value={Values.FORMATTED}
+                                                    />
+                                                    <Radio
+                                                        label="Raw"
+                                                        value={Values.RAW}
+                                                    />
+                                                </Stack>
+                                            </Radio.Group>
+                                            <Stack spacing="xs">
+                                                <Radio.Group
+                                                    label="Limit"
+                                                    {...form.getInputProps(
+                                                        'options.limit',
+                                                    )}
+                                                >
+                                                    <Stack
+                                                        spacing="xxs"
+                                                        pt="xs"
+                                                    >
+                                                        <Radio
+                                                            label="Results in Table"
+                                                            value={Limit.TABLE}
+                                                        />
+                                                        <Radio
+                                                            label="All Results"
+                                                            value={Limit.ALL}
+                                                        />
+                                                        <Radio
+                                                            label="Custom..."
+                                                            value={Limit.CUSTOM}
+                                                        />
+                                                    </Stack>
+                                                </Radio.Group>
+                                                {limit === Limit.CUSTOM && (
+                                                    <NumberInput
+                                                        w={150}
+                                                        min={1}
+                                                        precision={0}
+                                                        required
+                                                        {...form.getInputProps(
+                                                            'options.customLimit',
+                                                        )}
+                                                    />
+                                                )}
+
+                                                {(form.values?.options
+                                                    ?.limit === Limit.ALL ||
+                                                    form.values?.options
+                                                        ?.limit ===
+                                                        Limit.CUSTOM) && (
+                                                    <i>
+                                                        Results are limited to{' '}
+                                                        {Number(
+                                                            health.data?.query
+                                                                .csvCellsLimit ||
+                                                                100000,
+                                                        ).toLocaleString()}{' '}
+                                                        cells for each file
+                                                    </i>
+                                                )}
+                                            </Stack>
+                                        </Group>
+                                    </Collapse>
+                                </Stack>
                             )}
                         </Stack>
-                    </Stack>
-                </Input.Wrapper>
 
-                {/* 
-                  TODO: Implement second tab with <SchedulerAdvancedOptions />
-                */}
-            </Stack>
+                        <Input.Wrapper
+                            label="Destinations"
+                            description={
+                                showDestinationLabel
+                                    ? 'No destination(s) selected'
+                                    : ''
+                            }
+                        >
+                            <Stack mt="sm">
+                                <Group noWrap>
+                                    <MantineIcon
+                                        icon={IconMail}
+                                        size="xl"
+                                        color="gray.7"
+                                    />
+                                    <HoverCard
+                                        disabled={!isAddEmailDisabled}
+                                        width={300}
+                                        position="bottom-start"
+                                        shadow="md"
+                                    >
+                                        <HoverCard.Target>
+                                            <Box w="100%">
+                                                <TagInput
+                                                    clearable
+                                                    error={
+                                                        emailValidationError ||
+                                                        null
+                                                    }
+                                                    placeholder="Enter email addresses"
+                                                    disabled={
+                                                        isAddEmailDisabled
+                                                    }
+                                                    value={
+                                                        form.values
+                                                            ?.emailTargets
+                                                    }
+                                                    allowDuplicates={false}
+                                                    splitChars={[',', ' ']}
+                                                    validationFunction={
+                                                        validateEmail
+                                                    }
+                                                    onBlur={() =>
+                                                        setEmailValidationError(
+                                                            undefined,
+                                                        )
+                                                    }
+                                                    onValidationReject={(val) =>
+                                                        setEmailValidationError(
+                                                            `'${val}' doesn't appear to be an email address`,
+                                                        )
+                                                    }
+                                                    onChange={(val) => {
+                                                        setEmailValidationError(
+                                                            undefined,
+                                                        );
+                                                        form.setFieldValue(
+                                                            'emailTargets',
+                                                            val,
+                                                        );
+                                                    }}
+                                                />
+                                            </Box>
+                                        </HoverCard.Target>
+                                        <HoverCard.Dropdown>
+                                            <>
+                                                <Text pb="sm">
+                                                    No Email integration found
+                                                </Text>
+                                                <Text>
+                                                    To create an email scheduled
+                                                    delivery, you need to add
+                                                    <Anchor
+                                                        target="_blank"
+                                                        href="https://docs.lightdash.com/references/environmentVariables"
+                                                    >
+                                                        {' '}
+                                                        SMTP environment
+                                                        variables{' '}
+                                                    </Anchor>
+                                                    for your Lightdash instance
+                                                </Text>
+                                            </>
+                                        </HoverCard.Dropdown>
+                                    </HoverCard>
+                                </Group>
+                                <Stack spacing="xs" mb="md">
+                                    <Group noWrap>
+                                        <SlackIcon
+                                            style={{ margin: '5px 2px' }}
+                                        />
+                                        <HoverCard
+                                            disabled={!isAddSlackDisabled}
+                                            width={300}
+                                            position="bottom-start"
+                                            shadow="md"
+                                        >
+                                            <HoverCard.Target>
+                                                <Box w="100%">
+                                                    <MultiSelect
+                                                        placeholder="Search slack channels"
+                                                        data={slackChannels}
+                                                        searchable
+                                                        creatable
+                                                        rightSection={
+                                                            slackChannelsQuery.isLoading ?? (
+                                                                <Loader size="sm" />
+                                                            )
+                                                        }
+                                                        disabled={
+                                                            isAddSlackDisabled
+                                                        }
+                                                        getCreateLabel={(
+                                                            query,
+                                                        ) =>
+                                                            `Send to private channel #${query}`
+                                                        }
+                                                        onCreate={(newItem) => {
+                                                            setPrivateChannels(
+                                                                (current) => [
+                                                                    ...current,
+                                                                    {
+                                                                        label: newItem,
+                                                                        value: newItem,
+                                                                        group: 'Private channels',
+                                                                    },
+                                                                ],
+                                                            );
+                                                            return newItem;
+                                                        }}
+                                                        onChange={(val) => {
+                                                            form.setFieldValue(
+                                                                'slackTargets',
+                                                                val,
+                                                            );
+                                                        }}
+                                                    />
+                                                </Box>
+                                            </HoverCard.Target>
+                                            <HoverCard.Dropdown>
+                                                <SlackErrorContent
+                                                    slackState={slackState}
+                                                />
+                                            </HoverCard.Dropdown>
+                                        </HoverCard>
+                                    </Group>
+                                    {!isAddSlackDisabled && (
+                                        <Text size="xs" color="gray.6" ml="3xl">
+                                            If delivering to a private Slack
+                                            channel, please type the name of the
+                                            channel in the input box exactly as
+                                            it appears in Slack. Also ensure you
+                                            invite the Lightdash Slackbot into
+                                            that channel.
+                                        </Text>
+                                    )}
+                                </Stack>
+                            </Stack>
+                        </Input.Wrapper>
+                    </Stack>
+                </Tabs.Panel>
+                <Tabs.Panel value="customization">
+                    <MDEditor
+                        preview="edit"
+                        commands={[
+                            commands.bold,
+                            commands.italic,
+                            commands.strikethrough,
+                            commands.divider,
+                            commands.link,
+                        ]}
+                        value={form.values.message}
+                        onChange={(value) =>
+                            form.setFieldValue('message', value || '')
+                        }
+                    />
+                </Tabs.Panel>
+            </Tabs>
             <SchedulersModalFooter
                 confirmText={confirmText}
                 onBack={onBack}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm2.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm2.tsx
@@ -513,7 +513,7 @@ const SchedulerForm2: FC<{
                                         </HoverCard.Dropdown>
                                     </HoverCard>
                                 </Group>
-                                <Stack spacing="xs" mb="md">
+                                <Stack spacing="xs" mb="sm">
                                     <Group noWrap>
                                         <SlackIcon
                                             style={{ margin: '5px 2px' }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7390 

### Description:

> **NOTE**: to test these changes, turn the feature flag on by pasting and running this in the console: `localStorage.setItem('scheduler-modal-2', true)`

Add customization tab to scheduled deliveries. The new tab has the markdown input.

![Kapture 2023-10-18 at 16 09 05](https://github.com/lightdash/lightdash/assets/1864179/b1ca00d0-50fe-4ab9-b447-7b412859e47b)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
