### PR TITLE
style: remove dividers on add tile menu

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,14 +1,6 @@
 import { PopoverPosition } from '@blueprintjs/core';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
-import {
-    Button,
-    ButtonProps,
-    Divider,
-    Group,
-    Menu,
-    Text,
-    Tooltip,
-} from '@mantine/core';
+import { Button, ButtonProps, Group, Menu, Text, Tooltip } from '@mantine/core';
 import {
     IconChartBar,
     IconInfoCircle,
@@ -83,8 +75,6 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
                         Saved chart
                     </Menu.Item>
 
-                    <Divider />
-
                     <Menu.Item
                         onClick={() => {
                             storeDashboard(
@@ -110,8 +100,6 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
                         </Group>
                     </Menu.Item>
 
-                    <Divider />
-
                     <Menu.Item
                         onClick={() =>
                             setAddTileType(DashboardTileTypes.MARKDOWN)
@@ -120,8 +108,6 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
                     >
                         Markdown
                     </Menu.Item>
-
-                    <Divider />
 
                     <Menu.Item
                         onClick={() => setAddTileType(DashboardTileTypes.LOOM)}


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: N/A

### Description:

Remove `Divider`s when adding tile on dashboards

<img width="274" alt="Screenshot 2023-10-19 at 12 54 58" src="https://github.com/lightdash/lightdash/assets/7611706/ce79eb92-6a72-4bb1-a5db-c186c43cb783">
### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
