### PR TITLE
fix: persist selected tags in multiselect

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -120,7 +120,6 @@ const FilterStringAutoComplete: FC<Props> = ({
             disabled={disabled}
             creatable
             getCreateLabel={(query) => `+ Add "${query}"`}
-            selectOnBlur
             disableSelectedItemFiltering
             searchable
             clearSearchOnChange


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7812 

### Description:
Initially, the last item you hovered over before the dropdown closed, was selected causing unexpected behavior. Disabling selectonblur property fixes that.

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 04-11-23 13:20:20.webm](https://github.com/lightdash/lightdash/assets/76876702/f07f407a-6ec9-45f4-9e8f-33fda89e2bcf)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
