### PR TITLE
chore: improve lightdash team marker

### DIFF
--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -1,6 +1,7 @@
 import { ProjectType } from '@lightdash/common';
 import {
     ActionIcon,
+    Badge,
     Box,
     Button,
     Center,
@@ -194,9 +195,11 @@ const NavBar = memo(() => {
                 <Box sx={{ flexGrow: 1 }} />
 
                 <PostHogFeature flag={'lightdash-team-flair'} match={true}>
-                    <Group sx={{ flexShrink: 0 }}>
-                        <span style={{ color: 'white' }}>LIGHTDASH TEAM</span>
-                    </Group>
+                    <Box mx="sm">
+                        <Badge color="violet" variant="filled">
+                            LIGHTDASH TEAM
+                        </Badge>
+                    </Box>
                 </PostHogFeature>
 
                 <Group sx={{ flexShrink: 0 }}>


### PR DESCRIPTION
### Description:

Lightsmash day!

Makes the internal dev banner look nicer. I'm not sure if we want to keep this thing, but if we do this at least makes it look better.

Before:
<img width="541" alt="Screenshot 2023-10-20 at 15 13 54" src="https://github.com/lightdash/lightdash/assets/1864179/180beb40-8aed-4968-8570-849875c58d72">

After:
<img width="354" alt="Screenshot 2023-10-20 at 15 13 37" src="https://github.com/lightdash/lightdash/assets/1864179/eb9f3f83-777a-4599-b03d-0a28668f0445">

If we don't do this, we should probably remove this thing instead 😄 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
