### PR TITLE
refactor: split chart results endpoint

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -4,7 +4,6 @@ import {
     ApiGetChartHistoryResponse,
     ApiGetChartVersionResponse,
     ApiSuccessEmpty,
-    DashboardFilters,
     SortField,
 } from '@lightdash/common';
 import {
@@ -46,12 +45,10 @@ export class SavedChartController extends Controller {
     @SuccessResponse('200', 'Success')
     @Post('/results')
     @OperationId('postChartResults')
-    async postDashboardTile(
+    async postChartResults(
         @Body()
         body: {
-            dashboardFilters?: any; // DashboardFilters; temp disable validation
             invalidateCache?: boolean;
-            dashboardSorts?: SortField[];
         },
         @Path() chartUuid: string,
         @Request() req: express.Request,
@@ -62,8 +59,33 @@ export class SavedChartController extends Controller {
             results: await projectService.runViewChartQuery({
                 user: req.user!,
                 chartUuid,
-                dashboardFilters: body.dashboardFilters,
                 versionUuid: undefined,
+                invalidateCache: body.invalidateCache,
+            }),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/chart-and-results')
+    @OperationId('postChartResults')
+    async postDashboardTile(
+        @Body()
+        body: {
+            dashboardFilters: any; // DashboardFilters; temp disable validation
+            invalidateCache?: boolean;
+            dashboardSorts: SortField[];
+        },
+        @Path() chartUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiRunQueryResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await projectService.getChartAndResults({
+                user: req.user!,
+                chartUuid,
+                dashboardFilters: body.dashboardFilters,
                 invalidateCache: body.invalidateCache,
                 dashboardSorts: body.dashboardSorts,
             }),
@@ -137,7 +159,6 @@ export class SavedChartController extends Controller {
             results: await projectService.runViewChartQuery({
                 user: req.user!,
                 chartUuid,
-                dashboardFilters: undefined,
                 versionUuid,
             }),
         };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2262,7 +2262,6 @@ const models: TsoaRoute.Models = {
                 filters: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        tableCalculations: { dataType: 'any' },
                         metrics: { dataType: 'any' },
                         dimensions: { dataType: 'any' },
                     },
@@ -6666,6 +6665,61 @@ export function RegisterRoutes(app: express.Router) {
         '/api/v1/saved/:chartUuid/results',
         ...fetchMiddlewares<RequestHandler>(SavedChartController),
         ...fetchMiddlewares<RequestHandler>(
+            SavedChartController.prototype.postChartResults,
+        ),
+
+        function SavedChartController_postChartResults(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        invalidateCache: { dataType: 'boolean' },
+                    },
+                },
+                chartUuid: {
+                    in: 'path',
+                    name: 'chartUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new SavedChartController();
+
+                const promise = controller.postChartResults.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/saved/:chartUuid/chart-and-results',
+        ...fetchMiddlewares<RequestHandler>(SavedChartController),
+        ...fetchMiddlewares<RequestHandler>(
             SavedChartController.prototype.postDashboardTile,
         ),
 
@@ -6684,9 +6738,10 @@ export function RegisterRoutes(app: express.Router) {
                         dashboardSorts: {
                             dataType: 'array',
                             array: { dataType: 'refAlias', ref: 'SortField' },
+                            required: true,
                         },
                         invalidateCache: { dataType: 'boolean' },
-                        dashboardFilters: { dataType: 'any' },
+                        dashboardFilters: { dataType: 'any', required: true },
                     },
                 },
                 chartUuid: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2262,6 +2262,7 @@ const models: TsoaRoute.Models = {
                 filters: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        tableCalculations: { dataType: 'any' },
                         metrics: { dataType: 'any' },
                         dimensions: { dataType: 'any' },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2590,6 +2590,7 @@
                     },
                     "filters": {
                         "properties": {
+                            "tableCalculations": {},
                             "metrics": {},
                             "dimensions": {}
                         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2590,7 +2590,6 @@
                     },
                     "filters": {
                         "properties": {
-                            "tableCalculations": {},
                             "metrics": {},
                             "dimensions": {}
                         },
@@ -5401,7 +5400,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.875.0",
+        "version": "0.875.2",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -7287,6 +7286,60 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
+                                    "invalidateCache": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/saved/{chartUuid}/chart-and-results": {
+            "post": {
+                "operationId": "postChartResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRunQueryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Charts"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "chartUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
                                     "dashboardSorts": {
                                         "items": {
                                             "$ref": "#/components/schemas/SortField"
@@ -7298,6 +7351,10 @@
                                     },
                                     "dashboardFilters": {}
                                 },
+                                "required": [
+                                    "dashboardSorts",
+                                    "dashboardFilters"
+                                ],
                                 "type": "object"
                             }
                         }

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -215,7 +215,7 @@ describe('Lightdash API tests for member user with admin project permissions', (
         );
     });
 
-    it('Should get success response (200) from POST chart results with filters', () => {
+    it('Should get success response (200) from POST chart-and-results with filters', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
@@ -224,7 +224,7 @@ describe('Lightdash API tests for member user with admin project permissions', (
                 const savedChartUuid = spacesResponse.body.results.find(
                     (space) => space.queries.length > 0,
                 ).queries[0].uuid;
-                const endpoint = `/saved/${savedChartUuid}/results`;
+                const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
@@ -879,7 +879,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         );
     });
 
-    it('Should get success response (200) from POST chart results with filters', () => {
+    it('Should get success response (200) from POST chart-and-results with filters', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
@@ -888,7 +888,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
                 const savedChartUuid = spacesResponse.body.results.find(
                     (space) => space.queries.length > 0,
                 ).queries[0].uuid;
-                const endpoint = `/saved/${savedChartUuid}/results`;
+                const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },
@@ -1133,7 +1133,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         );
     });
 
-    it('Should get success response (200) from POST chart results with filters', () => {
+    it('Should get success response (200) from POST chart-and-results with filters', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
@@ -1142,7 +1142,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
                 const savedChartUuid = spacesResponse.body.results.find(
                     (space) => space.queries.length > 0,
                 ).queries[0].uuid;
-                const endpoint = `/saved/${savedChartUuid}/results`;
+                const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
                     headers: { 'Content-type': 'application/json' },

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -235,6 +235,7 @@ describe('Lightdash API tests for member user with admin project permissions', (
                             dimensions: [],
                             tableCalculations: [],
                         },
+                        dashboardSorts: [],
                     },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
@@ -899,6 +900,7 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
                             dimensions: [],
                             tableCalculations: [],
                         },
+                        dashboardSorts: [],
                     },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);
@@ -1153,6 +1155,7 @@ describe('Lightdash API tests for member user with viewer project permissions', 
                             dimensions: [],
                             tableCalculations: [],
                         },
+                        dashboardSorts: [],
                     },
                 }).then((resp) => {
                     expect(resp.status).to.eq(200);

--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -1,5 +1,5 @@
 import { useDashboardContext } from '../../providers/DashboardProvider';
-import { useChartResults } from '../useQueryResults';
+import { useChartAndResults } from '../useQueryResults';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 const useDashboardChart = (tileUuid: string, savedChartUuid: string | null) => {
@@ -7,7 +7,7 @@ const useDashboardChart = (tileUuid: string, savedChartUuid: string | null) => {
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const chartSort = useDashboardContext((c) => c.chartSort);
     const tileSort = chartSort[tileUuid] || [];
-    return useChartResults(
+    return useChartAndResults(
         savedChartUuid,
         dashboardFilters,
         tileSort,

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -26,8 +26,24 @@ type QueryResultsProps = {
     chartUuid?: string;
 };
 
-// This API call will be used for getting charts in view mode and dashboard tiles
 const getChartResults = async ({
+    chartUuid,
+    invalidateCache,
+}: {
+    chartUuid?: string;
+    invalidateCache?: boolean;
+    dashboardSorts?: SortField[];
+}) => {
+    return lightdashApi<ApiQueryResults>({
+        url: `/saved/${chartUuid}/results`,
+        method: 'POST',
+        body: JSON.stringify({
+            ...(invalidateCache && { invalidateCache: true }),
+        }),
+    });
+};
+
+const getChartAndResults = async ({
     chartUuid,
     dashboardFilters,
     invalidateCache,
@@ -39,7 +55,7 @@ const getChartResults = async ({
     dashboardSorts?: SortField[];
 }) => {
     return lightdashApi<ApiChartAndResults>({
-        url: `/saved/${chartUuid}/results`,
+        url: `/saved/${chartUuid}/chart-and-results`,
         method: 'POST',
         body: JSON.stringify({
             dashboardFilters,
@@ -175,8 +191,7 @@ export const useUnderlyingDataResults = (
     });
 };
 
-// This hook will be used for getting charts in view mode and dashboard tiles
-export const useChartResults = (
+export const useChartAndResults = (
     chartUuid: string | null,
     dashboardFilters?: DashboardFilters,
     dashboardSorts?: SortField[],
@@ -199,7 +214,7 @@ export const useChartResults = (
     return useQuery<ApiChartAndResults, ApiError>({
         queryKey,
         queryFn: () =>
-            getChartResults({
+            getChartAndResults({
                 chartUuid: chartUuid!,
                 dashboardFilters: timezoneFixFilters,
                 invalidateCache,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

The `/results` endpoint was being used for the dashboard page and the chart page in view mode.
This was causing a few issues:
- increasing logic and params to handle both scenarios 
- since we stopped fetching the chart separately on the dashboard page, we stopped counting chart views (#8067)
  - this will be fixed in following PR 
 
Now we have
`/results` used by chart page in view mode
`/chart-and-results` used by dashboard page

Even though most of the service code is similar, it is now simpler and easier to keep diverging logic between them. eg: count for chart view in `/chart-and-results` 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
