### PR TITLE
feat: filter inputs - date picker input to mantine

### DIFF
--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -365,9 +365,14 @@ describe('Date tests', () => {
             .should('exist');
 
         // Keep same date
-        cy.get('.bp4-date-input input').should('have.value', todayDate);
+        cy.get('.mantine-DateInput-root input').should(
+            'have.value',
+            dayjs(todayDate).format('MMMM D, YYYY'),
+        );
         cy.get('.mantine-Prism-root').contains(
-            `(DATE_TRUNC('DAY', "customers".created)) != ('${todayDate}')`,
+            `(DATE_TRUNC('DAY', "customers".created)) != ('${getLocalISOString(
+                todayDate,
+            )}')`,
         );
 
         cy.get('.tabler-icon-x').click({ multiple: true });

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -329,8 +329,7 @@ describe('Date tests', () => {
     });
 
     it('Should keep value when changing date operator', () => {
-        const now = new Date();
-        const todayDate = getLocalISOString(now);
+        const todayDate = new Date();
 
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/customers`);
 
@@ -343,9 +342,14 @@ describe('Date tests', () => {
         cy.findByPlaceholderText('Search field...').type('created day');
         cy.contains('Created day').click();
 
-        cy.get('.bp4-date-input input').should('have.value', todayDate);
+        cy.get('.mantine-DateInput-root input').should(
+            'have.value',
+            dayjs(todayDate).format('MMMM D, YYYY'),
+        );
         cy.get('.mantine-Prism-root').contains(
-            `(DATE_TRUNC('DAY', "customers".created)) = ('${todayDate}')`,
+            `(DATE_TRUNC('DAY', "customers".created)) = ('${getLocalISOString(
+                todayDate,
+            )}')`,
         );
 
         // Change date operator

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -369,7 +369,7 @@ describe('Date tests', () => {
         cy.get('.tabler-icon-x').click({ multiple: true });
     });
 
-    it('Should filter by date on dimension', () => {
+    it.only('Should filter by date on dimension', () => {
         const now = moment();
         const exploreStateUrlParams = `?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22dimensions%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%2C%22metrics%22%3A%5B%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_date_day%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A1%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_day%22%2C%22yField%22%3A%5B%22orders_order_date_week%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_day%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_order_date_week%22%7D%7D%2C%22type%22%3A%22bar%22%7D%5D%7D%7D%7D%7D`;
         cy.visit(
@@ -434,11 +434,16 @@ describe('Date tests', () => {
         cy.findByRole('button', { name: 'Day' }).findByRole('button').click();
         cy.findByRole('menuitem', { name: 'Add filter' }).click();
 
-        const todayDate = getLocalISOString(now.toDate());
+        const todayDate = now.toDate();
 
-        cy.get('.bp4-date-input input').should('have.value', todayDate);
+        cy.get('.mantine-DateInput-root input').should(
+            'have.value',
+            dayjs(todayDate).format('MMMM D, YYYY'),
+        );
         cy.get('.mantine-Prism-root').contains(
-            `(DATE_TRUNC('DAY', "orders".order_date)) = ('${todayDate}')`,
+            `(DATE_TRUNC('DAY', "orders".order_date)) = ('${getLocalISOString(
+                todayDate,
+            )}')`,
         );
         cy.get('.tabler-icon-x').click({ multiple: true });
     });

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -369,7 +369,7 @@ describe('Date tests', () => {
         cy.get('.tabler-icon-x').click({ multiple: true });
     });
 
-    it.only('Should filter by date on dimension', () => {
+    it('Should filter by date on dimension', () => {
         const now = moment();
         const exploreStateUrlParams = `?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22dimensions%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%2C%22metrics%22%3A%5B%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_date_day%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A1%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_day%22%2C%22yField%22%3A%5B%22orders_order_date_week%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_day%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_order_date_week%22%7D%7D%2C%22type%22%3A%22bar%22%7D%5D%7D%7D%7D%7D`;
         cy.visit(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -20,6 +20,7 @@ import WeekPicker from '../../WeekPicker';
 import YearInput from '../../YearInput';
 import { useFiltersContext } from '../FiltersProvider';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
+import DatePicker from './DatePicker';
 import { getFirstDayOfWeek, normalizeWeekDay } from './dateUtils';
 import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
 import {
@@ -220,38 +221,27 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
             }
 
             return (
-                <DateInput2
-                    className={disabled ? 'disabled-filter' : ''}
-                    placeholder={placeholder}
+                <DatePicker
                     disabled={disabled}
-                    fill
-                    value={
-                        rule.values && rule.values.length > 0
-                            ? formatDate(rule.values?.[0], undefined, false)
-                            : null
-                    }
-                    formatDate={(value: Date) =>
-                        formatDate(value, undefined, false)
-                    }
-                    parseDate={parseDate}
-                    onChange={(value: string | null) => {
-                        if (value) {
-                            onChange({
-                                ...rule,
-                                values: [formatDate(value, undefined, false)],
-                            });
-                        }
-                    }}
+                    placeholder={placeholder}
+                    startOfWeek={startOfWeek ?? undefined}
+                    // FIXME: remove this once we migrate off of Blueprint
+                    // we are doing type conversion here because Blueprint expects DOM element
+                    // Mantine does not provide a DOM element on onOpen/onClose
                     popoverProps={{
-                        placement: 'bottom',
-                        ...popoverProps,
+                        onOpen: () => popoverProps?.onOpened?.(null as any),
+                        onClose: () => popoverProps?.onClose?.(null as any),
                     }}
-                    dayPickerProps={{
-                        firstDayOfWeek: isWeekDay(startOfWeek)
-                            ? normalizeWeekDay(startOfWeek)
-                            : undefined,
+                    value={rule.values ? rule.values[0] : null}
+                    onChange={(value: Date | null) => {
+                        onChange({
+                            ...rule,
+                            values:
+                                value === null
+                                    ? undefined
+                                    : [moment(value).toDate()],
+                        });
                     }}
-                    maxDate={moment(new Date()).add(7, 'years').toDate()}
                 />
             );
         case FilterOperator.IN_THE_PAST:

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -224,7 +224,10 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                 <DatePicker
                     disabled={disabled}
                     placeholder={placeholder}
-                    startOfWeek={startOfWeek ?? undefined}
+                    // FIXME: mantine v7
+                    // mantine does not set the first day of the week based on the locale
+                    // so we need to do it manually and always pass it as a prop
+                    firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     // FIXME: remove this once we migrate off of Blueprint
                     // we are doing type conversion here because Blueprint expects DOM element
                     // Mantine does not provide a DOM element on onOpen/onClose

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DatePicker.tsx
@@ -1,7 +1,6 @@
-import { WeekDay } from '@lightdash/common';
-import { DateInput, DateInputProps } from '@mantine/dates';
+import { DateInput, DateInputProps, DayOfWeek } from '@mantine/dates';
 import { FC, useMemo } from 'react';
-import { getDateValueFromUnknown, normalizeWeekDay } from './dateUtils';
+import { getDateValueFromUnknown } from './dateUtils';
 
 interface Props
     extends Omit<
@@ -10,23 +9,18 @@ interface Props
     > {
     value: unknown;
     onChange: (value: Date) => void;
-    startOfWeek?: WeekDay;
+    firstDayOfWeek: DayOfWeek;
 }
 
 const DatePicker: FC<Props> = ({
-    startOfWeek: startOfWeekDay = WeekDay.SUNDAY,
     value: stringOrDateValue,
     onChange,
+    firstDayOfWeek,
     ...rest
 }) => {
     const dateValue = useMemo(
         () => getDateValueFromUnknown(stringOrDateValue),
         [stringOrDateValue],
-    );
-
-    const normalizedStartOfWeekDay = useMemo(
-        () => normalizeWeekDay(startOfWeekDay),
-        [startOfWeekDay],
     );
 
     return (
@@ -35,7 +29,7 @@ const DatePicker: FC<Props> = ({
             size="xs"
             {...rest}
             popoverProps={{ ...rest.popoverProps, shadow: 'sm' }}
-            firstDayOfWeek={normalizedStartOfWeekDay}
+            firstDayOfWeek={firstDayOfWeek}
             value={dateValue}
             onChange={(date) => {
                 if (!date) return;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DatePicker.tsx
@@ -1,0 +1,48 @@
+import { WeekDay } from '@lightdash/common';
+import { DateInput, DateInputProps } from '@mantine/dates';
+import { FC, useMemo } from 'react';
+import { getDateValueFromUnknown, normalizeWeekDay } from './dateUtils';
+
+interface Props
+    extends Omit<
+        DateInputProps,
+        'firstDayOfWeek' | 'getDayProps' | 'value' | 'onChange'
+    > {
+    value: unknown;
+    onChange: (value: Date) => void;
+    startOfWeek?: WeekDay;
+}
+
+const DatePicker: FC<Props> = ({
+    startOfWeek: startOfWeekDay = WeekDay.SUNDAY,
+    value: stringOrDateValue,
+    onChange,
+    ...rest
+}) => {
+    const dateValue = useMemo(
+        () => getDateValueFromUnknown(stringOrDateValue),
+        [stringOrDateValue],
+    );
+
+    const normalizedStartOfWeekDay = useMemo(
+        () => normalizeWeekDay(startOfWeekDay),
+        [startOfWeekDay],
+    );
+
+    return (
+        <DateInput
+            w="100%"
+            size="xs"
+            {...rest}
+            popoverProps={{ ...rest.popoverProps, shadow: 'sm' }}
+            firstDayOfWeek={normalizedStartOfWeekDay}
+            value={dateValue}
+            onChange={(date) => {
+                if (!date) return;
+                onChange(date);
+            }}
+        />
+    );
+};
+
+export default DatePicker;


### PR DESCRIPTION
closes: #7314 

### Description:

migrates DateInput2 to mantine (this one is without time picker)

https://github.com/lightdash/lightdash/assets/962095/505fe414-c8e3-4ada-b112-7b4d4f3745cb

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
