### PR TITLE
fix: When changing from date filter from month to year, the value updates on the UI but not on the generated SQL #7689

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -122,6 +122,20 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             </Flex>
                         );
                     case TimeFrames.MONTH:
+                        const parsedMonth =
+                            rule.values && rule.values[0]
+                                ? parseDate(
+                                      formatDate(
+                                          rule.values[0],
+                                          TimeFrames.MONTH,
+                                      ),
+                                      TimeFrames.MONTH,
+                                  )
+                                : null;
+
+                        if (parsedMonth) {
+                            rule.values = [parsedMonth];
+                        }
                         return (
                             <FilterMonthAndYearPicker
                                 disabled={disabled}
@@ -136,17 +150,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onClose?.(null as any),
                                     withinPortal: inModal,
                                 }}
-                                value={
-                                    rule.values && rule.values[0]
-                                        ? parseDate(
-                                              formatDate(
-                                                  rule.values[0],
-                                                  TimeFrames.MONTH,
-                                              ),
-                                              TimeFrames.MONTH,
-                                          )
-                                        : null
-                                }
+                                value={parsedMonth}
                                 onChange={(value: Date) => {
                                     onChange({
                                         ...rule,
@@ -158,6 +162,20 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                             />
                         );
                     case TimeFrames.YEAR:
+                        const parsedYear: Date | null =
+                            rule.values && rule.values[0]
+                                ? parseDate(
+                                      formatDate(
+                                          rule.values[0],
+                                          TimeFrames.YEAR,
+                                      ),
+                                      TimeFrames.YEAR,
+                                  )
+                                : null;
+
+                        if (parsedYear) {
+                            rule.values = [parsedYear];
+                        }
                         return (
                             <FilterYearPicker
                                 disabled={disabled}
@@ -172,17 +190,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         popoverProps?.onClose?.(null as any),
                                     withinPortal: inModal,
                                 }}
-                                value={
-                                    rule.values && rule.values[0]
-                                        ? parseDate(
-                                              formatDate(
-                                                  rule.values[0],
-                                                  TimeFrames.YEAR,
-                                              ),
-                                              TimeFrames.YEAR,
-                                          )
-                                        : null
-                                }
+                                value={parsedYear}
                                 onChange={(newDate: Date) => {
                                     onChange({
                                         ...rule,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7689

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

1. When the **FilterYearPicker** or **FilterMonthAndYearPicker** components are rendered for the first time, the update on the Filter rule is not done because it is handled in the onChange function. 
2. If the onChange function is not triggered there is no way that Filter rule has the updated date value. 
3. So I added this logic before the component is rendered and component will have the updated Filter Rule even when the component is rendered for the first time

<!-- Even better add a screenshot / gif / loom -->

https://github.com/lightdash/lightdash/assets/86364607/20135228-97b5-4bbc-967c-fd18aad06b32


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
