### PR TITLE
fix: don't show gsheets sync in schedulers list

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -1,4 +1,8 @@
-import { ApiError, SchedulerAndTargets } from '@lightdash/common';
+import {
+    ApiError,
+    SchedulerAndTargets,
+    SchedulerFormat,
+} from '@lightdash/common';
 import { Loader, Stack, Text, Title } from '@mantine/core';
 import React, { FC, useState } from 'react';
 import { UseQueryResult } from 'react-query/types/react/types';
@@ -40,14 +44,17 @@ const SchedulersList: FC<Props> = ({ schedulersQuery, onEdit }) => {
     }
     return (
         <div>
-            {schedulers.map((scheduler) => (
-                <SchedulersListItem
-                    key={scheduler.schedulerUuid}
-                    scheduler={scheduler}
-                    onEdit={onEdit}
-                    onDelete={setSchedulerUuid}
-                />
-            ))}
+            {schedulers.map(
+                (scheduler) =>
+                    scheduler.format !== SchedulerFormat.GSHEETS && (
+                        <SchedulersListItem
+                            key={scheduler.schedulerUuid}
+                            scheduler={scheduler}
+                            onEdit={onEdit}
+                            onDelete={setSchedulerUuid}
+                        />
+                    ),
+            )}
             {schedulerUuid && (
                 <SchedulerDeleteModal
                     opened={true}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7977 

### Description:

Filter google sheets syncs out of the scheduled deliveries modal list. They show up in the google sync modal. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
