### PR TITLE
feat: add filter data to scheduler events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -659,6 +659,12 @@ export type SchedulerUpsertEvent = BaseTrack & {
     };
 };
 
+export type SchedulerDashboardUpsertEvent = SchedulerUpsertEvent & {
+    properties: SchedulerUpsertEvent['properties'] & {
+        filtersUpdatedNum: number;
+    };
+};
+
 export type SchedulerDeleteEvent = BaseTrack & {
     event: 'scheduler.deleted';
     userId: string;

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -29,6 +29,7 @@ import { analytics } from '../../analytics/client';
 import {
     ConditionalFormattingRuleSavedEvent,
     CreateSavedChartVersionEvent,
+    SchedulerUpsertEvent,
 } from '../../analytics/LightdashAnalytics';
 import { schedulerClient, slackClient } from '../../clients/clients';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
@@ -640,7 +641,7 @@ export class SavedChartService {
             dashboardUuid: null,
             savedChartUuid: chartUuid,
         });
-        analytics.track({
+        const createSchedulerEventData: SchedulerUpsertEvent = {
             userId: user.userUuid,
             event: 'scheduler.created',
             properties: {
@@ -664,7 +665,8 @@ export class SavedChartService {
                         ? []
                         : scheduler.targets.map(getSchedulerTargetType),
             },
-        });
+        };
+        analytics.track(createSchedulerEventData);
 
         await slackClient.joinChannels(
             user.organizationUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7397

### Description:
Add `filtersUpdatedNum` to: 
* `scheduler.created`
* `scheduler.updated`

Also, type event data objects with the already created types.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
