### PR TITLE
fix: optimise chart results endpoint

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -883,8 +883,6 @@ export class ProjectService {
             throw new ForbiddenError();
         }
 
-        console.log('has access');
-
         const [space, explore] = await Promise.all([
             this.spaceModel.getSpaceSummary(savedChart.spaceUuid),
             this.getExplore(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Avoid making 2 extra calls to get `getExplore` by passing `explore` to relevant methods so that's reused until the end of getting results

Also, parallelise 2 db queries: to get the space summary + get explore to speed things up.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
