### PR TITLE
fix: improve available filters and metric query suggestions

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5346,7 +5346,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.862.0",
+        "version": "0.863.9",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -60,6 +60,7 @@ import {
     ProjectType,
     RequestMethod,
     ResultRow,
+    SavedChartsInfoForDashboardAvailableFilters,
     SessionUser,
     SpaceQuery,
     SpaceSummary,
@@ -2113,7 +2114,7 @@ export class ProjectService {
 
     async getAvailableFiltersForSavedQueries(
         user: SessionUser,
-        savedQueryUuids: string[],
+        savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
     ): Promise<DashboardAvailableFilters> {
         const transaction = Sentry.getCurrentHub()
             ?.getScope()
@@ -2127,6 +2128,10 @@ export class ProjectService {
             uuid: string;
             filters: CompiledDimension[];
         }[] = [];
+
+        const savedQueryUuids = savedChartUuidsAndTileUuids.map(
+            ({ savedChartUuid }) => savedChartUuid,
+        );
 
         try {
             const savedCharts =
@@ -2206,11 +2211,12 @@ export class ProjectService {
             });
         });
 
-        const savedQueryFilters = savedQueryUuids.reduce<
+        const savedQueryFilters = savedChartUuidsAndTileUuids.reduce<
             DashboardAvailableFilters['savedQueryFilters']
-        >((acc, savedQueryUuid) => {
+        >((acc, savedChartUuidAndTileUuid) => {
             const filterResult = allFilters.find(
-                (result) => result.uuid === savedQueryUuid,
+                (result) =>
+                    result.uuid === savedChartUuidAndTileUuid.savedChartUuid,
             );
             if (!filterResult || !filterResult.filters.length) return acc;
 
@@ -2219,7 +2225,7 @@ export class ProjectService {
             );
             return {
                 ...acc,
-                [savedQueryUuid]: filterIndexes,
+                [savedChartUuidAndTileUuid.tileUuid]: filterIndexes,
             };
         }, {});
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -938,6 +938,21 @@ export class ProjectService {
             explore,
         });
 
+        const suggestionsToAddToFields = dashboardFilters
+            ? metricQuery.dimensions.reduce((sum, dimensionId) => {
+                  //! this is bad, but necessary for UX - optimise so it's not extremely slow when there are many rows
+                  const newSuggestions: string[] =
+                      rows.reduce<string[]>((acc, row) => {
+                          const value = row[dimensionId]?.value.raw;
+                          if (typeof value === 'string') {
+                              return [...acc, value];
+                          }
+                          return acc;
+                      }, []) || [];
+                  return { ...sum, [dimensionId]: newSuggestions };
+              }, {})
+            : {};
+
         return {
             chart: savedChart,
             explore,
@@ -945,6 +960,7 @@ export class ProjectService {
             cacheMetadata,
             rows,
             appliedDashboardFilters,
+            suggestionsToAddToFields,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2142,7 +2142,7 @@ export class ProjectService {
 
             const uniqueExplores = new Set<string>();
             savedCharts.forEach((chart) => {
-                const key = `${chart.projectUuid}_${chart.tableName}`;
+                const key = chart.tableName;
                 if (!uniqueExplores.has(key)) {
                     uniqueExplores.add(key);
                 }
@@ -2183,8 +2183,7 @@ export class ProjectService {
                     return { uuid: savedChart.uuid, filters: [] };
                 }
 
-                const exploreKey = `${savedChart.projectUuid}_${savedChart.tableName}`;
-                const explore = exploreCache[exploreKey];
+                const explore = exploreCache[savedChart.tableName];
 
                 const filters = getDimensions(explore).filter(
                     (field) => isFilterableDimension(field) && !field.hidden,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -938,21 +938,6 @@ export class ProjectService {
             explore,
         });
 
-        const suggestionsToAddToFields = dashboardFilters
-            ? metricQuery.dimensions.reduce((sum, dimensionId) => {
-                  //! this is bad, but necessary for UX - optimise so it's not extremely slow when there are many rows
-                  const newSuggestions: string[] =
-                      rows.reduce<string[]>((acc, row) => {
-                          const value = row[dimensionId]?.value.raw;
-                          if (typeof value === 'string') {
-                              return [...acc, value];
-                          }
-                          return acc;
-                      }, []) || [];
-                  return { ...sum, [dimensionId]: newSuggestions };
-              }, {})
-            : {};
-
         return {
             chart: savedChart,
             explore,
@@ -960,7 +945,6 @@ export class ProjectService {
             cacheMetadata,
             rows,
             appliedDashboardFilters,
-            suggestionsToAddToFields,
         };
     }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -341,7 +341,6 @@ export type ApiChartAndResults = {
     metricQuery: MetricQuery;
     cacheMetadata: CacheMetadata;
     rows: ResultRow[];
-    suggestionsToAddToFields: Record<string, string[]> | undefined;
 };
 
 export type ApiSqlQueryResults = {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -341,6 +341,7 @@ export type ApiChartAndResults = {
     metricQuery: MetricQuery;
     cacheMetadata: CacheMetadata;
     rows: ResultRow[];
+    suggestionsToAddToFields: Record<string, string[]> | undefined;
 };
 
 export type ApiSqlQueryResults = {

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -153,6 +153,13 @@ export type DashboardAvailableFilters = {
     allFilterableFields: FilterableField[];
 };
 
+export type SavedChartsInfoForDashboardAvailableFilters = {
+    tileUuid: DashboardChartTile['uuid'];
+    savedChartUuid: NonNullable<
+        DashboardChartTile['properties']['savedChartUuid']
+    >;
+}[];
+
 export const isDashboardUnversionedFields = (
     data: UpdateDashboard,
 ): data is DashboardUnversionedFields =>

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -148,7 +148,10 @@ export type UpdateMultipleDashboards = Pick<
     'uuid' | 'name' | 'description' | 'spaceUuid'
 >;
 
-export type DashboardAvailableFilters = Record<string, FilterableField[]>;
+export type DashboardAvailableFilters = {
+    savedQueryFilters: Record<string, number[]>;
+    allFilterableFields: FilterableField[];
+};
 
 export const isDashboardUnversionedFields = (
     data: UpdateDashboard,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -154,7 +154,14 @@ const ValidDashboardChartTile: FC<{
 }> = ({
     tileUuid,
     isTitleHidden = false,
-    chartAndResults: { chart, explore, metricQuery, rows, cacheMetadata },
+    chartAndResults: {
+        chart,
+        explore,
+        metricQuery,
+        rows,
+        cacheMetadata,
+        suggestionsToAddToFields,
+    },
     onSeriesContextMenu,
 }) => {
     const addSuggestions = useDashboardContext((c) => c.addSuggestions);
@@ -165,21 +172,16 @@ const ValidDashboardChartTile: FC<{
     const { health } = useApp();
 
     useEffect(() => {
-        addSuggestions(
-            metricQuery.dimensions.reduce((sum, dimensionId) => {
-                const newSuggestions: string[] =
-                    rows.reduce<string[]>((acc, row) => {
-                        const value = row[dimensionId]?.value.raw;
-                        if (typeof value === 'string') {
-                            return [...acc, value];
-                        }
-                        return acc;
-                    }, []) || [];
-                return { ...sum, [dimensionId]: newSuggestions };
-            }, {}),
-        );
+        if (suggestionsToAddToFields) {
+            addSuggestions(suggestionsToAddToFields);
+        }
         addResultsCacheTime(cacheMetadata);
-    }, [addSuggestions, addResultsCacheTime, metricQuery, cacheMetadata, rows]);
+    }, [
+        suggestionsToAddToFields,
+        cacheMetadata,
+        addResultsCacheTime,
+        addSuggestions,
+    ]);
 
     const resultData = useMemo(
         () => ({

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -154,17 +154,9 @@ const ValidDashboardChartTile: FC<{
 }> = ({
     tileUuid,
     isTitleHidden = false,
-    chartAndResults: {
-        chart,
-        explore,
-        metricQuery,
-        rows,
-        cacheMetadata,
-        suggestionsToAddToFields,
-    },
+    chartAndResults: { chart, explore, metricQuery, rows, cacheMetadata },
     onSeriesContextMenu,
 }) => {
-    const addSuggestions = useDashboardContext((c) => c.addSuggestions);
     const addResultsCacheTime = useDashboardContext(
         (c) => c.addResultsCacheTime,
     );
@@ -172,16 +164,8 @@ const ValidDashboardChartTile: FC<{
     const { health } = useApp();
 
     useEffect(() => {
-        if (suggestionsToAddToFields) {
-            addSuggestions(suggestionsToAddToFields);
-        }
         addResultsCacheTime(cacheMetadata);
-    }, [
-        suggestionsToAddToFields,
-        cacheMetadata,
-        addResultsCacheTime,
-        addSuggestions,
-    ]);
+    }, [cacheMetadata, addResultsCacheTime]);
 
     const resultData = useMemo(
         () => ({

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -5,6 +5,7 @@ import {
     Dashboard,
     DashboardAvailableFilters,
     DashboardTile,
+    SavedChartsInfoForDashboardAvailableFilters,
     UpdateDashboard,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
@@ -52,11 +53,13 @@ const deleteDashboard = async (id: string) =>
         body: undefined,
     });
 
-const postDashboardsAvailableFilters = async (savedQueryUuids: string[]) =>
+const postDashboardsAvailableFilters = async (
+    savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
+) =>
     lightdashApi<DashboardAvailableFilters>({
         url: `/dashboards/availableFilters`,
         method: 'POST',
-        body: JSON.stringify(savedQueryUuids),
+        body: JSON.stringify(savedChartUuidsAndTileUuids),
     });
 
 const exportDashboard = async (id: string, queryFilters: string) =>
@@ -66,12 +69,17 @@ const exportDashboard = async (id: string, queryFilters: string) =>
         body: JSON.stringify({ queryFilters }),
     });
 
-export const useDashboardsAvailableFilters = (savedQueryUuids: string[]) =>
-    useQuery<DashboardAvailableFilters, ApiError>(
-        ['dashboards', 'availableFilters', ...savedQueryUuids],
-        () => postDashboardsAvailableFilters(savedQueryUuids),
-        { enabled: savedQueryUuids.length > 0 },
+export const useDashboardsAvailableFilters = (
+    savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
+) => {
+    console.log('useDashboardsAvailableFilters', savedChartUuidsAndTileUuids);
+
+    return useQuery<DashboardAvailableFilters, ApiError>(
+        ['dashboards', 'availableFilters', ...savedChartUuidsAndTileUuids],
+        () => postDashboardsAvailableFilters(savedChartUuidsAndTileUuids),
+        { enabled: savedChartUuidsAndTileUuids.length > 0 },
     );
+};
 
 export const useDashboardQuery = (
     id?: string,

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -71,15 +71,12 @@ const exportDashboard = async (id: string, queryFilters: string) =>
 
 export const useDashboardsAvailableFilters = (
     savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
-) => {
-    console.log('useDashboardsAvailableFilters', savedChartUuidsAndTileUuids);
-
-    return useQuery<DashboardAvailableFilters, ApiError>(
+) =>
+    useQuery<DashboardAvailableFilters, ApiError>(
         ['dashboards', 'availableFilters', ...savedChartUuidsAndTileUuids],
         () => postDashboardsAvailableFilters(savedChartUuidsAndTileUuids),
         { enabled: savedChartUuidsAndTileUuids.length > 0 },
     );
-};
 
 export const useDashboardQuery = (
     id?: string,

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -259,11 +259,9 @@ export const DashboardProvider: React.FC = ({ children }) => {
 
         const filterFieldsMapping = savedChartUuidsAndTileUuids?.reduce<
             Record<string, FilterableField[]>
-        >((acc, { tileUuid, savedChartUuid }) => {
+        >((acc, { tileUuid }) => {
             const filterFields =
-                dashboardAvailableFiltersData.savedQueryFilters[
-                    savedChartUuid
-                ]?.map(
+                dashboardAvailableFiltersData.savedQueryFilters[tileUuid]?.map(
                     (index) =>
                         dashboardAvailableFiltersData.allFilterableFields[
                             index

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -6,6 +6,7 @@ import {
     Dashboard,
     DashboardFilterRule,
     DashboardFilters,
+    fieldId,
     FilterableField,
     isDashboardChartTileType,
 } from '@lightdash/common';
@@ -21,6 +22,7 @@ import React, {
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 import { createContext, useContextSelector } from 'use-context-selector';
+import { FieldsWithSuggestions } from '../components/common/Filters/FiltersProvider';
 import { isFilterConfigRevertButtonEnabled as hasSavedFilterValueChanged } from '../components/DashboardFilter/FilterConfiguration/utils';
 import {
     useDashboardQuery,
@@ -74,6 +76,7 @@ type DashboardContext = {
     oldestCacheTime: Date | undefined;
     invalidateCache: boolean | undefined;
     clearCacheAndFetch: () => void;
+    fieldsWithSuggestions: FieldsWithSuggestions;
     allFilterableFields: FilterableField[] | undefined;
     filterableFieldsByTileUuid: Record<string, FilterableField[]> | undefined;
     hasChartTiles: boolean;
@@ -274,6 +277,20 @@ export const DashboardProvider: React.FC = ({ children }) => {
             );
     }, [dashboard, dashboardTiles, dashboardAvailableFiltersData]);
 
+    const fieldsWithSuggestions = useMemo(() => {
+        return dashboardAvailableFiltersData &&
+            dashboardAvailableFiltersData.allFilterableFields &&
+            dashboardAvailableFiltersData.allFilterableFields.length > 0
+            ? dashboardAvailableFiltersData.allFilterableFields.reduce<FieldsWithSuggestions>(
+                  (sum, field) => ({
+                      ...sum,
+                      [fieldId(field)]: field,
+                  }),
+                  {},
+              )
+            : {};
+    }, [dashboardAvailableFiltersData]);
+
     const allFilters = useMemo(() => {
         return {
             dimensions: [
@@ -438,6 +455,7 @@ export const DashboardProvider: React.FC = ({ children }) => {
         oldestCacheTime,
         invalidateCache,
         clearCacheAndFetch,
+        fieldsWithSuggestions,
         allFilterableFields: dashboardAvailableFiltersData?.allFilterableFields,
         isLoadingDashboardFilters,
         isFetchingDashboardFilters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7946

### Description:

**Improving `/availableFilters` payload by reducing its size:**
Currently, we store **all** available filterable fields per tile in a massive object, like so: 
```
{
[chartUuid]: [{...field1}, {...field2}]
}
```
This can be extremely big if the table the chart belongs to contains many fields + joined tables

With this change, we are: 
* caching explores in memory - reducing the call of `getExplore` if charts in a dashboard share the same `tableName`
* getting all filterable fields
* and an indexed map per tile
* Sending extra info to the body of the request, by sending an array of objects that contains both the tileUuid and the savedChartUuid
like so (from render)

<img width="614" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/180b9d9c-1700-46ab-a112-272d5e326797">

**Note^**

Now the Uuids are the tile Uuids and not the saved query Uuids - these don't need to be computed on the FE anymore

This payload then gets computed on the FE - where each tile has these fields populated by the index mapped between the tile and the filterable fields map. 
Besides this, I've removed the `allFilterableFields` FE computation and reused the map sent already by the BE `/availableFilters`; also removed `filterableFieldsBySavedQueryUuid` from the provider because it's not being used


>  [!IMPORTANT]
> We've removed the `suggestions` logic for each chart, so the above comments on **Suggestions per metricQuery** are no longer relevant. Instead, we are not getting any pre-fetched suggestions and we let the filter components do their thing. This is so we avoid looping through all rows of a chart on the FE


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
