### PR TITLE
fix: add missing tableCalculations type property

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2262,6 +2262,7 @@ const models: TsoaRoute.Models = {
                 filters: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        tableCalculations: { dataType: 'any' },
                         metrics: { dataType: 'any' },
                         dimensions: { dataType: 'any' },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2590,6 +2590,7 @@
                     },
                     "filters": {
                         "properties": {
+                            "tableCalculations": {},
                             "metrics": {},
                             "dimensions": {}
                         },
@@ -5400,7 +5401,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.873.4",
+        "version": "0.875.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -131,6 +131,7 @@ export type MetricQueryRequest = {
     filters: {
         dimensions?: any;
         metrics?: any;
+        tableCalculations?: any;
     };
     sorts: SortField[]; // Sorts for the data
     limit: number; // Max number of rows to return from query


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

There's a missing `tableCalculations` property that `MetricQueryRequest` could take in the `filters` property. 

I think this came from work on table calculations + filters, but yea, all good now

Error before: 
```ts 
{
    "status": "error",
    "error": {
        "statusCode": 422,
        "name": "ValidateError",
        "message": "",
        "data": {
            "body.filters": {
                "message": "\"tableCalculations\" is an excess property and therefore is not allowed",
                "value": {
                    "tableCalculations": {
                        "id": "c8cb4287-c5a1-4c8d-baf3-e84a1288e461",
                        "and": []
                    }
                }
            }
        }
    }
}
```

You can test by: 
* adding a saved filter to a dashboard
* applying a filter that affects a chart
* `Explore from here` on that chart that has a dsahboard filter applied

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
