### PR TITLE
chore: filter feature tidyup

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -11,7 +11,7 @@ import { useDashboardContext } from '../../providers/DashboardProvider';
 import {
     getConditionalRuleLabel,
     getFilterRuleTables,
-} from '../common/Filters/configs';
+} from '../common/Filters/FilterInputs';
 import MantineIcon from '../common/MantineIcon';
 import FilterConfiguration from './FilterConfiguration';
 
@@ -229,12 +229,9 @@ const Filter: FC<Props> = ({
                         availableTileFilters={filterableFieldsByTileUuid}
                         defaultFilterRule={defaultFilterRule}
                         onSave={handelSaveChanges}
-                        // FIXME: remove this once we migrate off of Blueprint
                         popoverProps={{
-                            onOpened: () => openSubPopover(),
-                            onOpening: () => openSubPopover(),
-                            onClose: () => closeSubPopover(),
-                            onClosing: () => closeSubPopover(),
+                            onOpen: openSubPopover,
+                            onClose: closeSubPopover,
                         }}
                     />
                 )}

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -1,4 +1,3 @@
-import { Popover2Props } from '@blueprintjs/popover2';
 import {
     DashboardFilterRule,
     DashboardTile,
@@ -13,6 +12,7 @@ import {
     Box,
     Checkbox,
     Flex,
+    PopoverProps,
     Stack,
     Text,
     Tooltip,
@@ -29,7 +29,7 @@ type Props = {
     availableTileFilters: Record<string, Field[] | undefined>;
     field: Field;
     filterRule: DashboardFilterRule;
-    popoverProps?: Popover2Props;
+    popoverProps?: Omit<PopoverProps, 'children'>;
     onChange: (action: FilterActions, tileUuid: string, field?: Field) => void;
     onToggleAll: (checked: boolean) => void;
 };
@@ -39,6 +39,7 @@ const TileFilterConfiguration: FC<Props> = ({
     field,
     filterRule,
     availableTileFilters,
+    popoverProps,
     onChange,
     onToggleAll,
 }) => {
@@ -226,6 +227,9 @@ const TileFilterConfiguration: FC<Props> = ({
                                     disabled={!value.checked}
                                     item={value.selectedField}
                                     items={value.sortedFilters}
+                                    withinPortal={popoverProps?.withinPortal}
+                                    onDropdownOpen={popoverProps?.onOpen}
+                                    onDropdownClose={popoverProps?.onClose}
                                     onChange={(newField) => {
                                         onChange(
                                             FilterActions.ADD,

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -1,4 +1,3 @@
-import { Popover2Props } from '@blueprintjs/popover2';
 import {
     assertUnreachable,
     createDashboardFilterRuleFromField,
@@ -18,6 +17,7 @@ import {
     Button,
     Flex,
     Group,
+    PopoverProps,
     Stack,
     Tabs,
     Text,
@@ -57,7 +57,7 @@ interface Props {
     availableTileFilters: Record<string, FilterableField[] | undefined>;
     originalFilterRule?: DashboardFilterRule;
     defaultFilterRule?: DashboardFilterRule;
-    popoverProps?: Popover2Props;
+    popoverProps?: Omit<PopoverProps, 'children'>;
     isEditMode: boolean;
     isCreatingNew?: boolean;
     isTemporary?: boolean;
@@ -287,6 +287,9 @@ const FilterConfiguration: FC<Props> = ({
                                         </Text>{' '}
                                     </Text>
                                 }
+                                withinPortal={popoverProps?.withinPortal}
+                                onDropdownOpen={popoverProps?.onOpen}
+                                onDropdownClose={popoverProps?.onClose}
                                 hasGrouping
                                 item={selectedField}
                                 items={fields}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -51,7 +51,7 @@ import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import { Can } from '../common/Authorization';
 import ErrorState from '../common/ErrorState';
-import { getConditionalRuleLabel } from '../common/Filters/configs';
+import { getConditionalRuleLabel } from '../common/Filters/FilterInputs';
 import LinkMenuItem from '../common/LinkMenuItem';
 import MantineIcon from '../common/MantineIcon';
 import MoveChartThatBelongsToDashboardModal from '../common/modal/MoveChartThatBelongsToDashboardModal';

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -249,7 +249,9 @@ export const CustomMetricModal = () => {
                                     projectUuid={projectUuid}
                                     fieldsMap={fieldsMap}
                                     startOfWeek={startOfWeek ?? undefined}
-                                    inModal
+                                    popoverProps={{
+                                        withinPortal: true,
+                                    }}
                                 >
                                     <FilterForm
                                         defaultFilterRuleFieldId={

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../providers/ExplorerProvider';
 import CollapsableCard from '../../common/CollapsableCard';
 import FiltersForm from '../../common/Filters';
-import { getConditionalRuleLabel } from '../../common/Filters/configs';
+import { getConditionalRuleLabel } from '../../common/Filters/FilterInputs';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
 import { DisabledFilterHeader, FilterValues } from './FiltersCard.styles';
 import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -83,7 +83,6 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                         <FilterWeekPicker
                             size="sm"
                             value={moment(value).toDate()}
-                            popoverProps={{ withinPortal: false }}
                             firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                             onChange={(dateValue) => {
                                 if (!dateValue) return;

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -15,11 +15,15 @@ import {
 } from '@mantine/core';
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
 import { FC, useState } from 'react';
-import { FilterTypeConfig } from '../../common/Filters/configs';
+import {
+    FilterInputComponent,
+    getFilterOperatorOptions,
+} from '../../common/Filters/FilterInputs';
 import MantineIcon from '../../common/MantineIcon';
 
-// conditional formatting only supports number fields for now
-const filterConfig = FilterTypeConfig[FilterType.NUMBER];
+// conditional formatting only supports number filters
+const filterType = FilterType.NUMBER;
+const filterOperatorOptions = getFilterOperatorOptions(filterType);
 
 interface ConditionalFormattingRuleProps {
     isDefaultOpen?: boolean;
@@ -72,15 +76,15 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                 <Stack spacing="xs">
                     <Select
                         value={rule.operator}
-                        data={filterConfig.operatorOptions}
+                        data={filterOperatorOptions}
                         onChange={(value) => {
                             if (!value) return;
                             onChangeRuleOperator(value as ConditionalOperator);
                         }}
                     />
 
-                    <filterConfig.inputs
-                        filterType={FilterType.NUMBER}
+                    <FilterInputComponent
+                        filterType={filterType}
                         field={field}
                         rule={rule}
                         onChange={onChangeRule}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -4,13 +4,14 @@ import {
     isFilterRule,
 } from '@lightdash/common';
 import { Select } from '@mantine/core';
+import { FilterInputsProps } from '.';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
-import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
+import DefaultFilterInputs from './DefaultFilterInputs';
 
 const BooleanFilterInputs = <T extends ConditionalRule>(
-    props: React.PropsWithChildren<FilterInputsProps<T>>,
+    props: FilterInputsProps<T>,
 ) => {
-    const { rule, onChange, disabled, filterType } = props;
+    const { rule, onChange, disabled, filterType, popoverProps } = props;
 
     const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
 
@@ -26,7 +27,9 @@ const BooleanFilterInputs = <T extends ConditionalRule>(
                 <Select
                     w="100%"
                     size="xs"
-                    withinPortal
+                    withinPortal={popoverProps?.withinPortal}
+                    onDropdownOpen={popoverProps?.onOpen}
+                    onDropdownClose={popoverProps?.onClose}
                     disabled={disabled}
                     placeholder={placeholder}
                     data={[

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -28,15 +28,7 @@ import FilterYearPicker from './FilterYearPicker';
 const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
     props: React.PropsWithChildren<FilterInputsProps<T>>,
 ) => {
-    const {
-        field,
-        rule,
-        onChange,
-        popoverProps,
-        disabled,
-        filterType,
-        inModal,
-    } = props;
+    const { field, rule, onChange, popoverProps, disabled, filterType } = props;
     const { startOfWeek } = useFiltersContext();
     const isTimestamp =
         isField(field) && field.type === DimensionType.TIMESTAMP;
@@ -91,20 +83,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                     firstDayOfWeek={getFirstDayOfWeek(
                                         startOfWeek,
                                     )}
-                                    // FIXME: remove this once we migrate off of Blueprint
-                                    // we are doing type conversion here because Blueprint expects DOM element
-                                    // Mantine does not provide a DOM element on onOpen/onClose
-                                    popoverProps={{
-                                        onOpen: () =>
-                                            popoverProps?.onOpened?.(
-                                                null as any,
-                                            ),
-                                        onClose: () =>
-                                            popoverProps?.onClose?.(
-                                                null as any,
-                                            ),
-                                        withinPortal: inModal,
-                                    }}
+                                    popoverProps={popoverProps}
                                     onChange={(value: Date | null) => {
                                         onChange({
                                             ...rule,
@@ -126,16 +105,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <FilterMonthAndYearPicker
                                 disabled={disabled}
                                 placeholder={placeholder}
-                                // FIXME: remove this once we migrate off of Blueprint
-                                // we are doing type conversion here because Blueprint expects DOM element
-                                // Mantine does not provide a DOM element on onOpen/onClose
-                                popoverProps={{
-                                    onOpen: () =>
-                                        popoverProps?.onOpened?.(null as any),
-                                    onClose: () =>
-                                        popoverProps?.onClose?.(null as any),
-                                    withinPortal: inModal,
-                                }}
+                                popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
                                         ? parseDate(
@@ -162,16 +132,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             <FilterYearPicker
                                 disabled={disabled}
                                 placeholder={placeholder}
-                                // FIXME: remove this once we migrate off of Blueprint
-                                // we are doing type conversion here because Blueprint expects DOM element
-                                // Mantine does not provide a DOM element on onOpen/onClose
-                                popoverProps={{
-                                    onOpen: () =>
-                                        popoverProps?.onOpened?.(null as any),
-                                    onClose: () =>
-                                        popoverProps?.onClose?.(null as any),
-                                    withinPortal: inModal,
-                                }}
+                                popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
                                         ? parseDate(
@@ -211,14 +172,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         // mantine does not set the first day of the week based on the locale
                         // so we need to do it manually and always pass it as a prop
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                        // FIXME: remove this once we migrate off of Blueprint
-                        // we are doing type conversion here because Blueprint expects DOM element
-                        // Mantine does not provide a DOM element on onOpen/onClose
-                        popoverProps={{
-                            onOpen: () => popoverProps?.onOpened?.(null as any),
-                            onClose: () => popoverProps?.onClose?.(null as any),
-                            withinPortal: inModal,
-                        }}
+                        popoverProps={popoverProps}
                         value={
                             rule.values
                                 ? parseDate(
@@ -256,14 +210,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     // mantine does not set the first day of the week based on the locale
                     // so we need to do it manually and always pass it as a prop
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                    // FIXME: remove this once we migrate off of Blueprint
-                    // we are doing type conversion here because Blueprint expects DOM element
-                    // Mantine does not provide a DOM element on onOpen/onClose
-                    popoverProps={{
-                        onOpen: () => popoverProps?.onOpened?.(null as any),
-                        onClose: () => popoverProps?.onClose?.(null as any),
-                        withinPortal: inModal,
-                    }}
+                    popoverProps={popoverProps}
                     value={
                         rule.values
                             ? parseDate(
@@ -309,8 +256,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         isTimestamp={isTimestamp}
                         unitOfTime={rule.settings?.unitOfTime}
                         completed={rule.settings?.completed || false}
-                        popoverProps={popoverProps}
-                        withinPortal={inModal}
+                        withinPortal={popoverProps?.withinPortal}
+                        onDropdownOpen={popoverProps?.onOpen}
+                        onDropdownClose={popoverProps?.onClose}
                         onChange={(value) =>
                             onChange({
                                 ...rule,
@@ -333,7 +281,9 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
                     completed={false}
-                    popoverProps={popoverProps}
+                    withinPortal={popoverProps?.withinPortal}
+                    onDropdownOpen={popoverProps?.onOpen}
+                    onDropdownClose={popoverProps?.onClose}
                     onChange={(value) =>
                         onChange({
                             ...rule,
@@ -343,7 +293,6 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             },
                         })
                     }
-                    withinPortal={inModal}
                 />
             );
         case FilterOperator.IN_BETWEEN:
@@ -372,14 +321,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                   ]
                                 : null
                         }
-                        // FIXME: remove this once we migrate off of Blueprint
-                        // we are doing type conversion here because Blueprint expects DOM element
-                        // Mantine does not provide a DOM element on onOpen/onClose
-                        popoverProps={{
-                            onOpen: () => popoverProps?.onOpened?.(null as any),
-                            onClose: () => popoverProps?.onClose?.(null as any),
-                            withinPortal: inModal,
-                        }}
+                        popoverProps={popoverProps}
                         onChange={(value: [Date, Date] | null) => {
                             onChange({
                                 ...rule,
@@ -425,14 +367,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                               ]
                             : null
                     }
-                    // FIXME: remove this once we migrate off of Blueprint
-                    // we are doing type conversion here because Blueprint expects DOM element
-                    // Mantine does not provide a DOM element on onOpen/onClose
-                    popoverProps={{
-                        onOpen: () => popoverProps?.onOpened?.(null as any),
-                        onClose: () => popoverProps?.onClose?.(null as any),
-                        withinPortal: inModal,
-                    }}
+                    popoverProps={popoverProps}
                     onChange={(value: [Date, Date] | null) => {
                         onChange({
                             ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -11,11 +11,11 @@ import {
     TimeFrames,
 } from '@lightdash/common';
 import { Flex, NumberInput, Text } from '@mantine/core';
-import React from 'react';
+import { FilterInputsProps } from '.';
 import { useFiltersContext } from '../FiltersProvider';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
-import DefaultFilterInputs, { FilterInputsProps } from './DefaultFilterInputs';
+import DefaultFilterInputs from './DefaultFilterInputs';
 import FilterDatePicker from './FilterDatePicker';
 import FilterDateRangePicker from './FilterDateRangePicker';
 import FilterDateTimePicker from './FilterDateTimePicker';
@@ -26,7 +26,7 @@ import FilterWeekPicker from './FilterWeekPicker';
 import FilterYearPicker from './FilterYearPicker';
 
 const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
-    props: React.PropsWithChildren<FilterInputsProps<T>>,
+    props: FilterInputsProps<T>,
 ) => {
     const { field, rule, onChange, popoverProps, disabled, filterType } = props;
     const { startOfWeek } = useFiltersContext();

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -1,4 +1,3 @@
-import { Popover2Props } from '@blueprintjs/popover2';
 import {
     assertUnreachable,
     ConditionalRule,
@@ -7,6 +6,7 @@ import {
     FilterType,
     isFilterRule,
 } from '@lightdash/common';
+import { PopoverProps } from '@mantine/core';
 import isString from 'lodash-es/isString';
 import { PropsWithChildren } from 'react';
 import { TagInput } from '../../TagInput/TagInput';
@@ -21,8 +21,7 @@ export type FilterInputsProps<T extends ConditionalRule> = {
     rule: T;
     onChange: (value: T) => void;
     disabled?: boolean;
-    popoverProps?: Popover2Props;
-    inModal?: boolean;
+    popoverProps?: PopoverProps;
 };
 
 const DefaultFilterInputs = <T extends ConditionalRule>({
@@ -31,7 +30,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     rule,
     disabled,
     onChange,
-    inModal,
+    popoverProps,
 }: PropsWithChildren<FilterInputsProps<T>>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
@@ -64,15 +63,15 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             disabled={disabled}
                             field={field}
                             placeholder={placeholder}
-                            values={(rule.values || []).filter(isString)}
                             suggestions={suggestions || []}
+                            withinPortal={popoverProps?.withinPortal}
+                            values={(rule.values || []).filter(isString)}
                             onChange={(values) =>
                                 onChange({
                                     ...rule,
                                     values,
                                 })
                             }
-                            withinPortal={inModal}
                         />
                     );
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -1,28 +1,17 @@
 import {
     assertUnreachable,
     ConditionalRule,
-    FilterableItem,
     FilterOperator,
     FilterType,
     isFilterRule,
 } from '@lightdash/common';
-import { PopoverProps } from '@mantine/core';
 import isString from 'lodash-es/isString';
-import { PropsWithChildren } from 'react';
+import { FilterInputsProps } from '.';
 import { TagInput } from '../../TagInput/TagInput';
 import { useFiltersContext } from '../FiltersProvider';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
 import FilterNumberInput from './FilterNumberInput';
 import FilterStringAutoComplete from './FilterStringAutoComplete';
-
-export type FilterInputsProps<T extends ConditionalRule> = {
-    filterType: FilterType;
-    field: FilterableItem;
-    rule: T;
-    onChange: (value: T) => void;
-    disabled?: boolean;
-    popoverProps?: PopoverProps;
-};
 
 const DefaultFilterInputs = <T extends ConditionalRule>({
     field,
@@ -31,7 +20,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     disabled,
     onChange,
     popoverProps,
-}: PropsWithChildren<FilterInputsProps<T>>) => {
+}: FilterInputsProps<T>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
         ? getField(rule)?.suggestions
@@ -65,6 +54,8 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             placeholder={placeholder}
                             suggestions={suggestions || []}
                             withinPortal={popoverProps?.withinPortal}
+                            onDropdownOpen={popoverProps?.onOpen}
+                            onDropdownClose={popoverProps?.onClose}
                             values={(rule.values || []).filter(isString)}
                             onChange={(values) =>
                                 onChange({

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDatePicker.tsx
@@ -22,7 +22,7 @@ const FilterDatePicker: FC<Props> = ({
             w="100%"
             size="xs"
             {...rest}
-            popoverProps={{ ...rest.popoverProps, shadow: 'sm' }}
+            popoverProps={{ shadow: 'sm', ...rest.popoverProps }}
             firstDayOfWeek={firstDayOfWeek}
             value={value}
             onChange={(date) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -22,7 +22,7 @@ const FilterDateTimePicker: FC<Props> = ({
             w="100%"
             size="xs"
             {...rest}
-            popoverProps={{ ...rest.popoverProps, shadow: 'sm' }}
+            popoverProps={{ shadow: 'sm', ...rest.popoverProps }}
             firstDayOfWeek={firstDayOfWeek}
             value={value}
             onChange={(date) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
@@ -22,10 +22,9 @@ const FilterMonthAndYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
             onClick={toggle}
             {...props}
             popoverProps={{
-                withArrow: true,
-                withinPortal: false,
                 shadow: 'md',
-                // FIXME: remove this once we migrate off of Blueprint
+                // Month and year picker does not manage its own state properly.
+                // additional props are needed to make it work
                 ...props.popoverProps,
                 opened: isPopoverOpen,
                 onOpen: () => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -15,10 +15,7 @@ import {
 } from '../../../../hooks/useFieldValues';
 import { useFiltersContext } from '../FiltersProvider';
 
-type Props = Pick<
-    MultiSelectProps,
-    'disabled' | 'placeholder' | 'withinPortal'
-> & {
+type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     filterId: string;
     field: FilterableItem;
     values: string[];

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -31,6 +31,7 @@ const FilterStringAutoComplete: FC<Props> = ({
     disabled,
     onChange,
     placeholder,
+    ...rest
 }) => {
     const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
     if (!projectUuid) {
@@ -121,6 +122,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             disableSelectedItemFiltering
             searchable
             clearSearchOnChange
+            {...rest}
             searchValue={search}
             onSearchChange={setSearch}
             limit={MAX_AUTOCOMPLETE_RESULTS}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
@@ -1,4 +1,3 @@
-import { Popover2Props } from '@blueprintjs/popover2';
 import { UnitOfTime } from '@lightdash/common';
 import { Select, SelectProps } from '@mantine/core';
 import { FC } from 'react';
@@ -64,7 +63,6 @@ interface Props extends Omit<SelectProps, 'data' | 'onChange'> {
     showOptionsInPlural?: boolean;
     showCompletedOptions?: boolean;
     completed: boolean;
-    popoverProps?: Popover2Props;
     onChange: (value: { unitOfTime: UnitOfTime; completed: boolean }) => void;
 }
 
@@ -75,7 +73,6 @@ const FilterUnitOfTimeAutoComplete: FC<Props> = ({
     showCompletedOptions = true,
     completed,
     onChange,
-    popoverProps,
     ...rest
 }) => (
     <Select

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterWeekPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterWeekPicker.tsx
@@ -30,7 +30,7 @@ const FilterWeekPicker: FC<Props> = ({
             w="100%"
             size="xs"
             {...rest}
-            popoverProps={{ ...rest.popoverProps, shadow: 'sm' }}
+            popoverProps={{ shadow: 'sm', ...rest.popoverProps }}
             getDayProps={(date) => {
                 const isHovered = isInWeekRange(
                     date,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
@@ -21,11 +21,10 @@ const FilterYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
             onClick={toggle}
             {...props}
             popoverProps={{
-                withArrow: true,
-                withinPortal: false,
                 shadow: 'md',
-                // FIXME: remove this once we migrate off of Blueprint
                 ...props.popoverProps,
+                // Month and year picker does not manage its own state properly.
+                // additional props are needed to make it work
                 opened: isPopoverOpen,
                 onOpen: () => {
                     props.popoverProps?.onOpen?.();

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -12,7 +12,7 @@ import { IconDots, IconX } from '@tabler/icons-react';
 import { FC, useCallback, useMemo } from 'react';
 import FieldSelect from '../FieldSelect';
 import MantineIcon from '../MantineIcon';
-import { FilterTypeConfig } from './configs';
+import { FilterInputComponent, getFilterOperatorOptions } from './FilterInputs';
 import { useFiltersContext } from './FiltersProvider';
 
 type Props = {
@@ -33,17 +33,21 @@ const FilterRuleForm: FC<Props> = ({
     onConvertToGroup,
 }) => {
     const { popoverProps } = useFiltersContext();
-    const activeField = fields.find(
-        (field) => getFieldId(field) === filterRule.target.fieldId,
-    );
+    const activeField = useMemo(() => {
+        return fields.find(
+            (field) => getFieldId(field) === filterRule.target.fieldId,
+        );
+    }, [fields, filterRule.target.fieldId]);
 
-    const filterType = activeField
-        ? getFilterTypeFromItem(activeField)
-        : FilterType.STRING;
-    const filterConfig = useMemo(
-        () => FilterTypeConfig[filterType],
-        [filterType],
-    );
+    const filterType = useMemo(() => {
+        return activeField
+            ? getFilterTypeFromItem(activeField)
+            : FilterType.STRING;
+    }, [activeField]);
+
+    const filterOperatorOptions = useMemo(() => {
+        return getFilterOperatorOptions(filterType);
+    }, [filterType]);
 
     const onFieldChange = useCallback(
         (fieldId: string) => {
@@ -101,7 +105,7 @@ const FilterRuleForm: FC<Props> = ({
                         onDropdownClose={popoverProps?.onClose}
                         disabled={!isEditMode}
                         value={filterRule.operator}
-                        data={filterConfig.operatorOptions}
+                        data={filterOperatorOptions}
                         onChange={(value) => {
                             if (!value) return;
 
@@ -121,7 +125,7 @@ const FilterRuleForm: FC<Props> = ({
                         }}
                     />
 
-                    <filterConfig.inputs
+                    <FilterInputComponent
                         filterType={filterType}
                         field={activeField}
                         rule={filterRule}

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -32,7 +32,7 @@ const FilterRuleForm: FC<Props> = ({
     onDelete,
     onConvertToGroup,
 }) => {
-    const { inModal } = useFiltersContext();
+    const { popoverProps } = useFiltersContext();
     const activeField = fields.find(
         (field) => getFieldId(field) === filterRule.target.fieldId,
     );
@@ -80,7 +80,9 @@ const FilterRuleForm: FC<Props> = ({
                     <FieldSelect
                         size="xs"
                         disabled={!isEditMode}
-                        withinPortal={inModal}
+                        withinPortal={popoverProps?.withinPortal}
+                        onDropdownOpen={popoverProps?.onOpen}
+                        onDropdownClose={popoverProps?.onClose}
                         hasGrouping
                         item={activeField}
                         items={fields}
@@ -94,7 +96,9 @@ const FilterRuleForm: FC<Props> = ({
                         size="xs"
                         w="150px"
                         sx={{ flexShrink: 0 }}
-                        withinPortal={inModal}
+                        withinPortal={popoverProps?.withinPortal}
+                        onDropdownOpen={popoverProps?.onOpen}
+                        onDropdownClose={popoverProps?.onClose}
                         disabled={!isEditMode}
                         value={filterRule.operator}
                         data={filterConfig.operatorOptions}
@@ -123,7 +127,7 @@ const FilterRuleForm: FC<Props> = ({
                         rule={filterRule}
                         onChange={onChange}
                         disabled={!isEditMode}
-                        inModal={inModal}
+                        popoverProps={popoverProps}
                     />
                 </>
             ) : (

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -26,7 +26,7 @@ type FiltersContext = {
         filterId: string,
         item: FilterableItem,
     ) => AndFilterGroup | undefined;
-    popoverProps?: PopoverProps;
+    popoverProps?: Omit<PopoverProps, 'children'>;
 };
 
 const Context = createContext<FiltersContext | undefined>(undefined);
@@ -36,7 +36,7 @@ type Props = {
     fieldsMap?: Record<string, FieldWithSuggestions>;
     startOfWeek?: WeekDay;
     dashboardFilters?: DashboardFilters;
-    popoverProps?: PopoverProps;
+    popoverProps?: Omit<PopoverProps, 'children'>;
 };
 
 export const FiltersProvider: FC<Props> = ({

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -7,6 +7,7 @@ import {
     isField,
     WeekDay,
 } from '@lightdash/common';
+import { PopoverProps } from '@mantine/core';
 import { uuid4 } from '@sentry/utils';
 import { createContext, FC, useCallback, useContext } from 'react';
 
@@ -25,7 +26,7 @@ type FiltersContext = {
         filterId: string,
         item: FilterableItem,
     ) => AndFilterGroup | undefined;
-    inModal: boolean;
+    popoverProps?: PopoverProps;
 };
 
 const Context = createContext<FiltersContext | undefined>(undefined);
@@ -35,7 +36,7 @@ type Props = {
     fieldsMap?: Record<string, FieldWithSuggestions>;
     startOfWeek?: WeekDay;
     dashboardFilters?: DashboardFilters;
-    inModal?: boolean;
+    popoverProps?: PopoverProps;
 };
 
 export const FiltersProvider: FC<Props> = ({
@@ -43,7 +44,7 @@ export const FiltersProvider: FC<Props> = ({
     fieldsMap = {},
     startOfWeek,
     dashboardFilters,
-    inModal = false,
+    popoverProps,
     children,
 }) => {
     const getField = useCallback(
@@ -82,7 +83,7 @@ export const FiltersProvider: FC<Props> = ({
                 startOfWeek,
                 getField,
                 getAutocompleteFilterGroup,
-                inModal,
+                popoverProps,
             }}
         >
             {children}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -19,7 +19,7 @@ import { readableColor } from 'polished';
 import React, { FC, useCallback, useMemo, useRef } from 'react';
 import { isSummable } from '../../../hooks/useColumnTotals';
 import { getColorFromRange } from '../../../utils/colorUtils';
-import { getConditionalRuleLabel } from '../Filters/configs';
+import { getConditionalRuleLabel } from '../Filters/FilterInputs';
 import Table from '../LightTable';
 import { CELL_HEIGHT } from '../LightTable/styles';
 import TotalCellMenu from './TotalCellMenu';

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -9,7 +9,7 @@ import { flexRender, Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { FC } from 'react';
 import { getColorFromRange, readableColor } from '../../../../utils/colorUtils';
-import { getConditionalRuleLabel } from '../../Filters/configs';
+import { getConditionalRuleLabel } from '../../Filters/FilterInputs';
 import BodyCell from '../BodyCell';
 import { ROW_HEIGHT_PX, Tr } from '../Table.styles';
 import { TableContext, useTableContext } from '../TableProvider';

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -13,10 +13,13 @@ import {
     Stack,
     Text,
 } from '@mantine/core';
-import { FC } from 'react';
-import { FilterTypeConfig } from '../../../components/common/Filters/configs';
+import { FC, useMemo } from 'react';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
+import {
+    FilterInputComponent,
+    getFilterOperatorOptions,
+} from '../../../components/common/Filters/FilterInputs';
 import {
     FiltersProvider,
     useFiltersContext,
@@ -32,8 +35,13 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({ filter }) => {
     const { fieldsMap } = useFiltersContext();
     const field = fieldsMap[filter.target.fieldId];
 
-    const filterType = field ? getFilterTypeFromItem(field) : FilterType.STRING;
-    const filterConfig = FilterTypeConfig[filterType];
+    const filterType = useMemo(() => {
+        return field ? getFilterTypeFromItem(field) : FilterType.STRING;
+    }, [field]);
+
+    const filterOperatorOptions = useMemo(() => {
+        return getFilterOperatorOptions(filterType);
+    }, [filterType]);
 
     return (
         <Stack key={filter.id} spacing="xs">
@@ -49,13 +57,13 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({ filter }) => {
                     }}
                     size="xs"
                     value={filter.operator}
-                    data={filterConfig.operatorOptions}
+                    data={filterOperatorOptions}
                     onChange={(value) => {
                         console.info(value);
                     }}
                 />
 
-                <filterConfig.inputs
+                <FilterInputComponent
                     filterType={filterType}
                     field={field}
                     rule={filter}
@@ -88,7 +96,7 @@ const SchedulerFilters: FC<SchedulerFiltersProps> = ({ dashboard }) => {
 
     return (
         <FiltersProvider
-            inModal
+            popoverProps={{ withinPortal: true }}
             projectUuid={project.projectUuid}
             fieldsMap={fieldsWithSuggestions}
             startOfWeek={project.warehouseConnection?.startOfWeek ?? undefined}


### PR DESCRIPTION
### Description:

- [x] normalizes filter components
- [x] gets rid of `FilterTypeConfig` that returns operatorOptions and component
- [x] instead introduces `FilterInputComponent` and `getFilterOperatorOptions`
- [x] gets rid of complicated types from filters
- [x] introduces cross component consistency of `popoverProps` across all filter components

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
