### PR TITLE
feat: disable and clear date zoom on edit mode

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -5,7 +5,7 @@ import {
     IconChevronDown,
     IconChevronUp,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 
 const DATE_ZOOM_OPTIONS = [
@@ -28,12 +28,20 @@ const DATE_ZOOM_OPTIONS = [
     },
 ];
 
-export const DateZoom = () => {
+type Props = {
+    isEditMode: boolean;
+};
+
+export const DateZoom: FC<Props> = ({ isEditMode }) => {
     const theme = useMantineTheme();
     const [isOpen, setIsOpen] = useState(false);
     const [dateGranularity, setDateGranularity] = useState<
         typeof DATE_ZOOM_OPTIONS[0] | undefined
     >(undefined);
+
+    useEffect(() => {
+        if (isEditMode) setDateGranularity(undefined);
+    }, [isEditMode]);
 
     return (
         <Menu
@@ -44,12 +52,14 @@ export const DateZoom = () => {
             opened={isOpen}
             offset={-1}
             position="bottom-end"
+            disabled={isEditMode}
         >
             <Menu.Target>
                 <Button
                     size="xs"
                     variant="default"
                     loaderPosition="center"
+                    disabled={isEditMode}
                     onClick={() => {
                         setIsOpen((prev) => !prev);
                     }}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -574,7 +574,9 @@ const Dashboard: FC = () => {
                     {dashboardChartTiles && dashboardChartTiles.length > 0 && (
                         <DashboardFilter isEditMode={isEditMode} />
                     )}
-                    {isDateZoomFeatureFlagEnabled && <DateZoom />}
+                    {isDateZoomFeatureFlagEnabled && (
+                        <DateZoom isEditMode={isEditMode} />
+                    )}
                 </Group>
 
                 <ResponsiveGridLayout


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8036

### Description:

Disables Menu when editing a dashboard. 
Once user leaves edit mode, then reset the date zoom.

screen recording: 

https://github.com/lightdash/lightdash/assets/7611706/64daeb38-f493-4936-b6b2-805d4ae97fd7



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
