### PR TITLE
fix: make scheduler time inputs more compact

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/CronInput/CustomInputs.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/CustomInputs.tsx
@@ -28,7 +28,6 @@ const CustomInputs: FC<{
 
     return (
         <TextInput
-            label="Cron expression (UTC)"
             withAsterisk
             value={cronExpression}
             placeholder="0 9 * * 1"

--- a/packages/frontend/src/components/ReactHookForm/CronInput/DailyInputs.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/DailyInputs.tsx
@@ -13,7 +13,7 @@ const DailyInputs: FC<{
     };
 
     return (
-        <Group spacing="xs">
+        <Group spacing="sm">
             <Input.Label>at</Input.Label>
             <TimePicker
                 disabled={disabled}

--- a/packages/frontend/src/components/ReactHookForm/CronInput/FrequencySelect.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/FrequencySelect.tsx
@@ -26,7 +26,7 @@ const FrequencyItems: Array<FrequencyItem> = [
     },
     {
         value: Frequency.CUSTOM,
-        label: 'Custom',
+        label: 'Custom cron expression',
     },
 ];
 
@@ -42,6 +42,8 @@ const FrequencySelect: FC<{
             withinPortal
             disabled={disabled}
             onChange={onChange}
+            w={210}
+            sx={{ alignSelf: 'start' }}
         />
     );
 };

--- a/packages/frontend/src/components/ReactHookForm/CronInput/HourlyInputs.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/HourlyInputs.tsx
@@ -20,7 +20,7 @@ const HourlyInputs: FC<{
     };
 
     return (
-        <Group spacing="xs">
+        <Group spacing="sm">
             <Input.Label>at minute</Input.Label>
             <NumberInput
                 value={minutes}

--- a/packages/frontend/src/components/ReactHookForm/CronInput/MonthlyInputs.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/MonthlyInputs.tsx
@@ -24,7 +24,7 @@ const MonthlyInputs: FC<{
     };
 
     return (
-        <Group spacing="xs">
+        <Group spacing="sm">
             <Input.Label>on day</Input.Label>
             <NumberInput
                 value={day}

--- a/packages/frontend/src/components/ReactHookForm/CronInput/WeekDaySelect.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/WeekDaySelect.tsx
@@ -48,6 +48,7 @@ const WeekDaySelect: FC<{
             value={String(value)}
             disabled={disabled}
             withinPortal
+            w={140}
             onChange={(val) => {
                 onChange(Number(val));
             }}

--- a/packages/frontend/src/components/ReactHookForm/CronInput/WeeklyInputs.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/WeeklyInputs.tsx
@@ -21,17 +21,19 @@ const WeeklyInputs: FC<{
         );
     };
     return (
-        <Group spacing="xs">
+        <>
             <Input.Label>on</Input.Label>
             <WeekDaySelect value={weekDay} onChange={onDayChange} />
             <Input.Label>at</Input.Label>
-            <TimePicker
-                disabled={disabled}
-                cronExpression={cronExpression}
-                onChange={onTimeChange}
-            />
-            <Input.Label>UTC</Input.Label>
-        </Group>
+            <Group noWrap spacing="sm">
+                <TimePicker
+                    disabled={disabled}
+                    cronExpression={cronExpression}
+                    onChange={onTimeChange}
+                />
+                <Input.Label>UTC</Input.Label>
+            </Group>
+        </>
     );
 };
 export default WeeklyInputs;

--- a/packages/frontend/src/components/ReactHookForm/CronInput/index.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/index.tsx
@@ -1,4 +1,4 @@
-import { FormGroup } from '@blueprintjs/core';
+import { Group } from '@mantine/core';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import {
     Controller,
@@ -51,14 +51,12 @@ export const CronInternalInputs: FC<
     );
 
     return (
-        <div>
-            <FormGroup className={'input-wrapper'}>
-                <FrequencySelect
-                    value={frequency}
-                    disabled={disabled}
-                    onChange={onFrequencyChange}
-                />
-            </FormGroup>
+        <Group spacing="sm">
+            <FrequencySelect
+                value={frequency}
+                disabled={disabled}
+                onChange={onFrequencyChange}
+            />
             {frequency === Frequency.HOURLY && (
                 <HourlyInputs cronExpression={value} onChange={onChange} />
             )}
@@ -80,7 +78,7 @@ export const CronInternalInputs: FC<
                     error={error}
                 />
             )}
-        </div>
+        </Group>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7804 

### Description:

Updates scheduler form layout so that the time inputs are mostly on one line. Google sheets dialog gets the updates too -- it could probably use a design pass, but it doesn't look worse than it did before. 

Here's an example
<img width="640" alt="Screenshot 2023-11-03 at 17 52 14" src="https://github.com/lightdash/lightdash/assets/1864179/aae55f3f-0a38-42cb-8aca-77a21a20cd89">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
