### PR TITLE
fix: dashboard chart tile perf by caching results

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -181,6 +181,15 @@ const ValidDashboardChartTile: FC<{
         addResultsCacheTime(cacheMetadata);
     }, [addSuggestions, addResultsCacheTime, metricQuery, cacheMetadata, rows]);
 
+    const resultData = useMemo(
+        () => ({
+            rows,
+            metricQuery,
+            cacheMetadata,
+        }),
+        [rows, metricQuery, cacheMetadata],
+    );
+
     if (health.isLoading || !health.data) {
         return null;
     }
@@ -190,11 +199,7 @@ const ValidDashboardChartTile: FC<{
             chartType={chart.chartConfig.type}
             initialChartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
-            resultsData={{
-                rows,
-                metricQuery,
-                cacheMetadata,
-            }}
+            resultsData={resultData}
             explore={explore}
             isLoading={false}
             onSeriesContextMenu={onSeriesContextMenu}
@@ -222,6 +227,11 @@ const ValidDashboardChartTileMinimal: FC<{
 }) => {
     const { health } = useApp();
 
+    const resultData = useMemo(
+        () => ({ rows, metricQuery, cacheMetadata }),
+        [rows, metricQuery, cacheMetadata],
+    );
+
     if (health.isLoading || !health.data) {
         return null;
     }
@@ -232,11 +242,7 @@ const ValidDashboardChartTileMinimal: FC<{
             chartType={chart.chartConfig.type}
             initialChartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
-            resultsData={{
-                rows,
-                cacheMetadata,
-                metricQuery,
-            }}
+            resultsData={resultData}
             isLoading={false}
             explore={explore}
             columnOrder={chart.tableConfig.columnOrder}


### PR DESCRIPTION
### Description:

this actually has a significant performance impact (positive) and regression was recently introduced

toggling between edit/view mode now is 0.5 sec instead of 3 sec 🎉 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
