### PR TITLE
feat: scroll restoration on filter lists

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -9,7 +9,15 @@ import {
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash-es/uniq';
-import { FC, ReactNode, useCallback, useMemo, useState } from 'react';
+import {
+    FC,
+    ReactNode,
+    useCallback,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import {
     MAX_AUTOCOMPLETE_RESULTS,
     useFieldValues,
@@ -42,6 +50,10 @@ const FilterStringAutoComplete: FC<Props> = ({
 
     const [search, setSearch] = useState('');
 
+    const [scrollHeight, setScrollHeight] = useState(0);
+
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
     const autocompleteFilterGroup = useMemo(
         () => getAutocompleteFilterGroup(filterId, field),
         [field, filterId, getAutocompleteFilterGroup],
@@ -65,6 +77,8 @@ const FilterStringAutoComplete: FC<Props> = ({
 
     const handleChange = useCallback(
         (updatedValues: string[]) => {
+            if (dropdownRef.current)
+                setScrollHeight(dropdownRef.current.scrollTop);
             onChange(uniq(updatedValues));
         },
         [onChange],
@@ -109,6 +123,11 @@ const FilterStringAutoComplete: FC<Props> = ({
             label: value,
         }));
     }, [results, values]);
+
+    useLayoutEffect(() => {
+        //scroll restoration in dropdown
+        if (dropdownRef.current) dropdownRef.current.scrollTop = scrollHeight;
+    }, [onChange, scrollHeight]);
 
     return (
         <MultiSelect
@@ -155,7 +174,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             }: {
                 children: ReactNode;
             }) => (
-                <div {...others}>
+                <div {...others} ref={dropdownRef}>
                     {results.length === MAX_AUTOCOMPLETE_RESULTS ? (
                         <Text
                             color="dimmed"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7835 

### Description:
This restores the scroll position after selecting an item from the filter dropdown for requirement 1. UseLayouteffect is preferred to useEffect, because useeffect has sudden noticeable shift when scrolling back after the component re-renders.

The second requirement  is unclear to me, and is not covered in this PR yet. 
When searching using a search term, the results change, which also changes the size of a list. I am not sure if keeping the scroll for different size lists is the intended behavior. Also when using a search term, the letters are cleared when clicking on a result in the list, and the list resets. 

I'd be happy to continue work on this provided the information, or otherwise  take over the PR and make changes :)

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 12-11-23 10:15:05.webm](https://github.com/lightdash/lightdash/assets/76876702/602515ef-173e-4da0-9625-48ec6e7707e6)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
