### PR TITLE
fix: readd saved filter overrides

### DIFF
--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -2,7 +2,9 @@ import { DashboardFilterRule, DashboardFilters } from '@lightdash/common';
 import { useReducer } from 'react';
 import { useLocation } from 'react-router-dom';
 
-export const hasNonEmptyOverrides = (overrides: DashboardFilters | undefined) =>
+export const hasSavedFiltersOverrides = (
+    overrides: DashboardFilters | undefined,
+) =>
     !!(
         overrides &&
         (overrides.dimensions?.length > 0 || overrides.metrics?.length > 0)

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -1,0 +1,88 @@
+import { DashboardFilterRule, DashboardFilters } from '@lightdash/common';
+import { useReducer } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const hasNonEmptyOverrides = (overrides: DashboardFilters | undefined) =>
+    !!(
+        overrides &&
+        (overrides.dimensions?.length > 0 || overrides.metrics?.length > 0)
+    );
+
+export const applyDimensionOverrides = (
+    dashboardFilters: DashboardFilters,
+    savedFiltersOverrides: DashboardFilters,
+) =>
+    dashboardFilters.dimensions.map((dimension) => {
+        const override = savedFiltersOverrides.dimensions.find(
+            (overrideDimension) => overrideDimension.id === dimension.id,
+        );
+        return override || dimension;
+    });
+
+const ADD_SAVED_FILTER_OVERRIDE = 'ADD_SAVED_FILTER_OVERRIDE';
+const REMOVE_SAVED_FILTER_OVERRIDE = 'REMOVE_SAVED_FILTER_OVERRIDE';
+
+interface AddSavedFilterOverrideAction {
+    type: typeof ADD_SAVED_FILTER_OVERRIDE;
+    payload: DashboardFilterRule;
+}
+
+interface RemoveSavedFilterOverrideAction {
+    type: typeof REMOVE_SAVED_FILTER_OVERRIDE;
+    payload: DashboardFilterRule;
+}
+
+type Action = AddSavedFilterOverrideAction | RemoveSavedFilterOverrideAction;
+
+const reducer = (state: DashboardFilters, action: Action) => {
+    let newDimensions = [...state.dimensions];
+    const { type, payload } = action;
+
+    switch (type) {
+        case ADD_SAVED_FILTER_OVERRIDE:
+            newDimensions = state.dimensions.some(
+                (dim) => dim.id === payload.id,
+            )
+                ? state.dimensions.map((dim) =>
+                      dim.id === payload.id ? payload : dim,
+                  )
+                : [...state.dimensions, payload];
+            return { ...state, dimensions: newDimensions };
+
+        case REMOVE_SAVED_FILTER_OVERRIDE:
+            newDimensions = state.dimensions.filter(
+                (dim) => dim.id !== payload.id,
+            );
+            return { ...state, dimensions: newDimensions };
+
+        default:
+            return state;
+    }
+};
+
+export const useSavedDashboardFiltersOverrides = () => {
+    const { search } = useLocation();
+    const searchParams = new URLSearchParams(search);
+    const overridesForSavedDashboardFiltersParam = searchParams.get('filters');
+
+    const [state, dispatch] = useReducer(
+        reducer,
+        overridesForSavedDashboardFiltersParam
+            ? JSON.parse(overridesForSavedDashboardFiltersParam)
+            : { dimensions: [], metrics: [] },
+    );
+
+    const addSavedFilterOverride = (item: DashboardFilterRule) => {
+        dispatch({ type: ADD_SAVED_FILTER_OVERRIDE, payload: item });
+    };
+
+    const removeSavedFilterOverride = (item: DashboardFilterRule) => {
+        dispatch({ type: REMOVE_SAVED_FILTER_OVERRIDE, payload: item });
+    };
+
+    return {
+        overridesForSavedDashboardFilters: state,
+        addSavedFilterOverride,
+        removeSavedFilterOverride,
+    };
+};

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -32,7 +32,7 @@ import {
 } from '../hooks/dashboard/useDashboard';
 import {
     applyDimensionOverrides,
-    hasNonEmptyOverrides,
+    hasSavedFiltersOverrides,
     useSavedDashboardFiltersOverrides,
 } from '../hooks/useSavedDashboardFiltersOverrides';
 
@@ -129,7 +129,9 @@ export const DashboardProvider: React.FC = ({ children }) => {
             if (dashboardFilters === emptyFilters) {
                 let updatedDashboardFilters;
 
-                if (hasNonEmptyOverrides(overridesForSavedDashboardFilters)) {
+                if (
+                    hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
+                ) {
                     updatedDashboardFilters = {
                         ...dashboard.filters,
                         dimensions: applyDimensionOverrides(
@@ -147,7 +149,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
             setOriginalDashboardFilters(dashboard.filters);
         }
-    }, [dashboardFilters, dashboard, overridesForSavedDashboardFilters]);
+    }, [dashboard, dashboardFilters, overridesForSavedDashboardFilters]);
 
     // Updates url with temp filters
     useEffect(() => {
@@ -195,7 +197,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
     useEffect(() => {
         if (
             dashboard?.filters &&
-            hasNonEmptyOverrides(overridesForSavedDashboardFilters)
+            hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
         ) {
             setDashboardFilters({
                 ...dashboard.filters,

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -77,9 +77,11 @@ type DashboardContext = {
     hasChartTiles: boolean;
 };
 
+// TODO: move to separate action
 const hasNonEmptyOverrides = (overrides: DashboardFilters) =>
     overrides.dimensions.length > 0 || overrides.metrics.length > 0;
 
+// TODO: move to separate action
 const applyDimensionOverrides = (
     dashboardFilters: DashboardFilters,
     savedFiltersOverrides: DashboardFilters,
@@ -354,6 +356,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
                 : setDashboardFilters;
 
             setFunction((previousFilters) => {
+                // TODO: move to separate action
                 if (!isTemporary) {
                     const hasChanged = hasSavedFilterValueChanged(
                         previousFilters.dimensions[index],
@@ -367,6 +370,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
                             item,
                         );
 
+                    // TODO: move to separate action
                     setSavedFiltersOverrides((prev) => {
                         let newDimensions = [...prev.dimensions];
 
@@ -427,6 +431,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
                 ? setDashboardTemporaryFilters
                 : setDashboardFilters;
             setFunction((previousFilters) => {
+                // TODO: move to separate action
                 if (!isTemporary) {
                     setSavedFiltersOverrides((prev) => ({
                         ...prev,

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -140,9 +140,10 @@ export const DashboardProvider: React.FC = ({ children }) => {
                 setDashboardFilters(dashboard.filters);
             }
 
-            setOriginalDashboardFilters(dashboard.filters);
-
             setHaveFiltersChanged(false);
+        }
+        if (dashboard) {
+            setOriginalDashboardFilters(dashboard.filters);
         }
     }, [
         dashboardFilters,
@@ -331,10 +332,20 @@ export const DashboardProvider: React.FC = ({ children }) => {
                         previousFilters.dimensions[index],
                         item,
                     );
-                    const isReverted = !hasSavedFilterValueChanged(
-                        originalDashboardFilters.dimensions[index],
+                    console.log({
+                        originalDashboardFilters,
                         item,
-                    );
+                        current: originalDashboardFilters.dimensions[index],
+                    });
+
+                    const isReverted =
+                        originalDashboardFilters.dimensions[index] &&
+                        !hasSavedFilterValueChanged(
+                            originalDashboardFilters.dimensions[index],
+                            item,
+                        );
+
+                    console.log({ isReverted });
 
                     if (hasChanged) {
                         setSavedFiltersOverrides((prev) => {
@@ -345,7 +356,8 @@ export const DashboardProvider: React.FC = ({ children }) => {
                                         (dim) => dim.id !== item.id,
                                     ),
                                 };
-                            } else {
+                            }
+                            if (hasChanged) {
                                 return {
                                     ...prev,
                                     dimensions: prev.dimensions.some(
@@ -356,7 +368,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
                                           )
                                         : [...prev.dimensions, item],
                                 };
-                            }
+                            } else return prev;
                         });
                     }
                 }

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -367,30 +367,30 @@ export const DashboardProvider: React.FC = ({ children }) => {
                             item,
                         );
 
-                    if (hasChanged) {
-                        setSavedFiltersOverrides((prev) => {
-                            if (isReverted) {
-                                return {
-                                    ...prev,
-                                    dimensions: prev.dimensions.filter(
-                                        (dim) => dim.id !== item.id,
-                                    ),
-                                };
-                            }
-                            if (hasChanged) {
-                                return {
-                                    ...prev,
-                                    dimensions: prev.dimensions.some(
-                                        (dim) => dim.id === item.id,
-                                    )
-                                        ? prev.dimensions.map((dim) =>
-                                              dim.id === item.id ? item : dim,
-                                          )
-                                        : [...prev.dimensions, item],
-                                };
-                            } else return prev;
-                        });
-                    }
+                    setSavedFiltersOverrides((prev) => {
+                        let newDimensions = [...prev.dimensions];
+
+                        if (hasChanged) {
+                            newDimensions = prev.dimensions.some(
+                                (dim) => dim.id === item.id,
+                            )
+                                ? prev.dimensions.map((dim) =>
+                                      dim.id === item.id ? item : dim,
+                                  )
+                                : [...prev.dimensions, item];
+                        }
+
+                        if (isReverted) {
+                            newDimensions = newDimensions.filter(
+                                (dim) => dim.id !== item.id,
+                            );
+                        }
+
+                        return {
+                            ...prev,
+                            dimensions: newDimensions,
+                        };
+                    });
                 }
 
                 return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7696

### Description:

Add JSON.stringified overrides of saved filters to the dashboard url as `filters` search param; 

Reintroduces changes reverted in #7261 (which were effectively fixing an issue with URLs being too long and unprocessable by the browser), but also **only** adds these overrides if they're actually overriding the **saved** filter. 

This ensures that when users share dashboard urls + if there are overrides to **saved** filters, the URL will include these; 
This also ensures that when users override **saved** dashboard filters, these will also be reflected on `Export Dashboard` functionality. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
