### PR TITLE
chore: expect 10 models in tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -156,7 +156,7 @@ const testCompile = (): Cypress.Chainable<string> => {
     cy.contains('Step 2/3', { timeout: 60000 });
     cy.contains('Successfully synced dbt project!', { timeout: 60000 });
 
-    cy.contains('selected 8 models');
+    cy.contains('selected 10 models');
     // Configure
     cy.findByText('Save changes')
         .parent('button')


### PR DESCRIPTION
### Description:

Expect 10 models in the tests


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

Trigger all e2e tests:
test-cli
test-backend
test-frontend
