### PR TITLE
fix: run query stays on the right

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Group } from '@mantine/core';
+import { Box, Group } from '@mantine/core';
 import { FC, memo, useEffect } from 'react';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
@@ -40,8 +40,9 @@ const ExplorerHeader: FC = memo(() => {
     if (isEditMode) {
         return (
             <Group position="apart">
-                <RefreshDbtButton />
-
+                <Box>
+                    <RefreshDbtButton />
+                </Box>
                 <Group spacing="xs">
                     <RefreshButton />
                     {!savedChart && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7910 

### Description:

When the refresh dbt button doesn't show, it returns null. This puts it in a box so the layout doesn't break when that button isn't there. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
