### PR TITLE
fix: add undefined value to posthog if no key

### DIFF
--- a/packages/backend/src/analytics/client.ts
+++ b/packages/backend/src/analytics/client.ts
@@ -34,7 +34,7 @@ export const identifyUser = (
               },
     });
 
-    postHogClient.identify({
+    postHogClient?.identify({
         distinctId: user.userUuid,
         properties: {
             uuid: user.userUuid,
@@ -57,7 +57,7 @@ export const identifyUser = (
             },
         });
 
-        postHogClient.groupIdentify({
+        postHogClient?.groupIdentify({
             groupType: 'organization',
             groupKey: 'organization',
             properties: {

--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -1,9 +1,8 @@
 import { PostHog } from 'posthog-node';
 import { lightdashConfig } from './config/lightdashConfig';
 
-export const postHogClient = new PostHog(
-    lightdashConfig.posthog.projectApiKey,
-    {
-        host: lightdashConfig.posthog.apiHost,
-    },
-);
+export const postHogClient = lightdashConfig.posthog.projectApiKey
+    ? new PostHog(lightdashConfig.posthog.projectApiKey, {
+          host: lightdashConfig.posthog.apiHost,
+      })
+    : undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Allow PostHog client to be undefined if no `projectApiKey` provided. No need to check for `apiHost` because it's got a default of: `'https://app.posthog.com'`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
