### PR TITLE
fix: filters + z indices on custom metric modal

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -249,6 +249,7 @@ export const CustomMetricModal = () => {
                                     projectUuid={projectUuid}
                                     fieldsMap={fieldsMap}
                                     startOfWeek={startOfWeek ?? undefined}
+                                    inModal
                                 >
                                     <FilterForm
                                         defaultFilterRuleFieldId={

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,7 +10,7 @@ import {
     parseDate,
     TimeFrames,
 } from '@lightdash/common';
-import { Flex, NumberInput, Text } from '@mantine/core';
+import { Flex, getDefaultZIndex, NumberInput, Text } from '@mantine/core';
 import React from 'react';
 import { useFiltersContext } from '../FiltersProvider';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
@@ -28,7 +28,15 @@ import FilterYearPicker from './FilterYearPicker';
 const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
     props: React.PropsWithChildren<FilterInputsProps<T>>,
 ) => {
-    const { field, rule, onChange, popoverProps, disabled, filterType } = props;
+    const {
+        field,
+        rule,
+        onChange,
+        popoverProps,
+        disabled,
+        filterType,
+        inModal,
+    } = props;
     const { startOfWeek } = useFiltersContext();
     const isTimestamp =
         isField(field) && field.type === DimensionType.TIMESTAMP;
@@ -42,6 +50,12 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
         operator: rule.operator,
         disabled: rule.disabled && !rule.values,
     });
+
+    const increaseZIndexIfInModal = inModal
+        ? {
+              zIndex: getDefaultZIndex('modal') + 1,
+          }
+        : {};
 
     switch (rule.operator) {
         case FilterOperator.EQUALS:
@@ -65,6 +79,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
 
                                 <FilterWeekPicker
                                     placeholder={placeholder}
+                                    sx={increaseZIndexIfInModal}
                                     disabled={disabled}
                                     value={
                                         rule.values && rule.values[0]
@@ -137,6 +152,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                           )
                                         : null
                                 }
+                                sx={increaseZIndexIfInModal}
                                 onChange={(value: Date) => {
                                     onChange({
                                         ...rule,
@@ -183,6 +199,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         ],
                                     });
                                 }}
+                                sx={increaseZIndexIfInModal}
                             />
                         );
                     default:
@@ -232,6 +249,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                           ],
                             });
                         }}
+                        sx={increaseZIndexIfInModal}
                     />
                 );
             }
@@ -267,6 +285,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 : [],
                         });
                     }}
+                    sx={increaseZIndexIfInModal}
                 />
             );
         case FilterOperator.IN_THE_PAST:
@@ -329,6 +348,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             },
                         })
                     }
+                    sx={increaseZIndexIfInModal}
                 />
             );
         case FilterOperator.IN_BETWEEN:
@@ -381,6 +401,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     : [],
                             });
                         }}
+                        sx={increaseZIndexIfInModal}
                     />
                 );
             }
@@ -427,6 +448,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 : [],
                         });
                     }}
+                    sx={increaseZIndexIfInModal}
                 />
             );
         default: {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,7 +10,7 @@ import {
     parseDate,
     TimeFrames,
 } from '@lightdash/common';
-import { Flex, getDefaultZIndex, NumberInput, Text } from '@mantine/core';
+import { Flex, NumberInput, Text } from '@mantine/core';
 import React from 'react';
 import { useFiltersContext } from '../FiltersProvider';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
@@ -51,12 +51,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
         disabled: rule.disabled && !rule.values,
     });
 
-    const increaseZIndexIfInModal = inModal
-        ? {
-              zIndex: getDefaultZIndex('modal') + 1,
-          }
-        : {};
-
     switch (rule.operator) {
         case FilterOperator.EQUALS:
         case FilterOperator.NOT_EQUALS:
@@ -79,7 +73,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
 
                                 <FilterWeekPicker
                                     placeholder={placeholder}
-                                    sx={increaseZIndexIfInModal}
                                     disabled={disabled}
                                     value={
                                         rule.values && rule.values[0]
@@ -110,6 +103,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                             popoverProps?.onClose?.(
                                                 null as any,
                                             ),
+                                        withinPortal: inModal,
                                     }}
                                     onChange={(value: Date | null) => {
                                         onChange({
@@ -140,6 +134,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onOpened?.(null as any),
                                     onClose: () =>
                                         popoverProps?.onClose?.(null as any),
+                                    withinPortal: inModal,
                                 }}
                                 value={
                                     rule.values && rule.values[0]
@@ -152,7 +147,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                           )
                                         : null
                                 }
-                                sx={increaseZIndexIfInModal}
                                 onChange={(value: Date) => {
                                     onChange({
                                         ...rule,
@@ -176,6 +170,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onOpened?.(null as any),
                                     onClose: () =>
                                         popoverProps?.onClose?.(null as any),
+                                    withinPortal: inModal,
                                 }}
                                 value={
                                     rule.values && rule.values[0]
@@ -199,7 +194,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         ],
                                     });
                                 }}
-                                sx={increaseZIndexIfInModal}
                             />
                         );
                     default:
@@ -223,6 +217,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         popoverProps={{
                             onOpen: () => popoverProps?.onOpened?.(null as any),
                             onClose: () => popoverProps?.onClose?.(null as any),
+                            withinPortal: inModal,
                         }}
                         value={
                             rule.values
@@ -249,7 +244,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                           ],
                             });
                         }}
-                        sx={increaseZIndexIfInModal}
                     />
                 );
             }
@@ -268,6 +262,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     popoverProps={{
                         onOpen: () => popoverProps?.onOpened?.(null as any),
                         onClose: () => popoverProps?.onClose?.(null as any),
+                        withinPortal: inModal,
                     }}
                     value={
                         rule.values
@@ -285,7 +280,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 : [],
                         });
                     }}
