### PR TITLE
fix: tooltips in config sidebar

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/FieldLayoutOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/FieldLayoutOptions.tsx
@@ -233,6 +233,7 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
             <Tooltip
                 label="You need at least one metric in your chart to add a group"
                 position="left"
+                withinPortal
                 disabled={chartHasMetricOrTableCalc}
             >
                 <Stack spacing="xs" mb="md">
@@ -314,6 +315,8 @@ const FieldLayoutOptions: FC<Props> = ({ items }) => {
             {pivotDimensions && pivotDimensions.length > 0 && canBeStacked && (
                 <Tooltip
                     label="x-axis must be non-numeric to enable stacking"
+                    withinPortal
+                    position="top-start"
                     disabled={!isXAxisFieldNumeric}
                 >
                     <Stack spacing="xs">

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -275,7 +275,11 @@ export const ReferenceLine: FC<Props> = ({
                     <Text fw={500}>Line {index}</Text>
                 </Group>
 
-                <Tooltip label="Remove reference line" position="left">
+                <Tooltip
+                    label="Remove reference line"
+                    position="left"
+                    withinPortal
+                >
                     <ActionIcon
                         onClick={() =>
                             removeReferenceLine(referenceLine.data.name)

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -76,6 +76,7 @@ const PieChartLayoutConfig: React.FC = () => {
                             ? 'To add more groups you need to add more dimensions to your query'
                             : undefined
                     }
+                    withinPortal
                 >
                     <Box w="fit-content">
                         <Button

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
@@ -81,6 +81,7 @@ const ValueOptions: FC<ValueOptionsProps> = ({
             position="top-start"
             disabled={valueLabel !== 'hidden'}
             label="Enable Value label to configure this option"
+            withinPortal
         >
             <div>
                 <Checkbox
@@ -99,6 +100,7 @@ const ValueOptions: FC<ValueOptionsProps> = ({
             position="top-start"
             disabled={valueLabel !== 'hidden'}
             label="Enable Value label to configure this option"
+            withinPortal
         >
             <div>
                 <Checkbox
@@ -205,7 +207,7 @@ const GroupItem = forwardRef<HTMLDivElement, StackProps & GroupItemProps>(
                         }}
                     />
 
-                    <Tooltip label="Override value label options">
+                    <Tooltip label="Override value label options" withinPortal>
                         <ActionIcon onClick={toggle} size="sm">
                             <MantineIcon
                                 icon={opened ? IconChevronUp : IconChevronDown}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -47,6 +47,7 @@ const ColumnConfiguration: React.FC<{ fieldId: string }> = ({ fieldId }) => {
             <Tooltip
                 position="top"
                 opened={isShowTooltipVisible}
+                withinPortal
                 label={
                     isPivotingDimension
                         ? "Can't hide pivot dimensions"
@@ -95,6 +96,7 @@ const ColumnConfiguration: React.FC<{ fieldId: string }> = ({ fieldId }) => {
             {!pivotDimensions ? (
                 <Tooltip
                     position="top"
+                    withinPortal
                     opened={isFreezeTooltipVisible}
                     label={
                         isColumnFrozen(fieldId)

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -263,7 +263,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                         <Text fw={500}>Rule {configIndex + 1}</Text>
                     </Group>
 
-                    <Tooltip label="Remove rule" position="left">
+                    <Tooltip label="Remove rule" position="left" withinPortal>
                         <ActionIcon onClick={handleRemove} size="sm">
                             <MantineIcon icon={IconX} />
                         </ActionIcon>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -60,7 +60,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                 </Group>
 
                 {hasRemove && (
-                    <Tooltip label="Remove rule" position="left">
+                    <Tooltip label="Remove rule" position="left" withinPortal>
                         <ActionIcon onClick={onRemoveRule} size="sm">
                             <MantineIcon icon={IconX} />
                         </ActionIcon>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -169,9 +169,12 @@ const GeneralSettings: FC = () => {
             <Tooltip
                 disabled={!!canUsePivotTable}
                 label={
-                    'To use metrics as rows, you need to move a dimension to "Columns".'
+                    'To use metrics as rows, you need to move a dimension to "Columns"'
                 }
-                position="top"
+                w={300}
+                multiline
+                withinPortal
+                position="top-start"
             >
                 <Box my="sm">
                     <Checkbox


### PR DESCRIPTION
### Description:

Fixes tooltips getting cut off in the chart config sidebar. Mostly by putting them in a portal. 

🤔 is there a downside to setting `withinPortal` as the default? We can think about it. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
