### PR TITLE
fix: expose correct Postgres error notification 

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -172,13 +172,13 @@ export class PostgresClient<
             pool = new pg.Pool(this.config);
 
             pool.connect((err, client, done) => {
-                if (!client) {
-                    reject(new Error('client undefined'));
+                if (err) {
+                    reject(err);
                     done();
                     return;
                 }
-                if (err) {
-                    reject(err);
+                if (!client) {
+                    reject(new Error('client undefined'));
                     done();
                     return;
                 }


### PR DESCRIPTION
### Description:
The Postgres client connection error detection order often prevents helpful information from bubbling up to the end user. I suspect many error conditions will have an undefined client and a defined error.

Prior to this PR this is what I see on the command line when an error occurs:

```
22:21:13  Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
Generated .yml files:
✖   Failed to generate ld__historical_organization_user.yml
Error running postgres query: Error: client undefined
```

After this PR this is what I see:

```
22:21:53  Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
Generated .yml files:
✖   Failed to generate ld__historical_organization_user.yml
Error running postgres query: Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: [redacted] is not in the cert's altnames: DNS:[redacted]
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
