### PR TITLE
feat: scheduled deliveries list in mantine

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerModalBase.styles.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalBase.styles.ts
@@ -1,4 +1,4 @@
-import { Card, H5, HTMLSelect } from '@blueprintjs/core';
+import { HTMLSelect } from '@blueprintjs/core';
 import { IconMail } from '@tabler/icons-react';
 import styled from 'styled-components';
 import { ReactComponent as SlackSvg } from '../../../svgs/slack.svg';
@@ -22,24 +22,6 @@ export const TargetRow = styled.div`
         margin-bottom: 0;
         flex: 1;
     }
-`;
-
-export const SchedulerContainer = styled(Card)`
-    display: flex;
-    flex-direction: column;
-    padding: 5px 10px 11px;
-    margin-bottom: 10px;
-`;
-
-export const SchedulerName = styled(H5)`
-    font-size: 14px !important;
-    flex: 1;
-    margin: 0;
-`;
-
-export const SchedulerDetailsContainer = styled.div`
-    display: flex;
-    align-items: center;
 `;
 
 export const Title = styled.p`

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent2.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent2.tsx
@@ -41,7 +41,7 @@ const ListStateContent: FC<{
             <Box
                 py="sm"
                 mih={220}
-                px="md"
+                px="sm"
                 sx={(theme) => ({ backgroundColor: theme.colors.gray[2] })}
             >
                 <SchedulersList

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -1,5 +1,5 @@
-import { NonIdealState, Spinner } from '@blueprintjs/core';
 import { ApiError, SchedulerAndTargets } from '@lightdash/common';
+import { Loader, Stack, Text, Title } from '@mantine/core';
 import React, { FC, useState } from 'react';
 import { UseQueryResult } from 'react-query/types/react/types';
 import ErrorState from '../../../components/common/ErrorState';
@@ -16,18 +16,26 @@ const SchedulersList: FC<Props> = ({ schedulersQuery, onEdit }) => {
     const [schedulerUuid, setSchedulerUuid] = useState<string>();
 
     if (isLoading) {
-        return <NonIdealState title="Loading schedulers" icon={<Spinner />} />;
+        return (
+            <Stack h={300} w="100%" align="center">
+                <Text fw={600}>Loading schedulers</Text>
+                <Loader size="lg" />
+            </Stack>
+        );
     }
     if (error) {
         return <ErrorState error={error.error} />;
     }
     if (!schedulers || schedulers.length <= 0) {
         return (
-            <NonIdealState
-                title="There are no existing scheduled deliveries"
-                description='Add one by clicking on "Create new" below'
-                icon={'blank'}
-            />
+            <Stack color="gray" align="center" mt="xxl">
+                <Title order={4} color="gray.6">
+                    There are no existing scheduled deliveries
+                </Title>
+                <Text color="gray.6">
+                    Add one by clicking on "Create new" below
+                </Text>
+            </Stack>
         );
     }
     return (

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -1,23 +1,19 @@
-import { Classes } from '@blueprintjs/core';
 import {
     getHumanReadableCronExpression,
     SchedulerAndTargets,
 } from '@lightdash/common';
-import { Divider, Menu } from '@mantine/core';
-import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Box,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { IconCircleFilled, IconPencil, IconTrash } from '@tabler/icons-react';
 import { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import {
-    InfoContainer,
-    PageDetailsContainer,
-    SeparatorDot,
-    UpdatedInfoLabel,
-} from '../../../components/common/PageHeader';
-import {
-    SchedulerContainer,
-    SchedulerDetailsContainer,
-    SchedulerName,
-} from './SchedulerModalBase.styles';
 
 type SchedulersListItemProps = {
     scheduler: SchedulerAndTargets;
@@ -31,47 +27,53 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
     onDelete,
 }) => {
     return (
-        <SchedulerContainer>
-            <SchedulerDetailsContainer
-                className={Classes.TEXT_OVERFLOW_ELLIPSIS}
-            >
-                <SchedulerName>{scheduler.name}</SchedulerName>
-                <Menu withArrow withinPortal width={100}>
-                    <Menu.Target>
-                        <MantineIcon icon={IconDots} />
-                    </Menu.Target>
+        <Paper p="sm" mb="xs" withBorder sx={{ overflow: 'hidden' }}>
+            <Group noWrap position="apart">
+                <Stack spacing="xs" w={475}>
+                    <Text fw={600} truncate>
+                        {scheduler.name}
+                    </Text>
+                    <Group>
+                        <Text color="gray" size={12}>
+                            {getHumanReadableCronExpression(scheduler.cron)}
+                        </Text>
 
-                    <Menu.Dropdown>
-                        <Menu.Item
-                            icon={<MantineIcon icon={IconPencil} />}
+                        {/* TODO: This icon should use Mantine icon,
+                            but MantineIcon doesn't support filled icons atm.
+                            Util we fix that, this style is imperfect
+                        */}
+                        <Box
+                            sx={(theme) => ({
+                                color: theme.colors.gray[4],
+                                marginTop: '-6px',
+                            })}
+                        >
+                            <IconCircleFilled style={{ width: 5, height: 5 }} />
+                        </Box>
+
+                        <Text color="gray" size={12}>
+                            {scheduler.targets.length} recipients
+                        </Text>
+                    </Group>
+                </Stack>
+                <Group noWrap spacing="xs">
+                    <Tooltip label="Edit">
+                        <ActionIcon
+                            variant="light"
                             onClick={() => onEdit(scheduler.schedulerUuid)}
                         >
-                            Edit
-                        </Menu.Item>
-                        <Divider />
-
-                        <Menu.Item
-                            icon={<MantineIcon color="red" icon={IconTrash} />}
-                            onClick={() => onDelete(scheduler.schedulerUuid)}
-                            color="red"
-                        >
-                            Delete
-                        </Menu.Item>
-                    </Menu.Dropdown>
-                </Menu>
-            </SchedulerDetailsContainer>
-            <PageDetailsContainer>
-                <UpdatedInfoLabel>
-                    {getHumanReadableCronExpression(scheduler.cron)}
-                </UpdatedInfoLabel>
-
-                <SeparatorDot icon="dot" size={6} />
-
-                <InfoContainer>
-                    {scheduler.targets.length} recipients
-                </InfoContainer>
-            </PageDetailsContainer>
-        </SchedulerContainer>
+                            <MantineIcon icon={IconPencil} />
+                        </ActionIcon>
+                    </Tooltip>
+                    <ActionIcon
+                        variant="light"
+                        onClick={() => onDelete(scheduler.schedulerUuid)}
+                    >
+                        <MantineIcon color="red" icon={IconTrash} />
+                    </ActionIcon>
+                </Group>
+            </Group>
+        </Paper>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7645 

### Description:

Port scheduled deliveries list to mantine.

Before:
<img width="649" alt="Screenshot 2023-10-26 at 11 18 21" src="https://github.com/lightdash/lightdash/assets/1864179/cc3d5ddb-e732-445b-a70a-62736fbfe0ef">

After:
<img width="628" alt="Screenshot 2023-10-26 at 11 18 42" src="https://github.com/lightdash/lightdash/assets/1864179/581b30f4-8877-4d2b-9e8a-a4c68a892c1a">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
