### PR TITLE
feat: add user error on chart parse failure

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -41,6 +41,7 @@ import {
 } from '../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
+import useToaster from '../hooks/toaster/useToaster';
 import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import {
@@ -165,6 +166,8 @@ const Dashboard: FC = () => {
     );
     const oldestCacheTime = useDashboardContext((c) => c.oldestCacheTime);
 
+    const { showToastError } = useToaster();
+
     const { data: organization } = useOrganization();
     const hasTemporaryFilters = useMemo(
         () =>
@@ -219,7 +222,14 @@ const Dashboard: FC = () => {
                         unsavedDashboardTilesRaw,
                     );
                 } catch {
-                    // do nothing
+                    showToastError({
+                        title: 'Error parsing chart',
+                        subtitle: 'Unable to save chart in dashboard',
+                    });
+                    console.error(
+                        'Error parsing chart in dashboard. Attempted to parse: ',
+                        unsavedDashboardTilesRaw,
+                    );
                 }
             }
 
@@ -231,6 +241,7 @@ const Dashboard: FC = () => {
         setDashboardTiles,
         savedTiles,
         clearIsEditingDashboardChart,
+        showToastError,
     ]);
 
     useEffect(() => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -6,7 +6,8 @@ import {
     DashboardTileTypes,
     isDashboardChartTileType,
 } from '@lightdash/common';
-import { useProfiler } from '@sentry/react';
+import { captureException, useProfiler } from '@sentry/react';
+
 import React, {
     FC,
     memo,
@@ -229,6 +230,9 @@ const Dashboard: FC = () => {
                     console.error(
                         'Error parsing chart in dashboard. Attempted to parse: ',
                         unsavedDashboardTilesRaw,
+                    );
+                    captureException(
+                        `Error parsing chart in dashboard. Attempted to parse: ${unsavedDashboardTilesRaw} `,
                     );
                 }
             }


### PR DESCRIPTION
### Description:

Adds a user error when charts in dashboards fail to parse

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
