### PR TITLE
fix: add missing foreign key to cached explores table

### DIFF
--- a/packages/backend/src/database/migrations/20231101164443_add_cache_explores_foreign_key.ts
+++ b/packages/backend/src/database/migrations/20231101164443_add_cache_explores_foreign_key.ts
@@ -1,0 +1,34 @@
+import { Knex } from 'knex';
+
+const CACHED_EXPLORES_TABLE_NAME = 'cached_explores';
+
+export async function up(knex: Knex): Promise<void> {
+    // delete all rows where the project doesn't exist before applying foreign key
+    await knex(CACHED_EXPLORES_TABLE_NAME)
+        .whereNotExists(
+            knex('projects')
+                .select('project_id')
+                .whereRaw(
+                    'projects.project_uuid = cached_explores.project_uuid',
+                ),
+        )
+        .delete();
+
+    if (await knex.schema.hasTable(CACHED_EXPLORES_TABLE_NAME)) {
+        await knex.schema.alterTable(CACHED_EXPLORES_TABLE_NAME, (table) => {
+            table
+                .foreign('project_uuid')
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(CACHED_EXPLORES_TABLE_NAME)) {
+        await knex.schema.alterTable(CACHED_EXPLORES_TABLE_NAME, (table) => {
+            table.dropForeign('project_uuid');
+        });
+    }
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -556,7 +556,7 @@ export class ProjectModel {
     };
 
     private getExploreQueryBuilder(projectUuid: string) {
-        return this.database('cached_explores')
+        return this.database(CachedExploresTableName)
             .select<{ explore: Explore | ExploreError }[]>(['explore'])
             .crossJoin(
                 this.database.raw('jsonb_array_elements(explores) as explore'),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7274 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- delete all cached explores for projects that no longer exist ( eg: preview projects ) 
- add foreign key to project table so the rows are deleted when a project is deleted

Force tests:

test-frontend
test-cli

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
