### PR TITLE
chore: dashboard provider use context selector

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -9,15 +9,25 @@ interface ActiveFiltersProps {
 }
 
 const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
-    const {
-        dashboardFilters,
-        dashboardTemporaryFilters,
-        updateDimensionDashboardFilter,
-        removeDimensionDashboardFilter,
-        allFilterableFields,
-        isLoadingDashboardFilters,
-        isFetchingDashboardFilters,
-    } = useDashboardContext();
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
+    const allFilterableFields = useDashboardContext(
+        (c) => c.allFilterableFields,
+    );
+    const isLoadingDashboardFilters = useDashboardContext(
+        (c) => c.isLoadingDashboardFilters,
+    );
+    const isFetchingDashboardFilters = useDashboardContext(
+        (c) => c.isFetchingDashboardFilters,
+    );
+    const removeDimensionDashboardFilter = useDashboardContext(
+        (c) => c.removeDimensionDashboardFilter,
+    );
+    const updateDimensionDashboardFilter = useDashboardContext(
+        (c) => c.updateDimensionDashboardFilter,
+    );
 
     if (isLoadingDashboardFilters || isFetchingDashboardFilters) {
         return (

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -36,14 +36,20 @@ const Filter: FC<Props> = ({
     onUpdate,
     onRemove,
 }) => {
-    const {
-        dashboard,
-        dashboardTiles,
-        allFilterableFields,
-        filterableFieldsByTileUuid,
-        isLoadingDashboardFilters,
-        isFetchingDashboardFilters,
-    } = useDashboardContext();
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const allFilterableFields = useDashboardContext(
+        (c) => c.allFilterableFields,
+    );
+    const filterableFieldsByTileUuid = useDashboardContext(
+        (c) => c.filterableFieldsByTileUuid,
+    );
+    const isLoadingDashboardFilters = useDashboardContext(
+        (c) => c.isLoadingDashboardFilters,
+    );
+    const isFetchingDashboardFilters = useDashboardContext(
+        (c) => c.isFetchingDashboardFilters,
+    );
 
     const [isPopoverOpen, { close: closePopover, toggle: togglePopover }] =
         useDisclosure();

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -23,12 +23,15 @@ const DashboardFilter: FC<Props> = ({ isEditMode }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
     const project = useProject(projectUuid);
-    const {
-        allFilters,
-        fieldsWithSuggestions,
-        addDimensionDashboardFilter,
-        hasChartTiles,
-    } = useDashboardContext();
+
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const fieldsWithSuggestions = useDashboardContext(
+        (c) => c.fieldsWithSuggestions,
+    );
+    const addDimensionDashboardFilter = useDashboardContext(
+        (c) => c.addDimensionDashboardFilter,
+    );
+    const hasChartTiles = useDashboardContext((c) => c.hasChartTiles);
 
     const handleSaveNew = (
         value: DashboardFilterRule<

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -26,13 +26,11 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
 
-    const {
-        dashboardTiles,
-        dashboardFilters,
-        haveTilesChanged,
-        haveFiltersChanged,
-        dashboard,
-    } = useDashboardContext();
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
+    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
+    const dashboard = useDashboardContext((c) => c.dashboard);
 
     const { storeDashboard } = useDashboardStorage();
     const history = useHistory();

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -157,7 +157,10 @@ const ValidDashboardChartTile: FC<{
     chartAndResults: { chart, explore, metricQuery, rows, cacheMetadata },
     onSeriesContextMenu,
 }) => {
-    const { addSuggestions, addResultsCacheTime } = useDashboardContext();
+    const addSuggestions = useDashboardContext((c) => c.addSuggestions);
+    const addResultsCacheTime = useDashboardContext(
+        (c) => c.addResultsCacheTime,
+    );
 
     const { health } = useApp();
 
@@ -281,15 +284,16 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         dashboardUuid: string;
     }>();
 
-    const {
-        addDimensionDashboardFilter,
-        setDashboardTiles,
-        dashboardTiles,
-        dashboardFilters: filtersFromCOntext,
-        haveTilesChanged,
-        haveFiltersChanged,
-        dashboard,
-    } = useDashboardContext();
+    const addDimensionDashboardFilter = useDashboardContext(
+        (c) => c.addDimensionDashboardFilter,
+    );
+
+    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filtersFromContext = useDashboardContext((c) => c.dashboardFilters);
+    const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
+    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
+    const dashboard = useDashboardContext((c) => c.dashboard);
 
     const { storeDashboard } = useDashboardStorage();
 
@@ -511,7 +515,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                             if (belongsToDashboard) {
                                                 storeDashboard(
                                                     dashboardTiles,
-                                                    filtersFromCOntext,
+                                                    filtersFromContext,
                                                     haveTilesChanged,
                                                     haveFiltersChanged,
                                                     dashboard?.uuid,

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -52,7 +52,10 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
 const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: savedCharts, isLoading } = useChartSummaries(projectUuid);
-    const { dashboardTiles, dashboard } = useDashboardContext();
+
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const dashboard = useDashboardContext((c) => c.dashboard);
+
     const form = useForm({
         initialValues: {
             savedChartsUuids: [],

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -41,7 +41,11 @@ const DashboardCellContextMenu: FC<
     const { showToastSuccess } = useToaster();
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
-    const { addDimensionDashboardFilter } = useDashboardContext();
+
+    const addDimensionDashboardFilter = useDashboardContext(
+        (c) => c.addDimensionDashboardFilter,
+    );
+
     const dashboardFiltersThatApplyToChart = useDashboardFiltersForExplore(
         tileUuid,
         explore,

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -48,7 +48,7 @@ export const DashboardRefreshButton = () => {
 
     const { isFetching, invalidateDashboardRelatedQueries } =
         useDashboardRefresh();
-    const { clearCacheAndFetch } = useDashboardContext();
+    const clearCacheAndFetch = useDashboardContext((c) => c.clearCacheAndFetch);
 
     const isOneAtLeastFetching = isFetching > 0;
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -139,8 +139,13 @@ const SchedulerFilters: FC<SchedulerFiltersProps> = ({
         [schedulerFilters],
     );
 
-    const { isLoadingDashboardFilters, allFilters, fieldsWithSuggestions } =
-        useDashboardContext();
+    const isLoadingDashboardFilters = useDashboardContext(
+        (c) => c.isLoadingDashboardFilters,
+    );
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const fieldsWithSuggestions = useDashboardContext(
+        (c) => c.fieldsWithSuggestions,
+    );
 
     if (isLoading || isLoadingDashboardFilters || !project) {
         return (

--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -3,7 +3,7 @@ import { useChartResults } from '../useQueryResults';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 const useDashboardChart = (tileUuid: string, savedChartUuid: string | null) => {
-    const { invalidateCache } = useDashboardContext();
+    const invalidateCache = useDashboardContext((c) => c.invalidateCache);
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     return useChartResults(savedChartUuid, dashboardFilters, invalidateCache);
 };

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForExplore.ts
@@ -10,8 +10,10 @@ const useDashboardFiltersForExplore = (
     tileUuid: string,
     explore: Explore | undefined,
 ): DashboardFilters => {
-    const { dashboardFilters, dashboardTemporaryFilters } =
-        useDashboardContext();
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
 
     const tables = useMemo(
         () => (explore ? Object.keys(explore.tables) : []),

--- a/packages/frontend/src/hooks/dashboard/useDashboardFiltersForTile.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardFiltersForTile.ts
@@ -6,8 +6,10 @@ import { useMemo } from 'react';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 
 const useDashboardFiltersForTile = (tileUuid: string): DashboardFilters => {
-    const { dashboardFilters, dashboardTemporaryFilters } =
-        useDashboardContext();
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
 
     return useMemo(
         () => ({

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -141,21 +141,29 @@ const Dashboard: FC = () => {
 
     const { clearIsEditingDashboardChart } = useDashboardStorage();
 
-    const {
-        dashboard,
-        dashboardError,
-        dashboardFilters,
-        dashboardTemporaryFilters,
-        haveFiltersChanged,
-        setHaveFiltersChanged,
-        dashboardTiles,
-        setDashboardTiles,
-        haveTilesChanged,
-        setHaveTilesChanged,
-        setDashboardFilters,
-        setDashboardTemporaryFilters,
-        oldestCacheTime,
-    } = useDashboardContext();
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardError = useDashboardContext((c) => c.dashboardError);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
+    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
+    const setHaveFiltersChanged = useDashboardContext(
+        (c) => c.setHaveFiltersChanged,
+    );
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
+    const setHaveTilesChanged = useDashboardContext(
+        (c) => c.setHaveTilesChanged,
+    );
+    const setDashboardFilters = useDashboardContext(
+        (c) => c.setDashboardFilters,
+    );
+    const setDashboardTemporaryFilters = useDashboardContext(
+        (c) => c.setDashboardTemporaryFilters,
+    );
+    const oldestCacheTime = useDashboardContext((c) => c.oldestCacheTime);
 
     const { data: organization } = useOrganization();
     const hasTemporaryFilters = useMemo(

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -498,7 +498,7 @@ export function useDashboardContext<Selected>(
     return useContextSelector(Context, (context) => {
         if (context === undefined) {
             throw new Error(
-                'useExplorer must be used within a ExplorerProvider',
+                'useDashboardContext must be used within a DashboardProvider',
             );
         }
         return selector(context);

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -14,17 +14,16 @@ import {
 import { min } from 'lodash-es';
 import uniqBy from 'lodash-es/uniqBy';
 import React, {
-    createContext,
     Dispatch,
     SetStateAction,
     useCallback,
-    useContext,
     useEffect,
     useMemo,
     useState,
 } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
+import { createContext, useContextSelector } from 'use-context-selector';
 import { FieldsWithSuggestions } from '../components/common/Filters/FiltersProvider';
 import { isFilterConfigRevertButtonEnabled as hasSavedFilterValueChanged } from '../components/DashboardFilter/FilterConfiguration/utils';
 import {
@@ -493,12 +492,15 @@ export const DashboardProvider: React.FC = ({ children }) => {
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };
 
-export const useDashboardContext = (): DashboardContext => {
-    const context = useContext(Context);
-    if (context === undefined) {
-        throw new Error(
-            'useDashboardContext must be used within a DashboardProvider',
-        );
-    }
-    return context;
-};
+export function useDashboardContext<Selected>(
+    selector: (value: DashboardContext) => Selected,
+) {
+    return useContextSelector(Context, (context) => {
+        if (context === undefined) {
+            throw new Error(
+                'useExplorer must be used within a ExplorerProvider',
+            );
+        }
+        return selector(context);
+    });
+}


### PR DESCRIPTION
### Description:

- adding `use-context-selector` to dashboard context
- we use this library for explore contexts → see `useExplorerContext`

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
