### PR TITLE
fix: date zoom on table calcs

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -881,6 +881,7 @@ export class ProjectService {
 
             if (timeDimension) {
                 const { baseDimensionId } = getDateDimension(timeDimension);
+                if (!baseDimensionId) return { metricQuery };
 
                 const newTimeDimension = `${baseDimensionId}_${granularity.toLowerCase()}`;
 
@@ -907,6 +908,8 @@ export class ProjectService {
                                 if (!dim) return tc;
 
                                 const baseDim = getDateDimension(dim.name);
+                                if (!baseDim) return tc;
+
                                 const oldDimension = `${dim.table}.${dim.name}`;
                                 // Rebuild the newDimension instead of looking at dimensions,
                                 // so we can even filter missing time frames from explore

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -898,6 +898,31 @@ export class ProjectService {
                                 ? { ...sort, fieldId: newTimeDimension }
                                 : sort,
                         ),
+                        tableCalculations: metricQuery.tableCalculations.map(
+                            (tc) => {
+                                const dim = dimensions.find(
+                                    (d) => getFieldId(d) === timeDimension,
+                                );
+
+                                if (!dim) return tc;
+
+                                const baseDim = getDateDimension(dim.name);
+                                const oldDimension = `${dim.table}.${dim.name}`;
+                                // Rebuild the newDimension instead of looking at dimensions,
+                                // so we can even filter missing time frames from explore
+                                const newDimension = `${dim.table}.${
+                                    baseDim.baseDimensionId
+                                }_${granularity.toLowerCase()}`;
+
+                                return {
+                                    ...tc,
+                                    sql: tc.sql.replaceAll(
+                                        oldDimension,
+                                        newDimension,
+                                    ),
+                                };
+                            },
+                        ),
                     },
                     oldDimension: timeDimension,
                     newDimension: newTimeDimension,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#8104](https://github.com/lightdash/lightdash/issues/8104)

### How to test

Create a chat with a date on table calculation, like this 

```
SUM(${orders.unique_order_count})
OVER(ORDER BY ${orders.order_date_day})
```

Then add it to the filter and change the time zoom

This should also work with missing frames (eg: quarter) 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2023-11-28 10-18-11](https://github.com/lightdash/lightdash/assets/1983672/d6b841fa-b67d-4212-b5be-143325e59f0d)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
