### PR TITLE
fix: replace wrong function name call

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -24,8 +24,8 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     );
 
     useEffect(() => {
-        if (isEditMode) setDateGranularity(undefined);
-    }, [isEditMode]);
+        if (isEditMode) setDateZoomGranularity(undefined);
+    }, [isEditMode, setDateZoomGranularity]);
 
     return (
         <Menu


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After some merges, forgot to replace the function call `setDateGranularity` with the correct one: `setDateZoomGranularity`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
