### PR TITLE
fix: optimize get project summary

### DIFF
--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -59,7 +59,7 @@ export class PinningService {
         projectUuid: string,
         pinnedListUuid: string,
     ): Promise<PinnedItems> {
-        const project = await this.projectModel.get(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
         if (user.ability.cannot('view', subject('Project', project))) {
             throw new ForbiddenError();
         }

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -18,6 +18,7 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     Project,
+    ProjectSummary,
     ProjectType,
     SessionUser,
     Space,
@@ -232,6 +233,12 @@ export const projectWithSensitiveFields: Project = {
         project_id: 'project_id',
         type: DbtProjectType.DBT_CLOUD_IDE,
     } as any as DbtCloudIDEProjectConfig,
+};
+
+export const projectSummary: ProjectSummary = {
+    organizationUuid: user.organizationUuid!,
+    projectUuid: 'projectUuid',
+    name: 'name',
 };
 export const defaultProject: OrganizationProject = {
     projectUuid: 'projectUuid',

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -29,6 +29,7 @@ import {
     expectedSqlResults,
     job,
     lightdashConfigWithNoSMTP,
+    projectSummary,
     projectWithSensitiveFields,
     spacesWithSavedCharts,
     tablesConfiguration,
@@ -49,6 +50,7 @@ jest.mock('../../models/models', () => ({
     projectModel: {
         getWithSensitiveFields: jest.fn(async () => projectWithSensitiveFields),
         get: jest.fn(async () => projectWithSensitiveFields),
+        getSummary: jest.fn(async () => projectSummary),
         getTablesConfiguration: jest.fn(async () => tablesConfiguration),
         updateTablesConfiguration: jest.fn(),
         getExploresFromCache: jest.fn(async () => allExplores),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -279,7 +279,7 @@ export class ProjectService {
 
         if (data.copiedFromProjectUuid) {
             try {
-                const project = await this.projectModel.get(
+                const { organizationUuid } = await this.projectModel.getSummary(
                     data.copiedFromProjectUuid,
                 );
                 // We only allow copying from projects if the user is an admin until we remove the `createProjectAccess` call above
@@ -287,7 +287,7 @@ export class ProjectService {
                     user.ability.cannot(
                         'manage',
                         subject('Project', {
-                            organizationUuid: project.organizationUuid,
+                            organizationUuid,
                             projectUuid: data.copiedFromProjectUuid,
                         }),
                     )
@@ -430,7 +430,9 @@ export class ProjectService {
         projectUuid: string,
         explores: (Explore | ExploreError)[],
     ): Promise<void> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'update',
@@ -1037,9 +1039,7 @@ export class ProjectService {
                     }
 
                     const { organizationUuid } =
-                        await this.projectModel.getWithSensitiveFields(
-                            projectUuid,
-                        );
+                        await this.projectModel.getSummary(projectUuid);
 
                     if (
                         user.ability.cannot(
@@ -1189,8 +1189,9 @@ export class ProjectService {
         projectUuid: string,
         sql: string,
     ): Promise<ApiSqlQueryResults> {
-        const { organizationUuid } =
-            await this.projectModel.getWithSensitiveFields(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1231,8 +1232,9 @@ export class ProjectService {
         limit: number,
         filters: AndFilterGroup | undefined,
     ): Promise<Array<unknown>> {
-        const { organizationUuid } =
-            await this.projectModel.getWithSensitiveFields(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1500,8 +1502,9 @@ export class ProjectService {
         const job = await this.jobModel.get(jobUuid);
 
         if (job.projectUuid) {
-            const { organizationUuid } =
-                await this.projectModel.getWithSensitiveFields(job.projectUuid);
+            const { organizationUuid } = await this.projectModel.getSummary(
+                job.projectUuid,
+            );
             if (
                 user.ability.cannot(
                     'view',
@@ -1525,7 +1528,9 @@ export class ProjectService {
         projectUuid: string,
         requestMethod: RequestMethod,
     ): Promise<{ jobUuid: string }> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot('create', 'Job') ||
             user.ability.cannot(
@@ -1570,7 +1575,9 @@ export class ProjectService {
         requestMethod: RequestMethod,
         jobUuid: string,
     ) {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot('create', 'Job') ||
             user.ability.cannot(
@@ -1630,7 +1637,9 @@ export class ProjectService {
         projectUuid: string,
         filtered: boolean,
     ): Promise<SummaryExplore[]> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -1709,7 +1718,7 @@ export class ProjectService {
             description: 'Gets a single explore from the cache',
         });
         try {
-            const { organizationUuid } = await this.projectModel.get(
+            const { organizationUuid } = await this.projectModel.getSummary(
                 projectUuid,
             );
             if (
@@ -1753,7 +1762,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ProjectCatalog> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -1787,7 +1798,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<TablesConfiguration> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -1805,7 +1818,9 @@ export class ProjectService {
         projectUuid: string,
         data: TablesConfiguration,
     ): Promise<TablesConfiguration> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'update',
@@ -1951,7 +1966,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<boolean> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -1973,7 +1990,9 @@ export class ProjectService {
         projectUuid: string,
         userUuid: string,
     ): Promise<ProjectMemberProfile> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -2003,7 +2022,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ProjectMemberProfile[]> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -2023,7 +2044,9 @@ export class ProjectService {
         projectUuid: string,
         data: CreateProjectMember,
     ): Promise<void> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2041,7 +2064,7 @@ export class ProjectService {
             data.email,
             data.role,
         );
-        const project = await this.projectModel.get(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
         const projectUrl = new URL(
             `/projects/${projectUuid}/home`,
             lightdashConfig.siteUrl,
@@ -2062,7 +2085,9 @@ export class ProjectService {
         userUuid: string,
         data: UpdateProjectMember,
     ): Promise<void> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2087,7 +2112,9 @@ export class ProjectService {
         projectUuid: string,
         userUuid: string,
     ): Promise<void> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2108,7 +2135,9 @@ export class ProjectService {
         projectUuid: string,
         integration: CreateDbtCloudIntegration,
     ) {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2132,7 +2161,9 @@ export class ProjectService {
     }
 
     async deleteDbtCloudIntegration(user: SessionUser, projectUuid: string) {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2152,7 +2183,9 @@ export class ProjectService {
     }
 
     async findDbtCloudIntegration(user: SessionUser, projectUuid: string) {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -2168,7 +2201,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ChartSummary[]> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -2279,7 +2314,9 @@ export class ProjectService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<SpaceSummary[]> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -380,7 +380,7 @@ export class SavedChartService {
         projectUuid: string,
         data: UpdateMultipleSavedChart[],
     ): Promise<SavedChart[]> {
-        const project = await this.projectModel.get(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
 
         if (
             user.ability.cannot(
@@ -497,7 +497,9 @@ export class SavedChartService {
         projectUuid: string,
         savedChart: CreateSavedChart,
     ): Promise<SavedChart> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'create',

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -43,7 +43,9 @@ export class SearchService {
         projectUuid: string,
         query: string,
     ): Promise<SearchResults> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -103,7 +103,9 @@ export class SpaceService {
         user: SessionUser,
         space: CreateSpace,
     ): Promise<Space> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'create',

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -163,7 +163,7 @@ export class UnfurlService {
                     chartType: chart.chartType,
                 };
             case LightdashPage.EXPLORE:
-                const project = await this.projectModel.get(
+                const project = await this.projectModel.getSummary(
                     parsedUrl.projectUuid!,
                 );
 

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -524,7 +524,9 @@ export class ValidationService {
         context?: RequestMethod,
         explores?: (Explore | ExploreError)[],
     ): Promise<string> {
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -288,6 +288,11 @@ export type Project = {
     dbtVersion: SupportedDbtVersions;
 };
 
+export type ProjectSummary = Pick<
+    Project,
+    'name' | 'projectUuid' | 'organizationUuid'
+>;
+
 export type ApiProjectResponse = {
     status: 'ok';
     results: Project;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7598 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem:
I noticed that we were requesting the entire project information from the DB when we just needed the organisation uuid. 

Changes:
- Added type ProjectSummary
- Added new DB query to just fetch the project uuid, name and org uuid
- Update all the services to use new method when possible
- Update mocks
- My IDE also auto formatted some raw SQL in the model


Force tests:
test-frontend


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
