### PR TITLE
fix: update refresh dbt button tooltip styles

### DIFF
--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -146,6 +146,9 @@ const RefreshDbtButton = () => {
     return (
         <Tooltip
             withinPortal
+            multiline
+            w={320}
+            position="bottom"
             label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
         >
             <Button


### PR DESCRIPTION
### Description:

Updates the refresh dbt button tooltip style

Before:
<img width="768" alt="Screenshot 2023-11-27 at 10 07 57" src="https://github.com/lightdash/lightdash/assets/1864179/88634689-8172-40d4-9259-0301503e3318">

After:
<img width="483" alt="Screenshot 2023-11-27 at 16 26 31" src="https://github.com/lightdash/lightdash/assets/1864179/f5692589-7d88-4527-a512-338cda03d5e3">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
