### PR TITLE
docs: add missing import paths to gh secrets

### DIFF
--- a/docs/docs/guides/cli/how-to-use-lightdash-preview.mdx
+++ b/docs/docs/guides/cli/how-to-use-lightdash-preview.mdx
@@ -1,4 +1,5 @@
 import AutomaticallyDeployChangesGithub from './../../snippets/github-secrets.mdx';
+import GithubSecrets from '../../snippets/github-secrets.mdx';
 
 # Lightdash Preview
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Add import to `GithubSecrets` snippet. It wasn't showing before in https://docs.lightdash.com/guides/cli/how-to-use-lightdash-preview#step-1-add-the-credentials-to-github-secrets after `If you haven't already set up a GitHub action for Lightdash, you'll need to add some secrets to GitHub. If you already have a GitHub action for Lightdash, then you can use the same Lightdash secrets you created for your other action.`


Now, it is rendered:
<img width="1106" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/4c473388-2ca2-4303-a888-839fcecd61af">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
