### PR TITLE
fix: order on dashboards subquery first

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -998,11 +998,17 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceItemCategory: {
+        dataType: 'refEnum',
+        enums: ['mostPopular', 'recentlyUpdated'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ResourceViewDashboardItem: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                category: { ref: 'ResourceItemCategory' },
                 data: {
                     ref: 'Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_',
                     required: true,
@@ -1096,6 +1102,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                category: { ref: 'ResourceItemCategory' },
                 data: {
                     ref: 'Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_',
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1109,8 +1109,15 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
+            "ResourceItemCategory": {
+                "enum": ["mostPopular", "recentlyUpdated"],
+                "type": "string"
+            },
             "ResourceViewDashboardItem": {
                 "properties": {
+                    "category": {
+                        "$ref": "#/components/schemas/ResourceItemCategory"
+                    },
                     "data": {
                         "$ref": "#/components/schemas/Pick_DashboardBasicDetails.uuid-or-spaceUuid-or-description-or-name-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder-or-updatedAt-or-updatedByUser-or-validationErrors_"
                     },
@@ -1210,6 +1217,9 @@
             },
             "ResourceViewChartItem": {
                 "properties": {
+                    "category": {
+                        "$ref": "#/components/schemas/ResourceItemCategory"
+                    },
                     "data": {
                         "$ref": "#/components/schemas/Pick_SpaceQuery.uuid-or-name-or-chartType-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_"
                     },
@@ -5147,7 +5157,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.811.0",
+        "version": "0.814.1",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -221,7 +221,6 @@ export class DashboardModel {
     async getAllByProject(
         projectUuid: string,
         chartUuid?: string,
-        limit?: number,
     ): Promise<DashboardBasicDetails[]> {
         const cteTableName = 'cte';
         const dashboardsQuery = this.database
@@ -306,10 +305,6 @@ export class DashboardModel {
                     .where(`${ProjectTableName}.project_uuid`, projectUuid);
             })
             .select(`${cteTableName}.*`);
-
-        if (limit) {
-            dashboardsQuery.limit(limit);
-        }
 
         if (chartUuid) {
             dashboardsQuery

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -278,13 +278,20 @@ export class SpaceModel {
                         ), '[]'
                     ) as validation_errors
                 `),
-            ])
-            .distinctOn(`${DashboardVersionsTableName}.dashboard_id`)
-            .select(
                 `${DashboardVersionsTableName}.created_at as dashboard_version_created_at`,
                 `${DashboardVersionsTableName}.dashboard_id as dashboard_id`,
-            )
+            ])
+            .distinctOn(`${DashboardVersionsTableName}.dashboard_id`)
             .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .orderBy([
+                {
+                    column: `dashboard_id`,
+                },
+                {
+                    column: `dashboard_version_created_at`,
+                    order: 'desc',
+                },
+            ])
             .as('subQuery');
 
         let dashboardsQuery = this.database.select('*').from(subQuery);
@@ -297,16 +304,6 @@ export class SpaceModel {
             dashboardsQuery = dashboardsQuery
                 .orderBy(sortByColumn, 'desc')
                 .limit(this.MOST_POPULAR_OR_RECENTLY_UPDATED_LIMIT);
-        } else {
-            dashboardsQuery = dashboardsQuery.orderBy([
-                {
-                    column: `dashboard_id`,
-                },
-                {
-                    column: `dashboard_version_created_at`,
-                    order: 'desc',
-                },
-            ]);
         }
 
         const dashboards = await dashboardsQuery;

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -59,8 +59,6 @@ export class DashboardService {
 
     savedChartModel: SavedChartModel;
 
-    RECENTLY_UPDATED_DASHBOARDS_LIMIT: number;
-
     constructor({
         dashboardModel,
         spaceModel,
@@ -75,7 +73,6 @@ export class DashboardService {
         this.pinnedListModel = pinnedListModel;
         this.schedulerModel = schedulerModel;
         this.savedChartModel = savedChartModel;
-        this.RECENTLY_UPDATED_DASHBOARDS_LIMIT = 10;
     }
 
     static getCreateEventProperties(
@@ -169,46 +166,6 @@ export class DashboardService {
             const dashboardSpace = spaces.find(
                 (space) => space.uuid === dashboard.spaceUuid,
             );
-            return (
-                hasAbility &&
-                dashboardSpace &&
-                hasSpaceAccess(user, dashboardSpace, includePrivate)
-            );
-        });
-    }
-
-    async getRecentlyUpdatedByProject(
-        user: SessionUser,
-        projectUuid: string,
-        chartUuid?: string,
-        includePrivate?: boolean,
-    ): Promise<DashboardBasicDetails[]> {
-        const dashboards = await this.dashboardModel.getAllByProject(
-            projectUuid,
-            chartUuid,
-            this.RECENTLY_UPDATED_DASHBOARDS_LIMIT,
-        );
-
-        const spaceUuids = [
-            ...new Set(dashboards.map((dashboard) => dashboard.spaceUuid)),
-        ];
-        const spaces = await Promise.all(
-            spaceUuids.map((spaceUuid) =>
-                this.spaceModel.getSpaceSummary(spaceUuid),
-            ),
-        );
-
-        const spaceMap = new Map();
-        spaces.forEach((space) => {
-            spaceMap.set(space.uuid, space);
-        });
-
-        return dashboards.filter((dashboard) => {
-            const hasAbility = user.ability.can(
-                'view',
-                subject('Dashboard', dashboard),
-            );
-            const dashboardSpace = spaceMap.get(dashboard.spaceUuid);
             return (
                 hasAbility &&
                 dashboardSpace &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After merging this: #7370, I noticed I did the ordering of latest dashboard version outside of the subquery, making it not work as expected. 

This addresses that + removes an unused function

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
