### PR TITLE
fix: google sheet column names

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -6,7 +6,9 @@ import {
     CreateSchedulerTarget,
     DownloadCsvPayload,
     EmailNotificationPayload,
+    getCustomLabelsFromTableConfig,
     getHumanReadableCronExpression,
+    getItemMap,
     getRequestMethod,
     getSchedulerUuid,
     GsheetsNotificationPayload,
@@ -18,6 +20,7 @@ import {
     isSchedulerCsvOptions,
     isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
+    isTableChartConfig,
     LightdashPage,
     NotificationPayloadBase,
     ScheduledDeliveryPayload,
@@ -701,12 +704,26 @@ export const uploadGsheetFromQuery = async (
         if (!spreadsheetId) {
             throw new Error('Unable to create new sheet');
         }
+
+        const explore = await projectService.getExplore(
+            user,
+            payload.projectUuid,
+            payload.exploreId,
+        );
+        const itemMap = getItemMap(
+            explore,
+            payload.metricQuery.additionalMetrics,
+            payload.metricQuery.tableCalculations,
+        );
         await googleDriveClient.appendToSheet(
             refreshToken,
             spreadsheetId,
             rows,
-            undefined,
+            itemMap,
+            true, // showTableNames
+            undefined, // tabName
             payload.columnOrder,
+            {}, // customLabels
         );
         const truncated = csvService.couldBeTruncated(rows);
 
@@ -963,6 +980,23 @@ export const uploadGsheets = async (
                 savedChartUuid,
             );
 
+            const explore = await projectService.getExplore(
+                user,
+                chart.projectUuid,
+                chart.tableName,
+            );
+            const itemMap = getItemMap(
+                explore,
+                chart.metricQuery.additionalMetrics,
+                chart.metricQuery.tableCalculations,
+            );
+            const showTableNames = isTableChartConfig(chart.chartConfig.config)
+                ? chart.chartConfig.config.showTableNames ?? false
+                : true;
+            const customLabels = getCustomLabelsFromTableConfig(
+                chart.chartConfig.config,
+            );
+
             const refreshToken = await userService.getRefreshToken(
                 scheduler.createdBy,
             );
@@ -976,8 +1010,11 @@ export const uploadGsheets = async (
                 refreshToken,
                 gdriveId,
                 rows,
+                itemMap,
+                showTableNames,
                 undefined,
                 chart.tableConfig.columnOrder,
+                customLabels,
             );
         } else if (dashboardUuid) {
             const dashboard = await dashboardService.getById(
@@ -1038,6 +1075,24 @@ export const uploadGsheets = async (
                     user,
                     chartUuid,
                 );
+                const explore = await projectService.getExplore(
+                    user,
+                    chart.projectUuid,
+                    chart.tableName,
+                );
+                const itemMap = getItemMap(
+                    explore,
+                    chart.metricQuery.additionalMetrics,
+                    chart.metricQuery.tableCalculations,
+                );
+                const showTableNames = isTableChartConfig(
+                    chart.chartConfig.config,
+                )
+                    ? chart.chartConfig.config.showTableNames ?? false
+                    : true;
+                const customLabels = getCustomLabelsFromTableConfig(
+                    chart.chartConfig.config,
+                );
 
                 const tabName = await googleDriveClient.createNewTab(
                     refreshToken,
@@ -1049,8 +1104,11 @@ export const uploadGsheets = async (
                     refreshToken,
                     gdriveId,
                     rows,
+                    itemMap,
+                    showTableNames,
                     tabName,
                     chart.tableConfig.columnOrder,
+                    customLabels,
                 );
             }, Promise.resolve());
         } else {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Before: 

![image](https://github.com/lightdash/lightdash/assets/1983672/6e0047fd-7b91-40ae-8bfa-7327710032ca)

After: 

When downloading from chart or results (uploadGsheetFromQuery)

![Screenshot from 2023-11-08 15-47-05](https://github.com/lightdash/lightdash/assets/1983672/697beb91-540f-4947-99de-5338f8f283c7)




From google sync (uploadGsheet)  we can hide table names and use custom label s
<!-- Add a description of the changes proposed in the pull request. -->
![image](https://github.com/lightdash/lightdash/assets/1983672/4a6fd3bf-5af1-4d87-bc8d-47c78f22bb86)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
