### PR TITLE
chore: remove ToastSpinner

### DIFF
--- a/packages/frontend/src/components/ToastSpinner/index.ts
+++ b/packages/frontend/src/components/ToastSpinner/index.ts
@@ -1,9 +1,0 @@
-import { Spinner } from '@blueprintjs/core';
-import styled from 'styled-components';
-
-export const ToastSpinner = styled(Spinner)`
-    margin-left: 12px;
-    margin-bottom: 12px;
-    margin-top: 12px;
-    vertical-align: text-bottom;
-`;

--- a/packages/frontend/src/providers/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJobProvider.tsx
@@ -1,5 +1,5 @@
-import { SpinnerSize } from '@blueprintjs/core';
 import { ApiError, Job, JobStatusType, JobType } from '@lightdash/common';
+import { Loader } from '@mantine/core';
 import React, {
     createContext,
     Dispatch,
@@ -12,7 +12,6 @@ import React, {
 } from 'react';
 import { useQueryClient } from 'react-query';
 import { AppToaster } from '../components/AppToaster';
-import { ToastSpinner } from '../components/ToastSpinner';
 import useToaster from '../hooks/toaster/useToaster';
 import {
     jobStatusLabel,
@@ -64,7 +63,7 @@ export const ActiveJobProvider: FC = ({ children }) => {
                                 ? runningStepsInfo(job?.steps)
                                       .runningStepMessage
                                 : '',
-                            icon: <ToastSpinner size={SpinnerSize.SMALL} />,
+                            icon: <Loader size="sm" mt="xs" ml="xs" />,
                             timeout: 0,
                             action: {
                                 text: 'View log',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Remove ToastSpinner and replace it's usage with Mantine. Refreshing dbt is a good way to test this. It appears in the toast. 

Before (blueprint)
<img width="334" alt="Screenshot 2023-11-27 at 09 36 45" src="https://github.com/lightdash/lightdash/assets/1864179/61819431-1e7e-4370-9561-c9f6dd554c9a">

After 🎉 
<img width="343" alt="Screenshot 2023-11-27 at 09 36 26" src="https://github.com/lightdash/lightdash/assets/1864179/5d50282e-4c86-4f0e-b9c1-2b12abedf1b9">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
