### PR TITLE
fix: explore models tooltip

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -106,6 +106,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                             withinPortal
                             position="right"
                             label={explore.description}
+                            multiline
                         >
                             <MantineIcon
                                 icon={IconInfoCircle}


### PR DESCRIPTION
Closes: #7579 

### Description:

adds multiline prop to the tooltip avoid overflow

![CleanShot 2023-10-23 at 11 28 44@2x](https://github.com/lightdash/lightdash/assets/962095/5d0ef228-8c9d-4833-91ab-e04e0d0bfb0f)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
