### PR TITLE
chore: add space_id index to saved_queries table

### DIFF
--- a/packages/backend/src/database/migrations/20231026185236_add-index-space-id-to-saved-queries.ts
+++ b/packages/backend/src/database/migrations/20231026185236_add-index-space-id-to-saved-queries.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('saved_queries')) {
+        await knex.schema.alterTable('saved_queries', (table) => {
+            table.index(['space_id']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable('saved_queries')) {
+        await knex.schema.alterTable('saved_queries', (table) => {
+            table.dropIndex(['space_id']);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Similar to: https://github.com/lightdash/lightdash/pull/7556/files - add index `space_id` to the `saved_queries` table

This will help on
`SpaceModel.find` - https://github.com/lightdash/lightdash/blob/chore/add-index-spaceid-to-saved-queries/packages/backend/src/models/SpaceModel.ts#L63
getting info for availableFilters -  https://github.com/lightdash/lightdash/blob/chore/add-index-spaceid-to-saved-queries/packages/backend/src/models/SavedChartModel.ts#L912


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-frontend