### PR TITLE
fix: add indices to saved chart tables

### DIFF
--- a/packages/backend/src/database/migrations/20231019161823_add_missing_index_to_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20231019161823_add_missing_index_to_saved_queries.ts
@@ -1,0 +1,95 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('saved_queries_version_fields')) {
+        await knex.schema.alterTable(
+            'saved_queries_version_fields',
+            (table) => {
+                table.index(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (await knex.schema.hasTable('saved_queries_version_sorts')) {
+        await knex.schema.alterTable('saved_queries_version_sorts', (table) => {
+            table.index(['saved_queries_version_id']);
+        });
+    }
+    if (
+        await knex.schema.hasTable('saved_queries_version_table_calculations')
+    ) {
+        await knex.schema.alterTable(
+            'saved_queries_version_table_calculations',
+            (table) => {
+                table.index(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (
+        await knex.schema.hasTable('saved_queries_version_additional_metrics')
+    ) {
+        await knex.schema.alterTable(
+            'saved_queries_version_additional_metrics',
+            (table) => {
+                table.index(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (await knex.schema.hasTable('saved_queries_versions')) {
+        await knex.schema.alterTable('saved_queries_versions', (table) => {
+            table.index(['saved_query_id']);
+        });
+    }
+    if (await knex.schema.hasTable('validations')) {
+        await knex.schema.alterTable('validations', (table) => {
+            table.index(['dashboard_uuid']);
+            table.index(['saved_chart_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('saved_queries_version_fields')) {
+        await knex.schema.alterTable(
+            'saved_queries_version_fields',
+            (table) => {
+                table.dropIndex(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (await knex.schema.hasTable('saved_queries_version_sorts')) {
+        await knex.schema.alterTable('saved_queries_version_sorts', (table) => {
+            table.dropIndex(['saved_queries_version_id']);
+        });
+    }
+    if (
+        await knex.schema.hasTable('saved_queries_version_table_calculations')
+    ) {
+        await knex.schema.alterTable(
+            'saved_queries_version_table_calculations',
+            (table) => {
+                table.dropIndex(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (
+        await knex.schema.hasTable('saved_queries_version_additional_metrics')
+    ) {
+        await knex.schema.alterTable(
+            'saved_queries_version_additional_metrics',
+            (table) => {
+                table.dropIndex(['saved_queries_version_id']);
+            },
+        );
+    }
+    if (await knex.schema.hasTable('saved_queries_versions')) {
+        await knex.schema.alterTable('saved_queries_versions', (table) => {
+            table.dropIndex(['saved_query_id']);
+        });
+    }
+    if (await knex.schema.hasTable('validations')) {
+        await knex.schema.alterTable('validations', (table) => {
+            table.dropIndex(['dashboard_uuid']);
+            table.dropIndex(['saved_chart_uuid']);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add indices on our slowest queries in production. 

- saved_queries_versions (missing index on foreign key to parent)
- saved_queries_version_fields (missing index on foreign key to parent)
- saved_queries_version_additional_metrics (missing index on foreign key to parent)
- saved_queries_version_table_calculations (missing index on foreign key to parent)
- validations (missing index for scans by dashboard_uuid or saved_chart_uuid)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
