### PR TITLE
feat: add send now scheduler filters to URL

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -27,6 +27,7 @@ import {
     NotificationPayloadBase,
     ScheduledDeliveryPayload,
     SchedulerAndTargets,
+    SchedulerFilterRule,
     SchedulerFormat,
     SchedulerJobStatus,
     SchedulerLog,
@@ -57,8 +58,6 @@ import {
 } from '../clients/Slack/SlackMessageBlocks';
 import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
-import { metricQuery } from '../services/CsvService/CsvService.mock';
-import { SavedChartService } from '../services/SavedChartsService/SavedChartService';
 import {
     csvService,
     dashboardService,
@@ -73,6 +72,7 @@ const getChartOrDashboard = async (
     chartUuid: string | null,
     dashboardUuid: string | null,
     schedulerUuid: string | undefined,
+    sendNowSchedulerFilters: SchedulerFilterRule[] | undefined,
 ) => {
     if (chartUuid) {
         const chart = await schedulerService.savedChartModel.getSummary(
@@ -102,6 +102,12 @@ const getChartOrDashboard = async (
                 dashboard.projectUuid
             }/dashboards/${dashboardUuid}${
                 schedulerUuid ? `?schedulerUuid=${schedulerUuid}` : ''
+            }${
+                sendNowSchedulerFilters
+                    ? `?sendNowchedulerFilters=${encodeURI(
+                          JSON.stringify(sendNowSchedulerFilters),
+                      )}`
+                    : ''
             }`,
             details: {
                 name: dashboard.name,
@@ -139,6 +145,11 @@ export const getNotificationPageData = async (
             ? scheduler.schedulerUuid
             : undefined;
 
+    const sendNowSchedulerFilters =
+        !schedulerUuid && isDashboardScheduler(scheduler)
+            ? scheduler.filters
+            : undefined;
+
     const {
         url,
         minimalUrl,
@@ -146,7 +157,12 @@ export const getNotificationPageData = async (
         details,
         organizationUuid,
         projectUuid,
-    } = await getChartOrDashboard(savedChartUuid, dashboardUuid, schedulerUuid);
+    } = await getChartOrDashboard(
+        savedChartUuid,
+        dashboardUuid,
+        schedulerUuid,
+        sendNowSchedulerFilters,
+    );
 
     switch (format) {
         case SchedulerFormat.IMAGE:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8025 

### Description:

Note: this was already working with CSV exports

With the `Send Now` feature for scheduled deliveries, we want to be able to include the filters to the minimal URL (like we do with the exporting of a dashboard (with saved filter overrides) 

I was looking at different ways to avoid using the URL search param: 
* reuse the `schedulerUuid` search param, but the `send now` feature does not create one 
* set a cookie - didn't work as expected. Even when set properly, the screenshot wouldn't work properly
* set localstorage - this didn't work at all

So, instead, we set a searchParam `sendNowSchedulerFilters` that has the same format as `SchedulerFilterRule[]` and get that or the other (from the scheduler with the `schedulerUuid`), depending on what's present. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
