### PR TITLE
fix: multiple reference lines

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -253,7 +253,10 @@ export const ReferenceLine: FC<Props> = ({
                 >
                     <ActionIcon
                         onClick={() =>
-                            removeReferenceLine(referenceLine.data.name)
+                            removeReferenceLine(
+                                referenceLine.data.value ||
+                                    referenceLine.data.name,
+                            )
                         }
                         size="sm"
                     >
@@ -284,7 +287,8 @@ export const ReferenceLine: FC<Props> = ({
                                     newField,
                                     label,
                                     lineColor,
-                                    referenceLine.data.name,
+                                    referenceLine.data.value ||
+                                        referenceLine.data.name,
                                 );
                         }}
                     />
@@ -304,7 +308,8 @@ export const ReferenceLine: FC<Props> = ({
                                         selectedField,
                                         label,
                                         lineColor,
-                                        referenceLine.data.name,
+                                        referenceLine.data.value ||
+                                            referenceLine.data.name,
                                     );
                             }}
                         />
@@ -324,7 +329,8 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     lineColor,
-                                    referenceLine.data.name,
+                                    referenceLine.data.value ||
+                                        referenceLine.data.name,
                                 );
                         }}
                     />
@@ -348,7 +354,8 @@ export const ReferenceLine: FC<Props> = ({
                                     selectedField,
                                     label,
                                     color,
-                                    referenceLine.data.name,
+                                    referenceLine.data.value ||
+                                        referenceLine.data.name,
                                 );
                         }}
                     />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #7875

### Description:

What happened: I recently moved from using `name` to `value` to set a label instead of an uuid (but kept the name for backwards compatibility) , however, the update method was not updated to use the new id field, this was causing that all the lines were updated at the same time because it was sending name (reference line).


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-11-09 10-04-09](https://github.com/lightdash/lightdash/assets/1983672/a13a6c00-0e3b-412d-8382-7bcb3b22fb71)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
