### PR TITLE
fix: view underlying data with null pivot value

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/data/raw_customers.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_customers.csv
@@ -99,3 +99,4 @@ id,first_name,last_name,created
 98,Nicole,M.,2017-01-30 11:00:00
 99,Mary,G.,2017-01-19 11:00:00
 100,"Quo'te",C.,2017-01-30 07:07:07
+101,null,null,2017-02-30 01:01:01

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -176,8 +176,11 @@ const UnderlyingDataModalContent: FC<Props> = () => {
             target: {
                 fieldId: pivot.field,
             },
-            operator: FilterOperator.EQUALS,
-            values: [pivot.value],
+            operator:
+                pivot.value === null
+                    ? FilterOperator.NULL
+                    : FilterOperator.EQUALS,
+            values: pivot.value === null ? undefined : [pivot.value],
         }));
 
         const metric: Metric | undefined =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7970 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We were handling null values for the dimension filters but not for the pivot filter.

Steps to replicate:
- create chart from customers
- pick: any date dimension, first name and a metric
- group chart by first name
- see underlying data of bar that has `null` first name 

https://github.com/lightdash/lightdash/assets/9117144/9568a5ce-ad9a-4165-b6c5-8b02b1a5797b


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
