### PR TITLE
fix: set undefined maxDate when creating isbetween date filter

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
@@ -21,8 +21,13 @@ const FilterDateRangePicker: FC<Props> = ({
     onChange,
     ...rest
 }) => {
-    const [date1, setDate1] = useState(value?.[0] ?? null);
-    const [date2, setDate2] = useState(value?.[1] ?? null);
+    const [date1, setDate1] = useState(value?.[0] ?? new Date());
+    const [date2, setDate2] = useState(value?.[1] ?? new Date());
+
+    console.log('date1', date1);
+    console.log('date2', date2);
+    console.log('disabled', disabled);
+    console.log('rest', rest);
 
     return (
         <Flex align="center" w="100%" gap="xxs">

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
@@ -21,13 +21,8 @@ const FilterDateRangePicker: FC<Props> = ({
     onChange,
     ...rest
 }) => {
-    const [date1, setDate1] = useState(value?.[0] ?? new Date());
-    const [date2, setDate2] = useState(value?.[1] ?? new Date());
-
-    console.log('date1', date1);
-    console.log('date2', date2);
-    console.log('disabled', disabled);
-    console.log('rest', rest);
+    const [date1, setDate1] = useState(value?.[0] ?? null);
+    const [date2, setDate2] = useState(value?.[1] ?? null);
 
     return (
         <Flex align="center" w="100%" gap="xxs">
@@ -35,7 +30,9 @@ const FilterDateRangePicker: FC<Props> = ({
                 size="xs"
                 disabled={disabled}
                 placeholder="Start date"
-                maxDate={dayjs(date2).subtract(1, 'day').toDate()}
+                maxDate={
+                    date2 ? dayjs(date2).subtract(1, 'day').toDate() : undefined
+                }
                 firstDayOfWeek={firstDayOfWeek}
                 {...rest}
                 value={date1}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7767

### Description:

When selecting a new date (non-timestamp) filter + `is between` operator, and there's no value set yet, set `maxDate` as undefined like we do already on `timestamp` date filters in: https://github.com/lightdash/lightdash/blob/fix/default-to-new-date-instance-on-is-between/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx#L34

Screen recording:

https://github.com/lightdash/lightdash/assets/7611706/29133a9d-cf77-499f-83d1-fa64d60664c6



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
