### PR TITLE
fix: missing custom metric on join

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -17,6 +17,7 @@ type Props = {
     additionalMetrics: AdditionalMetric[];
     selectedItems: Set<string>;
     onSelectedNodeChange: (itemId: string, isDimension: boolean) => void;
+    missingCustomMetrics: AdditionalMetric[];
     customDimensions?: CustomDimension[];
 };
 const TableTreeSections: FC<Props> = ({
@@ -25,6 +26,7 @@ const TableTreeSections: FC<Props> = ({
     additionalMetrics,
     customDimensions,
     selectedItems,
+    missingCustomMetrics,
     onSelectedNodeChange,
 }) => {
     const dimensions = useMemo(() => {
@@ -42,13 +44,14 @@ const TableTreeSections: FC<Props> = ({
     }, [table.metrics]);
 
     const customMetrics = useMemo(() => {
-        return additionalMetrics
-            .filter((metric) => metric.table === table.name)
-            .reduce<Record<string, AdditionalMetric>>(
-                (acc, item) => ({ ...acc, [getItemId(item)]: item }),
-                {},
-            );
-    }, [additionalMetrics, table]);
+        const customMetricsTable = additionalMetrics.filter(
+            (metric) => metric.table === table.name,
+        );
+
+        return [...customMetricsTable, ...missingCustomMetrics].reduce<
+            Record<string, AdditionalMetric>
+        >((acc, item) => ({ ...acc, [getItemId(item)]: item }), {});
+    }, [additionalMetrics, , missingCustomMetrics, table]);
     const customDimensionsMap = useMemo(() => {
         if (customDimensions === undefined) return undefined;
         return customDimensions
@@ -172,6 +175,7 @@ const TableTreeSections: FC<Props> = ({
                     searchQuery={searchQuery}
                     itemsMap={customMetrics}
                     selectedItems={selectedItems}
+                    missingCustomMetrics={missingCustomMetrics}
                     onItemClick={(key) => onSelectedNodeChange(key, false)}
                 >
                     <TreeRoot />

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
@@ -158,6 +158,7 @@ type Props = {
     searchQuery?: string;
     itemsMap: Record<string, Item>;
     selectedItems: Set<string>;
+    missingCustomMetrics?: AdditionalMetric[];
     onItemClick: (key: string, item: Item) => void;
 };
 
@@ -174,6 +175,7 @@ export const TreeProvider: FC<Props> = ({
     children,
     itemsMap,
     selectedItems,
+    missingCustomMetrics,
     ...rest
 }) => {
     const nodeMap = getNodeMapFromItemsMap(itemsMap, selectedItems);
@@ -188,6 +190,7 @@ export const TreeProvider: FC<Props> = ({
                 isSearching,
                 searchQuery,
                 searchResults,
+                missingCustomMetrics,
                 ...rest,
             }}
         >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -34,6 +34,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         isSearching,
         searchResults,
         searchQuery,
+        missingCustomMetrics,
         onItemClick,
     } = useTableTreeContext();
     const { isFilteredField } = useFilters();
@@ -57,7 +58,15 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
 
     const isFiltered = isField(item) && isFilteredField(item);
 
-    const label = isField(item) ? timeIntervalLabel || item.label : item.name;
+    const label =
+        isField(item) || isAdditionalMetric(item)
+            ? timeIntervalLabel || item.label || item.name
+            : item.name;
+
+    const isMissing =
+        isAdditionalMetric(item) &&
+        missingCustomMetrics &&
+        missingCustomMetrics.includes(item);
     const description = isField(item) ? item.description : undefined;
     const bgColor = getItemBgColor(item);
 
@@ -83,11 +92,15 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                 },
             }}
             icon={
-                <FieldIcon
-                    item={item}
-                    color={getFieldIconColor(item)}
-                    size="md"
-                />
+                isMissing ? (
+                    <MantineIcon icon={IconAlertTriangle} color="gray.7" />
+                ) : (
+                    <FieldIcon
+                        item={item}
+                        color={getFieldIconColor(item)}
+                        size="md"
+                    />
+                )
             }
             onClick={() => onItemClick(node.key, item)}
             onMouseEnter={() => toggle(true)}
@@ -98,8 +111,12 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         withinPortal
                         multiline
                         sx={{ whiteSpace: 'normal' }}
-                        disabled={!description}
-                        label={description}
+                        disabled={!description && !isMissing}
+                        label={
+                            isMissing
+                                ? `This field from '${item.table}' table is no longer available`
+                                : description
+                        }
                         position="top-start"
                         maw={700}
                     >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -61,6 +61,7 @@ type Props = {
     additionalMetrics: AdditionalMetric[];
     selectedItems: Set<string>;
     onSelectedNodeChange: (itemId: string, isDimension: boolean) => void;
+    missingCustomMetrics: AdditionalMetric[];
     customDimensions?: CustomDimension[];
 };
 
@@ -88,6 +89,7 @@ const TableTree: FC<Props> = ({
     table,
     additionalMetrics,
     customDimensions,
+    missingCustomMetrics,
 
     ...rest
 }) => {
@@ -101,6 +103,7 @@ const TableTree: FC<Props> = ({
                         table={table}
                         additionalMetrics={additionalMetrics}
                         customDimensions={customDimensions}
+                        missingCustomMetrics={missingCustomMetrics}
                         {...rest}
                     />
                 </Wrapper>

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -63,6 +63,13 @@ const ExploreTree: FC<ExploreTreeProps> = ({
             .filter((table) => !(isSearching && !searchHasResults(table)));
     }, [explore, searchHasResults, isSearching]);
 
+    const missingCustomMetrics = useMemo(() => {
+        const allTables = Object.keys(explore.tables);
+        return additionalMetrics.filter(
+            (metric) => !allTables.includes(metric.table),
+        );
+    }, [explore, additionalMetrics]);
+
     return (
         <>
             <TextInput
@@ -93,6 +100,11 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                             selectedItems={selectedNodes}
                             onSelectedNodeChange={onSelectedFieldChange}
                             customDimensions={customDimensions}
+                            missingCustomMetrics={
+                                table.name === explore.baseTable
+                                    ? missingCustomMetrics
+                                    : []
+                            }
                         />
                     ))
                 ) : (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7809

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2023-11-08 10-51-54](https://github.com/lightdash/lightdash/assets/1983672/d183312f-4a6a-42e2-badc-d6482c0a10c4)
You can now remove a custom metric even if the joined table is missing 


<!-- Even better add a screenshot / gif / loom -->
[Screencast from 08-11-23 10:57:49.webm](https://github.com/lightdash/lightdash/assets/1983672/cab03887-0934-4fdd-9359-938a5dfdb903)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
