### PR TITLE
style: use mantine skeleton for dashboard tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -3,25 +3,8 @@ import styled, { createGlobalStyle, css } from 'styled-components';
 
 interface HeaderContainerProps {
     $isEditMode: boolean;
-    $isHovering?: boolean;
     $isEmpty?: boolean;
 }
-
-export const TileBaseWrapper = styled.div<HeaderContainerProps>`
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    padding: 16px;
-    background: ${Colors.WHITE};
-    border-radius: 2px;
-    box-sizing: border-box;
-    border: 1px solid transparent;
-
-    ${(props) =>
-        props.$isEditMode
-            ? `border: 1px dashed #7ea5ff;`
-            : `box-shadow: 0 0 0 1px #bec1c426;`}
-`;
 
 export const TILE_HEADER_HEIGHT = 24;
 const TILE_HEADER_MARGIN_BOTTOM = 12;
@@ -56,7 +39,7 @@ export const HeaderContainer = styled.div<HeaderContainerProps>`
 `;
 
 export const GlobalTileStyles = createGlobalStyle`
-  .react-draggable.react-draggable-dragging ${TileBaseWrapper} {
+  .react-draggable.react-draggable-dragging {
     box-shadow: 0 0 0 1px ${Colors.BLUE4};
   }
 `;
@@ -86,7 +69,6 @@ export const TitleWrapper = styled.div<TileTitleProps>`
                       }
                   `
                 : ''}
-        }
     }
 `;
 

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -1,13 +1,7 @@
-import {
-    Button,
-    Classes,
-    Menu,
-    MenuDivider,
-    PopoverPosition,
-} from '@blueprintjs/core';
+import { Button, Menu, MenuDivider, PopoverPosition } from '@blueprintjs/core';
 import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
 import { Dashboard, DashboardTileTypes, isChartTile } from '@lightdash/common';
-import { Text, Tooltip } from '@mantine/core';
+import { Flex, Skeleton, Text, Tooltip } from '@mantine/core';
 import { useHover, useToggle } from '@mantine/hooks';
 import React, { ReactNode, useState } from 'react';
 import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/DeleteChartTileThatBelongsToDashboardModal';
@@ -17,7 +11,6 @@ import {
     ButtonsWrapper,
     ChartContainer,
     HeaderContainer,
-    TileBaseWrapper,
     TileTitleLink,
     TitleWrapper,
 } from './TileBase.styles';
@@ -57,7 +50,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         isDeletingChartThatBelongsToDashboard,
         setIsDeletingChartThatBelongsToDashboard,
     ] = useState(false);
-    const [isHovering, setIsHovering] = useState(false);
     const { hovered: containerHovered, ref: containerRef } = useHover();
     const { hovered: titleHovered, ref: titleRef } =
         useHover<HTMLAnchorElement>();
@@ -74,18 +66,28 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
     return (
-        <TileBaseWrapper
-            className={isLoading ? Classes.SKELETON : undefined}
-            ref={containerRef}
-            $isEditMode={isEditMode}
-            $isHovering={isHovering}
-        >
-            {!isLoading && (
+        <Skeleton h="100%" visible={isLoading}>
+            <Flex
+                ref={containerRef}
+                h="100%"
+                direction="column"
+                p="sm"
+                bg="white"
+                sx={{
+                    borderRadius: '2px',
+                    ...(isEditMode
+                        ? {
+                              border: '1px dashed #7ea5ff',
+                          }
+                        : {
+                              border: '1px solid transparent',
+                              boxShadow: '0 0 0 1px #bec1c426',
+                          }),
+                }}
+            >
                 <>
                     <HeaderContainer
                         $isEditMode={isEditMode}
-                        onMouseEnter={() => setIsHovering(true)}
-                        onMouseLeave={() => setIsHovering(false)}
                         $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
                     >
                         <Tooltip
@@ -243,8 +245,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         }}
                     />
                 </>
-            )}
-        </TileBaseWrapper>
+            </Flex>
+        </Skeleton>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Use Mantine Skeleton for Dashboard tiles: 
https://github.com/lightdash/lightdash/assets/7611706/04c808fd-9c7b-4a79-a585-f9538e474cb5

With this approach, we're wrapping the the whole tile with a `Skeleton`


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
