### PR TITLE
fix: only parse necessary columns

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,13 +1,10 @@
 import { BigQuery } from '@google-cloud/bigquery';
-
-import { Readable } from 'stream';
 import { BigqueryWarehouseClient } from './BigqueryWarehouseClient';
 import {
     createJobResponse,
     credentials,
     getDatasetResponse,
     getTableResponse,
-    rows,
 } from './BigqueryWarehouseClient.mock';
 import {
     config,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
@@ -3,6 +3,7 @@ import {
     DimensionType,
     WarehouseTypes,
 } from '@lightdash/common';
+import { Readable } from 'stream';
 import { SnowflakeTypes } from './SnowflakeWarehouseClient';
 import { config } from './WarehouseClient.mock';
 
@@ -184,6 +185,27 @@ export const expectedRow: Record<string, any> = {
     MYDATECOLUMN: new Date('2021-03-10T00:00:00.000Z'),
     MYTIMESTAMPCOLUMN: new Date('1990-03-02T08:30:00.010Z'),
     MYBOOLEANCOLUMN: false,
-    MYARRAYCOLUMN: '1,2,3',
-    MYOBJECTCOLUMN: '[object Object]',
+    MYARRAYCOLUMN: ['1', '2', '3'],
+    MYOBJECTCOLUMN: { test: '1' },
 };
+
+const rows: Record<string, any>[] = [
+    {
+        MYSTRINGCOLUMN: 'string value',
+        MYNUMBERCOLUMN: 100,
+        MYDATECOLUMN: new Date('2021-03-10T00:00:00.000Z'),
+        MYTIMESTAMPCOLUMN: new Date('1990-03-02T08:30:00.010Z'),
+        MYBOOLEANCOLUMN: false,
+        MYARRAYCOLUMN: ['1', '2', '3'],
+        MYOBJECTCOLUMN: { test: '1' },
+    },
+];
+
+export const mockStreamRows = () =>
+    new Readable({
+        objectMode: true,
+        read() {
+            rows.forEach((row) => this.push(row));
+            this.push(null);
+        },
+    });

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -1,6 +1,5 @@
 import { DimensionType } from '@lightdash/common';
 import { createConnection } from 'snowflake-sdk';
-import { Readable } from 'stream';
 import {
     mapFieldType,
     SnowflakeWarehouseClient,
@@ -11,18 +10,10 @@ import {
     expectedFields,
     expectedRow,
     expectedWarehouseSchema,
+    mockStreamRows,
     queryColumnsMock,
 } from './SnowflakeWarehouseClient.mock';
 import { config } from './WarehouseClient.mock';
-
-const mockStreamRows = () =>
-    new Readable({
-        objectMode: true,
-        read() {
-            this.push(expectedRow);
-            this.push(null);
-        },
-    });
 
 jest.mock('snowflake-sdk', () => ({
     ...jest.requireActual('snowflake-sdk'),

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -100,11 +100,16 @@ const parseCell = (cell: any) => {
     return cell;
 };
 
-const parseRow = (row: Record<string, any>) =>
-    Object.fromEntries(
-        Object.entries(row).map(([name, value]) => [name, parseCell(value)]),
-    );
-const parseRows = (rows: Record<string, any>[]) => rows.map(parseRow);
+const parseRow = (row: Record<string, any>, columnsToParse: string[]) => {
+    if (columnsToParse.length <= 0) {
+        return row;
+    }
+    const parsedRow = row;
+    columnsToParse.forEach((column) => {
+        parsedRow[column] = parseCell(row[column]);
+    });
+    return parsedRow;
+};
 
 export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflakeCredentials> {
     connectionOptions: ConnectionOptions;
@@ -206,13 +211,37 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                         reject(new WarehouseQueryError(err.message));
                     }
                     const rows: any[] = [];
-
+                    const columns = stmt.getColumns();
+                    const columnsToParse: string[] = [];
+                    const fields = columns
+                        ? columns.reduce<
+                              Record<string, { type: DimensionType }>
+                          >((acc, column) => {
+                              const dimensionType = mapFieldType(
+                                  column.getType().toUpperCase(),
+                              );
+                              if (
+                                  [
+                                      DimensionType.DATE,
+                                      DimensionType.TIMESTAMP,
+                                  ].includes(dimensionType)
+                              ) {
+                                  columnsToParse.push(column.getName());
+                              }
+                              return {
+                                  ...acc,
+                                  [column.getName()]: {
+                                      type: dimensionType,
+                                  },
+                              };
+                          }, {})
+                        : {};
                     pipeline(
                         stmt.streamRows(),
                         new Transform({
                             objectMode: true,
                             transform(chunk, encoding, callback) {
-                                callback(null, parseRow(chunk));
+                                callback(null, parseRow(chunk, columnsToParse));
                             },
                         }),
                         new Writable({
@@ -226,23 +255,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                             if (error) {
                                 reject(new WarehouseQueryError(error.message));
                             } else {
-                                const columns = stmt.getColumns();
-                                const fields = columns
-                                    ? columns.reduce(
-                                          (acc, column) => ({
-                                              ...acc,
-                                              [column.getName()]: {
-                                                  type: mapFieldType(
-                                                      column
-                                                          .getType()
-                                                          .toUpperCase(),
-                                                  ),
-                                              },
-                                          }),
-                                          {},
-                                      )
-                                    : {};
-
                                 resolve({ fields, rows });
                             }
                         },
@@ -276,7 +288,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                             }),
                             {},
                         );
-                        resolve({ fields, rows: parseRows(data) });
+                        resolve({ fields, rows: data });
                     } else {
                         reject(
                             new WarehouseQueryError(

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.mock.ts
@@ -62,8 +62,8 @@ export const queryResponse = {
             new Date('2021-03-10T00:00:00.000Z'),
             new Date('1990-03-02T08:30:00.010Z'),
             false,
-            '1,2,3',
-            '[object Object]',
+            ['1', '2', '3'],
+            { test: '1' },
         ],
     ],
 };

--- a/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
@@ -45,6 +45,6 @@ export const expectedRow: Record<string, any> = {
     myDateColumn: new Date('2021-03-10T00:00:00.000Z'),
     myTimestampColumn: new Date('1990-03-02T08:30:00.010Z'),
     myBooleanColumn: false,
-    myArrayColumn: '1,2,3',
-    myObjectColumn: '[object Object]',
+    myArrayColumn: ['1', '2', '3'],
+    myObjectColumn: { test: '1' },
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7596<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- only parse rows if there are columns that need to be parsed
- only parse necessary columns
- stop formatting arrays/objects for Bigquery. It was the only warehouse doing it so I amended the tests.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
