### PR TITLE
feat: add stale time and cacheTime to useExplore

### DIFF
--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -25,6 +25,7 @@ export const useExplore = (
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
+        staleTime: 1000 * 60 * 60,
         ...useQueryOptions,
     });
 };

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -30,7 +30,8 @@ export const useExplore = (
         onError: (result) => setErrorResponse(result),
         retry: false,
         ...(isStaleTimeFeatureEnabled && {
-            staleTime: 1000 * 60 * 60,
+            staleTime: 1000 * 60 * 15,
+            cacheTime: 1000 * 60 * 20,
         }),
         ...useQueryOptions,
     });

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -1,5 +1,4 @@
 import { ApiError, ApiExploreResults } from '@lightdash/common';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { useQuery } from 'react-query';
 import { UseQueryOptions } from 'react-query/types/react/types';
 import { useParams } from 'react-router-dom';
@@ -17,9 +16,6 @@ export const useExplore = (
     activeTableName: string | undefined,
     useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
 ) => {
-    const isStaleTimeFeatureEnabled = useFeatureFlagEnabled(
-        'stale-time-on-use-explore',
-    );
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const setErrorResponse = useQueryError();
     const queryKey = ['tables', activeTableName, projectUuid];
@@ -29,10 +25,8 @@ export const useExplore = (
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
-        ...(isStaleTimeFeatureEnabled && {
-            staleTime: 1000 * 60 * 15,
-            cacheTime: 1000 * 60 * 20,
-        }),
+        staleTime: 1000 * 60 * 15,
+        cacheTime: 1000 * 60 * 20,
         ...useQueryOptions,
     });
 };

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -1,4 +1,5 @@
 import { ApiError, ApiExploreResults } from '@lightdash/common';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { useQuery } from 'react-query';
 import { UseQueryOptions } from 'react-query/types/react/types';
 import { useParams } from 'react-router-dom';
@@ -16,6 +17,9 @@ export const useExplore = (
     activeTableName: string | undefined,
     useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
 ) => {
+    const isStaleTimeFeatureEnabled = useFeatureFlagEnabled(
+        'stale-time-on-use-explore',
+    );
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const setErrorResponse = useQueryError();
     const queryKey = ['tables', activeTableName, projectUuid];
@@ -25,7 +29,9 @@ export const useExplore = (
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
-        staleTime: 1000 * 60 * 60,
+        ...(isStaleTimeFeatureEnabled && {
+            staleTime: 1000 * 60 * 60,
+        }),
         ...useQueryOptions,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Add `staleTime` and `cacheTime` to `useExplore` query to reduce queries to the backend. 

`staleTime` will tell `react-query` that the data is fresh for `15` minutes; 
`cacheTime` will tell `react-query` to store the data in-memory (for `20` minutes)in order to avoid having to request the server for data that won't change that often. 

Why higher cacheTime? 
followed this article: https://www.codemzy.com/blog/react-query-cachetime-staletime

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
