### PR TITLE
fix: custom metrics (count) generates wrong sql with includes operator #7565

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -185,7 +185,7 @@ describe('Compile metrics with filters', () => {
                 tablesWithMetricsWithFilters,
             ).compiledSql,
         ).toStrictEqual(
-            `MAX(CASE WHEN (LOWER("table1".shared) LIKE LOWER('%foo%')) THEN ("table1".number_column) ELSE NULL END)`,
+            `MAX(CASE WHEN ((LOWER("table1".shared) LIKE LOWER('%foo%'))) THEN ("table1".number_column) ELSE NULL END)`,
         );
     });
     test('should show filters as columns metric2', () => {
@@ -195,7 +195,7 @@ describe('Compile metrics with filters', () => {
                 tablesWithMetricsWithFilters,
             ).compiledSql,
         ).toStrictEqual(
-            `MAX(CASE WHEN (("table2".dim2) < (10) AND ("table2".dim2) > (5)) THEN ("table2".number_column) ELSE NULL END)`,
+            `MAX(CASE WHEN ((("table2".dim2) < (10)) AND (("table2".dim2) > (5))) THEN ("table2".number_column) ELSE NULL END)`,
         );
     });
 
@@ -206,7 +206,7 @@ describe('Compile metrics with filters', () => {
                 tablesWithMetricsWithFilters,
             ).compiledSql,
         ).toStrictEqual(
-            `MAX(CASE WHEN (LOWER("table1".shared) LIKE LOWER('%foo%')) THEN (CASE WHEN "table1".number_column THEN 1 ELSE 0 END) ELSE NULL END)`,
+            `MAX(CASE WHEN ((LOWER("table1".shared) LIKE LOWER('%foo%'))) THEN (CASE WHEN "table1".number_column THEN 1 ELSE 0 END) ELSE NULL END)`,
         );
     });
 });

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,9 +11,9 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
+    Metric,
     friendlyName,
     isNonAggregateMetric,
-    Metric,
 } from '../types/field';
 import { WarehouseClient } from '../types/warehouse';
 
@@ -362,7 +362,7 @@ export class ExploreCompiler {
                     this.warehouseClient.getAdapterType(),
                 );
             });
-            renderedSql = `CASE WHEN (${conditions.join(
+            renderedSql = `CASE WHEN (${conditions.map(cond => `(${cond})`).join(
                 ' AND ',
             )}) THEN (${renderedSql}) ELSE NULL END`;
         }

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -362,9 +362,9 @@ export class ExploreCompiler {
                     this.warehouseClient.getAdapterType(),
                 );
             });
-            renderedSql = `CASE WHEN (${conditions.map(cond => `(${cond})`).join(
-                ' AND ',
-            )}) THEN (${renderedSql}) ELSE NULL END`;
+            renderedSql = `CASE WHEN (${conditions
+                .map((cond) => `(${cond})`)
+                .join(' AND ')}) THEN (${renderedSql}) ELSE NULL END`;
         }
         const compiledSql = this.warehouseClient.getMetricSql(
             renderedSql,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,9 +11,9 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
-    Metric,
     friendlyName,
     isNonAggregateMetric,
+    Metric,
 } from '../types/field';
 import { WarehouseClient } from '../types/warehouse';
 


### PR DESCRIPTION
Closes #7565 

Attaching the screenshot of the SQL query after the fix
![image](https://github.com/lightdash/lightdash/assets/86364607/37aa8d5f-772a-4917-83c5-a163eb1c54de)

Now every condition is enclosed in brackets.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7565

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
