### PR TITLE
chore: store date zoom granularity in dashboard provider

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,4 +1,3 @@
-import { TimeFrames } from '@lightdash/common';
 import { Button, Menu, Text, useMantineTheme } from '@mantine/core';
 import {
     IconCalendarSearch,
@@ -7,33 +6,18 @@ import {
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-
-const DATE_ZOOM_OPTIONS = [
-    // TODO: add support for these times
-    {
-        value: TimeFrames.DAY,
-        label: 'Day',
-    },
-    {
-        value: TimeFrames.MONTH,
-        label: 'Month',
-    },
-    {
-        value: TimeFrames.QUARTER,
-        label: 'Quarter',
-    },
-    {
-        value: TimeFrames.YEAR,
-        label: 'Year',
-    },
-];
+import { useDashboardContext } from '../../../providers/DashboardProvider';
+import { DATE_ZOOM_OPTIONS } from '../constants';
 
 export const DateZoom = () => {
     const theme = useMantineTheme();
     const [isOpen, setIsOpen] = useState(false);
-    const [dateGranularity, setDateGranularity] = useState<
-        typeof DATE_ZOOM_OPTIONS[0] | undefined
-    >(undefined);
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const setDateZoomGranularity = useDashboardContext(
+        (c) => c.setDateZoomGranularity,
+    );
 
     return (
         <Menu
@@ -54,7 +38,7 @@ export const DateZoom = () => {
                         setIsOpen((prev) => !prev);
                     }}
                     sx={{
-                        borderColor: dateGranularity
+                        borderColor: dateZoomGranularity
                             ? theme.colors.blue['6']
                             : 'default',
                     }}
@@ -67,10 +51,10 @@ export const DateZoom = () => {
                 >
                     <Text>
                         Date Zoom
-                        {dateGranularity ? `:` : null}{' '}
-                        {dateGranularity ? (
+                        {dateZoomGranularity ? `:` : null}{' '}
+                        {dateZoomGranularity ? (
                             <Text span fw={500}>
-                                {dateGranularity.label}
+                                {dateZoomGranularity.label}
                             </Text>
                         ) : null}
                     </Text>
@@ -81,19 +65,19 @@ export const DateZoom = () => {
                 <Menu.Item
                     fz="xs"
                     onClick={() => {
-                        setDateGranularity(undefined);
+                        setDateZoomGranularity(undefined);
                         setIsOpen(false);
                     }}
                     bg={
-                        dateGranularity === undefined
+                        dateZoomGranularity === undefined
                             ? theme.colors.blue['6']
                             : 'white'
                     }
-                    disabled={dateGranularity === undefined}
+                    disabled={dateZoomGranularity === undefined}
                     sx={{
                         '&[disabled]': {
                             color:
-                                dateGranularity === undefined
+                                dateZoomGranularity === undefined
                                     ? 'white'
                                     : 'black',
                         },
@@ -106,19 +90,19 @@ export const DateZoom = () => {
                         fz="xs"
                         key={value}
                         onClick={() => {
-                            setDateGranularity({ value, label });
+                            setDateZoomGranularity({ value, label });
                             setIsOpen(false);
                         }}
-                        disabled={dateGranularity?.value === value}
+                        disabled={dateZoomGranularity?.value === value}
                         bg={
-                            dateGranularity?.value === value
+                            dateZoomGranularity?.value === value
                                 ? theme.colors.blue['6']
                                 : 'white'
                         }
                         sx={{
                             '&[disabled]': {
                                 color:
-                                    dateGranularity?.value === value
+                                    dateZoomGranularity?.value === value
                                         ? 'white'
                                         : 'black',
                             },

--- a/packages/frontend/src/features/dateZoom/constants/index.ts
+++ b/packages/frontend/src/features/dateZoom/constants/index.ts
@@ -1,0 +1,21 @@
+import { TimeFrames } from '@lightdash/common';
+
+export const DATE_ZOOM_OPTIONS = [
+    // TODO: add support for these times
+    {
+        value: TimeFrames.DAY,
+        label: 'Day',
+    },
+    {
+        value: TimeFrames.MONTH,
+        label: 'Month',
+    },
+    {
+        value: TimeFrames.QUARTER,
+        label: 'Quarter',
+    },
+    {
+        value: TimeFrames.YEAR,
+        label: 'Year',
+    },
+];

--- a/packages/frontend/src/features/dateZoom/constants/index.ts
+++ b/packages/frontend/src/features/dateZoom/constants/index.ts
@@ -7,6 +7,10 @@ export const DATE_ZOOM_OPTIONS = [
         label: 'Day',
     },
     {
+        value: TimeFrames.WEEK,
+        label: 'Week',
+    },
+    {
         value: TimeFrames.MONTH,
         label: 'Month',
     },

--- a/packages/frontend/src/features/dateZoom/index.ts
+++ b/packages/frontend/src/features/dateZoom/index.ts
@@ -1,1 +1,2 @@
 export { DateZoom } from './components/DateZoom';
+export { DATE_ZOOM_OPTIONS } from './constants';

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -28,6 +28,7 @@ import { useMount } from 'react-use';
 import { createContext, useContextSelector } from 'use-context-selector';
 import { FieldsWithSuggestions } from '../components/common/Filters/FiltersProvider';
 import { isFilterConfigRevertButtonEnabled as hasSavedFilterValueChanged } from '../components/DashboardFilter/FilterConfiguration/utils';
+import { DATE_ZOOM_OPTIONS } from '../features/dateZoom';
 import {
     useDashboardQuery,
     useDashboardsAvailableFilters,
@@ -87,6 +88,10 @@ type DashboardContext = {
     hasChartTiles: boolean;
     chartSort: Record<string, SortField[]>;
     setChartSort: (sort: Record<string, SortField[]>) => void;
+    dateZoomGranularity: typeof DATE_ZOOM_OPTIONS[0] | undefined;
+    setDateZoomGranularity: Dispatch<
+        SetStateAction<typeof DATE_ZOOM_OPTIONS[0] | undefined>
+    >;
 };
 
 const Context = createContext<DashboardContext | undefined>(undefined);
@@ -140,6 +145,10 @@ export const DashboardProvider: React.FC<{
     const [invalidateCache, setInvalidateCache] = useState<boolean>(false);
 
     const [chartSort, setChartSort] = useState<Record<string, SortField[]>>({});
+
+    const [dateZoomGranularity, setDateZoomGranularity] = useState<
+        typeof DATE_ZOOM_OPTIONS[0] | undefined
+    >(undefined);
 
     const {
         overridesForSavedDashboardFilters,
@@ -521,6 +530,8 @@ export const DashboardProvider: React.FC<{
         hasChartTiles,
         chartSort,
         setChartSort,
+        dateZoomGranularity,
+        setDateZoomGranularity,
     };
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/8036

### Description:

`DashboardProvider` should store current date zoom granularity to it can be used by a chart tile when user changes its value. 

Also, moved the options to `dateZoom`/`constants` folder. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
