### PR TITLE
feat: migrate last date picker to mantine

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,8 +4,6 @@
     "private": true,
     "dependencies": {
         "@blueprintjs/core": "^4.16.3",
-        "@blueprintjs/datetime": "^4.4.18",
-        "@blueprintjs/datetime2": "^0.9.16",
         "@blueprintjs/popover2": "^1.13.3",
         "@blueprintjs/select": "^4.9.3",
         "@casl/ability": "^5.4.4",

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -1,4 +1,3 @@
-import { DateInput2 } from '@blueprintjs/datetime2';
 import {
     CompiledDimension,
     CustomDimension,
@@ -6,7 +5,6 @@ import {
     Field,
     fieldId as getFieldId,
     formatDate,
-    getDateFormat,
     isCustomDimension,
     isDateItem,
     isDimension,
@@ -34,6 +32,7 @@ import {
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
 import { useOrganization } from '../../../../hooks/organization/useOrganization';
 import FieldSelect from '../../../common/FieldSelect';
+import FilterDatePicker from '../../../common/Filters/FilterInputs/FilterDatePicker';
 import FilterMonthAndYearPicker from '../../../common/Filters/FilterInputs/FilterMonthAndYearPicker';
 import FilterWeekPicker from '../../../common/Filters/FilterInputs/FilterWeekPicker';
 import FilterYearPicker from '../../../common/Filters/FilterInputs/FilterYearPicker';
@@ -83,6 +82,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                 case TimeFrames.WEEK:
                     return (
                         <FilterWeekPicker
+                            size="sm"
                             value={moment(value).toDate()}
                             popoverProps={{ withinPortal: false }}
                             firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
@@ -101,25 +101,25 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                     );
                 case TimeFrames.MONTH:
                     return (
-                        <Group noWrap spacing={0}>
-                            <FilterMonthAndYearPicker
-                                value={moment(value).toDate()}
-                                onChange={(dateValue: Date) => {
-                                    onChange(
-                                        formatDate(
-                                            dateValue,
-                                            TimeFrames.MONTH,
-                                            false,
-                                        ),
-                                    );
-                                }}
-                            />
-                        </Group>
+                        <FilterMonthAndYearPicker
+                            size="sm"
+                            value={moment(value).toDate()}
+                            onChange={(dateValue: Date) => {
+                                onChange(
+                                    formatDate(
+                                        dateValue,
+                                        TimeFrames.MONTH,
+                                        false,
+                                    ),
+                                );
+                            }}
+                        />
                     );
 
                 case TimeFrames.YEAR:
                     return (
                         <FilterYearPicker
+                            size="sm"
                             value={moment(value).toDate()}
                             onChange={(dateValue: Date) => {
                                 onChange(
@@ -135,25 +135,12 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
             }
 
             return (
-                <DateInput2
-                    fill
-                    value={value}
-                    popoverProps={{ usePortal: false }}
-                    formatDate={(dateValue: Date) =>
-                        formatDate(dateValue, undefined, false)
-                    }
-                    parseDate={(
-                        str: string,
-                        timeInterval: TimeFrames | undefined = TimeFrames.DAY,
-                    ) => {
-                        return moment(
-                            str,
-                            getDateFormat(timeInterval),
-                        ).toDate();
-                    }}
-                    defaultValue={new Date().toString()}
-                    onChange={(dateValue: string | null) => {
-                        if (dateValue) onChange(dateValue);
+                <FilterDatePicker
+                    size="sm"
+                    value={moment(value).toDate()}
+                    firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
+                    onChange={(newValue) => {
+                        onChange(formatDate(newValue, TimeFrames.DAY, false));
                     }}
                 />
             );

--- a/packages/frontend/src/providers/BlueprintProvider.tsx
+++ b/packages/frontend/src/providers/BlueprintProvider.tsx
@@ -6,8 +6,6 @@
 import './../styles/blueprint-core.css';
 import './../styles/blueprint-popover2.css';
 // NOTE: imports below does not have a conflicting z-indexes
-import '@blueprintjs/datetime/lib/css/blueprint-datetime.css';
-import '@blueprintjs/datetime2/lib/css/blueprint-datetime2.css';
 import '@blueprintjs/select/lib/css/blueprint-select.css';
 
 import { Colors, Dialog, FocusStyleManager } from '@blueprintjs/core';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,31 +2434,6 @@
     react-transition-group "^4.4.5"
     tslib "~2.3.1"
 
-"@blueprintjs/datetime2@^0.9.16":
-  version "0.9.16"
-  resolved "https://registry.npmjs.org/@blueprintjs/datetime2/-/datetime2-0.9.16.tgz"
-  integrity sha512-fHEAm1ya43xfouQOO/Lsg/2xpAQx5RRW6PtExjF1hljzkuDHge7zACOFyF7Z+P1bY1IFqmwdXJi/UAdwU9UAGg==
-  dependencies:
-    "@blueprintjs/core" "^4.16.3"
-    "@blueprintjs/datetime" "^4.4.18"
-    "@blueprintjs/popover2" "^1.13.3"
-    "@blueprintjs/select" "^4.9.3"
-    classnames "^2.3.1"
-    date-fns "^2.28.0"
-    date-fns-tz "^1.3.7"
-    lodash "^4.17.21"
-    tslib "~2.3.1"
-
-"@blueprintjs/datetime@^4.4.18":
-  version "4.4.18"
-  resolved "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-4.4.18.tgz"
-  integrity sha512-ui9T4Vxi39uHxKwYA9UO65QRQlQVskebGGO0BbUC34OUMxvsHpNWiG922NeNcLZpm5m1ET+/MCfr2TAERGSXgQ==
-  dependencies:
-    "@blueprintjs/core" "^4.16.3"
-    classnames "^2.3.1"
-    react-day-picker "7.4.9"
-    tslib "~2.3.1"
-
 "@blueprintjs/icons@^4.13.2":
   version "4.13.2"
   resolved "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.13.2.tgz"
@@ -8881,16 +8856,6 @@ data-uri-to-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz#db89a9e279c2ffe74f50637a59a32fb23b3e4d7c"
   integrity sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==
-
-date-fns-tz@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz"
-  integrity sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==
-
-date-fns@^2.28.0:
-  version "2.29.3"
-  resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-fns@^2.30.0:
   version "2.30.0"
@@ -16549,13 +16514,6 @@ react-csv@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz"
   integrity sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw==
-
-react-day-picker@7.4.9:
-  version "7.4.9"
-  resolved "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.9.tgz"
-  integrity sha512-CcXf0p7p6gTYnG0+n/4wNGljZuQDXl4HhgcxsXB0nX+8D4LnRho9EclPA/aLz4WlvvVpfY+AEgj2ylgPj4nm/g==
-  dependencies:
-    prop-types "^15.6.2"
 
 react-dom@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
### Description:

- gets rid of last blueprint date picker from reference lines
- adjusts spaces for other date inputs in reference lines
- removes npm dependencies and imports

day picker:
![CleanShot 2023-11-03 at 13 06 57@2x](https://github.com/lightdash/lightdash/assets/962095/c2cd7366-fa97-4bad-a16a-e0557c64374d)

week picker:
![CleanShot 2023-11-03 at 13 06 36@2x](https://github.com/lightdash/lightdash/assets/962095/eb703a5e-3370-4f52-89e5-756439349992)

month picker:
![CleanShot 2023-11-03 at 13 07 27@2x](https://github.com/lightdash/lightdash/assets/962095/152453d5-9366-4ef7-8594-075da380c4d7)

quarter:
![CleanShot 2023-11-03 at 13 07 52@2x](https://github.com/lightdash/lightdash/assets/962095/4f6bea74-33d0-479e-a097-18b6a556801c)

year:
![CleanShot 2023-11-03 at 13 08 07@2x](https://github.com/lightdash/lightdash/assets/962095/1ab08ca1-0e27-48d4-9da4-e88cdb5e1d39)


### Reviewer actions

🎉 🎉 🎉 

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
