### PR TITLE
chore: move some dashboard buttons to mantine

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,4 +1,3 @@
-import { PopoverPosition } from '@blueprintjs/core';
 import { Dashboard, DashboardTileTypes } from '@lightdash/common';
 import { Button, ButtonProps, Group, Menu, Text, Tooltip } from '@mantine/core';
 import {
@@ -18,7 +17,6 @@ import { TileAddModal } from './TileForms/TileAddModal';
 
 type Props = {
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
-    popoverPosition?: PopoverPosition;
 } & Pick<ButtonProps, 'disabled'>;
 
 const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {

--- a/packages/frontend/src/components/DownloadCsvButton/index.tsx
+++ b/packages/frontend/src/components/DownloadCsvButton/index.tsx
@@ -1,9 +1,11 @@
-import { Button } from '@blueprintjs/core';
 import { ApiScheduledDownloadCsv } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconTableExport } from '@tabler/icons-react';
 import { FC, memo } from 'react';
 import { pollCsvFileUrl } from '../../api/csv';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
+import MantineIcon from '../common/MantineIcon';
 
 type Props = {
     disabled: boolean;
@@ -16,8 +18,9 @@ const DownloadCsvButton: FC<Props> = memo(({ disabled, getCsvLink }) => {
 
     return (
         <Button
-            intent="primary"
-            icon="export"
+            compact
+            variant="subtle"
+            leftIcon={<MantineIcon icon={IconTableExport} />}
             disabled={disabled}
             onClick={() => {
                 getCsvLink()

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -346,12 +346,7 @@ const UnderlyingDataModalContent: FC<Props> = () => {
                         projectUuid: projectUuid,
                     })}
                 >
-                    <LinkButton
-                        intent="primary"
-                        href={exploreFromHereUrl}
-                        icon="series-search"
-                        forceRefresh
-                    >
+                    <LinkButton href={exploreFromHereUrl} forceRefresh>
                         Explore from here
                     </LinkButton>
                 </Can>

--- a/packages/frontend/src/components/common/LinkButton.tsx
+++ b/packages/frontend/src/components/common/LinkButton.tsx
@@ -1,13 +1,16 @@
-import { AnchorButton, AnchorButtonProps } from '@blueprintjs/core';
+import { Button, ButtonProps } from '@mantine/core';
+import { IconTelescope } from '@tabler/icons-react';
 import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { EventData, useTracking } from '../../providers/TrackingProvider';
+import MantineIcon from './MantineIcon';
 
-export interface LinkButtonProps extends AnchorButtonProps {
+export interface LinkButtonProps extends ButtonProps {
     href: string;
     trackingEvent?: EventData;
     target?: React.HTMLAttributeAnchorTarget;
     forceRefresh?: boolean;
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }
 
 const LinkButton: FC<LinkButtonProps> = ({
@@ -22,9 +25,13 @@ const LinkButton: FC<LinkButtonProps> = ({
     const { track } = useTracking();
 
     return (
-        <AnchorButton
+        <Button
             {...rest}
+            component="a"
+            compact
+            variant="subtle"
             href={href}
+            leftIcon={<MantineIcon icon={IconTelescope} />}
             target={target}
             onClick={(e) => {
                 if (


### PR DESCRIPTION
### Description:

Small mantine migrations:
- Remove unused PopoverPosition
- Move the underlying data modal buttons to mantine. Make them not primary. 

Buttons before
<img width="446" alt="Screenshot 2023-11-27 at 15 45 40" src="https://github.com/lightdash/lightdash/assets/1864179/51ab6d9d-fe29-4415-9c4c-1fccb2f64518">

Buttons after
<img width="428" alt="Screenshot 2023-11-27 at 15 56 52" src="https://github.com/lightdash/lightdash/assets/1864179/d5b94dae-f155-4b84-a8d4-19c72ecbb9db">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
