### PR TITLE
fix: dont save tileTargets in overrides and sync with state

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,4 +1,5 @@
 import { ConditionalOperator, ConditionalRule } from './conditionalRule';
+import type { SchedulerFilterRule } from './scheduler';
 
 export enum FilterType {
     STRING = 'string',
@@ -66,6 +67,11 @@ export type DashboardFilterRule<
     tileTargets?: Record<string, DashboardTileTarget>;
     label: undefined | string;
 };
+
+export type DashboardFilterRuleOverride = Omit<
+    DashboardFilterRule,
+    'tileTargets'
+>;
 
 export type DateFilterRule = FilterRule<
     ConditionalOperator,
@@ -155,26 +161,26 @@ export const getFilterRules = (filters: Filters): FilterRule[] => {
 
 export const applyDimensionOverrides = (
     dashboardFilters: DashboardFilters,
-    overrides: DashboardFilters | DashboardFilterRule[],
-    keepTileTargets = false,
+    overrides: DashboardFilters | SchedulerFilterRule[],
 ) =>
     dashboardFilters.dimensions.map((dimension) => {
-        if (overrides instanceof Array) {
-            const override = overrides.find(
-                (overrideDimension) => overrideDimension.id === dimension.id,
-            );
-            if (override && keepTileTargets) {
-                return {
-                    ...override,
-                    tileTargets: dimension.tileTargets,
-                };
-            }
-            return dimension;
+        const override =
+            overrides instanceof Array
+                ? overrides.find(
+                      (overrideDimension) =>
+                          overrideDimension.id === dimension.id,
+                  )
+                : overrides.dimensions.find(
+                      (overrideDimension) =>
+                          overrideDimension.id === dimension.id,
+                  );
+        if (override) {
+            return {
+                ...override,
+                tileTargets: dimension.tileTargets,
+            };
         }
-        const override = overrides.dimensions.find(
-            (overrideDimension) => overrideDimension.id === dimension.id,
-        );
-        return override || dimension;
+        return dimension;
     });
 
 export const isDashboardFilterRule = (

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -1,4 +1,8 @@
-import { DashboardFilterRule, DashboardFilters } from '@lightdash/common';
+import {
+    DashboardFilterRule,
+    DashboardFilterRuleOverride,
+    DashboardFilters,
+} from '@lightdash/common';
 import { useReducer } from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -15,17 +19,23 @@ const REMOVE_SAVED_FILTER_OVERRIDE = 'REMOVE_SAVED_FILTER_OVERRIDE';
 
 interface AddSavedFilterOverrideAction {
     type: typeof ADD_SAVED_FILTER_OVERRIDE;
-    payload: DashboardFilterRule;
+    payload: DashboardFilterRuleOverride;
 }
 
 interface RemoveSavedFilterOverrideAction {
     type: typeof REMOVE_SAVED_FILTER_OVERRIDE;
-    payload: DashboardFilterRule;
+    payload: DashboardFilterRuleOverride;
 }
 
 type Action = AddSavedFilterOverrideAction | RemoveSavedFilterOverrideAction;
 
-const reducer = (state: DashboardFilters, action: Action) => {
+const reducer = (
+    state: {
+        dimensions: DashboardFilterRuleOverride[];
+        metrics: DashboardFilterRuleOverride[];
+    },
+    action: Action,
+) => {
     let newDimensions = [...state.dimensions];
     const { type, payload } = action;
 
@@ -63,11 +73,17 @@ export const useSavedDashboardFiltersOverrides = () => {
             : { dimensions: [], metrics: [] },
     );
 
-    const addSavedFilterOverride = (item: DashboardFilterRule) => {
+    const addSavedFilterOverride = ({
+        tileTargets,
+        ...item
+    }: DashboardFilterRule) => {
         dispatch({ type: ADD_SAVED_FILTER_OVERRIDE, payload: item });
     };
 
-    const removeSavedFilterOverride = (item: DashboardFilterRule) => {
+    const removeSavedFilterOverride = ({
+        tileTargets,
+        ...item
+    }: DashboardFilterRule) => {
         dispatch({ type: REMOVE_SAVED_FILTER_OVERRIDE, payload: item });
     };
 

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -108,7 +108,6 @@ export const DashboardProvider: React.FC<{
                     const overriddenDimensions = applyDimensionOverrides(
                         d.filters,
                         schedulerFilters,
-                        true,
                     );
 
                     return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8008

### Description:

Never store `tileTargets` on the searchParam for `filters` so it doesn't mess with the internal state. Instead, always get the tileTargets defined by the filter stored in the base filter the override is _overriding_

I've tested the scenario described on the ticket, and also tested the exporting of a dashboard - would be great to get some extra 👀 on this!

Added a clearer type for these overrides: `DashboardFilterRuleOverride` which clearly omits `tileTargets` 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
