### PR TITLE
feat: adjusting table calculation shouldn't reset chart config

### DIFF
--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -13,6 +13,7 @@ import {
     FieldId,
     fieldId as getFieldId,
     getCustomDimensionId,
+    getItemId,
     MetricQuery,
     MetricType,
     PieChartConfig,
@@ -981,9 +982,13 @@ function reducer(
                         tableCalculations:
                             state.unsavedChartVersion.metricQuery.tableCalculations.map(
                                 (tableCalculation) =>
-                                    tableCalculation.name ===
+                                    getItemId(tableCalculation) ===
                                     action.payload.oldName
-                                        ? action.payload.tableCalculation
+                                        ? {
+                                              ...action.payload
+                                                  .tableCalculation,
+                                              ...tableCalculation,
+                                          }
                                         : tableCalculation,
                             ),
                         sorts: state.unsavedChartVersion.metricQuery.sorts.map(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7996 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Fixed a check in comparing table calculations to get the correct id. 
I'm not sure if it's fine to use getItemId() to check

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 19-11-23 20:11:54.webm](https://github.com/lightdash/lightdash/assets/76876702/51ce603d-234e-414b-8707-69781691ac60)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
