### PR TITLE
feat: apply dashboard filter to chart in server

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -3,7 +3,7 @@ import {
     ApiGetChartHistoryResponse,
     ApiGetChartVersionResponse,
     ApiSuccessEmpty,
-    FiltersResponse,
+    DashboardFilters,
 } from '@lightdash/common';
 import { Body, Get, Post } from '@tsoa/runtime';
 import express from 'express';
@@ -33,7 +33,9 @@ export class SavedChartController extends Controller {
     /**
      * Run a query for a chart
      * @param chartUuid chartUuid for the chart to run
-     * @param filters dashboard filters
+     * @param body
+     * @param body.dashboardFilters dashboard filters
+     * @param body.invalidateCache invalidate cache
      * @param req express request
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -41,7 +43,11 @@ export class SavedChartController extends Controller {
     @Post('/results')
     @OperationId('postChartResults')
     async postDashboardTile(
-        @Body() body: { filters?: FiltersResponse; invalidateCache?: boolean },
+        @Body()
+        body: {
+            dashboardFilters?: DashboardFilters;
+            invalidateCache?: boolean;
+        },
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRunQueryResponse> {
@@ -51,7 +57,7 @@ export class SavedChartController extends Controller {
             results: await projectService.runViewChartQuery({
                 user: req.user!,
                 chartUuid,
-                filters: body.filters,
+                dashboardFilters: body.dashboardFilters,
                 versionUuid: undefined,
                 invalidateCache: body.invalidateCache,
             }),
@@ -125,7 +131,7 @@ export class SavedChartController extends Controller {
             results: await projectService.runViewChartQuery({
                 user: req.user!,
                 chartUuid,
-                filters: undefined,
+                dashboardFilters: undefined,
                 versionUuid,
             }),
         };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1053,7 +1053,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ResourceItemCategory: {
         dataType: 'refEnum',
-        enums: ['mostPopular', 'recentlyUpdated'],
+        enums: ['mostPopular', 'recentlyUpdated', 'pinned'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ResourceViewDashboardItem: {
@@ -2284,6 +2284,87 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardFieldTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tableName: { dataType: 'string', required: true },
+                fieldId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'FilterRule_ConditionalOperator.T.V.any_': {
+        dataType: 'refObject',
+        properties: {
+            values: { dataType: 'array', array: { dataType: 'any' } },
+            operator: { ref: 'ConditionalOperator', required: true },
+            id: { dataType: 'string', required: true },
+            target: { ref: 'DashboardFieldTarget', required: true },
+            settings: { dataType: 'any' },
+            disabled: { dataType: 'boolean' },
+        },
+        additionalProperties: false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.DashboardTileTarget_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardFilterRule: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'FilterRule_ConditionalOperator.T.V.any_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        label: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'undefined' },
+                                { dataType: 'string' },
+                            ],
+                            required: true,
+                        },
+                        tileTargets: {
+                            ref: 'Record_string.DashboardTileTarget_',
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardFilters: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DashboardFilterRule' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DashboardFilterRule' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_LightdashUser.userUuid-or-firstName-or-lastName_': {
         dataType: 'refAlias',
         type: {
@@ -3347,6 +3428,13 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        filters: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'DashboardFilterRule',
+                            },
+                        },
                         dashboardUuid: { dataType: 'string', required: true },
                         savedChartUuid: {
                             dataType: 'enum',
@@ -6467,7 +6555,7 @@ export function RegisterRoutes(app: express.Router) {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         invalidateCache: { dataType: 'boolean' },
-                        filters: { ref: 'FiltersResponse' },
+                        dashboardFilters: { ref: 'DashboardFilters' },
                     },
                 },
                 chartUuid: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1169,7 +1169,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ResourceItemCategory": {
-                "enum": ["mostPopular", "recentlyUpdated"],
+                "enum": ["mostPopular", "recentlyUpdated", "pinned"],
                 "type": "string"
             },
             "ResourceViewDashboardItem": {
@@ -2622,6 +2622,83 @@
                 ],
                 "type": "object"
             },
+            "DashboardFieldTarget": {
+                "properties": {
+                    "tableName": {
+                        "type": "string"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    }
+                },
+                "required": ["tableName", "fieldId"],
+                "type": "object"
+            },
+            "FilterRule_ConditionalOperator.T.V.any_": {
+                "properties": {
+                    "values": {
+                        "items": {},
+                        "type": "array"
+                    },
+                    "operator": {
+                        "$ref": "#/components/schemas/ConditionalOperator"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "target": {
+                        "$ref": "#/components/schemas/DashboardFieldTarget"
+                    },
+                    "settings": {},
+                    "disabled": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["operator", "id", "target"],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "Record_string.DashboardTileTarget_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "DashboardFilterRule": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/FilterRule_ConditionalOperator.T.V.any_"
+                    },
+                    {
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "tileTargets": {
+                                "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "DashboardFilters": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/DashboardFilterRule"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/DashboardFilterRule"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["metrics", "dimensions"],
+                "type": "object"
+            },
             "Pick_LightdashUser.userUuid-or-firstName-or-lastName_": {
                 "properties": {
                     "userUuid": {
@@ -3833,6 +3910,12 @@
                     },
                     {
                         "properties": {
+                            "filters": {
+                                "items": {
+                                    "$ref": "#/components/schemas/DashboardFilterRule"
+                                },
+                                "type": "array"
+                            },
                             "dashboardUuid": {
                                 "type": "string"
                             },
@@ -5244,7 +5327,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.844.0",
+        "version": "0.853.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -7080,8 +7163,8 @@
                                     "invalidateCache": {
                                         "type": "boolean"
                                     },
-                                    "filters": {
-                                        "$ref": "#/components/schemas/FiltersResponse"
+                                    "dashboardFilters": {
+                                        "$ref": "#/components/schemas/DashboardFilters"
                                     }
                                 },
                                 "type": "object"

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -12,7 +12,7 @@ import {
     friendlyName,
     getCustomDimensionId,
     getCustomLabelsFromTableConfig,
-    getDashboardFiltersForTile,
+    getDashboardFiltersForTileAndTables,
     getItemLabel,
     getItemLabelWithoutTableName,
     getItemMap,
@@ -374,7 +374,7 @@ export class CsvService {
 
         const dashboardFiltersForTile =
             tileUuid && dashboardFilters
-                ? getDashboardFiltersForTile(
+                ? getDashboardFiltersForTileAndTables(
                       tileUuid,
                       Object.keys(explore.tables),
                       dashboardFilters,

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -379,7 +379,6 @@ export const getFilterRulesByFieldType = (
 
 export const getDashboardFilterRulesForTile = (
     tileUuid: string,
-    tables: string[],
     rules: DashboardFilterRule[],
 ): DashboardFilterRule[] =>
     rules
@@ -407,20 +406,35 @@ export const getDashboardFilterRulesForTile = (
                 },
             };
         })
-        .filter((f): f is DashboardFilterRule => f !== null)
-        .filter((f) => tables.includes(f.target.tableName));
+        .filter((f): f is DashboardFilterRule => f !== null);
 
-export const getDashboardFiltersForTile = (
+export const getDashboardFilterRulesForTables = (
+    tables: string[],
+    rules: DashboardFilterRule[],
+): DashboardFilterRule[] =>
+    rules.filter((f) => tables.includes(f.target.tableName));
+
+export const getDashboardFilterRulesForTileAndTables = (
+    tileUuid: string,
+    tables: string[],
+    rules: DashboardFilterRule[],
+): DashboardFilterRule[] =>
+    getDashboardFilterRulesForTables(
+        tables,
+        getDashboardFilterRulesForTile(tileUuid, rules),
+    );
+
+export const getDashboardFiltersForTileAndTables = (
     tileUuid: string,
     tables: string[],
     dashboardFilters: DashboardFilters,
 ): DashboardFilters => ({
-    dimensions: getDashboardFilterRulesForTile(
+    dimensions: getDashboardFilterRulesForTileAndTables(
         tileUuid,
         tables,
         dashboardFilters.dimensions,
     ),
-    metrics: getDashboardFilterRulesForTile(
+    metrics: getDashboardFilterRulesForTileAndTables(
         tileUuid,
         tables,
         dashboardFilters.metrics,

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -229,7 +229,7 @@ describe('Lightdash API tests for member user with admin project permissions', (
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { filters: {} },
+                    body: { dashboardFilters: {} },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');
@@ -887,7 +887,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { filters: {} },
+                    body: { dashboardFilters: {} },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');
@@ -1131,7 +1131,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { filters: {} },
+                    body: { dashboardFilters: {} },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -229,7 +229,7 @@ describe('Lightdash API tests for member user with admin project permissions', (
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { dashboardFilters: {} },
+                    body: { dashboardFilters: { metrics: [], dimensions: [] } },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');
@@ -887,7 +887,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { dashboardFilters: {} },
+                    body: { dashboardFilters: { metrics: [], dimensions: [] } },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');
@@ -1131,7 +1131,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: { dashboardFilters: {} },
+                    body: { dashboardFilters: { metrics: [], dimensions: [] } },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
                     expect(resp.body).to.have.property('status', 'ok');

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -36,6 +36,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { downloadCsv } from '../../api/csv';
 import { ExportToGoogleSheet } from '../../features/export';
 import useDashboardFiltersForExplore from '../../hooks/dashboard/useDashboardFiltersForExplore';
+import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import useSavedQueryWithDashboardFilters from '../../hooks/dashboard/useSavedQueryWithDashboardFilters';
 import { EChartSeries } from '../../hooks/echarts/useEcharts';
@@ -74,21 +75,24 @@ import {
 interface ExportResultAsCSVModalProps {
     projectUuid: string;
     savedChart: SavedChart;
+    tileUuid: string;
     onClose: () => void;
     onConfirm: () => void;
 }
 
 const ExportResultAsCSVModal: FC<ExportResultAsCSVModalProps> = ({
+    tileUuid,
     savedChart,
     onClose,
     onConfirm,
 }) => {
     const { showToastError } = useToaster();
+    const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const {
         data: resultData,
         isLoading,
         error,
-    } = useChartResults(savedChart.uuid, savedChart.metricQuery.filters);
+    } = useChartResults(savedChart.uuid, dashboardFilters);
 
     useEffect(() => {
         if (error) {
@@ -167,11 +171,12 @@ const ValidDashboardChartTile: FC<{
 }> = ({ tileUuid, isTitleHidden = false, data, onSeriesContextMenu }) => {
     const { addSuggestions, addResultsCacheTime, invalidateCache } =
         useDashboardContext();
+    const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const {
         data: resultData,
         isLoading,
         error,
-    } = useChartResults(data.uuid, data.metricQuery.filters, invalidateCache);
+    } = useChartResults(data.uuid, dashboardFilters, invalidateCache);
     const { data: explore } = useExplore(data.tableName);
     const { health } = useApp();
 
@@ -229,11 +234,12 @@ const ValidDashboardChartTileMinimal: FC<{
     title: string;
     data: SavedChart;
 }> = ({ tileUuid, data, isTitleHidden = false }) => {
+    const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const {
         data: resultData,
         isLoading,
         error,
-    } = useChartResults(data.uuid, data.metricQuery.filters);
+    } = useChartResults(data.uuid, dashboardFilters);
     const { data: explore } = useExplore(data.tableName);
 
     const { health } = useApp();
@@ -819,6 +825,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
             {savedQueryWithDashboardFilters && isCSVExportModalOpen ? (
                 <ExportResultAsCSVModal
                     projectUuid={projectUuid}
+                    tileUuid={tileUuid}
                     savedChart={savedQueryWithDashboardFilters}
                     onClose={() => setIsCSVExportModalOpen(false)}
                     onConfirm={() => setIsCSVExportModalOpen(false)}

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -1,7 +1,7 @@
 import {
     DashboardFilters,
     Explore,
-    getDashboardFilterRulesForTile,
+    getDashboardFilterRulesForTileAndTables,
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { useDashboardContext } from '../../providers/DashboardProvider';
@@ -20,11 +20,15 @@ const useDashboardFiltersForExplore = (
 
     return useMemo(
         () => ({
-            dimensions: getDashboardFilterRulesForTile(tileUuid, tables, [
-                ...dashboardFilters.dimensions,
-                ...(dashboardTemporaryFilters?.dimensions ?? []),
-            ]),
-            metrics: getDashboardFilterRulesForTile(tileUuid, tables, [
+            dimensions: getDashboardFilterRulesForTileAndTables(
+                tileUuid,
+                tables,
+                [
+                    ...dashboardFilters.dimensions,
+                    ...(dashboardTemporaryFilters?.dimensions ?? []),
+                ],
+            ),
+            metrics: getDashboardFilterRulesForTileAndTables(tileUuid, tables, [
                 ...dashboardFilters.metrics,
                 ...(dashboardTemporaryFilters?.metrics ?? []),
             ]),

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForTile.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForTile.ts
@@ -1,0 +1,27 @@
+import {
+    DashboardFilters,
+    getDashboardFilterRulesForTile,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { useDashboardContext } from '../../providers/DashboardProvider';
+
+const useDashboardFiltersForTile = (tileUuid: string): DashboardFilters => {
+    const { dashboardFilters, dashboardTemporaryFilters } =
+        useDashboardContext();
+
+    return useMemo(
+        () => ({
+            dimensions: getDashboardFilterRulesForTile(tileUuid, [
+                ...dashboardFilters.dimensions,
+                ...(dashboardTemporaryFilters?.dimensions ?? []),
+            ]),
+            metrics: getDashboardFilterRulesForTile(tileUuid, [
+                ...dashboardFilters.metrics,
+                ...(dashboardTemporaryFilters?.metrics ?? []),
+            ]),
+        }),
+        [tileUuid, dashboardFilters, dashboardTemporaryFilters],
+    );
+};
+
+export default useDashboardFiltersForTile;

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -1,7 +1,7 @@
 import {
     ApiError,
     ApiQueryResults,
-    Filters,
+    DashboardFilters,
     getCustomDimensionId,
     MetricQuery,
 } from '@lightdash/common';
@@ -9,7 +9,10 @@ import { useCallback, useMemo } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { lightdashApi } from '../api';
-import { convertDateFilters } from '../utils/dateFilter';
+import {
+    convertDateDashboardFilters,
+    convertDateFilters,
+} from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
@@ -24,18 +27,18 @@ type QueryResultsProps = {
 // This API call will be used for getting charts in view mode and dashboard tiles
 const getChartResults = async ({
     chartUuid,
-    filters,
+    dashboardFilters,
     invalidateCache,
 }: {
     chartUuid?: string;
-    filters?: Filters;
+    dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
 }) => {
     return lightdashApi<ApiQueryResults>({
         url: `/saved/${chartUuid}/results`,
         method: 'POST',
         body: JSON.stringify({
-            filters,
+            dashboardFilters,
             ...(invalidateCache && { invalidateCache: true }),
         }),
     });
@@ -170,23 +173,24 @@ export const useUnderlyingDataResults = (
 // This hook will be used for getting charts in view mode and dashboard tiles
 export const useChartResults = (
     chartUuid: string,
-    filters?: Filters,
+    dashboardFilters?: DashboardFilters,
     invalidateCache?: boolean,
 ) => {
     const queryKey = [
         'savedChartResults',
         chartUuid,
-        JSON.stringify(filters),
+        dashboardFilters,
         invalidateCache,
     ];
-    const timezoneFixFilters = filters && convertDateFilters(filters);
+    const timezoneFixFilters =
+        dashboardFilters && convertDateDashboardFilters(dashboardFilters);
 
     return useQuery<ApiQueryResults, ApiError>({
         queryKey,
         queryFn: () =>
             getChartResults({
                 chartUuid,
-                filters: timezoneFixFilters,
+                dashboardFilters: timezoneFixFilters,
                 invalidateCache,
             }),
         retry: false,

--- a/packages/frontend/src/utils/dateFilter.ts
+++ b/packages/frontend/src/utils/dateFilter.ts
@@ -1,4 +1,5 @@
 import {
+    DashboardFilters,
     FilterGroup,
     FilterGroupItem,
     FilterRule,
@@ -9,33 +10,44 @@ import {
 } from '@lightdash/common';
 import moment from 'moment';
 
+const convertFilterRule = <T extends FilterRule>(filterRule: T): T => {
+    return {
+        ...filterRule,
+        values: filterRule.values?.map((value) => {
+            if (value instanceof Date) {
+                return moment(value).format('YYYY-MM-DDTHH:mm:ss') + 'Z';
+            }
+            return value;
+        }),
+    };
+};
+const convertFilterGroups = (filterGroup: FilterGroup): FilterGroup => {
+    const items = getItemsFromFilterGroup(filterGroup);
+    const convertedItems: FilterGroupItem[] = items.map((item) => {
+        if (isFilterGroup(item)) return convertFilterGroups(item);
+        else return convertFilterRule(item);
+    });
+    return {
+        ...filterGroup,
+        [getFilterGroupItemsPropertyName(filterGroup)]: convertedItems,
+    };
+};
+
 export const convertDateFilters = (filters: Filters): Filters => {
     // Fix original date time values on filters instead of converting dates into UTC when using JSON.stringify on API request
-    const convertFilterRule = (filterRule: FilterRule): FilterRule => {
-        return {
-            ...filterRule,
-            values: filterRule.values?.map((value) => {
-                if (value instanceof Date) {
-                    return moment(value).format('YYYY-MM-DDTHH:mm:ss') + 'Z';
-                }
-                return value;
-            }),
-        };
-    };
-    const convertFilterGroups = (filterGroup: FilterGroup): FilterGroup => {
-        const items = getItemsFromFilterGroup(filterGroup);
-        const convertedItems: FilterGroupItem[] = items.map((item) => {
-            if (isFilterGroup(item)) return convertFilterGroups(item);
-            else return convertFilterRule(item);
-        });
-        return {
-            ...filterGroup,
-            [getFilterGroupItemsPropertyName(filterGroup)]: convertedItems,
-        };
-    };
     return {
         dimensions:
             filters.dimensions && convertFilterGroups(filters.dimensions),
         metrics: filters.metrics && convertFilterGroups(filters.metrics),
+    };
+};
+
+export const convertDateDashboardFilters = (
+    filters: DashboardFilters,
+): DashboardFilters => {
+    // Fix original date time values on filters instead of converting dates into UTC when using JSON.stringify on API request
+    return {
+        dimensions: filters.dimensions.map(convertFilterRule),
+        metrics: filters.metrics.map(convertFilterRule),
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

At the moment, the logic to find what dashboard filters are applied to each chart is in the frontend. 
This PR is moving that logic to the BE. The FE sends all filters based on the tileUuid and the BE filters those based on the explore tables for that chart. 

The following PR is going to merge a few of the requests from the frontend and some of this code ( frontend/common) is going to be removed. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
