### PR TITLE
fix: do not include private resources if admin when on home page

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2213,7 +2213,7 @@ export class ProjectService {
         const allowedSpaces = spaces.filter(
             (space) =>
                 space.projectUuid === projectUuid &&
-                hasSpaceAccess(user, space, true),
+                hasSpaceAccess(user, space, false), // NOTE: We don't check for admin access to the space - exclude private spaces from this panel if admin
         );
 
         const mostPopular = await this.getMostPopular(allowedSpaces);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After work done on: https://github.com/lightdash/lightdash/pull/7370, one thing I missed was the:
`hasSpaceAccess` that was including private items for Admins' homepages. 

Before, we used to get:
* `charts` from `spaces-and-content` query: which has: `hasSpaceAccess(user, space, false),` -> does not include private spaces for admins (ref: https://github.com/lightdash/lightdash/blob/main/packages/backend/src/services/SpaceService/SpaceService.ts#L74)
* `dashboards` from `/projects/${projectUuid}/dashboards?includePrivate=false`, which also did the same: `hasSpaceAccess(user, space, false)` https://github.com/lightdash/lightdash/blob/main/packages/backend/src/services/DashboardService/DashboardService.ts#L172 where the hook defaults to false when no param is passed: https://github.com/lightdash/lightdash/blob/e4ffa7e84e23299adf52ce9070365245da69f5c2/packages/frontend/src/hooks/dashboard/useDashboards.tsx#L39 

This ensures that, with the new endpoint, we keep the same space access requirements and mimic the behaviour with the two previous hooks we used.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
