### PR TITLE
chore: show dashboard filter label if exists in scheduler filters

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -57,7 +57,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
     }, [filterType]);
 
     return (
-        <Stack key={dashboardFilter.id} spacing="xs">
+        <Stack key={dashboardFilter.id} spacing="xs" w="100%">
             <Group spacing="xs">
                 <FieldIcon item={field} />
                 <FieldLabel
@@ -251,7 +251,7 @@ const SchedulerFilters: FC<SchedulerFiltersProps> = ({
                                 spacing="xs"
                                 align="flex-start"
                                 key={filter.id}
-                                w="100%"
+                                noWrap
                             >
                                 <Tooltip
                                     label="Reset filter back to original"

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -60,7 +60,13 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
         <Stack key={dashboardFilter.id} spacing="xs">
             <Group spacing="xs">
                 <FieldIcon item={field} />
-                <FieldLabel item={field} hideTableName />
+                <FieldLabel
+                    item={{
+                        ...field,
+                        label: dashboardFilter.label ?? field.label,
+                    }}
+                    hideTableName
+                />
             </Group>
 
             <Flex gap="xs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #4425

### Description:

Display `dashboard filter`'s label if it exists, but always fallback to the field label when viewing scheduled delivery filters 


<img width="451" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/4febe1d0-30ee-40b8-8c7a-b223ca153f33">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
