### PR TITLE
fix: redirect on register

### DIFF
--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -129,7 +129,7 @@ export const storeOIDCRedirect: RequestHandler = (req, res, next) => {
     }
     if (typeof redirect === 'string') {
         try {
-            const redirectUrl = new URL(redirect);
+            const redirectUrl = new URL(redirect, lightdashConfig.siteUrl);
             const originUrl = new URL(lightdashConfig.siteUrl);
             if (
                 redirectUrl.host === originUrl.host ||
@@ -149,15 +149,15 @@ export const redirectOIDCSuccess: RequestHandler = (req, res) => {
             ? decodeURIComponent(req.query.returnTo.toString())
             : undefined;
 
-    if (queryReturn && queryReturn.startsWith(lightdashConfig.siteUrl)) {
+    if (
+        queryReturn &&
+        new URL(queryReturn, lightdashConfig.siteUrl).host ===
+            new URL(lightdashConfig.siteUrl).host
+    ) {
         res.redirect(queryReturn);
-        return;
     }
-
-    const { returnTo } = req.session.oauth || {};
-
-    res.redirect(returnTo || '/');
 };
+
 export const redirectOIDCFailure: RequestHandler = (req, res) => {
     const { returnTo } = req.session.oauth || {};
     res.redirect(returnTo || '/');

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -4,7 +4,6 @@ import {
 } from '@lightdash/common';
 import { Button, ButtonProps, Image } from '@mantine/core';
 import { FC } from 'react';
-import { useLocation } from 'react-router-dom';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import { useApp } from '../../../providers/AppProvider';
@@ -13,6 +12,8 @@ type ThirdPartySignInButtonProps = {
     inviteCode?: string;
     intent?: 'signin' | 'add' | 'signup';
     providerName: OpenIdIdentitySummary['issuerType'];
+    // Default redirect is the current window.location.href
+    redirect?: string;
 } & ButtonProps;
 
 const ThirdPartySignInButtonBase: FC<
@@ -71,21 +72,17 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
     inviteCode,
     intent = 'signin',
     providerName,
+    redirect,
     ...props
 }) => {
     const { health } = useApp();
-    const location = useLocation<{ from?: Location } | undefined>();
 
     switch (providerName) {
         case OpenIdIdentityIssuerType.GOOGLE:
             return health.data?.auth.google.enabled ? (
                 <ThirdPartySignInButtonBase
                     loginPath={health.data.auth.google.loginPath}
-                    redirect={
-                        location.state?.from?.pathname
-                            ? `${health.data.siteUrl}${location.state.from.pathname}${location.state.from.search}`
-                            : undefined
-                    }
+                    redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
                     providerName="Google"
@@ -98,6 +95,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
             return health.data?.auth.okta.enabled ? (
                 <ThirdPartySignInButtonBase
                     loginPath={health.data.auth.okta.loginPath}
+                    redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
                     providerName="Okta"
@@ -109,6 +107,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
             return health.data?.auth.oneLogin.enabled ? (
                 <ThirdPartySignInButtonBase
                     loginPath={health.data.auth.oneLogin.loginPath}
+                    redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
                     providerName="OneLogin"
@@ -121,6 +120,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
             return health.data?.auth.azuread.enabled ? (
                 <ThirdPartySignInButtonBase
                     loginPath={health.data.auth.azuread.loginPath}
+                    redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
                     providerName="Azure AD"

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -96,6 +96,7 @@ const Invite: FC = () => {
     const { showToastError } = useToaster();
     const { search } = useLocation();
     const { identify } = useTracking();
+    const redirectUrl = '/';
     const [isLinkFromEmail, setIsLinkFromEmail] = useState<boolean>(false);
     const { isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
@@ -105,7 +106,7 @@ const Invite: FC = () => {
         mutationKey: ['create_user'],
         onSuccess: (data) => {
             identify({ id: data.userUuid });
-            window.location.href = '/';
+            window.location.href = redirectUrl;
         },
         onError: (error) => {
             showToastError({
@@ -132,7 +133,7 @@ const Invite: FC = () => {
     }
 
     if (health.status === 'success' && health.data?.isAuthenticated) {
-        return <Redirect to={{ pathname: '/' }} />;
+        return <Redirect to={{ pathname: redirectUrl }} />;
     }
 
     const ssoAvailable =
@@ -148,6 +149,7 @@ const Invite: FC = () => {
                     providerName={providerName}
                     inviteCode={inviteCode}
                     intent="signup"
+                    redirect={redirectUrl}
                 />
             ))}
         </Stack>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -45,6 +45,10 @@ const Login: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
     const { health } = useApp();
     const { showToastError } = useToaster();
+    const redirectUrl = location.state?.from
+        ? `${location.state.from.pathname}${location.state.from.search}`
+        : '/';
+
     const form = useForm<LoginParams>({
         initialValues: {
             email: '',
@@ -66,9 +70,7 @@ const Login: FC = () => {
         mutationKey: ['login'],
         onSuccess: (data) => {
             identify({ id: data.userUuid });
-            window.location.href = location.state?.from
-                ? `${location.state.from.pathname}${location.state.from.search}`
-                : '/';
+            window.location.href = redirectUrl;
         },
         onError: (error) => {
             form.reset();
@@ -100,14 +102,14 @@ const Login: FC = () => {
             <Redirect
                 to={{
                     pathname: '/register',
-                    state: { from: location.state?.from },
+                    state: { from: redirectUrl },
                 }}
             />
         );
     }
 
     if (health.status === 'success' && health.data?.isAuthenticated) {
-        return <Redirect to={{ pathname: '/' }} />;
+        return <Redirect to={redirectUrl} />;
     }
 
     const ssoAvailable =
@@ -121,6 +123,7 @@ const Login: FC = () => {
                 <ThirdPartySignInButton
                     key={providerName}
                     providerName={providerName}
+                    redirect={redirectUrl}
                 />
             ))}
         </Stack>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -102,7 +102,7 @@ const Login: FC = () => {
             <Redirect
                 to={{
                     pathname: '/register',
-                    state: { from: redirectUrl },
+                    state: { from: location.state?.from },
                 }}
             />
         );

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -33,6 +33,9 @@ const Register: FC = () => {
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
     const { identify } = useTracking();
+    const redirectUrl = location.state?.from
+        ? `${location.state.from.pathname}${location.state.from.search}`
+        : '/';
     const { isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
         ApiError,
@@ -41,9 +44,7 @@ const Register: FC = () => {
         mutationKey: ['login'],
         onSuccess: (data) => {
             identify({ id: data.userUuid });
-            window.location.href = location.state?.from
-                ? `${location.state.from.pathname}${location.state.from.search}`
-                : '/';
+            window.location.href = redirectUrl;
         },
         onError: (error) => {
             showToastError({
@@ -69,6 +70,7 @@ const Register: FC = () => {
                     key={providerName}
                     providerName={providerName}
                     intent="signup"
+                    redirect={redirectUrl}
                 />
             ))}
         </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7571 

Things to tidy up:
- Refactor redirect code in Login, Register, Invite components - so that all methods use the same redirectURL
- Session data is cleared on `.authenticate` in passport: https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d - are we accounting for this?
- Apply redirect logic consistently across all OIDC providers

Cases to test (common across password and all SSO providers):
- After logging in, I'm redirected to the homepage or `from` if it exists
- After registering via `/register` I'm redirected to the homepage or `from` if it exists
- After registering via `/login` with SSO I'm redirected to the homepage or `from` if it exists
- After registering via an invite link I'm redirected to the hompage or `from` if it exists