### PR TITLE
fix: changing an unsaved filter won't delete it

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -56,7 +56,12 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
                             removeDimensionDashboardFilter(index, false)
                         }
                         onUpdate={(value) =>
-                            updateDimensionDashboardFilter(value, index, false)
+                            updateDimensionDashboardFilter(
+                                value,
+                                index,
+                                false,
+                                isEditMode,
+                            )
                         }
                     />
                 ))}
@@ -74,7 +79,12 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({ isEditMode }) => {
                             removeDimensionDashboardFilter(index, true)
                         }
                         onUpdate={(value) =>
-                            updateDimensionDashboardFilter(value, index, true)
+                            updateDimensionDashboardFilter(
+                                value,
+                                index,
+                                true,
+                                isEditMode,
+                            )
                         }
                     />
                 ))}

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -241,12 +241,10 @@ export const DashboardProvider: React.FC<{
         ) {
             setDashboardFilters((prevFilters) => ({
                 ...prevFilters,
-                dimensions: [
-                    ...applyDimensionOverrides(
-                        prevFilters,
-                        overridesForSavedDashboardFilters,
-                    ),
-                ],
+                dimensions: applyDimensionOverrides(
+                    prevFilters,
+                    overridesForSavedDashboardFilters,
+                ),
             }));
         }
     }, [dashboard?.filters, overridesForSavedDashboardFilters]);

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -239,13 +239,15 @@ export const DashboardProvider: React.FC<{
             dashboard?.filters &&
             hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
         ) {
-            setDashboardFilters({
-                ...dashboard.filters,
-                dimensions: applyDimensionOverrides(
-                    dashboard.filters,
-                    overridesForSavedDashboardFilters,
-                ),
-            });
+            setDashboardFilters((prevFilters) => ({
+                ...prevFilters,
+                dimensions: [
+                    ...applyDimensionOverrides(
+                        prevFilters,
+                        overridesForSavedDashboardFilters,
+                    ),
+                ],
+            }));
         }
     }, [dashboard?.filters, overridesForSavedDashboardFilters]);
 
@@ -368,6 +370,10 @@ export const DashboardProvider: React.FC<{
                 ? setDashboardTemporaryFilters
                 : setDashboardFilters;
 
+            const fitlerIsSaved = dashboard?.filters.dimensions.some((id) => {
+                return id.id === item.id;
+            });
+
             setFunction((previousFilters) => {
                 if (!isTemporary) {
                     const hasChanged = hasSavedFilterValueChanged(
@@ -382,7 +388,7 @@ export const DashboardProvider: React.FC<{
                             item,
                         );
 
-                    if (hasChanged) {
+                    if (hasChanged && fitlerIsSaved) {
                         addSavedFilterOverride(item);
                     }
 
@@ -390,7 +396,6 @@ export const DashboardProvider: React.FC<{
                         removeSavedFilterOverride(item);
                     }
                 }
-
                 return {
                     dimensions: [
                         ...previousFilters.dimensions.slice(0, index),
@@ -404,6 +409,7 @@ export const DashboardProvider: React.FC<{
         },
         [
             addSavedFilterOverride,
+            dashboard?.filters.dimensions,
             originalDashboardFilters.dimensions,
             removeSavedFilterOverride,
         ],

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -146,8 +146,6 @@ export const DashboardProvider: React.FC<{
         removeSavedFilterOverride,
     } = useSavedDashboardFiltersOverrides();
 
-    console.log({ overridesForSavedDashboardFilters, dashboardFilters });
-
     const savedChartUuidsAndTileUuids = useMemo(
         () =>
             dashboardTiles

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -368,9 +368,9 @@ export const DashboardProvider: React.FC<{
                 ? setDashboardTemporaryFilters
                 : setDashboardFilters;
 
-            const fitlerIsSaved = dashboard?.filters.dimensions.some((id) => {
-                return id.id === item.id;
-            });
+            const isFilterSaved = dashboard?.filters.dimensions.some(
+                ({ id }) => id === item.id,
+            );
 
             setFunction((previousFilters) => {
                 if (!isTemporary) {
@@ -386,7 +386,7 @@ export const DashboardProvider: React.FC<{
                             item,
                         );
 
-                    if (hasChanged && fitlerIsSaved) {
+                    if (hasChanged && isFilterSaved) {
                         addSavedFilterOverride(item);
                     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8001 

### Description:

Fixes an issue with changing filters while editing them. We were deleting filters in a draft state when they were changed. This patch makes two changes: 1) only add overrides to filters that have been saved to the DB, 2) When overrides are applied, include the draft filters in the set that gets updated. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
