### PR TITLE
feat: use mantine for schedule delete dialog

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
@@ -88,7 +88,6 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                 </Menu.Dropdown>
             </Menu>
             <SchedulerDeleteModal
-                lazy={true}
                 isOpen={isDeleting}
                 schedulerUuid={item.schedulerUuid}
                 onConfirm={handleDelete}

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
@@ -88,7 +88,7 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                 </Menu.Dropdown>
             </Menu>
             <SchedulerDeleteModal
-                isOpen={isDeleting}
+                opened={isDeleting}
                 schedulerUuid={item.schedulerUuid}
                 onConfirm={handleDelete}
                 onClose={handleDelete}

--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -1,26 +1,23 @@
-import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    DialogProps,
-    NonIdealState,
-    Spinner,
-} from '@blueprintjs/core';
+import { Box, Button, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
 import React, { FC, useCallback, useEffect } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { useScheduler } from '../hooks/useScheduler';
 import { useSchedulersDeleteMutation } from '../hooks/useSchedulersDeleteMutation';
 
-interface DashboardDeleteModalProps extends DialogProps {
+interface DashboardDeleteModalProps {
     schedulerUuid: string;
     onConfirm: () => void;
+    onClose: () => void;
+    isOpen: boolean;
 }
 
 export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
     schedulerUuid,
     onConfirm,
-    ...modalProps
+    onClose,
+    isOpen,
 }) => {
     const scheduler = useScheduler(schedulerUuid);
     const mutation = useSchedulersDeleteMutation();
@@ -35,49 +32,62 @@ export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
     }, [mutation, schedulerUuid]);
 
     return (
-        <Dialog
-            lazy
-            title="Delete scheduled delivery"
-            icon="trash"
-            {...modalProps}
+        <Modal
+            opened={isOpen}
+            title={
+                <Group spacing="xs">
+                    <MantineIcon icon={IconTrash} size="lg" color="red" />
+                    <Text fw={600}>Delete scheduled delivery</Text>
+                </Group>
+            }
+            onClose={onClose}
+            styles={(theme) => ({
+                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
+                body: { padding: 0 },
+            })}
         >
-            <DialogBody>
+            <Box px="md" py="xl">
                 {scheduler.isLoading || scheduler.error ? (
                     <>
                         {scheduler.isLoading ? (
-                            <NonIdealState
-                                title="Loading scheduler"
-                                icon={<Spinner />}
-                            />
+                            <Stack h={300} w="100%" align="center">
+                                <Text fw={600}>Loading schedulers</Text>
+                                <Loader />
+                            </Stack>
                         ) : (
                             <ErrorState error={scheduler.error.error} />
                         )}
                     </>
                 ) : (
-                    <p>
+                    <Text span>
                         Are you sure you want to delete{' '}
-                        <b>"{scheduler.data?.name}"</b>?
-                    </p>
+                        <Text fw={700} span>
+                            "{scheduler.data?.name}"
+                        </Text>
+                        ?
+                    </Text>
                 )}
-            </DialogBody>
-
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={modalProps.onClose}>Cancel</Button>
-
-                        {scheduler.isSuccess && (
-                            <Button
-                                loading={mutation.isLoading}
-                                intent="danger"
-                                onClick={handleConfirm}
-                            >
-                                Delete
-                            </Button>
-                        )}
-                    </>
-                }
-            />
-        </Dialog>
+            </Box>
+            <Group
+                position="right"
+                p="md"
+                sx={(theme) => ({
+                    borderTop: `1px solid ${theme.colors.gray[4]}`,
+                })}
+            >
+                <Button onClick={onClose} color="gray" variant="outline">
+                    Cancel
+                </Button>
+                {scheduler.isSuccess && (
+                    <Button
+                        loading={mutation.isLoading}
+                        onClick={handleConfirm}
+                        color="red"
+                    >
+                        Delete
+                    </Button>
+                )}
+            </Group>
+        </Modal>
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Group,
+    Loader,
+    Modal,
+    ModalProps,
+    Stack,
+    Text,
+} from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import React, { FC, useCallback, useEffect } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
@@ -6,18 +15,16 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useScheduler } from '../hooks/useScheduler';
 import { useSchedulersDeleteMutation } from '../hooks/useSchedulersDeleteMutation';
 
-interface DashboardDeleteModalProps {
+interface DashboardDeleteModalProps extends ModalProps {
     schedulerUuid: string;
     onConfirm: () => void;
-    onClose: () => void;
-    isOpen: boolean;
 }
 
 export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
     schedulerUuid,
     onConfirm,
     onClose,
-    isOpen,
+    opened,
 }) => {
     const scheduler = useScheduler(schedulerUuid);
     const mutation = useSchedulersDeleteMutation();
@@ -33,7 +40,7 @@ export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
 
     return (
         <Modal
-            opened={isOpen}
+            opened={opened}
             title={
                 <Group spacing="xs">
                     <MantineIcon icon={IconTrash} size="lg" color="red" />

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -50,7 +50,6 @@ const SchedulersList: FC<Props> = ({ schedulersQuery, onEdit }) => {
             ))}
             {schedulerUuid && (
                 <SchedulerDeleteModal
-                    lazy={true}
                     isOpen={true}
                     schedulerUuid={schedulerUuid}
                     onConfirm={() => setSchedulerUuid(undefined)}

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -50,7 +50,7 @@ const SchedulersList: FC<Props> = ({ schedulersQuery, onEdit }) => {
             ))}
             {schedulerUuid && (
                 <SchedulerDeleteModal
-                    isOpen={true}
+                    opened={true}
                     schedulerUuid={schedulerUuid}
                     onConfirm={() => setSchedulerUuid(undefined)}
                     onClose={() => setSchedulerUuid(undefined)}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7646 

### Description:

Migrate the scheduled deliveries delete dialog to mantine.

Old:
<img width="501" alt="Screenshot 2023-10-27 at 14 53 32" src="https://github.com/lightdash/lightdash/assets/1864179/9d33a4b3-f8c0-4a0e-a5b4-983d45d53759">

New!
<img width="441" alt="Screenshot 2023-10-27 at 14 53 50" src="https://github.com/lightdash/lightdash/assets/1864179/ff58f360-955c-4216-9318-21161e13b5ab">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
