### PR TITLE
fix: make dashboard tiles initially undefined to avoid extra call

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -217,7 +217,7 @@ const Filter: FC<Props> = ({
             </Popover.Target>
 
             <Popover.Dropdown ml={5}>
-                {filterableFieldsByTileUuid && (
+                {filterableFieldsByTileUuid && dashboardTiles && (
                     <FilterConfiguration
                         isCreatingNew={isCreatingNew}
                         isEditMode={isEditMode}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -733,18 +733,19 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     opened={isMovingChart}
                     onClose={() => setIsMovingChart(false)}
                     onConfirm={() => {
-                        setDashboardTiles((currentDashboardTiles) =>
-                            currentDashboardTiles.map((tile) =>
-                                tile.uuid === tileUuid && isChartTile(tile)
-                                    ? {
-                                          ...tile,
-                                          properties: {
-                                              ...tile.properties,
-                                              belongsToDashboard: false,
-                                          },
-                                      }
-                                    : tile,
-                            ),
+                        setDashboardTiles(
+                            (currentDashboardTiles) =>
+                                currentDashboardTiles?.map((tile) =>
+                                    tile.uuid === tileUuid && isChartTile(tile)
+                                        ? {
+                                              ...tile,
+                                              properties: {
+                                                  ...tile.properties,
+                                                  belongsToDashboard: false,
+                                              },
+                                          }
+                                        : tile,
+                                ) ?? [],
                         );
                     }}
                 />

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -67,7 +67,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                 : 0,
         );
         return (reorderedCharts || []).map(({ uuid, name, spaceName }) => {
-            const alreadyAddedChart = dashboardTiles.find((tile) => {
+            const alreadyAddedChart = dashboardTiles?.find((tile) => {
                 return (
                     tile.type === DashboardTileTypes.SAVED_CHART &&
                     tile.properties.savedChartUuid === uuid

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -66,13 +66,11 @@ const exportDashboard = async (id: string, queryFilters: string) =>
         body: JSON.stringify({ queryFilters }),
     });
 
-export const useDashboardsAvailableFilters = (
-    savedQueryUuids: string[] | undefined,
-) =>
+export const useDashboardsAvailableFilters = (savedQueryUuids: string[]) =>
     useQuery<DashboardAvailableFilters, ApiError>(
-        ['dashboards', 'availableFilters', ...(savedQueryUuids ?? [])],
-        () => postDashboardsAvailableFilters(savedQueryUuids!),
-        { enabled: savedQueryUuids && savedQueryUuids.length > 0 },
+        ['dashboards', 'availableFilters', ...savedQueryUuids],
+        () => postDashboardsAvailableFilters(savedQueryUuids),
+        { enabled: savedQueryUuids.length > 0 },
     );
 
 export const useDashboardQuery = (

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -66,11 +66,13 @@ const exportDashboard = async (id: string, queryFilters: string) =>
         body: JSON.stringify({ queryFilters }),
     });
 
-export const useDashboardsAvailableFilters = (savedQueryUuids: string[]) =>
+export const useDashboardsAvailableFilters = (
+    savedQueryUuids: string[] | undefined,
+) =>
     useQuery<DashboardAvailableFilters, ApiError>(
-        ['dashboards', 'availableFilters', ...savedQueryUuids],
-        () => postDashboardsAvailableFilters(savedQueryUuids),
-        { enabled: savedQueryUuids.length > 0 },
+        ['dashboards', 'availableFilters', ...(savedQueryUuids ?? [])],
+        () => postDashboardsAvailableFilters(savedQueryUuids!),
+        { enabled: savedQueryUuids && savedQueryUuids.length > 0 },
     );
 
 export const useDashboardQuery = (
@@ -350,7 +352,7 @@ export const useDashboardDeleteMutation = () => {
 };
 
 export const appendNewTilesToBottom = <T extends Pick<DashboardTile, 'y'>>(
-    existingTiles: T[] | [],
+    existingTiles: T[] | undefined,
     newTiles: T[],
 ): T[] => {
     const tilesY =
@@ -365,5 +367,5 @@ export const appendNewTilesToBottom = <T extends Pick<DashboardTile, 'y'>>(
         y: maxY + 1,
     })); //add to the bottom
 
-    return [...existingTiles, ...reorderedTiles];
+    return [...(existingTiles ?? []), ...reorderedTiles];
 };

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -37,7 +37,7 @@ const useDashboardStorage = () => {
 
     const storeDashboard = useCallback(
         (
-            dashboardTiles: DashboardTile[],
+            dashboardTiles: DashboardTile[] | undefined,
             dashboardFilters: DashboardFilters,
             haveTilesChanged: boolean,
             haveFiltersChanged: boolean,
@@ -48,7 +48,7 @@ const useDashboardStorage = () => {
             sessionStorage.setItem('dashboardUuid', dashboardUuid ?? '');
             sessionStorage.setItem(
                 'unsavedDashboardTiles',
-                JSON.stringify(dashboardTiles),
+                JSON.stringify(dashboardTiles ?? []),
             );
             if (
                 dashboardFilters.dimensions.length > 0 ||

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -151,9 +151,10 @@ const Dashboard: FC = () => {
 
     const layouts = useMemo(
         () => ({
-            lg: dashboardTiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, isEditMode),
-            ),
+            lg:
+                dashboardTiles?.map<Layout>((tile) =>
+                    getReactGridLayoutConfig(tile, isEditMode),
+                ) ?? [],
         }),
         [dashboardTiles, isEditMode],
     );
@@ -217,7 +218,7 @@ const Dashboard: FC = () => {
     const handleUpdateTiles = useCallback(
         async (layout: Layout[]) => {
             setDashboardTiles((currentDashboardTiles) =>
-                currentDashboardTiles.map((tile) => {
+                currentDashboardTiles?.map((tile) => {
                     const layoutTile = layout.find(({ i }) => i === tile.uuid);
                     if (
                         layoutTile &&
@@ -245,9 +246,9 @@ const Dashboard: FC = () => {
 
     const handleAddTiles = useCallback(
         async (tiles: IDashboard['tiles'][number][]) => {
-            setDashboardTiles((currentDashboardTiles) => {
-                return appendNewTilesToBottom(currentDashboardTiles, tiles);
-            });
+            setDashboardTiles((currentDashboardTiles) =>
+                appendNewTilesToBottom(currentDashboardTiles, tiles),
+            );
 
             setHaveTilesChanged(true);
         },
@@ -257,7 +258,7 @@ const Dashboard: FC = () => {
     const handleDeleteTile = useCallback(
         async (tile: IDashboard['tiles'][number]) => {
             setDashboardTiles((currentDashboardTiles) =>
-                currentDashboardTiles.filter(
+                currentDashboardTiles?.filter(
                     (filteredTile) => filteredTile.uuid !== tile.uuid,
                 ),
             );
@@ -270,7 +271,7 @@ const Dashboard: FC = () => {
     const handleEditTiles = useCallback(
         (updatedTile: IDashboard['tiles'][number]) => {
             setDashboardTiles((currentDashboardTiles) =>
-                currentDashboardTiles.map((tile) =>
+                currentDashboardTiles?.map((tile) =>
                     tile.uuid === updatedTile.uuid ? updatedTile : tile,
                 ),
             );
@@ -283,7 +284,7 @@ const Dashboard: FC = () => {
         sessionStorage.clear();
 
         // Delete charts that were created in edit mode
-        dashboardTiles.forEach((tile) => {
+        dashboardTiles?.forEach((tile) => {
             if (
                 isDashboardChartTileType(tile) &&
                 tile.properties.belongsToDashboard &&
@@ -420,7 +421,7 @@ const Dashboard: FC = () => {
             </div>
         );
     }
-    const dashboardChartTiles = dashboardTiles.filter(
+    const dashboardChartTiles = dashboardTiles?.filter(
         (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
     );
 
@@ -493,7 +494,7 @@ const Dashboard: FC = () => {
                     />
                 }
             >
-                {dashboardChartTiles.length > 0 && (
+                {dashboardChartTiles && dashboardChartTiles.length > 0 && (
                     <DashboardFilter isEditMode={isEditMode} />
                 )}
 
@@ -503,7 +504,7 @@ const Dashboard: FC = () => {
                     onResizeStop={handleUpdateTiles}
                     layouts={layouts}
                 >
-                    {dashboardTiles.map((tile) => {
+                    {dashboardTiles?.map((tile) => {
                         return (
                             <div key={tile.uuid}>
                                 <TrackSection name={SectionName.DASHBOARD_TILE}>
@@ -519,7 +520,7 @@ const Dashboard: FC = () => {
                     })}
                 </ResponsiveGridLayout>
 
-                {dashboardTiles.length <= 0 && (
+                {dashboardTiles && dashboardTiles.length === 0 && (
                     <EmptyStateNoTiles
                         onAddTiles={handleAddTiles}
                         isEditMode={isEditMode}

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -7,7 +7,6 @@ import {
     DashboardAvailableFilters,
     DashboardFilterRule,
     DashboardFilters,
-    DashboardTileTypes,
     fieldId,
     FilterableField,
     isDashboardChartTileType,
@@ -47,8 +46,8 @@ type DashboardContext = {
     dashboard: Dashboard | undefined;
     dashboardError: ApiError | null;
     fieldsWithSuggestions: FieldsWithSuggestions;
-    dashboardTiles: Dashboard['tiles'] | [];
-    setDashboardTiles: Dispatch<SetStateAction<Dashboard['tiles'] | []>>;
+    dashboardTiles: Dashboard['tiles'] | undefined;
+    setDashboardTiles: Dispatch<SetStateAction<Dashboard['tiles'] | undefined>>;
     haveTilesChanged: boolean;
     setHaveTilesChanged: Dispatch<SetStateAction<boolean>>;
     dashboardFilters: DashboardFilters;
@@ -100,9 +99,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const { data: dashboard, error: dashboardError } =
         useDashboardQuery(dashboardUuid);
-    const [dashboardTiles, setDashboardTiles] = useState<Dashboard['tiles']>(
-        [],
-    );
+    const [dashboardTiles, setDashboardTiles] = useState<Dashboard['tiles']>();
 
     const [haveTilesChanged, setHaveTilesChanged] = useState<boolean>(false);
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
@@ -128,7 +125,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const tileSavedChartUuids = useMemo(() => {
         return dashboardTiles
-            .filter(isDashboardChartTileType)
+            ?.filter(isDashboardChartTileType)
             .map((tile) => tile.properties.savedChartUuid)
             .filter((uuid): uuid is string => !!uuid);
     }, [dashboardTiles]);
@@ -296,9 +293,10 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
     const hasChartTiles = useMemo(
         () =>
-            dashboardTiles.filter(
-                (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
-            ).length >= 1,
+            Boolean(
+                dashboardTiles &&
+                    dashboardTiles.filter(isDashboardChartTileType).length >= 1,
+            ),
         [dashboardTiles],
     );
 

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -123,12 +123,14 @@ export const DashboardProvider: React.FC = ({ children }) => {
         removeSavedFilterOverride,
     } = useSavedDashboardFiltersOverrides();
 
-    const tileSavedChartUuids = useMemo(() => {
-        return dashboardTiles
-            ?.filter(isDashboardChartTileType)
-            .map((tile) => tile.properties.savedChartUuid)
-            .filter((uuid): uuid is string => !!uuid);
-    }, [dashboardTiles]);
+    const tileSavedChartUuids = useMemo(
+        () =>
+            dashboardTiles
+                ?.filter(isDashboardChartTileType)
+                .map((tile) => tile.properties.savedChartUuid)
+                .filter((uuid): uuid is string => !!uuid),
+        [dashboardTiles],
+    );
 
     useEffect(() => {
         if (dashboard) {
@@ -246,7 +248,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         isLoading: isLoadingDashboardFilters,
         isFetching: isFetchingDashboardFilters,
         data: filterableFieldsBySavedQueryUuid,
-    } = useDashboardsAvailableFilters(tileSavedChartUuids);
+    } = useDashboardsAvailableFilters(tileSavedChartUuids ?? []);
 
     const filterableFieldsByTileUuid = useMemo(() => {
         if (!dashboard || !dashboardTiles || !filterableFieldsBySavedQueryUuid)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Make `dashboardTiles` initial value `undefined` so that, when loading a dashboard that we know has `tiles`, we can avoid calling `/charts` endpoint in `EmptyStateNoTiles`.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
