### PR TITLE
fix: revert "feat: add stale time and cacheTime to useExplore (#7567)"

### DIFF
--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -25,8 +25,6 @@ export const useExplore = (
         enabled: !!activeTableName,
         onError: (result) => setErrorResponse(result),
         retry: false,
-        staleTime: 1000 * 60 * 15,
-        cacheTime: 1000 * 60 * 20,
         ...useQueryOptions,
     });
 };


### PR DESCRIPTION
This reverts commit 478d936cbe4c429bc72e2f23e51521737aae4b5a. - from PR: #7567 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

When users update the `explores` through the CLI, the browser isn't aware that the cache needs to be invalidated; The user could refresh and that would clear the in-memory cache set by `react-query`, but that can lead to frustration and UX shouldn't be hindered by this change. 

We should find a way to trigger a job from the CLI to the browser, so it knows that it needs to invalidate - can we trigger a page refresh from the CLI?

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
