### PR TITLE
fix: changing chart data requires dashboard refresh

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -457,7 +457,7 @@ export const useAddVersionMutation = () => {
             );
 
             queryClient.setQueryData(['saved_query', data.uuid], data);
-            queryClient.resetQueries(['savedChartResults', data.uuid]);
+            await queryClient.resetQueries(['savedChartResults', data.uuid]);
 
             if (dashboardUuid)
                 showToastSuccess({

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -457,6 +457,7 @@ export const useAddVersionMutation = () => {
             );
 
             queryClient.setQueryData(['saved_query', data.uuid], data);
+            queryClient.resetQueries(['savedChartResults', data.uuid]);
 
             if (dashboardUuid)
                 showToastSuccess({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7937 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
I tried invalidating manually with the react-query devtools but only resetting that query works. Chart config was also not changing in the cache but it is now.

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 15-11-23 19:11:41.webm](https://github.com/lightdash/lightdash/assets/76876702/84ba927b-d529-4c24-8550-20bc57317f5a)




### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
