### PR TITLE
fix: change custom metric sorting with custom metric name

### DIFF
--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -804,6 +804,9 @@ function reducer(
         }
 
         case ActionType.EDIT_ADDITIONAL_METRIC: {
+            const additionalMetricFieldId = getFieldId(
+                action.payload.additionalMetric,
+            );
             return {
                 ...state,
                 unsavedChartVersion: {
@@ -811,10 +814,12 @@ function reducer(
                     metricQuery: {
                         ...state.unsavedChartVersion.metricQuery,
                         metrics:
-                            state.unsavedChartVersion.metricQuery.metrics.filter(
+                            state.unsavedChartVersion.metricQuery.metrics.map(
                                 (metric) =>
-                                    metric !==
-                                    action.payload.previousAdditionalMetricName,
+                                    metric ===
+                                    action.payload.previousAdditionalMetricName
+                                        ? additionalMetricFieldId
+                                        : metric,
                             ),
                         additionalMetrics:
                             state.unsavedChartVersion.metricQuery.additionalMetrics?.map(
@@ -823,6 +828,27 @@ function reducer(
                                     action.payload.additionalMetric.uuid
                                         ? action.payload.additionalMetric
                                         : metric,
+                            ),
+                        sorts: state.unsavedChartVersion.metricQuery.sorts.map(
+                            (sortField) =>
+                                sortField.fieldId ===
+                                action.payload.previousAdditionalMetricName
+                                    ? {
+                                          ...sortField,
+                                          fieldId: additionalMetricFieldId,
+                                      }
+                                    : sortField,
+                        ),
+                    },
+                    tableConfig: {
+                        ...state.unsavedChartVersion.tableConfig,
+                        columnOrder:
+                            state.unsavedChartVersion.tableConfig.columnOrder.map(
+                                (fieldId) =>
+                                    fieldId ===
+                                    action.payload.previousAdditionalMetricName
+                                        ? additionalMetricFieldId
+                                        : fieldId,
                             ),
                     },
                 },
@@ -1252,10 +1278,6 @@ export const ExplorerProvider: FC<{
             dispatch({
                 type: ActionType.EDIT_ADDITIONAL_METRIC,
                 payload: { additionalMetric, previousAdditionalMetricName },
-            });
-            dispatch({
-                type: ActionType.TOGGLE_METRIC,
-                payload: getFieldId(additionalMetric),
             });
         },
         [],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7991 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
editing a custom metric now changes affected columns. I removed the `TOGGLE-METRIC` dispatch because it resets the custom metric's sort field which I don't think is necessary for an edit.

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 17-11-23 10:18:37.webm](https://github.com/lightdash/lightdash/assets/76876702/8fc0aa58-40ec-4996-991d-de43df5d7f43)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
