### PR TITLE
feat: enable dashboard scheduled delivery filters for csv export

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -17,6 +17,7 @@ import {
     isCreateScheduler,
     isCreateSchedulerSlackTarget,
     isDashboardChartTileType,
+    isDashboardScheduler,
     isDashboardValidationError,
     isSchedulerCsvOptions,
     isSchedulerGsheetsOptions,
@@ -209,6 +210,9 @@ export const getNotificationPageData = async (
                         user,
                         dashboardUuid,
                         csvOptions,
+                        isDashboardScheduler(scheduler)
+                            ? scheduler.filters
+                            : undefined,
                     );
 
                     analytics.track({

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -2,6 +2,8 @@ import { subject } from '@casl/ability';
 import {
     addDashboardFiltersToMetricQuery,
     ApiSqlQueryResults,
+    applyDimensionOverrides,
+    DashboardFilterRule,
     DashboardFilters,
     DimensionType,
     DownloadCsvPayload,
@@ -468,8 +470,19 @@ export class CsvService {
         user: SessionUser,
         dashboardUuid: string,
         options: SchedulerCsvOptions | undefined,
+        schedulerFilters?: DashboardFilterRule[],
     ) {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
+
+        const dashboardFilters = dashboard.filters;
+
+        if (schedulerFilters) {
+            dashboardFilters.dimensions = applyDimensionOverrides(
+                dashboard.filters,
+                schedulerFilters,
+                true,
+            );
+        }
 
         const chartTileUuidsWithChartUuids = dashboard.tiles
             .filter(isDashboardChartTileType)
@@ -487,7 +500,7 @@ export class CsvService {
                     options,
                     undefined,
                     tileUuid,
-                    dashboard.filters,
+                    dashboardFilters,
                 ),
         );
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -3,7 +3,6 @@ import {
     addDashboardFiltersToMetricQuery,
     ApiSqlQueryResults,
     applyDimensionOverrides,
-    DashboardFilterRule,
     DashboardFilters,
     DimensionType,
     DownloadCsvPayload,
@@ -25,6 +24,7 @@ import {
     isTableChartConfig,
     MetricQuery,
     SchedulerCsvOptions,
+    SchedulerFilterRule,
     SchedulerFormat,
     SessionUser,
     TableCalculation,
@@ -470,7 +470,7 @@ export class CsvService {
         user: SessionUser,
         dashboardUuid: string,
         options: SchedulerCsvOptions | undefined,
-        schedulerFilters?: DashboardFilterRule[],
+        schedulerFilters?: SchedulerFilterRule[],
     ) {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
 

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -153,6 +153,30 @@ export const getFilterRules = (filters: Filters): FilterRule[] => {
     return rules;
 };
 
+export const applyDimensionOverrides = (
+    dashboardFilters: DashboardFilters,
+    overrides: DashboardFilters | DashboardFilterRule[],
+    keepTileTargets = false,
+) =>
+    dashboardFilters.dimensions.map((dimension) => {
+        if (overrides instanceof Array) {
+            const override = overrides.find(
+                (overrideDimension) => overrideDimension.id === dimension.id,
+            );
+            if (override && keepTileTargets) {
+                return {
+                    ...override,
+                    tileTargets: dimension.tileTargets,
+                };
+            }
+            return dimension;
+        }
+        const override = overrides.dimensions.find(
+            (overrideDimension) => overrideDimension.id === dimension.id,
+        );
+        return override || dimension;
+    });
+
 export const isDashboardFilterRule = (
     value: ConditionalRule,
 ): value is DashboardFilterRule =>

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -10,32 +10,6 @@ export const hasSavedFiltersOverrides = (
         (overrides.dimensions?.length > 0 || overrides.metrics?.length > 0)
     );
 
-export const applyDimensionOverrides = (
-    dashboardFilters: DashboardFilters,
-    overrides: DashboardFilters | DashboardFilterRule[],
-    keepTileTargets = false,
-) =>
-    dashboardFilters.dimensions.map((dimension) => {
-        if (overrides instanceof Array) {
-            const override = overrides.find(
-                (overrideDimension) => overrideDimension.id === dimension.id,
-            );
-            if (override && keepTileTargets) {
-                if (override.disabled) delete override.disabled;
-                return {
-                    ...override,
-                    tileTargets: dimension.tileTargets,
-                };
-            }
-            return dimension;
-        } else {
-            const override = overrides.dimensions.find(
-                (overrideDimension) => overrideDimension.id === dimension.id,
-            );
-            return override || dimension;
-        }
-    });
-
 const ADD_SAVED_FILTER_OVERRIDE = 'ADD_SAVED_FILTER_OVERRIDE';
 const REMOVE_SAVED_FILTER_OVERRIDE = 'REMOVE_SAVED_FILTER_OVERRIDE';
 

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -1,5 +1,6 @@
 import {
     ApiError,
+    applyDimensionOverrides,
     CacheMetadata,
     compressDashboardFiltersToParam,
     convertDashboardFiltersParamToDashboardFilters,
@@ -31,7 +32,6 @@ import {
     useDashboardsAvailableFilters,
 } from '../hooks/dashboard/useDashboard';
 import {
-    applyDimensionOverrides,
     hasSavedFiltersOverrides,
     useSavedDashboardFiltersOverrides,
 } from '../hooks/useSavedDashboardFiltersOverrides';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #4425

### Description:

Passes `schedulerFilters` to `csvService` so that the charts are pulled with the dashboard filters + overrides (whatever the user changes on the scheduler

Moves util `applyDimensionOverrides` so that it can be reused across the stack.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
