### PR TITLE
fix: delay on tooltips in dashboard filter results

### DIFF
--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -31,6 +31,7 @@ const ItemComponent = forwardRef<HTMLDivElement, ItemComponentProps>(
             maw={400}
             offset={-2}
             withinPortal
+            openDelay={500}
         >
             <Box ref={ref} {...rest}>
                 <Group


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7927 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Added a delay on tooltip popups

[Screencast from 13-11-23 23:35:39.webm](https://github.com/lightdash/lightdash/assets/76876702/a1494d03-e013-458e-8f14-932f13d9f101)

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
