### PR TITLE
chore: pass schedulerUuid param to minimal dashboard if it exists

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -94,7 +94,7 @@ const getChartOrDashboard = async (
             minimalUrl: `${lightdashConfig.siteUrl}/minimal/projects/${
                 dashboard.projectUuid
             }/dashboards/${dashboardUuid}${
-                schedulerUuid ? `?schedulerId=${schedulerUuid}` : ''
+                schedulerUuid ? `?schedulerUuid=${schedulerUuid}` : ''
             }`,
             details: {
                 name: dashboard.name,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -65,6 +65,7 @@ import {
 const getChartOrDashboard = async (
     chartUuid: string | null,
     dashboardUuid: string | null,
+    schedulerUuid: string | undefined,
 ) => {
     if (chartUuid) {
         const chart = await schedulerService.savedChartModel.getSummary(
@@ -87,9 +88,14 @@ const getChartOrDashboard = async (
         const dashboard = await schedulerService.dashboardModel.getById(
             dashboardUuid,
         );
+
         return {
             url: `${lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}/view`,
-            minimalUrl: `${lightdashConfig.siteUrl}/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}`,
+            minimalUrl: `${lightdashConfig.siteUrl}/minimal/projects/${
+                dashboard.projectUuid
+            }/dashboards/${dashboardUuid}${
+                schedulerUuid ? `?schedulerId=${schedulerUuid}` : ''
+            }`,
             details: {
                 name: dashboard.name,
                 description: dashboard.description,
@@ -119,6 +125,13 @@ export const getNotificationPageData = async (
     let csvUrl;
     let csvUrls;
     let pdfFile;
+
+    const schedulerUuid =
+        'schedulerUuid' in scheduler &&
+        typeof scheduler.schedulerUuid === 'string'
+            ? scheduler.schedulerUuid
+            : undefined;
+
     const {
         url,
         minimalUrl,
@@ -126,7 +139,7 @@ export const getNotificationPageData = async (
         details,
         organizationUuid,
         projectUuid,
-    } = await getChartOrDashboard(savedChartUuid, dashboardUuid);
+    } = await getChartOrDashboard(savedChartUuid, dashboardUuid, schedulerUuid);
 
     switch (format) {
         case SchedulerFormat.IMAGE:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7784 

### Description:

Pass `schedulerUuid` to minimal dashboard params on scheduled deliveries if it exists;
We then can use the scheduler context on Minimal dashboards like so:
```tsx
const { search } = useLocation();
    const searchParams = new URLSearchParams(search);
    const schedulerUuid = searchParams.get('schedulerUuid');
    const { data: scheduler, isLoading } = useScheduler(schedulerUuid ?? '');
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