-                    sx={increaseZIndexIfInModal}
                 />
             );
         case FilterOperator.IN_THE_PAST:
@@ -316,6 +310,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         unitOfTime={rule.settings?.unitOfTime}
                         completed={rule.settings?.completed || false}
                         popoverProps={popoverProps}
+                        withinPortal={inModal}
                         onChange={(value) =>
                             onChange({
                                 ...rule,
@@ -348,7 +343,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             },
                         })
                     }
-                    sx={increaseZIndexIfInModal}
+                    withinPortal={inModal}
                 />
             );
         case FilterOperator.IN_BETWEEN:
@@ -383,6 +378,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         popoverProps={{
                             onOpen: () => popoverProps?.onOpened?.(null as any),
                             onClose: () => popoverProps?.onClose?.(null as any),
+                            withinPortal: inModal,
                         }}
                         onChange={(value: [Date, Date] | null) => {
                             onChange({
@@ -401,7 +397,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     : [],
                             });
                         }}
-                        sx={increaseZIndexIfInModal}
                     />
                 );
             }
@@ -436,6 +431,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     popoverProps={{
                         onOpen: () => popoverProps?.onOpened?.(null as any),
                         onClose: () => popoverProps?.onClose?.(null as any),
+                        withinPortal: inModal,
                     }}
                     onChange={(value: [Date, Date] | null) => {
                         onChange({
@@ -448,7 +444,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                 : [],
                         });
                     }}
-                    sx={increaseZIndexIfInModal}
                 />
             );
         default: {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -22,7 +22,7 @@ export type FilterInputsProps<T extends ConditionalRule> = {
     onChange: (value: T) => void;
     disabled?: boolean;
     popoverProps?: Popover2Props;
-    inModal: boolean;
+    inModal?: boolean;
 };
 
 const DefaultFilterInputs = <T extends ConditionalRule>({

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -22,6 +22,7 @@ export type FilterInputsProps<T extends ConditionalRule> = {
     onChange: (value: T) => void;
     disabled?: boolean;
     popoverProps?: Popover2Props;
+    inModal: boolean;
 };
 
 const DefaultFilterInputs = <T extends ConditionalRule>({
@@ -30,6 +31,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     rule,
     disabled,
     onChange,
+    inModal,
 }: PropsWithChildren<FilterInputsProps<T>>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
@@ -70,6 +72,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                                     values,
                                 })
                             }
+                            withinPortal={inModal}
                         />
                     );
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -15,7 +15,10 @@ import {
 } from '../../../../hooks/useFieldValues';
 import { useFiltersContext } from '../FiltersProvider';
 
-type Props = Pick<MultiSelectProps, 'disabled' | 'placeholder'> & {
+type Props = Pick<
+    MultiSelectProps,
+    'disabled' | 'placeholder' | 'withinPortal'
+> & {
     filterId: string;
     field: FilterableItem;
     values: string[];

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -13,6 +13,7 @@ import { FC, useCallback, useMemo } from 'react';
 import FieldSelect from '../FieldSelect';
 import MantineIcon from '../MantineIcon';
 import { FilterTypeConfig } from './configs';
+import { useFiltersContext } from './FiltersProvider';
 
 type Props = {
     fields: FilterableField[];
@@ -31,6 +32,7 @@ const FilterRuleForm: FC<Props> = ({
     onDelete,
     onConvertToGroup,
 }) => {
+    const { inModal } = useFiltersContext();
     const activeField = fields.find(
         (field) => getFieldId(field) === filterRule.target.fieldId,
     );
@@ -78,6 +80,7 @@ const FilterRuleForm: FC<Props> = ({
                     <FieldSelect
                         size="xs"
                         disabled={!isEditMode}
+                        withinPortal={inModal}
                         hasGrouping
                         item={activeField}
                         items={fields}
@@ -91,6 +94,7 @@ const FilterRuleForm: FC<Props> = ({
                         size="xs"
                         w="150px"
                         sx={{ flexShrink: 0 }}
+                        withinPortal={inModal}
                         disabled={!isEditMode}
                         value={filterRule.operator}
                         data={filterConfig.operatorOptions}
@@ -119,6 +123,7 @@ const FilterRuleForm: FC<Props> = ({
                         rule={filterRule}
                         onChange={onChange}
                         disabled={!isEditMode}
+                        inModal={inModal}
                     />
                 </>
             ) : (

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -25,6 +25,7 @@ type FiltersContext = {
         filterId: string,
         item: FilterableItem,
     ) => AndFilterGroup | undefined;
+    inModal: boolean;
 };
 
 const Context = createContext<FiltersContext | undefined>(undefined);
@@ -34,6 +35,7 @@ type Props = {
     fieldsMap?: Record<string, FieldWithSuggestions>;
     startOfWeek?: WeekDay;
     dashboardFilters?: DashboardFilters;
+    inModal?: boolean;
 };
 
 export const FiltersProvider: FC<Props> = ({
@@ -41,6 +43,7 @@ export const FiltersProvider: FC<Props> = ({
     fieldsMap = {},
     startOfWeek,
     dashboardFilters,
+    inModal = false,
     children,
 }) => {
     const getField = useCallback(
@@ -79,6 +82,7 @@ export const FiltersProvider: FC<Props> = ({
                 startOfWeek,
                 getField,
                 getAutocompleteFilterGroup,
+                inModal,
             }}
         >
             {children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7744
Closes: https://github.com/lightdash/lightdash/issues/7337

### Description:

Add `inModal` context to `FiltersProvider` so that inputs get correct `withinPortal` if so

> issue in mantine: https://github.com/mantinedev/mantine/issues/211

Screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/e8113784-6b08-4a05-906f-fe17c921b0a2



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
