### PR TITLE
feat: add filters to schedulers

### DIFF
--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -22,7 +22,6 @@ import {
     SuccessResponse,
     Tags,
 } from 'tsoa';
-import { SchedulerService } from '../services/SchedulerService/SchedulerService';
 import { schedulerService } from '../services/services';
 import {
     allowApiKeyAuthentication,

--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -25,6 +25,7 @@ export type SchedulerDb = {
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
     options: Record<string, any>;
+    filters: string | null;
 };
 
 export type ChartSchedulerDb = SchedulerDb & {
@@ -60,7 +61,13 @@ export type SchedulerTable = Knex.CompositeTableType<
     >,
     Pick<
         SchedulerDb,
-        'name' | 'message' | 'updated_at' | 'cron' | 'format' | 'options'
+        | 'name'
+        | 'message'
+        | 'updated_at'
+        | 'cron'
+        | 'format'
+        | 'options'
+        | 'filters'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20231102135932_add-filters-to-scheduler-table.ts
+++ b/packages/backend/src/database/migrations/20231102135932_add-filters-to-scheduler-table.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const SchedulerTableName = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.jsonb('filters').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SchedulerTableName, 'filters')) {
+        await knex.schema.alterTable(SchedulerTableName, (table) => {
+            table.dropColumn('filters');
+        });
+    }
+}

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5244,7 +5244,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.840.0",
+        "version": "0.844.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -3,6 +3,7 @@ import {
     CreateSchedulerLog,
     isChartScheduler,
     isCreateSchedulerSlackTarget,
+    isDashboardScheduler,
     isSlackTarget,
     isUpdateSchedulerEmailTarget,
     isUpdateSchedulerSlackTarget,
@@ -64,6 +65,7 @@ export class SchedulerModel {
             dashboardUuid: scheduler.dashboard_uuid,
             format: scheduler.format,
             options: scheduler.options,
+            filters: scheduler.filters,
         } as Scheduler;
     }
 
@@ -211,6 +213,11 @@ export class SchedulerModel {
                     dashboard_uuid: newScheduler.dashboardUuid,
                     updated_at: new Date(),
                     options: newScheduler.options,
+                    filters:
+                        isDashboardScheduler(newScheduler) &&
+                        newScheduler.filters
+                            ? JSON.stringify(newScheduler.filters)
+                            : null,
                 })
                 .returning('*');
             const targetPromises = newScheduler.targets.map(async (target) => {
@@ -247,6 +254,10 @@ export class SchedulerModel {
                     cron: scheduler.cron,
                     updated_at: new Date(),
                     options: scheduler.options,
+                    filters:
+                        'filters' in scheduler && scheduler.filters
+                            ? JSON.stringify(scheduler.filters)
+                            : null,
                 })
                 .where('scheduler_uuid', scheduler.schedulerUuid);
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1,4 +1,5 @@
 import { Explore, ExploreError } from './explore';
+import { DashboardFilterRule } from './filter';
 import { MetricQuery } from './metricQuery';
 
 export type SchedulerCsvOptions = {
@@ -76,9 +77,15 @@ export type ChartScheduler = SchedulerBase & {
     savedChartUuid: string;
     dashboardUuid: null;
 };
+
+export const isDashboardScheduler = (
+    scheduler: Scheduler | CreateSchedulerAndTargets,
+): scheduler is DashboardScheduler => scheduler.dashboardUuid !== undefined;
+
 export type DashboardScheduler = SchedulerBase & {
     savedChartUuid: null;
     dashboardUuid: string;
+    filters?: DashboardFilterRule[];
 };
 
 export type Scheduler = ChartScheduler | DashboardScheduler;
@@ -144,13 +151,14 @@ export type CreateSchedulerAndTargetsWithoutIds = Omit<
 export type UpdateSchedulerAndTargets = Pick<
     Scheduler,
     'schedulerUuid' | 'name' | 'message' | 'cron' | 'format' | 'options'
-> & {
-    targets: Array<
-        | CreateSchedulerTarget
-        | UpdateSchedulerSlackTarget
-        | UpdateSchedulerEmailTarget
-    >;
-};
+> &
+    Pick<DashboardScheduler, 'filters'> & {
+        targets: Array<
+            | CreateSchedulerTarget
+            | UpdateSchedulerSlackTarget
+            | UpdateSchedulerEmailTarget
+        >;
+    };
 
 export type UpdateSchedulerAndTargetsWithoutId = Omit<
     UpdateSchedulerAndTargets,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #4425

### Description:

Adds migration file to add `filters` column to a scheduler
Updates scheduler DB with `filters` type and adds type guard `isDashboardScheduler`

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
