### PR TITLE
fix: remove no destination text from scheduler

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -328,9 +328,6 @@ const SchedulerForm: FC<Props> = ({
     const isAddEmailDisabled = disabled || !health.data?.hasEmailClient;
     const isImageDisabled = !health.data?.hasHeadlessBrowser;
 
-    const showDestinationLabel =
-        form.values?.emailTargets.length + form.values?.slackTargets.length < 1;
-
     const limit = form.values?.options?.limit;
 
     return (
@@ -520,14 +517,7 @@ const SchedulerForm: FC<Props> = ({
                             )}
                         </Stack>
 
-                        <Input.Wrapper
-                            label="Destinations"
-                            description={
-                                showDestinationLabel
-                                    ? 'No destination(s) selected'
-                                    : ''
-                            }
-                        >
+                        <Input.Wrapper label="Destinations">
                             <Stack mt="sm">
                                 <Group noWrap>
                                     <MantineIcon


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7805 

### Description:

Removes the 'no destination' text from scheduled deliveries. It wasn't necessary wasn't really following an existing validation pattern. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
