### PR TITLE
chore: ignore resize observer exceptions in e2e tests

### DIFF
--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -78,6 +78,21 @@ declare global {
     }
 }
 
+/**
+ * Ignore uncaught resize observer exceptions. These are supposed to be
+ * benign, but they are making our tests fail. This is a solution from
+ * this thread:
+ * https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+ */
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+Cypress.on('uncaught:exception', (err) => {
+    /* returning false here prevents Cypress from failing the test */
+    if (resizeObserverLoopErrRe.test(err.message)) {
+        return false;
+    }
+    return true;
+});
+
 Cypress.Commands.add(
     'selectMantine',
     (inputName: string, optionLabel: string) => {

--- a/render.yaml
+++ b/render.yaml
@@ -2,17 +2,14 @@ previewsEnabled: true
 
 databases:
   - name: jaffle_db
-    region: frankfurt
     ipAllowList: []
 
 services:
   - type: pserv
-    region: frankfurt
     env: docker
     name: headless-browser
     dockerfilePath: docker/Dockerfile.headless-browser
   - type: web
-    region: frankfurt
     env: docker
     name: lightdash
     plan: standard


### PR DESCRIPTION
### Description:

The cypress tests are failing a wide range of PRs because of unhandled exceptions from the resize observer. This is an experiment to ignore those errors. Is there a downside to this? If it passes we could merge it if we are ok ignoring these errors. 

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
