### PR TITLE
fix: return redirect on OIDC

### DIFF
--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -164,9 +164,9 @@ export const redirectOIDC: RequestHandler = (req, res) => {
         new URL(queryReturn, lightdashConfig.siteUrl).host ===
             new URL(lightdashConfig.siteUrl).host
     ) {
-        res.redirect(queryReturn);
+        return res.redirect(queryReturn);
     }
-    res.redirect('/');
+    return res.redirect('/');
 };
 
 export const googlePassportStrategy: GoogleStrategy | undefined = !(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [<!-- reference the related issue e.g. #150 -->](https://lightdash.sentry.io/issues/4597992817/events/fdd2fb2daae54543a093e35ddc05ec46/?environment=cloud_beta&project=5959292&query=is%3Aunresolved&referrer=previous-event&statsPeriod=7d&stream_index=6)

### Description:

Users were getting this error: `Cannot set headers after they are sent to the client` because it was trying to do both redirects; 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
