### PR TITLE
chore: improve command to generate API docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
         "build-published-packages": "run-s common-build warehouses-build cli-build",
         "start": "run-p backend-start",
         "prepare": "husky install",
-        "load:env": "dotenv -c -e .env.development.local"
+        "load:env": "dotenv -c -e .env.development.local",
+        "generate-api": "yarn common-build && yarn workspace backend generate-api && yarn workspace backend formatter --write ./src/generated"
     },
     "lint-staged": {
         "packages/frontend/src/**/*.(ts|tsx|json|css)": [

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -41,7 +41,7 @@ Controllers are responsible for handling the request and response from the API. 
 be as thin as possible, delegating the business logic to services.
 
 When making changes to a controller or the types used in a controller, you should also generate the
-corresponding HOA files. You can do it by running `yarn workspace backend generate-api`.
+corresponding HOA files. You can do it by running `yarn generate-api`.
 
 Guidelines:
 

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5401,7 +5401,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.875.0",
+        "version": "0.875.2",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

There were some problems when rebasing where generating the API docs without compiling the common package where most types are.

The new command builds common + generates API + formats generated files


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
