### PR TITLE
chore: enable posthog on backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -96,6 +96,7 @@
         "pdf-lib": "^1.17.1",
         "pg": "^8.11.3",
         "pg-connection-string": "^2.5.0",
+        "posthog-node": "^3.1.3",
         "puppeteer": "^21.3.1",
         "redoc-express": "^1.0.0",
         "simple-git": "^3.16.0",

--- a/packages/backend/src/analytics/client.ts
+++ b/packages/backend/src/analytics/client.ts
@@ -32,11 +32,35 @@ export const identifyUser = (
                   is_marketing_opted_in: user.isMarketingOptedIn,
               },
     });
+
+    postHogClient.identify({
+        distinctId: user.userUuid,
+        properties: {
+            uuid: user.userUuid,
+            ...(user.isTrackingAnonymized
+                ? {}
+                : {
+                      email: user.email,
+                      first_name: user.firstName,
+                      last_name: user.lastName,
+                  }),
+        },
+    });
+
     if (user.organizationUuid) {
         analytics.group({
             userId: user.userUuid,
             groupId: user.organizationUuid,
             traits: {
+                name: user.organizationName,
+            },
+        });
+
+        postHogClient.groupIdentify({
+            groupType: 'organization',
+            groupKey: 'organization',
+            properties: {
+                uuid: user.organizationUuid,
                 name: user.organizationName,
             },
         });

--- a/packages/backend/src/analytics/client.ts
+++ b/packages/backend/src/analytics/client.ts
@@ -1,5 +1,6 @@
 import { LightdashMode, LightdashUser } from '@lightdash/common';
 import { lightdashConfig } from '../config/lightdashConfig';
+import { postHogClient } from '../postHog';
 import { LightdashAnalytics } from './LightdashAnalytics';
 
 export const analytics: LightdashAnalytics = new LightdashAnalytics(

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -41,7 +41,7 @@ import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import { VERSION } from './version';
 import { registerNodeMetrics } from './nodeMetrics';
 import { wrapOtelSpan } from './utils';
-import { postHogClient } from './posthog';
+import { postHogClient } from './postHog';
 
 // @ts-ignore
 // eslint-disable-next-line no-extend-native, func-names

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -281,30 +281,6 @@ passport.deserializeUser(async (id: string, done) => {
         const user = await wrapOtelSpan('Passport.deserializeUser', {}, () =>
             userModel.findSessionUserByUUID(id),
         );
-
-        postHogClient.identify({
-            distinctId: user.userUuid,
-            properties: {
-                uuid: user.userUuid,
-                ...(user.isTrackingAnonymized
-                    ? {}
-                    : {
-                          email: user.email,
-                          first_name: user.firstName,
-                          last_name: user.lastName,
-                      }),
-            },
-        });
-
-        postHogClient.groupIdentify({
-            groupType: 'organization',
-            groupKey: 'organization',
-            properties: {
-                uuid: user.organizationUuid,
-                name: user.organizationName,
-            },
-        });
-
         // Store that user on the request (`req`) object
         done(null, user);
     } catch (e) {

--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -1,0 +1,9 @@
+import { PostHog } from 'posthog-node';
+import { lightdashConfig } from './config/lightdashConfig';
+
+export const postHogClient = new PostHog(
+    lightdashConfig.posthog.projectApiKey,
+    {
+        host: lightdashConfig.posthog.apiHost,
+    },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7383,6 +7383,15 @@ axios@^1.5.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz"
@@ -16216,6 +16225,14 @@ posthog-js@^1.88.3:
   dependencies:
     fflate "^0.4.1"
 
+posthog-node@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-3.1.3.tgz#9c5c3dbe3360a5983a81fea2e093e5a7cdde6219"
+  integrity sha512-UaOOoWEUYTcaaDe1w0fgHW/sXvFr3RO0l7yI7RUDzkZNZCfwXNO9r3pc14d1EtNppF/SHBrV5hNiZZATpf/vUw==
+  dependencies:
+    axios "^1.6.0"
+    rusha "^0.8.14"
+
 precinct@^9.0.0:
   version "9.2.1"
   resolved "https://registry.npmjs.org/precinct/-/precinct-9.2.1.tgz"
@@ -17600,6 +17617,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rusha@^0.8.14:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/rusha/-/rusha-0.8.14.tgz#a977d0de9428406138b7bb90d3de5dcd024e2f68"
+  integrity sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==
 
 rw@1:
   version "1.3.3"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Adds `node-posthog` (followed this: https://posthog.com/docs/libraries/node)

Instantiates new PostHog client on the server; 
Identifies the user and group (same way we do in: https://github.com/lightdash/lightdash/blob/chore/enable-posthog-usage-on-backend/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx#L12)
Shuts down `onExit`

Example: 
```ts
  const isFeatureEnabled = await postHogClient.isFeatureEnabled(
            'date-zoom',
            user.userId.toString(),
        );
```
<img width="644" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/075254a2-0516-4233-bbb4-98b29e97aa1f">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
