### PR TITLE
feat: collapse join tables by default

### DIFF
--- a/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
+++ b/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
@@ -20,6 +20,7 @@ describe('Custom dimensions', () => {
         cy.findByText('Create').click();
 
         // Select metric
+        cy.findByText('Orders').click();
         cy.findByText('Total order amount').click();
         cy.get('button').contains('Run query').click();
 

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -145,6 +145,7 @@ describe('Download CSV on Explore', () => {
             }).as('apiDownloadCsv');
             // choose table and select fields
             cy.findByText('Orders').click();
+            cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();
 
@@ -178,6 +179,7 @@ describe('Download CSV on Explore', () => {
             }).as('apiDownloadCsv');
             // choose table and select fields
             cy.findByText('Orders').click();
+            cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();
 

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -9,6 +9,7 @@ describe('Explore', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
         cy.findByText('Orders').click();
+        cy.findByText('Customers').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
 
@@ -43,6 +44,7 @@ describe('Explore', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
         cy.findByText('Orders').click();
+        cy.findByText('Customers').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
 
@@ -75,6 +77,7 @@ describe('Explore', () => {
 
         // choose table and select fields
         cy.findByText('Orders').click();
+        cy.findByText('Customers').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
 
@@ -122,6 +125,7 @@ describe('Explore', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
         cy.findByText('Orders').click();
+        cy.findByText('Customers').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
 
@@ -148,6 +152,7 @@ describe('Explore', () => {
             cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
             cy.findByText('Orders').click();
+            cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();
 
@@ -191,6 +196,7 @@ describe('Explore', () => {
 
                     // choose table and select fields
                     cy.findByText('Orders').click();
+                    cy.findByText('Customers').click();
                     cy.findByText('First name').click();
                     cy.findByText('Unique order count').click();
 
@@ -234,6 +240,7 @@ describe('Explore', () => {
 
                     // choose table and select fields
                     cy.findByText('Orders').click();
+                    cy.findByText('Customers').click();
                     cy.findByText('First name').click();
                     cy.findByText('Unique order count').click();
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -15,11 +15,17 @@ import MantineIcon from '../../../common/MantineIcon';
 import TableTreeSections from './TableTreeSections';
 
 type TableTreeWrapperProps = {
+    isOpen: boolean;
+    toggle: () => void;
     table: CompiledTable;
 };
 
-const TableTreeWrapper: FC<TableTreeWrapperProps> = ({ table, children }) => {
-    const [isOpen, toggle] = useToggle(true);
+const TableTreeWrapper: FC<TableTreeWrapperProps> = ({
+    isOpen,
+    toggle,
+    table,
+    children,
+}) => {
     return (
         <NavLink
             opened={isOpen}
@@ -55,6 +61,7 @@ const TableTreeWrapper: FC<TableTreeWrapperProps> = ({ table, children }) => {
 };
 
 type Props = {
+    isOpenByDefault: boolean;
     searchQuery?: string;
     showTableLabel: boolean;
     table: CompiledTable;
@@ -85,22 +92,29 @@ const themeOverride = getMantineThemeOverride({
 });
 
 const TableTree: FC<Props> = ({
+    isOpenByDefault,
     showTableLabel,
     table,
     additionalMetrics,
     customDimensions,
     missingCustomMetrics,
-
+    searchQuery,
     ...rest
 }) => {
     const Wrapper = showTableLabel ? TableTreeWrapper : EmptyWrapper;
-
+    const [isOpen, toggle] = useToggle(isOpenByDefault);
+    const isSearching = !!searchQuery && searchQuery !== '';
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <MantineProvider inherit theme={themeOverride}>
-                <Wrapper table={table}>
+                <Wrapper
+                    isOpen={isSearching || isOpen}
+                    toggle={toggle}
+                    table={table}
+                >
                     <TableTreeSections
                         table={table}
+                        searchQuery={searchQuery}
                         additionalMetrics={additionalMetrics}
                         customDimensions={customDimensions}
                         missingCustomMetrics={missingCustomMetrics}

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -88,9 +88,10 @@ const ExploreTree: FC<ExploreTreeProps> = ({
 
             <Box style={{ flexGrow: 1, overflowY: 'auto' }}>
                 {tableTrees.length > 0 ? (
-                    tableTrees.map((table) => (
+                    tableTrees.map((table, index) => (
                         <TableTree
                             key={table.name}
+                            isOpenByDefault={index === 0}
                             searchQuery={search}
                             showTableLabel={
                                 Object.keys(explore.tables).length > 1


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3201 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- [x] I want to collapse the joined tables in the sidebar by default.
- [x] while searching, any of the matches should have the table toggles opened


https://github.com/lightdash/lightdash/assets/9117144/85e2a8c9-e2a6-4e9c-b8cf-3875a701dac0




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
