### PR TITLE
chore: not persist credentials for release action

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version: '18'


### PR DESCRIPTION
this should mean github triggers a tag-pushed action to trigger `main.yml` jobs 
