### PR TITLE
chore: edit mode for schedulers

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -145,7 +145,7 @@ const CreateStateContent: FC<{
     );
 };
 
-export const UpdateStateContent: FC<{
+const UpdateStateContent: FC<{
     schedulerUuid: string;
     onBack: () => void;
 }> = ({ schedulerUuid, onBack }) => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
@@ -13,7 +13,7 @@ interface FooterProps {
 }
 
 const SchedulersModalFooter = ({
-    confirmText = 'Confirm',
+    confirmText,
     onBack,
     onCancel,
     onSendNow,
@@ -53,13 +53,16 @@ const SchedulersModalFooter = ({
                         variant="light"
                         leftIcon={<MantineIcon icon={IconSend} />}
                         onClick={onSendNow}
+                        disabled={loading}
                     >
                         Send now
                     </Button>
                 )}
-                <Button type="submit" loading={loading} onClick={onConfirm}>
-                    {confirmText}
-                </Button>
+                {!!confirmText && (
+                    <Button type="submit" loading={loading} onClick={onConfirm}>
+                        {confirmText}
+                    </Button>
+                )}
             </Group>
         </Group>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7387 

### Description:

> **NOTE**: to test these changes, turn the feature flag on by pasting and running this in the console: `localStorage.setItem('scheduler-modal-2', true)`

Adds edit mode for the new scheduled deliveries UI. You can now edit an existing schedule, save it, and send now. 

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
