### PR TITLE
fix: big number tooltip gets cut off

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -188,7 +188,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                         marginTop: 10,
                     }}
                 >
-                    <Tooltip label={comparisonTooltip}>
+                    <Tooltip withinPortal label={comparisonTooltip}>
                         <BigNumber
                             $fontSize={comparisonFontSize}
                             style={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7790 

### Description:

Big number tooltip was getting cut off by adjacent tiles

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
