### PR TITLE
fix: dashboard filters performance (Part 1)

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -6,7 +6,7 @@ import {
 import { Button, CloseButton, Popover, Text, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconFilter } from '@tabler/icons-react';
-import { FC, useCallback } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import {
     getConditionalRuleLabel,
@@ -50,28 +50,48 @@ const Filter: FC<Props> = ({
     const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
         useDisclosure();
 
-    const defaultFilterRule =
-        filterableFieldsByTileUuid && filterRule && field
-            ? applyDefaultTileTargets(
-                  filterRule,
-                  field,
-                  filterableFieldsByTileUuid,
-              )
-            : undefined;
+    const defaultFilterRule = useMemo(() => {
+        if (!filterableFieldsByTileUuid || !field || !filterRule) return;
+
+        console.time('applyDefaultTileTargets');
+        const test = applyDefaultTileTargets(
+            filterRule,
+            field,
+            filterableFieldsByTileUuid,
+        );
+        console.timeEnd('applyDefaultTileTargets');
+        return test;
+    }, [filterableFieldsByTileUuid, field, filterRule]);
 
     // Only used by active filters
-    const originalFilterRule = dashboard?.filters?.dimensions.find(
-        (item) => filterRule && item.id === filterRule.id,
-    );
+    const originalFilterRule = useMemo(() => {
+        console.time('originalFilterRule');
+        const test = dashboard?.filters?.dimensions.find(
+            (item) => filterRule && item.id === filterRule.id,
+        );
+        console.timeEnd('originalFilterRule');
+        return test;
+    }, [dashboard, filterRule]);
 
-    const filterRuleLabels =
-        filterRule && field
-            ? getConditionalRuleLabel(filterRule, field)
-            : undefined;
-    const filterRuleTables =
-        filterRule && field && allFilterableFields
-            ? getFilterRuleTables(filterRule, field, allFilterableFields)
-            : undefined;
+    const filterRuleLabels = useMemo(() => {
+        if (!filterRule || !field) return;
+        console.time('getConditionalRuleLabel');
+        const test = getConditionalRuleLabel(filterRule, field);
+        console.timeEnd('getConditionalRuleLabel');
+        return test;
+    }, [filterRule, field]);
+
+    const filterRuleTables = useMemo(() => {
+        if (!filterRule || !field || !allFilterableFields) return;
+        console.time('getFilterRuleTables');
+        const test = getFilterRuleTables(
+            filterRule,
+            field,
+            allFilterableFields,
+        );
+        console.timeEnd('getFilterRuleTables');
+        return test;
+    }, [filterRule, field, allFilterableFields]);
 
     const handleClose = useCallback(() => {
         closeSubPopover();

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -53,44 +53,32 @@ const Filter: FC<Props> = ({
     const defaultFilterRule = useMemo(() => {
         if (!filterableFieldsByTileUuid || !field || !filterRule) return;
 
-        console.time('applyDefaultTileTargets');
-        const test = applyDefaultTileTargets(
+        return applyDefaultTileTargets(
             filterRule,
             field,
             filterableFieldsByTileUuid,
         );
-        console.timeEnd('applyDefaultTileTargets');
-        return test;
     }, [filterableFieldsByTileUuid, field, filterRule]);
 
     // Only used by active filters
     const originalFilterRule = useMemo(() => {
-        console.time('originalFilterRule');
-        const test = dashboard?.filters?.dimensions.find(
-            (item) => filterRule && item.id === filterRule.id,
+        if (!dashboard || !filterRule) return;
+
+        return dashboard.filters.dimensions.find(
+            (item) => item.id === filterRule.id,
         );
-        console.timeEnd('originalFilterRule');
-        return test;
     }, [dashboard, filterRule]);
 
     const filterRuleLabels = useMemo(() => {
         if (!filterRule || !field) return;
-        console.time('getConditionalRuleLabel');
-        const test = getConditionalRuleLabel(filterRule, field);
-        console.timeEnd('getConditionalRuleLabel');
-        return test;
+
+        return getConditionalRuleLabel(filterRule, field);
     }, [filterRule, field]);
 
     const filterRuleTables = useMemo(() => {
         if (!filterRule || !field || !allFilterableFields) return;
-        console.time('getFilterRuleTables');
-        const test = getFilterRuleTables(
-            filterRule,
-            field,
-            allFilterableFields,
-        );
-        console.timeEnd('getFilterRuleTables');
-        return test;
+
+        return getFilterRuleTables(filterRule, field, allFilterableFields);
     }, [filterRule, field, allFilterableFields]);
 
     const handleClose = useCallback(() => {


### PR DESCRIPTION
### Description:

I was analyzing performance related to 'filter pills,' and it appears that we were recalculating all the functions I memoized in the PR after every minor action, such as drag-and-drop, opening menus, and hovering over buttons. This is likely due to the heavy Dashboard provider state and not 'slicing' useDashboardContext anywhere.

Not memoizing the variables in the filter pill component leads to significant rerendering of child components. This happens because all recalculated variables are references (not value types), and React only performs shallow diffing.