### PR TITLE
fix: enable editing charts with errors

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -819,17 +819,19 @@ const DashboardChartTile: FC<DashboardChartTileProps> = ({
                 isEditMode={isEditMode}
                 tile={tile}
                 extraMenuItems={
-                    <Tooltip
-                        disabled={!isEditMode}
-                        label="Finish editing dashboard to edit this chart"
-                    >
-                        <Box>
-                            <EditChartMenuItem
-                                tile={tile}
-                                isEditMode={isEditMode}
-                            />
-                        </Box>
-                    </Tooltip>
+                    tile.properties.savedChartUuid && (
+                        <Tooltip
+                            disabled={!isEditMode}
+                            label="Finish editing dashboard to edit this chart"
+                        >
+                            <Box>
+                                <EditChartMenuItem
+                                    tile={tile}
+                                    isEditMode={isEditMode}
+                                />
+                            </Box>
+                        </Tooltip>
+                    )
                 }
                 {...rest}
             >

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -808,7 +808,17 @@ const DashboardChartTile: FC<DashboardChartTileProps> = ({
                 isEditMode={isEditMode}
                 tile={tile}
                 extraMenuItems={
-                    <EditChartMenuItem tile={tile} isEditMode={isEditMode} />
+                    <Tooltip
+                        disabled={!isEditMode}
+                        label="Finish editing dashboard to edit this chart"
+                    >
+                        <Box>
+                            <EditChartMenuItem
+                                tile={tile}
+                                isEditMode={isEditMode}
+                            />
+                        </Box>
+                    </Tooltip>
                 }
                 {...rest}
             >

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -24,9 +24,9 @@ function EditChartMenuItem(props: {
         dashboardUuid: string;
     }>();
 
-    const userCanMangeExplore = user.data?.ability?.can('manage', 'Explore');
+    const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
 
-    if (!tile.properties.savedChartUuid || !userCanMangeExplore) return null;
+    if (!tile.properties.savedChartUuid || !userCanManageExplore) return null;
 
     return (
         <LinkMenuItem

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -1,0 +1,53 @@
+import { DashboardChartTile } from '@lightdash/common';
+import { useParams } from 'react-router-dom';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useApp } from '../../providers/AppProvider';
+import { useDashboardContext } from '../../providers/DashboardProvider';
+import LinkMenuItem from '../common/LinkMenuItem';
+
+function EditChartMenuItem(props: {
+    tile: DashboardChartTile;
+    isEditMode: boolean;
+}) {
+    const { tile, isEditMode } = props;
+    const { user } = useApp();
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filtersFromContext = useDashboardContext((c) => c.dashboardFilters);
+    const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
+    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
+    const dashboard = useDashboardContext((c) => c.dashboard);
+
+    const { storeDashboard } = useDashboardStorage();
+
+    const { projectUuid, dashboardUuid } = useParams<{
+        projectUuid: string;
+        dashboardUuid: string;
+    }>();
+
+    const userCanMangeExplore = user.data?.ability?.can('manage', 'Explore');
+
+    if (!tile.properties.savedChartUuid || !userCanMangeExplore) return null;
+
+    return (
+        <LinkMenuItem
+            icon="document-open"
+            text="Edit chart"
+            disabled={isEditMode}
+            onClick={() => {
+                if (tile.properties.belongsToDashboard) {
+                    storeDashboard(
+                        dashboardTiles,
+                        filtersFromContext,
+                        haveTilesChanged,
+                        haveFiltersChanged,
+                        dashboard?.uuid,
+                        dashboard?.name,
+                    );
+                }
+            }}
+            href={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
+        />
+    );
+}
+
+export default EditChartMenuItem;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8016 

### Description:

We were not showing the chart editing controls when a chart errored out. This adds the edit button to a tile with errors. 

Writing this made me want to clean up the tile hierarchy more. There are a lot of wrappers that probably don't all need to be in there. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
