### PR TITLE
fix: sync override type with the dashboard filter one

### DIFF
--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -30,10 +30,7 @@ interface RemoveSavedFilterOverrideAction {
 type Action = AddSavedFilterOverrideAction | RemoveSavedFilterOverrideAction;
 
 const reducer = (
-    state: {
-        dimensions: DashboardFilterRuleOverride[];
-        metrics: DashboardFilterRuleOverride[];
-    },
+    state: Record<keyof DashboardFilters, DashboardFilterRuleOverride[]>,
     action: Action,
 ) => {
     let newDimensions = [...state.dimensions];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Now that Filters can have `tableCalculations`, let's ensure that the overrides types also include that, by syncing the state's types with `DashboardFilter` keys

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
