### PR TITLE
fix: close dashboard action menu on click

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -280,7 +280,6 @@ const DashboardHeader = ({
                         withArrow
                         withinPortal
                         shadow="md"
-                        closeOnItemClick={false}
                         disabled={!userCanManageDashboard && !userCanExportData}
                     >
                         <Menu.Target>


### PR DESCRIPTION
### Description:

Dashboard action menu was staying open when clicked. It shouldn't. And it was causing a bad interaction with the modals.

Before (with bug):
![Kapture 2023-10-18 at 16 23 05](https://github.com/lightdash/lightdash/assets/1864179/773ca73f-ed09-4d36-8300-27b02c4a1848)

After (fixed):
![Kapture 2023-10-18 at 16 24 11](https://github.com/lightdash/lightdash/assets/1864179/aecc74e2-f6cd-4633-b314-f2ab2ffca08b)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
