### PR TITLE
fix: explore search by fieldId to prioritise base table match over joined tables

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -622,7 +622,6 @@ export class ProjectModel {
                     })
                     .select()
                     .whereRaw('? = ANY(table_names)', tableName)
-                    .orWhereRaw("explore->>'base_table' = ?", tableName)
                     .andWhere('project_uuid', projectUuid)
                     .orderBy('baseMatch', 'desc')
                     .first();

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -613,9 +613,18 @@ export class ProjectModel {
             async (span) => {
                 // check individually cached explore
                 let exploreCache = await this.database(CachedExploreTableName)
-                    .select('explore')
+                    .columns({
+                        explore: 'explore',
+                        baseMatch: this.database.raw(
+                            "? = explore->>'base_table'",
+                            [tableName],
+                        ),
+                    })
+                    .select()
                     .whereRaw('? = ANY(table_names)', tableName)
+                    .orWhereRaw("explore->>'base_table' = ?", tableName)
                     .andWhere('project_uuid', projectUuid)
+                    .orderBy('baseMatch', 'desc')
                     .first();
 
                 span.setAttribute(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7965 

Field search behaviour was different depending on which explore cache we hit. This makes the behaviour the same.

note that this function still has the same limitations of the previous version (finding a field_id is not always reliable depending on explore and alias names) 
