### PR TITLE
fix: update reference line label on blur

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -16,9 +16,8 @@ import {
     TimeFrames,
     WeekDay,
 } from '@lightdash/common';
-import debounce from 'lodash/debounce';
 import moment from 'moment';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 
 import {
     ActionIcon,
@@ -248,21 +247,6 @@ export const ReferenceLine: FC<Props> = ({
         | undefined
     >(selectedFieldDefault);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const debouncedUpdateLabel = useCallback(
-        debounce((updatedLabel: string) => {
-            if (value !== undefined && selectedField !== undefined)
-                updateReferenceLine(
-                    value,
-                    selectedField,
-                    updatedLabel,
-                    lineColor,
-                    referenceLine.data.name,
-                );
-        }, 500),
-        [value, selectedField, updateReferenceLine],
-    );
-
     return (
         <Stack spacing="xs">
             <Group noWrap position="apart">
@@ -346,7 +330,16 @@ export const ReferenceLine: FC<Props> = ({
                         placeholder={value}
                         onChange={(e) => {
                             setLabel(e.target.value);
-                            debouncedUpdateLabel(e.target.value);
+                        }}
+                        onBlur={() => {
+                            if (value && selectedField)
+                                updateReferenceLine(
+                                    value,
+                                    selectedField,
+                                    label,
+                                    lineColor,
+                                    referenceLine.data.name,
+                                );
                         }}
                     />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7662

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
We previously used a `debounce` to mitigate this issue, because re-render makes it quite slow. That was a bit of a hack, instead I moved the render logic to `onblur` for label. 

[Screencast from 03-11-23 09:07:05.webm](https://github.com/lightdash/lightdash/assets/1983672/34d84b7b-61a2-4640-9bb5-4b246e9bcd5c)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
