### PR TITLE
fix: filter inputs numeric input decimals

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -7,13 +7,13 @@ import {
     FilterType,
     isFilterRule,
 } from '@lightdash/common';
-import { NumberInput } from '@mantine/core';
 import isString from 'lodash-es/isString';
-import React from 'react';
+import { PropsWithChildren } from 'react';
 import { TagInput } from '../../TagInput/TagInput';
 import { useFiltersContext } from '../FiltersProvider';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
 import MultiAutoComplete from './AutoComplete/MultiAutoComplete';
+import FilterNumberInput from './FilterNumberInput';
 
 export type FilterInputsProps<T extends ConditionalRule> = {
     filterType: FilterType;
@@ -31,7 +31,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     disabled,
     popoverProps,
     onChange,
-}: React.PropsWithChildren<FilterInputsProps<T>>) => {
+}: PropsWithChildren<FilterInputsProps<T>>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
         ? getField(rule)?.suggestions
@@ -111,26 +111,17 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
         case FilterOperator.IN_THE_NEXT:
         case FilterOperator.IN_THE_CURRENT:
         case FilterOperator.IN_BETWEEN:
-            const value = rule.values?.[0];
-            let parsedValue: number | undefined;
-
-            if (typeof value === 'string') parsedValue = parseInt(value, 10);
-            else if (typeof value === 'number') parsedValue = value;
-            else parsedValue = undefined;
-
-            if (parsedValue && isNaN(parsedValue)) parsedValue = undefined;
-
             return (
-                <NumberInput
+                <FilterNumberInput
                     disabled={disabled}
-                    w="100%"
-                    size="xs"
                     placeholder={placeholder}
-                    value={parsedValue}
+                    value={rule.values?.[0]}
                     onChange={(newValue) => {
+                        console.log(newValue);
+
                         onChange({
                             ...rule,
-                            values: newValue === '' ? [] : [newValue],
+                            values: newValue ? [newValue] : [],
                         });
                     }}
                 />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
@@ -1,0 +1,60 @@
+import { TextInput, TextInputProps } from '@mantine/core';
+import { ChangeEvent, FC, useEffect, useState } from 'react';
+
+interface Props extends Omit<TextInputProps, 'type' | 'value' | 'onChange'> {
+    value: unknown;
+    onChange: (value: number | null) => void;
+}
+
+const FilterNumberInput: FC<Props> = ({
+    value,
+    disabled,
+    placeholder,
+    onChange,
+    ...rest
+}) => {
+    const [internalValue, setInternalValue] = useState('');
+
+    useEffect(() => {
+        if (typeof value === 'string') {
+            setInternalValue(value);
+        } else if (typeof value === 'number') {
+            setInternalValue(value.toString());
+        } else if (value === undefined || value === null) {
+            setInternalValue('');
+        } else {
+            throw new Error(
+                `FilterNumberInput: Invalid value type: ${typeof value}`,
+            );
+        }
+    }, [value]);
+
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const newValue = e.target.value;
+
+        setInternalValue(newValue);
+
+        if (newValue === '') {
+            onChange(null);
+        } else if (/^-?\d+$/.test(newValue)) {
+            onChange(parseInt(newValue, 10));
+        } else if (/^-?\d+\.\d+$/.test(newValue)) {
+            onChange(parseFloat(newValue));
+        }
+    };
+
+    return (
+        <TextInput
+            w="100%"
+            size="xs"
+            disabled={disabled}
+            placeholder={placeholder}
+            {...rest}
+            type="number"
+            value={internalValue}
+            onChange={handleInputChange}
+        />
+    );
+};
+
+export default FilterNumberInput;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
@@ -6,6 +6,7 @@ interface Props extends Omit<TextInputProps, 'type' | 'value' | 'onChange'> {
     onChange: (value: number | null) => void;
 }
 
+// FIXME: remove this and use NumberInput from @mantine/core once we upgrade to mantine v7
 const FilterNumberInput: FC<Props> = ({
     value,
     disabled,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/7583

### Description:

**Mantine V6 does not support decimal values without precision in NumberInput. I've added a note to remove this component once we move to Mantine v7**

![CleanShot 2023-10-30 at 16 30 25@2x](https://github.com/lightdash/lightdash/assets/962095/d2f14105-2fb3-42e1-9812-cd99b503c117)

![CleanShot 2023-10-30 at 16 30 11@2x](https://github.com/lightdash/lightdash/assets/962095/5d25bca4-a49f-4c43-b17a-e1427ec223ed)

![CleanShot 2023-10-30 at 16 29 45@2x](https://github.com/lightdash/lightdash/assets/962095/737079fd-2a7b-49b5-8592-5f2995de59ed)

![CleanShot 2023-10-30 at 16 29 14@2x](https://github.com/lightdash/lightdash/assets/962095/f737a35a-2c82-4ed3-bbd4-0ce7d1a9dc53)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
