### PR TITLE
feat: dashboard filters with image format

### DIFF
--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -82,10 +82,14 @@ export const isDashboardScheduler = (
     scheduler: Scheduler | CreateSchedulerAndTargets,
 ): scheduler is DashboardScheduler => scheduler.dashboardUuid !== undefined;
 
+export type SchedulerFilterRule = Omit<DashboardFilterRule, 'tileTargets'> & {
+    tileTargets: undefined;
+};
+
 export type DashboardScheduler = SchedulerBase & {
     savedChartUuid: null;
     dashboardUuid: string;
-    filters?: DashboardFilterRule[];
+    filters?: SchedulerFilterRule[];
 };
 
 export type Scheduler = ChartScheduler | DashboardScheduler;

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -89,6 +89,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                             tileTargets: undefined,
                         });
                     }}
+                    popoverProps={{ withinPortal: true }}
                 />
             </Flex>
         </Stack>

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -111,7 +111,7 @@ const updateFilters = (
     originalFilter: DashboardFilterRule,
     schedulerFilters: SchedulerFilterRule[] | undefined,
 ): SchedulerFilterRule[] | undefined => {
-    if (isFilterReverted(originalFilter, schedulerFilter) && schedulerFilters) {
+    if (schedulerFilters && isFilterReverted(originalFilter, schedulerFilter)) {
         return schedulerFilters.filter((f) => f.id !== schedulerFilter.id);
     }
 
@@ -125,7 +125,7 @@ const updateFilters = (
             : originalFilter;
 
     if (hasFilterChanged(filterToCompareAgainst, schedulerFilter)) {
-        if (isExistingFilter && schedulerFilters) {
+        if (schedulerFilters && isExistingFilter) {
             return schedulerFilters.map((f) =>
                 f.id === schedulerFilter.id ? schedulerFilter : f,
             );

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -79,6 +79,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                             tileTargets: undefined,
                         });
                     }}
+                    withinPortal
                 />
 
                 <FilterInputComponent

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -201,24 +201,27 @@ const SchedulerFilters: FC<SchedulerFiltersProps> = ({
         >
             {dashboard && dashboard.filters.dimensions.length > 0 ? (
                 <Stack>
-                    {dashboard?.filters?.dimensions.map((filter) => (
-                        <FilterItem
-                            key={filter.id}
-                            dashboardFilter={filter}
-                            schedulerFilter={
-                                schedulerFilters && schedulerFilters.length
-                                    ? schedulerFilters.find(
-                                          (f) =>
-                                              f.target.fieldId ===
-                                                  filter.target.fieldId &&
-                                              f.target.tableName ===
-                                                  filter.target.tableName,
-                                      )
-                                    : undefined
-                            }
-                            onChange={handleUpdateSchedulerFilter}
-                        />
-                    ))}
+                    {dashboard?.filters?.dimensions.map((filter) => {
+                        const schedulerFilter =
+                            schedulerFiltersData && schedulerFiltersData.length
+                                ? schedulerFiltersData.find(
+                                      (f) =>
+                                          f.target.fieldId ===
+                                              filter.target.fieldId &&
+                                          f.target.tableName ===
+                                              filter.target.tableName,
+                                  )
+                                : undefined;
+
+                        return (
+                            <FilterItem
+                                key={filter.id}
+                                dashboardFilter={filter}
+                                schedulerFilter={schedulerFilter}
+                                onChange={handleUpdateSchedulerFilter}
+                            />
+                        );
+                    })}
                 </Stack>
             ) : (
                 <Center component={Stack} h={100}>

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -206,11 +206,7 @@ const SchedulerFilters: FC<SchedulerFiltersProps> = ({
                         const schedulerFilter =
                             schedulerFiltersData && schedulerFiltersData.length
                                 ? schedulerFiltersData.find(
-                                      (f) =>
-                                          f.target.fieldId ===
-                                              filter.target.fieldId &&
-                                          f.target.tableName ===
-                                              filter.target.tableName,
+                                      (f) => f.id === filter.id,
                                   )
                                 : undefined;
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -1,6 +1,7 @@
 import {
     CreateSchedulerAndTargetsWithoutIds,
     CreateSchedulerTarget,
+    isDashboardScheduler,
     isSchedulerCsvOptions,
     isSchedulerImageOptions,
     isSlackTarget,
@@ -82,11 +83,10 @@ const DEFAULT_VALUES = {
     },
     emailTargets: [] as string[],
     slackTargets: [] as string[],
+    filters: undefined,
 };
 
-const getFormValuesFromScheduler = (
-    schedulerData: SchedulerAndTargets,
-): any => {
+const getFormValuesFromScheduler = (schedulerData: SchedulerAndTargets) => {
     const options = schedulerData.options;
 
     const formOptions = DEFAULT_VALUES.options;
@@ -127,6 +127,9 @@ const getFormValuesFromScheduler = (
         options: formOptions,
         emailTargets: emailTargets,
         slackTargets: slackTargets,
+        ...(isDashboardScheduler(schedulerData) && {
+            filters: schedulerData.filters,
+        }),
     };
 };
 
@@ -256,6 +259,9 @@ const SchedulerForm: FC<Props> = ({
                 cron: values.cron,
                 options,
                 targets,
+                ...(resource?.type === 'dashboard' && {
+                    filters: values.filters,
+                }),
             };
         },
     });
@@ -685,11 +691,9 @@ const SchedulerForm: FC<Props> = ({
                     <Tabs.Panel value="filters" p="md">
                         <SchedulerFilters
                             dashboard={dashboard}
+                            schedulerFilters={form.values.filters}
                             onChange={(schedulerFilters) => {
-                                console.info(
-                                    'TODO: implement me!',
-                                    schedulerFilters,
-                                );
+                                form.setFieldValue('filters', schedulerFilters);
                             }}
                         />
                     </Tabs.Panel>

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -21,6 +21,7 @@ export const applyDimensionOverrides = (
                 (overrideDimension) => overrideDimension.id === dimension.id,
             );
             if (override && keepTileTargets) {
+                if (override.disabled) delete override.disabled;
                 return {
                     ...override,
                     tileTargets: dimension.tileTargets,

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -12,13 +12,27 @@ export const hasSavedFiltersOverrides = (
 
 export const applyDimensionOverrides = (
     dashboardFilters: DashboardFilters,
-    savedFiltersOverrides: DashboardFilters,
+    overrides: DashboardFilters | DashboardFilterRule[],
+    keepTileTargets = false,
 ) =>
     dashboardFilters.dimensions.map((dimension) => {
-        const override = savedFiltersOverrides.dimensions.find(
-            (overrideDimension) => overrideDimension.id === dimension.id,
-        );
-        return override || dimension;
+        if (overrides instanceof Array) {
+            const override = overrides.find(
+                (overrideDimension) => overrideDimension.id === dimension.id,
+            );
+            if (override && keepTileTargets) {
+                return {
+                    ...override,
+                    tileTargets: dimension.tileTargets,
+                };
+            }
+            return dimension;
+        } else {
+            const override = overrides.dimensions.find(
+                (overrideDimension) => overrideDimension.id === dimension.id,
+            );
+            return override || dimension;
+        }
     });
 
 const ADD_SAVED_FILTER_OVERRIDE = 'ADD_SAVED_FILTER_OVERRIDE';

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -28,16 +28,21 @@ const MinimalDashboard: FC = () => {
 
     const {
         data: dashboard,
-        isError,
-        error,
+        isError: isDashboardError,
+        error: dashboardError,
     } = useDashboardQuery(dashboardUuid);
 
-    const { data: scheduler } = useScheduler(schedulerUuid!, {
+    const {
+        data: scheduler,
+        isError: isSchedulerError,
+        error: schedulerError,
+    } = useScheduler(schedulerUuid!, {
         enabled: !!schedulerUuid,
     });
 
-    if (isError) {
-        return <>{error.error.message}</>;
+    if (isDashboardError || isSchedulerError) {
+        if (dashboardError) return <>{dashboardError.error.message}</>;
+        if (schedulerError) return <>{schedulerError.error.message}</>;
     }
 
     if (!dashboard) {

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -103,27 +103,17 @@ export const DashboardProvider: React.FC<{
         {
             select: (d) => {
                 if (schedulerFilters) {
-                    // TODO: Reuse applyDimensionOverrides from hook useSavedDashboardFiltersOverrides
+                    const overriddenDimensions = applyDimensionOverrides(
+                        d.filters,
+                        schedulerFilters,
+                        true,
+                    );
+
                     return {
                         ...d,
                         filters: {
                             ...d.filters,
-                            dimensions: d.filters.dimensions.map(
-                                (dimension) => {
-                                    const override = schedulerFilters.find(
-                                        (overrideDimension) =>
-                                            overrideDimension.id ===
-                                            dimension.id,
-                                    );
-                                    if (override) {
-                                        return {
-                                            ...override,
-                                            tileTargets: dimension.tileTargets,
-                                        };
-                                    }
-                                    return dimension;
-                                },
-                            ),
+                            dimensions: overriddenDimensions,
                         },
                     };
                 }

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -89,7 +89,7 @@ type DashboardContext = {
 const Context = createContext<DashboardContext | undefined>(undefined);
 
 export const DashboardProvider: React.FC<{
-    schedulerFilters: DashboardFilterRule[] | undefined;
+    schedulerFilters?: DashboardFilterRule[] | undefined;
 }> = ({ schedulerFilters, children }) => {
     const { search, pathname } = useLocation();
     const history = useHistory();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #4425

### Description:

Adds the ability to save `filters` into a scheduler
Overrides dashboard filters on Minimal page aka scheduler page for it to take a screenshot of. 

- [x] There is a third tab in the scheduled delivery modal called `filters`
- [x] The filters tab includes a list of all of the existing dashboard filters
- [x] You cannot add more filters or delete filters from the dashboard, only adjust the values. 
- [x] Adjusting the filter has the same behaviour as adjusting saved filters in a dashboard. E.g.:
  - [x] if the filter is applied to different fields on different tiles, then this is still the case for the scheduled delivery
  - [x] all the filter conditions are joined using `AND` 
  - [x] You can override the operator
  - [x] you can override the value
  - [x] you CANNOT override the field that's being filtered
- [x] temporary filters that you add in `view` mode are _**not**_ included _**or**_ able to be adjusted in the scheduled delivery  (they _**have**_ to be saved filters)
- [x] If you remove a saved filter from a dashboard, then it would also get removed fromt eh scheduled delivery (even if you overrode it or something)


**note**: This doesn't work with `Send now` feature yet


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
