### PR TITLE
chore: get rid of blueprint portals

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1,4 +1,4 @@
-import { Menu, NonIdealState, Portal, Tag } from '@blueprintjs/core';
+import { Menu, NonIdealState, Tag } from '@blueprintjs/core';
 import {
     MenuItem2,
     Popover2,
@@ -29,7 +29,7 @@ import {
     SavedChart,
     TableCalculation,
 } from '@lightdash/common';
-import { Box, Text, Tooltip } from '@mantine/core';
+import { Box, Portal, Text, Tooltip } from '@mantine/core';
 import { IconFilter, IconFolders } from '@tabler/icons-react';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, Portal } from '@blueprintjs/core';
+import { Menu } from '@blueprintjs/core';
 import {
     MenuItem2,
     Popover2,
@@ -6,6 +6,7 @@ import {
 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { getItemMap, hasCustomDimension } from '@lightdash/common';
+import { Portal } from '@mantine/core';
 import React, {
     FC,
     memo,


### PR DESCRIPTION
### Description:

blueprint portal uses legacy context. replacing it with mantine is a simple change which also gets rid of annoying console warnings like this:

![CleanShot 2023-11-13 at 12 56 30@2x](https://github.com/lightdash/lightdash/assets/962095/281d2a1f-ea8f-4718-9b8e-ae056b453576)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
