### PR TITLE
feat: add dashboard auto refresh behind feature flag

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -22,7 +22,6 @@ import {
     IconInfoCircle,
     IconPencil,
     IconPlus,
-    IconRefresh,
     IconSend,
     IconTrash,
     IconUpload,
@@ -33,9 +32,7 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
 import { DashboardSchedulersModal } from '../../../features/scheduler';
 import { getSchedulerUuidFromUrlParams } from '../../../features/scheduler/utils';
-import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
 import { useApp } from '../../../providers/AppProvider';
-import { useDashboardContext } from '../../../providers/DashboardProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import AddTileButton from '../../DashboardTiles/AddTileButton';
@@ -53,6 +50,7 @@ import SpaceAndDashboardInfo from '../PageHeader/SpaceAndDashboardInfo';
 import { UpdatedInfo } from '../PageHeader/UpdatedInfo';
 import ViewInfo from '../PageHeader/ViewInfo';
 import SpaceActionModal, { ActionType } from '../SpaceActionModal';
+import { DashboardRefreshButton } from './DashboardRefreshButton';
 
 type DashboardHeaderProps = {
     spaces?: SpaceSummary[];
@@ -107,10 +105,7 @@ const DashboardHeader = ({
         dashboardUuid: string;
         organizationUuid: string;
     }>();
-    const { isFetching, invalidateDashboardRelatedQueries } =
-        useDashboardRefresh();
 
-    const { clearCacheAndFetch } = useDashboardContext();
     const history = useHistory();
     const { track } = useTracking();
     const [isUpdating, setIsUpdating] = useState(false);
@@ -140,8 +135,6 @@ const DashboardHeader = ({
         'manage',
         subject('ExportCsv', { organizationUuid, projectUuid }),
     );
-
-    const isOneAtLeastFetching = isFetching > 0;
 
     return (
         <PageHeader h="auto">
@@ -260,19 +253,7 @@ const DashboardHeader = ({
                 </PageActionsContainer>
             ) : (
                 <PageActionsContainer>
-                    {userCanExportData && (
-                        <Button
-                            size="xs"
-                            loading={isOneAtLeastFetching}
-                            leftIcon={<MantineIcon icon={IconRefresh} />}
-                            onClick={() => {
-                                clearCacheAndFetch();
-                                invalidateDashboardRelatedQueries();
-                            }}
-                        >
-                            Refresh
-                        </Button>
-                    )}
+                    {userCanExportData && <DashboardRefreshButton />}
 
                     {!!userCanManageDashboard && (
                         <Tooltip

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -2,7 +2,7 @@ import { Button, Menu, Text, Tooltip } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import { IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
@@ -41,7 +41,6 @@ const REFRESH_INTERVAL_OPTIONS = [
 
 const DashboardRefreshButtonWithAutoRefresh = () => {
     const { showToastSuccess } = useToaster();
-    const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
     const [isOpen, setIsOpen] = useState(false);
     const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
     const [refreshInterval, setRefreshInterval] = useState<
@@ -97,7 +96,7 @@ const DashboardRefreshButtonWithAutoRefresh = () => {
                         invalidateAndSetRefreshTime();
                     }}
                 >
-                    {intervalIdRef && refreshInterval ? (
+                    {interval.active && refreshInterval ? (
                         <Text
                             span
                             mr="xs"

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -101,7 +101,7 @@ const DashboardRefreshButtonWithAutoRefresh = () => {
                 loaderPosition="center"
                 onClick={() => {
                     if (intervalIdRef && refreshInterval) {
-                        setIsOpen(true);
+                        setIsOpen((prev) => !prev);
                     } else {
                         invalidateAndSetRefreshTime();
                     }
@@ -111,7 +111,7 @@ const DashboardRefreshButtonWithAutoRefresh = () => {
                     <Text
                         span
                         mr="xs"
-                        c={isOneAtLeastFetching ? 'transparent' : 'gray'}
+                        c={isOneAtLeastFetching ? 'transparent' : 'gray.7'}
                     >
                         {
                             REFRESH_INTERVAL_OPTIONS.find(

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -1,0 +1,230 @@
+import { Button, Popover, Radio, Select, Stack, Text } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconChevronDown, IconRefresh } from '@tabler/icons-react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
+import { useDashboardContext } from '../../../providers/DashboardProvider';
+import MantineIcon from '../MantineIcon';
+
+const REFRESH_INTERVAL_OPTIONS = [
+    {
+        value: '1',
+        label: 'Every 1 minute',
+    },
+    {
+        value: '2',
+        label: 'Every 2 minutes',
+    },
+    {
+        value: '5',
+        label: 'Every 5 minutes',
+    },
+    {
+        value: '10',
+        label: 'Every 10 minutes',
+    },
+    {
+        value: '15',
+        label: 'Every 15 minutes',
+    },
+    {
+        value: '30',
+        label: 'Every 30 minutes',
+    },
+    {
+        value: '60',
+        label: 'Every 60 minutes',
+    },
+];
+
+const DashboardRefreshButtonWithAutoRefresh = () => {
+    const form = useForm({
+        initialValues: {
+            refreshInterval: REFRESH_INTERVAL_OPTIONS[0].value,
+            type: 'manual',
+        },
+    });
+    const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
+    const [refreshInterval, setRefreshInterval] = useState<
+        undefined | number
+    >();
+
+    const { isFetching, invalidateDashboardRelatedQueries } =
+        useDashboardRefresh();
+    const { clearCacheAndFetch } = useDashboardContext();
+
+    const isOneAtLeastFetching = isFetching > 0;
+
+    const invalidateAndSetRefreshTime = useCallback(() => {
+        clearCacheAndFetch();
+        invalidateDashboardRelatedQueries();
+        setLastRefreshTime(new Date());
+    }, [clearCacheAndFetch, invalidateDashboardRelatedQueries]);
+
+    useEffect(() => {
+        // Clear existing interval when refreshInterval changes or on unmount
+        const clearExistingInterval = () => {
+            if (intervalIdRef.current) {
+                clearInterval(intervalIdRef.current);
+                intervalIdRef.current = null;
+            }
+        };
+
+        if (refreshInterval !== undefined) {
+            intervalIdRef.current = setInterval(() => {
+                invalidateAndSetRefreshTime();
+            }, refreshInterval * 1000 * 60);
+        }
+
+        return clearExistingInterval;
+    }, [invalidateAndSetRefreshTime, refreshInterval]);
+
+    const handleSubmit = form.onSubmit((values) => {
+        if (values.type === 'auto') {
+            setRefreshInterval(+values.refreshInterval);
+        } else {
+            setRefreshInterval(undefined);
+        }
+    });
+
+    return (
+        <Button.Group>
+            <Button
+                size="xs"
+                h={28}
+                miw="sm"
+                variant="default"
+                loading={isOneAtLeastFetching}
+                loaderPosition="center"
+                onClick={() => {
+                    if (intervalIdRef && refreshInterval) {
+                        setIsOpen(true);
+                    } else {
+                        invalidateAndSetRefreshTime();
+                    }
+                }}
+            >
+                {intervalIdRef && refreshInterval ? (
+                    <Text
+                        span
+                        mr="xs"
+                        c={isOneAtLeastFetching ? 'transparent' : 'gray'}
+                    >
+                        {
+                            REFRESH_INTERVAL_OPTIONS.find(
+                                ({ value }) => refreshInterval === +value,
+                            )?.label
+                        }
+                    </Text>
+                ) : null}
+                <MantineIcon
+                    icon={IconRefresh}
+                    color={isOneAtLeastFetching ? 'transparent' : 'black'}
+                />
+            </Button>
+            <Popover withinPortal withArrow opened={isOpen}>
+                <Popover.Target>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        h={28}
+                        w="md"
+                        disabled={isOneAtLeastFetching}
+                        p={0}
+                        onClick={() => setIsOpen((prev) => !prev)}
+                    >
+                        <MantineIcon size="sm" icon={IconChevronDown} />
+                    </Button>
+                </Popover.Target>
+                <Popover.Dropdown fz="xs" miw={250}>
+                    <Stack>
+                        <Text fw={500} color="gray.6">
+                            Last refreshed at:{' '}
+                            {lastRefreshTime
+                                ? lastRefreshTime.toLocaleTimeString()
+                                : 'Never'}
+                        </Text>
+
+                        <form onSubmit={handleSubmit}>
+                            <Stack spacing="xs">
+                                <Radio.Group
+                                    label="Refresh frequency"
+                                    size="xs"
+                                    {...form.getInputProps('type')}
+                                >
+                                    <Stack spacing="xxs" pt="xs">
+                                        <Radio label="Manual" value="manual" />
+                                        <Radio label="Auto" value="auto" />
+                                    </Stack>
+                                </Radio.Group>
+                                {form.values.type === 'auto' && (
+                                    <Select
+                                        size="xs"
+                                        defaultValue={
+                                            REFRESH_INTERVAL_OPTIONS[0].value
+                                        }
+                                        data={REFRESH_INTERVAL_OPTIONS}
+                                        onChange={(value) =>
+                                            value &&
+                                            form.setFieldValue(
+                                                'refreshInterval',
+                                                value,
+                                            )
+                                        }
+                                    />
+                                )}
+
+                                <Button
+                                    type="submit"
+                                    size="xs"
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                    }}
+                                >
+                                    Confirm
+                                </Button>
+                            </Stack>
+                        </form>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+        </Button.Group>
+    );
+};
+
+const DashboardRefreshButtonWithoutAutoRefresh = () => {
+    const { isFetching, invalidateDashboardRelatedQueries } =
+        useDashboardRefresh();
+    const { clearCacheAndFetch } = useDashboardContext();
+
+    const isOneAtLeastFetching = isFetching > 0;
+
+    return (
+        <Button
+            size="xs"
+            loading={isOneAtLeastFetching}
+            leftIcon={<MantineIcon icon={IconRefresh} />}
+            onClick={() => {
+                clearCacheAndFetch();
+                invalidateDashboardRelatedQueries();
+            }}
+        >
+            Refresh
+        </Button>
+    );
+};
+
+export const DashboardRefreshButton = () => {
+    const isAutoRefreshFeatureEnabled = useFeatureFlagEnabled(
+        'dashboard-auto-refresh',
+    );
+
+    if (isAutoRefreshFeatureEnabled) {
+        return <DashboardRefreshButtonWithAutoRefresh />;
+    }
+
+    return <DashboardRefreshButtonWithoutAutoRefresh />;
+};

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -151,6 +151,7 @@ const DashboardRefreshButtonWithAutoRefresh = () => {
                     </Button>
                 </Menu.Target>
                 <Menu.Dropdown>
+                    <Menu.Label>Auto-refresh</Menu.Label>
                     <Menu.Item
                         fz="xs"
                         onClick={() => {

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -106,11 +106,7 @@ const DashboardRefreshButtonWithAutoRefresh = () => {
                     loading={isOneAtLeastFetching}
                     loaderPosition="center"
                     onClick={() => {
-                        if (intervalIdRef && refreshInterval) {
-                            setIsOpen((prev) => !prev);
-                        } else {
-                            invalidateAndSetRefreshTime();
-                        }
+                        invalidateAndSetRefreshTime();
                     }}
                 >
                     {intervalIdRef && refreshInterval ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3693 

### Description:

Adds feature flag check `dashboard-auto-refresh`
Adds client-only auto-refresh functionality - if the user refreshes the page, the auto-refresh settings are reset and back to `Manual`.
Once an interval is created, it will run: 
```ts
clearCacheAndFetch();
invalidateDashboardRelatedQueries();
```

Screen-recording

Refresh-every-1-minute 

https://github.com/lightdash/lightdash/assets/7611706/e2f49caf-e68e-44d9-8964-b3f96d96ab4c





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
