### PR TITLE
chore: close on add tile menu item click

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -62,7 +62,6 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
                 withArrow
                 withinPortal
                 shadow="md"
-                closeOnItemClick={false}
                 width={200}
             >
                 <Menu.Target>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to what this PR https://github.com/lightdash/lightdash/pull/7539 fixed

### Description:

On `add`  
<img width="364" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/9b15f34a-d032-4c0c-8d59-c8f9e029d33d">

We also should click on menu item click


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
