### PR TITLE
fix: parse bignumeric in bigquery

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -163,8 +163,10 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 if (field.name) {
                     const dimensionType = mapFieldType(field.type);
 
-                    // Big numbers can't be cloned by the Node Worker so we need to parse them
-                    if (field.type === BigqueryFieldType.BIGNUMERIC) {
+                    if (
+                        field.type === BigqueryFieldType.BIGNUMERIC || // Big numbers can't be cloned by the Node Worker so we need to parse them
+                        field.type === BigqueryFieldType.NUMERIC // Numbers can also possibly be Big() so we need to parse them; ref: https://github.com/steffnay/nodejs-bigquery/blob/master/src/bigquery.ts#L518
+                    ) {
                         columnsToParse.push(field.name);
                     }
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -162,6 +162,12 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             >((acc, field) => {
                 if (field.name) {
                     const dimensionType = mapFieldType(field.type);
+
+                    // Big numbers can't be cloned by the Node Worker so we need to parse them
+                    if (field.type === BigqueryFieldType.BIGNUMERIC) {
+                        columnsToParse.push(field.name);
+                    }
+
                     if (
                         [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                             dimensionType,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

`BIGNUMERIC` values should be parsed so when the rows are formatted in the worker https://github.com/lightdash/lightdash/blob/fix/parse-big-numeric-big-query-cells/packages/backend/src/services/ProjectService/ProjectService.ts#L973 couldn't clone, leading to this error: 
```
DataCloneError: function Big2(n){var x=this;if(!(x instanceof Big2))return n===UNDEFINED?Big():new Big2(n);if(n instanceof Bi......2} could not be cloned.
```

Then, the values are parsed here: https://github.com/lightdash/lightdash/blob/fix/parse-big-numeric-big-query-cells/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts#L44

(Note: I tried to reference `big.js` and do `x instaceof Big` but that was never truthy... 🤔 )
ref: https://github.com/MikeMcl/big.js

How to replicate:
* query a table with a BIGNUMERIC
* force https://github.com/lightdash/lightdash/blob/fix/parse-big-numeric-big-query-cells/packages/backend/src/services/ProjectService/ProjectService.ts#L973 to always run with a `worker` (remove ternary condition)
* Run query
* See error above ^ 


Force e2e tests:
test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
