### PR TITLE
feat: replace popover with menu on results table

### DIFF
--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -27,7 +27,7 @@ describe('Explore', () => {
             .click();
 
         // sort `Customers First-Name` by ascending
-        cy.findByRole('option', { name: 'Sort A-Z' }).click();
+        cy.findByRole('menuitem', { name: 'Sort A-Z' }).click();
 
         // wait for query to finish
         cy.findByText('Loading results').should('not.exist');
@@ -161,7 +161,7 @@ describe('Explore', () => {
                 .find('button')
                 .click();
             // sort `Orders Unique order count` by ascending
-            cy.findByRole('option', { name: 'Sort 1-9' }).click();
+            cy.findByRole('menuitem', { name: 'Sort 1-9' }).click();
 
             cy.get('span').contains('Sorted by 1 field').should('exist');
 
@@ -171,7 +171,7 @@ describe('Explore', () => {
                 .find('button')
                 .click();
             // sort `Customers First name` by ascending
-            cy.findByRole('option', { name: 'Sort Z-A' }).click();
+            cy.findByRole('menuitem', { name: 'Sort Z-A' }).click();
 
             cy.get('span').contains('Sorted by 2 fields').should('exist');
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -182,7 +182,7 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                     e.stopPropagation();
                 }}
             >
-                <Menu>
+                <Menu withinPortal withArrow>
                     <Menu.Target>
                         <ActionIcon size="xs" variant="light" bg="transparent">
                             <MantineIcon icon={IconChevronDown} />

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,5 +1,3 @@
-import { Divider, Menu } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     fieldId,
     getItemId,
@@ -7,8 +5,13 @@ import {
     isFilterableField,
     TableCalculation,
 } from '@lightdash/common';
-import { ActionIcon, Popover } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons-react';
+import { ActionIcon, Menu } from '@mantine/core';
+import {
+    IconChevronDown,
+    IconFilter,
+    IconPencil,
+    IconTrash,
+} from '@tabler/icons-react';
 import { FC, useMemo, useState } from 'react';
 import { useFilters } from '../../../hooks/useFilters';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
@@ -66,30 +69,26 @@ const ContextMenu: FC<ContextMenuProps> = ({
     if (item && isField(item) && isFilterableField(item)) {
         const itemFieldId = fieldId(item);
         return (
-            <Menu>
-                <MenuItem2
-                    text={
-                        <>
-                            Filter by <BolderLabel>{item.label}</BolderLabel>
-                        </>
-                    }
-                    icon="filter"
+            <>
+                <Menu.Item
+                    icon={<MantineIcon icon={IconFilter} />}
                     onClick={() => {
                         track({ name: EventName.ADD_FILTER_CLICKED });
                         addFilter(item, undefined, false);
                     }}
-                />
+                >
+                    Filter by <BolderLabel>{item.label}</BolderLabel>
+                </Menu.Item>
 
-                <Divider />
+                <Menu.Divider />
 
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
-                <Divider />
+                <Menu.Divider />
 
                 {isItemAdditionalMetric ? (
-                    <MenuItem2
-                        text={<>Edit custom metric</>}
-                        icon="edit"
+                    <Menu.Item
+                        icon={<MantineIcon icon={IconPencil} />}
                         onClick={() => {
                             toggleAdditionalMetricModal({
                                 item: additionalMetric,
@@ -97,38 +96,41 @@ const ContextMenu: FC<ContextMenuProps> = ({
                                 isEditing: true,
                             });
                         }}
-                    />
+                    >
+                        Edit custom metric
+                    </Menu.Item>
                 ) : null}
 
-                <MenuItem2
-                    text="Remove"
-                    icon="cross"
-                    intent="danger"
+                <Menu.Item
+                    icon={<MantineIcon icon={IconTrash} />}
+                    color="red"
                     onClick={() => {
                         removeActiveField(itemFieldId);
                     }}
-                />
-            </Menu>
+                >
+                    Remove
+                </Menu.Item>
+            </>
         );
     } else if (meta?.isInvalidItem) {
         return (
-            <Menu>
-                <MenuItem2
-                    text="Remove"
-                    icon="cross"
-                    intent="danger"
+            <>
+                <Menu.Item
+                    icon={<MantineIcon icon={IconTrash} />}
+                    color="red"
                     onClick={() => {
                         removeActiveField(header.column.id);
                     }}
-                />
-            </Menu>
+                >
+                    Remove
+                </Menu.Item>
+            </>
         );
     } else if (item && !isField(item)) {
         return (
-            <Menu>
-                <MenuItem2
-                    text="Edit calculation"
-                    icon="edit"
+            <>
+                <Menu.Item
+                    icon={<MantineIcon icon={IconPencil} />}
                     onClick={() => {
                         track({
                             name: EventName.EDIT_TABLE_CALCULATION_BUTTON_CLICKED,
@@ -136,18 +138,19 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                         onToggleCalculationEditModal(true);
                     }}
-                />
+                >
+                    Edit calculation
+                </Menu.Item>
 
-                <Divider />
+                <Menu />
 
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
-                <Divider />
+                <Menu.Divider />
 
-                <MenuItem2
-                    text="Remove"
-                    icon="cross"
-                    intent="danger"
+                <Menu.Item
+                    icon={<MantineIcon icon={IconTrash} />}
+                    color="red"
                     onClick={() => {
                         track({
                             name: EventName.DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
@@ -155,8 +158,10 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                         onToggleCalculationDeleteModal(true);
                     }}
-                />
-            </Menu>
+                >
+                    Remove
+                </Menu.Item>
+            </>
         );
     } else {
         return null;
@@ -177,20 +182,21 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                     e.stopPropagation();
                 }}
             >
-                <Popover withinPortal position="bottom" withArrow shadow="md">
-                    <Popover.Target>
+                <Menu>
+                    <Menu.Target>
                         <ActionIcon size="xs" variant="light" bg="transparent">
                             <MantineIcon icon={IconChevronDown} />
                         </ActionIcon>
-                    </Popover.Target>
-                    <Popover.Dropdown p={0}>
+                    </Menu.Target>
+
+                    <Menu.Dropdown>
                         <ContextMenu
                             header={header}
                             onToggleCalculationEditModal={setShowUpdate}
                             onToggleCalculationDeleteModal={setShowDelete}
                         />
-                    </Popover.Dropdown>
-                </Popover>
+                    </Menu.Dropdown>
+                </Menu>
 
                 {showUpdate && (
                     <UpdateTableCalculationModal

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
@@ -1,10 +1,11 @@
-import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
     getItemId,
     SortField,
     TableCalculation,
 } from '@lightdash/common';
+import { Menu } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import {
@@ -12,6 +13,7 @@ import {
     getSortLabel,
     SortDirection,
 } from '../../../utils/sortUtils';
+import MantineIcon from '../../common/MantineIcon';
 import { BolderLabel } from './ColumnHeaderContextMenu.styles';
 
 type Props = {
@@ -39,19 +41,16 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, sort }) => {
         <>
             {item &&
                 getSortDirectionOrder(item).map((sortDirection) => (
-                    <MenuItem2
+                    <Menu.Item
                         key={sortDirection}
-                        roleStructure="listoption"
-                        selected={
-                            hasSort && selectedSortDirection === sortDirection
+                        icon={
+                            hasSort &&
+                            selectedSortDirection === sortDirection ? (
+                                <MantineIcon icon={IconCheck} />
+                            ) : undefined
                         }
-                        text={
-                            <>
-                                Sort{' '}
-                                <BolderLabel>
-                                    {getSortLabel(item, sortDirection)}
-                                </BolderLabel>
-                            </>
+                        disabled={
+                            hasSort && selectedSortDirection === sortDirection
                         }
                         onClick={() =>
                             hasSort && selectedSortDirection === sortDirection
@@ -61,7 +60,12 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, sort }) => {
                                           sortDirection === SortDirection.DESC,
                                   })
                         }
-                    />
+                    >
+                        Sort{' '}
+                        <BolderLabel>
+                            {getSortLabel(item, sortDirection)}
+                        </BolderLabel>
+                    </Menu.Item>
                 ))}
         </>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Replace `Popover` with `Menu` on results table columns; 

This was triggered by working on: https://github.com/lightdash/lightdash/pull/7590


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
