### PR TITLE
fix: dont crash when column name contains a dot

### DIFF
--- a/packages/frontend/src/hooks/useSqlRunnerColumns.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerColumns.ts
@@ -32,9 +32,16 @@ const useSqlRunnerColumns = ({
                             ? columnHeader(dimension)
                             : dimension.label,
                     cell: (info) => {
-                        const {
-                            value: { raw },
-                        } = info.getValue();
+                        let raw;
+                        try {
+                            raw = info.getValue().value.raw;
+                        } catch {
+                            console.error(
+                                'Error getting cell data for field',
+                                fieldId,
+                            );
+                            return 'Error';
+                        }
                         if (raw === null) return '∅';
                         if (raw === undefined) return '-';
                         if (raw instanceof Date) return raw.toISOString();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

When a column name in the SQL runner contains a dot, the front end crashes. This fixes the crash by catching the error and logging the error. We could do more to handle this case, but I wasn't sure the best approach to fixing the underlying problem and fixing the crash is necessary anyway. With this change a field that has an error will show the string 'Error' in the table and log in the console. I hadn't put 'Error' in the results at first, but almost anything else could be misleading -- I wan't to make sure they know they aren't seeing data. 

The real problem here is that when there is a `.` in a field name, we use a fieldId to reference the column, which removes the dot. But the data still has the original field ID, so when the table tries to reference it, it fails. I'm not sure the best fix and since it's a bit of an edge-case with good workarounds, I left the rest of the behavior as is. I filed a ticket: https://github.com/lightdash/lightdash/issues/8113

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
