### PR TITLE
fix: reuse fields with suggestions

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -1,4 +1,3 @@
-import { FieldId, fieldId, FilterableField } from '@lightdash/common';
 import { Group, Skeleton } from '@mantine/core';
 import { FC } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
@@ -13,8 +12,8 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
     const dashboardTemporaryFilters = useDashboardContext(
         (c) => c.dashboardTemporaryFilters,
     );
-    const allFilterableFields = useDashboardContext(
-        (c) => c.allFilterableFields,
+    const fieldsWithSuggestions = useDashboardContext(
+        (c) => c.fieldsWithSuggestions,
     );
     const isLoadingDashboardFilters = useDashboardContext(
         (c) => c.isLoadingDashboardFilters,
@@ -41,21 +40,17 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
         );
     }
 
-    if (!allFilterableFields) return null;
-
-    const fieldMap = allFilterableFields?.reduce<
-        Record<FieldId, FilterableField>
-    >((acc, field) => ({ ...acc, [fieldId(field)]: field }), {});
+    if (!fieldsWithSuggestions) return null;
 
     return (
         <>
             {dashboardFilters.dimensions
-                .filter((item) => !!fieldMap[item.target.fieldId])
+                .filter((item) => !!fieldsWithSuggestions[item.target.fieldId])
                 .map((item, index) => (
                     <Filter
                         key={item.id}
                         isEditMode={isEditMode}
-                        field={fieldMap[item.target.fieldId]}
+                        field={fieldsWithSuggestions[item.target.fieldId]}
                         filterRule={item}
                         onRemove={() =>
                             removeDimensionDashboardFilter(index, false)
@@ -67,13 +62,13 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
                 ))}
 
             {dashboardTemporaryFilters.dimensions
-                .filter((item) => !!fieldMap[item.target.fieldId])
+                .filter((item) => !!fieldsWithSuggestions[item.target.fieldId])
                 .map((item, index) => (
                     <Filter
                         key={item.id}
                         isTemporary
                         isEditMode={isEditMode}
-                        field={fieldMap[item.target.fieldId]}
+                        field={fieldsWithSuggestions[item.target.fieldId]}
                         filterRule={item}
                         onRemove={() =>
                             removeDimensionDashboardFilter(index, true)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Reuse `fieldsWithSuggestions` from `DashboardProvider` which is basically the same as what was being done with `fieldMap`

```tsx
const fieldMap = allFilterableFields?.reduce<
        Record<FieldId, FilterableField>
    >((acc, field) => ({ ...acc, [fieldId(field)]: field }), {});
```

In `DashboardProvider` we do similar already: https://github.com/lightdash/lightdash/blob/fix/reuse-fields-with-suggestions/packages/frontend/src/providers/DashboardProvider.tsx#L308

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
