### PR TITLE
fix: charts sometimes dont save to dashboards

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -204,24 +204,22 @@ const Dashboard: FC = () => {
 
     const { tiles: savedTiles } = dashboard || {};
     useEffect(() => {
-        // TODO: The logic in this useEffect isn't right. It's checking if
-        // there are saved tiles, then checking for unsaved tiles,
-        // then replacing the saved tiles with the unsaved ones if they exist.
         if (savedTiles) {
-            // TODO: maybe this should move in the future, but it makes
-            // some sense here since this useEffect is essentially handling
-            // sessions storage
             clearIsEditingDashboardChart();
             const unsavedDashboardTilesRaw = sessionStorage.getItem(
                 'unsavedDashboardTiles',
             );
             sessionStorage.removeItem('unsavedDashboardTiles');
-            let unsavedDashboardTiles = undefined;
             if (unsavedDashboardTilesRaw) {
                 try {
-                    unsavedDashboardTiles = JSON.parse(
+                    const unsavedDashboardTiles = JSON.parse(
                         unsavedDashboardTilesRaw,
                     );
+                    // If there are unsaved tiles, add them to the dashboard
+                    setDashboardTiles((old = []) => {
+                        return [...old, ...unsavedDashboardTiles];
+                    });
+                    setHaveTilesChanged(!!unsavedDashboardTiles);
                 } catch {
                     showToastError({
                         title: 'Error parsing chart',
@@ -235,14 +233,18 @@ const Dashboard: FC = () => {
                         `Error parsing chart in dashboard. Attempted to parse: ${unsavedDashboardTilesRaw} `,
                     );
                 }
+            } else {
+                // If there are no dashboard tiles, set them to the saved ones
+                // This is the first time the dashboard is being loaded.
+                if (!dashboardTiles) {
+                    setDashboardTiles(savedTiles);
+                }
             }
-
-            setDashboardTiles(unsavedDashboardTiles || savedTiles);
-            setHaveTilesChanged(!!unsavedDashboardTiles);
         }
     }, [
         setHaveTilesChanged,
         setDashboardTiles,
+        dashboardTiles,
         savedTiles,
         clearIsEditingDashboardChart,
         showToastError,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8006 

### Description:

There was a race condition when returning from creating a chart in a dashboard that cause the new chart to sometimes not be saved. The useEffect that adds the live charts to the dashboard was setting the charts in the dashboard unsafely. It was setting the set of charts when a new chart was added, but sometimes then setting the charts back to the saved charts from the server. This makes sure we only set to the saved charts in the server when there are no other charts. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
