### PR TITLE
fix: clean up references to deleted tables in chart queries on dbt refresh

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -50,7 +50,7 @@ const TableTreeSections: FC<Props> = ({
             );
     }, [additionalMetrics, table]);
     const customDimensionsMap = useMemo(() => {
-        if (customDimensions === undefined) return undefined;
+        if (customDimensions === undefined) return {};
         return customDimensions
             .filter((customDimension) => customDimension.table === table.name)
             .reduce<Record<string, CustomDimension>>(
@@ -63,8 +63,8 @@ const TableTreeSections: FC<Props> = ({
 
     const hasMetrics = Object.keys(table.metrics).length > 0;
     const hasDimensions = Object.keys(table.dimensions).length > 0;
-    const hasCustomMetrics = additionalMetrics.length > 0;
-    const hasCustomDimensions = customDimensions && customDimensions.length > 0;
+    const hasCustomMetrics = Object.keys(customMetrics).length > 0;
+    const hasCustomDimensions = Object.keys(customDimensionsMap).length > 0;
 
     return (
         <>
@@ -179,7 +179,6 @@ const TableTreeSections: FC<Props> = ({
             ) : null}
 
             {hasCustomDimensions &&
-            customDimensionsMap &&
             !(
                 isSearching &&
                 getSearchResults(customDimensionsMap, searchQuery).size === 0
@@ -208,7 +207,7 @@ const TableTreeSections: FC<Props> = ({
                 </Group>
             ) : null}
 
-            {hasCustomDimensions && customDimensionsMap ? (
+            {hasCustomDimensions ? (
                 <TreeProvider
                     orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -15,6 +15,7 @@ import { useProject } from '../../hooks/useProject';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
 import { useActiveJob } from '../../providers/ActiveJobProvider';
 import { useApp } from '../../providers/AppProvider';
+import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
@@ -28,6 +29,10 @@ const RefreshDbtButton = () => {
 
     const { track } = useTracking();
     const { user } = useApp();
+
+    const cleanupQueryReferences = useExplorerContext(
+        (context) => context.actions.cleanupQueryReferences,
+    );
 
     useEffect(() => {
         if (activeJob) {
@@ -45,9 +50,11 @@ const RefreshDbtButton = () => {
                 )
             ) {
                 setIsLoading(false);
+                if (activeJob.jobStatus === JobStatusType.DONE)
+                    cleanupQueryReferences();
             }
         }
-    }, [activeJob, activeJob?.jobStatus]);
+    }, [activeJob, activeJob?.jobStatus, cleanupQueryReferences]);
 
     if (
         user.data?.ability?.cannot('manage', 'Job') ||


### PR DESCRIPTION
Closes: #7809 

### Description:

Added the `cleanupQueryReferences()` action to `ExplorerProvider`.
It removes obsolete dimensions and custom metrics/dimensions from `metricQuery` when the user refreshes dbt for a specific table.

https://github.com/lightdash/lightdash/assets/22333399/643cc63c-3ee8-448d-ad4e-caf0927f71cf

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
