### PR TITLE
fix: hide dashboard filter modals when clicking away

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -113,7 +113,6 @@ const Filter: FC<Props> = ({
             trapFocus
             opened={isPopoverOpen}
             closeOnEscape={!isSubPopoverOpen}
-            closeOnClickOutside={!isSubPopoverOpen}
             onClose={handleClose}
             disabled={isPopoverDisabled}
             transitionProps={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7930 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
closeonclickoutside defaults to true, so it always closes even with the sub-popover focused


[Screencast from 14-11-23 22:31:15.webm](https://github.com/lightdash/lightdash/assets/76876702/2bca2d9d-6d4d-476e-a4a7-c4ac615b5d96)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
