### PR TITLE
feat: cache explores individually

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -75,6 +75,8 @@ import {
 import {
     CachedExploresTable,
     CachedExploresTableName,
+    CachedExploreTable,
+    CachedExploreTableName,
     CachedWarehouseTable,
     CachedWarehouseTableName,
     ProjectTable,
@@ -190,6 +192,7 @@ declare module 'knex/types/tables' {
         [PasswordResetTableName]: PasswordResetTable;
         [PasswordLoginTableName]: PasswordLoginTable;
         [CachedExploresTableName]: CachedExploresTable;
+        [CachedExploreTableName]: CachedExploreTable;
         [CachedWarehouseTableName]: CachedWarehouseTable;
         [JobsTableName]: JobsTable;
         [JobStepsTableName]: JobStepsTable;

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -7,6 +7,7 @@ import { Knex } from 'knex';
 
 export const ProjectTableName = 'projects';
 export const CachedExploresTableName = 'cached_explores';
+export const CachedExploreTableName = 'cached_explore';
 export const CachedWarehouseTableName = 'cached_warehouse';
 
 export type DbProject = {
@@ -58,6 +59,19 @@ export type DbCachedExplores = {
 };
 
 export type CachedExploresTable = Knex.CompositeTableType<DbCachedExplores>;
+
+export type DbCachedExplore = {
+    cached_explore_uuid: string;
+    project_uuid: string;
+    name: string;
+    table_names: string[];
+    explore: any;
+};
+
+export type CachedExploreTable = Knex.CompositeTableType<
+    DbCachedExplore,
+    Omit<DbCachedExplore, 'cached_explore_uuid'>
+>;
 
 export type DbCachedWarehouse = {
     project_uuid: string;

--- a/packages/backend/src/database/migrations/20231102094206_add_cached_explore_table.ts
+++ b/packages/backend/src/database/migrations/20231102094206_add_cached_explore_table.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const CACHED_EXPLORE_TABLE_NAME = 'cached_explore';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(CACHED_EXPLORE_TABLE_NAME))) {
+        await knex.schema.createTable(CACHED_EXPLORE_TABLE_NAME, (table) => {
+            table
+                .uuid('cached_explore_uuid')
+                .primary()
+                .notNullable()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('project_uuid')
+                .references('project_uuid')
+                .inTable('projects')
+                .notNullable()
+                .onDelete('CASCADE');
+            table.string('name').notNullable();
+            table.specificType('table_names', 'TEXT[]').notNullable();
+            table.jsonb('explore').notNullable();
+            table.unique(['name', 'project_uuid']); // can't have duplicate explore names in the same project
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(CACHED_EXPLORE_TABLE_NAME);
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -44,6 +44,7 @@ import { PinnedListTableName } from '../../database/entities/pinnedList';
 import { DbProjectMembership } from '../../database/entities/projectMemberships';
 import {
     CachedExploresTableName,
+    CachedExploreTableName,
     CachedWarehouseTableName,
     DbCachedExplores,
     DbCachedWarehouse,
@@ -569,57 +570,121 @@ export class ProjectModel {
         projectUuid: string,
         exploreName: string,
     ): Promise<Explore | ExploreError> {
-        const row = await this.getExploreQueryBuilder(projectUuid).andWhereRaw(
-            "explore->>'name' = ?",
-            [exploreName],
+        return wrapOtelSpan(
+            'ProjectModel.getExploreFromCache',
+            {},
+            async (span) => {
+                // check individually cached explore
+                let exploreCache = await this.database(CachedExploreTableName)
+                    .select('explore')
+                    .where('name', exploreName)
+                    .first();
+
+                console.log('found individual cache?', !!exploreCache);
+                span.setAttribute(
+                    'foundIndividualExploreCache',
+                    !!exploreCache,
+                );
+                if (!exploreCache) {
+                    // fallback: check all cached explores
+                    exploreCache = await this.getExploreQueryBuilder(
+                        projectUuid,
+                    ).andWhereRaw("explore->>'name' = ?", [exploreName]);
+                    if (exploreCache === undefined) {
+                        throw new NotExistsError(
+                            `Explore "${exploreName}" does not exist.`,
+                        );
+                    }
+                }
+                return ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
+                    exploreCache.explore,
+                );
+            },
         );
-        if (row === undefined) {
-            throw new NotExistsError(
-                `Explore "${exploreName}" does not exist.`,
-            );
-        }
-        return ProjectModel.convertMetricFiltersFieldIdsToFieldRef(row.explore);
     }
 
     async findExploreByTableName(
         projectUuid: string,
         tableName: string,
     ): Promise<Explore | ExploreError | undefined> {
-        // try finding explore via base table name
-        let explore = await this.getExploreQueryBuilder(
-            projectUuid,
-        ).andWhereRaw("explore->>'baseTable' = ?", [tableName]);
+        return wrapOtelSpan(
+            'ProjectModel.findExploreByTableName',
+            {},
+            async (span) => {
+                // check individually cached explore
+                let exploreCache = await this.database(CachedExploreTableName)
+                    .select('explore')
+                    .whereRaw('? = ANY(table_names)', tableName)
+                    .first();
 
-        if (!explore) {
-            // try finding explore via joined table alias
-            // Note: there is an edge case where we return the wrong explore because join table aliases are not unique
-            explore = await this.getExploreQueryBuilder(
-                projectUuid,
-            ).andWhereRaw("(explore->>'tables')::json->? IS NOT NULL", [
-                tableName,
-            ]);
-        }
+                console.log('found individual cache?', !!exploreCache);
+                span.setAttribute(
+                    'foundIndividualExploreCache',
+                    !!exploreCache,
+                );
+                if (!exploreCache) {
+                    // fallback: check all cached explores
+                    // try finding explore via base table name
+                    exploreCache = await this.getExploreQueryBuilder(
+                        projectUuid,
+                    ).andWhereRaw("explore->>'baseTable' = ?", [tableName]);
 
-        return explore
-            ? ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
-                  explore.explore,
-              )
-            : undefined;
+                    if (!exploreCache) {
+                        // try finding explore via joined table alias
+                        // Note: there is an edge case where we return the wrong explore because join table aliases are not unique
+                        exploreCache = await this.getExploreQueryBuilder(
+                            projectUuid,
+                        ).andWhereRaw(
+                            "(explore->>'tables')::json->? IS NOT NULL",
+                            [tableName],
+                        );
+                    }
+                }
+
+                return exploreCache
+                    ? ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
+                          exploreCache.explore,
+                      )
+                    : undefined;
+            },
+        );
     }
 
     async saveExploresToCache(
         projectUuid: string,
         explores: (Explore | ExploreError)[],
     ): Promise<DbCachedExplores> {
-        const [cachedExplores] = await this.database(CachedExploresTableName)
-            .insert({
-                project_uuid: projectUuid,
-                explores: JSON.stringify(explores),
-            })
-            .onConflict('project_uuid')
-            .merge()
-            .returning('*');
-        return cachedExplores;
+        return wrapOtelSpan(
+            'ProjectModel.saveExploresToCache',
+            {},
+            async () => {
+                // cache explores individually
+                await this.database(CachedExploreTableName)
+                    .insert(
+                        explores.map((explore) => ({
+                            project_uuid: projectUuid,
+                            name: explore.name,
+                            table_names: Object.keys(explore.tables || {}),
+                            explore: JSON.stringify(explore),
+                        })),
+                    )
+                    .onConflict(['project_uuid', 'name'])
+                    .merge();
+
+                // cache explores together
+                const [cachedExplores] = await this.database(
+                    CachedExploresTableName,
+                )
+                    .insert({
+                        project_uuid: projectUuid,
+                        explores: JSON.stringify(explores),
+                    })
+                    .onConflict('project_uuid')
+                    .merge()
+                    .returning('*');
+                return cachedExplores;
+            },
+        );
     }
 
     async tryAcquireProjectLock(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -578,9 +578,9 @@ export class ProjectModel {
                 let exploreCache = await this.database(CachedExploreTableName)
                     .select('explore')
                     .where('name', exploreName)
+                    .andWhere('project_uuid', projectUuid)
                     .first();
 
-                console.log('found individual cache?', !!exploreCache);
                 span.setAttribute(
                     'foundIndividualExploreCache',
                     !!exploreCache,
@@ -615,9 +615,9 @@ export class ProjectModel {
                 let exploreCache = await this.database(CachedExploreTableName)
                     .select('explore')
                     .whereRaw('? = ANY(table_names)', tableName)
+                    .andWhere('project_uuid', projectUuid)
                     .first();
 
-                console.log('found individual cache?', !!exploreCache);
                 span.setAttribute(
                     'foundIndividualExploreCache',
                     !!exploreCache,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7162 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- keep existing table that caches all explores
- save explores individually in a new table
- if doesn't find explore by name in new table, fallback to old table
- add otel tracking

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
