### PR TITLE
feat: --skip-dbt-compile

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -33,7 +33,6 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     vars: string | undefined;
     verbose: boolean;
     startOfWeek?: number;
-    skipDbtCompile?: boolean;
 };
 
 export const compile = async (options: CompileHandlerOptions) => {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -33,6 +33,7 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     vars: string | undefined;
     verbose: boolean;
     startOfWeek?: number;
+    skipDbtCompile?: boolean;
 };
 
 export const compile = async (options: CompileHandlerOptions) => {
@@ -66,7 +67,11 @@ export const compile = async (options: CompileHandlerOptions) => {
             }
         }
     }
-    await dbtCompile(options);
+
+    // Skipping assumes manifest.json already exists.
+    if (!options.skipDbtCompile) {
+        await dbtCompile(options);
+    }
 
     const absoluteProjectPath = path.resolve(options.projectDir);
     const absoluteProfilesPath = path.resolve(options.profilesDir);

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -16,6 +16,7 @@ export type DbtCompileOptions = {
     selector: string | undefined;
     state: string | undefined;
     fullRefresh: boolean | undefined;
+    skipDbtCompile: boolean | undefined;
 };
 
 const dbtCompileArgs = [

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -29,6 +29,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     verbose: boolean;
     ignoreErrors: boolean;
     startOfWeek?: number;
+    skipDbtCompile?: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -29,7 +29,6 @@ type DeployHandlerOptions = DbtCompileOptions & {
     verbose: boolean;
     ignoreErrors: boolean;
     startOfWeek?: number;
-    skipDbtCompile?: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -427,6 +427,11 @@ program
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
         parseStartOfWeekArgument,
     )
+    .option(
+        '--skip-dbt-compile',
+        'Skip `dbt compile` and deploy from the existing ./target/manifest.json',
+        false,
+    )
     .action(deployHandler);
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -322,6 +322,11 @@ program
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
         parseStartOfWeekArgument,
     )
+    .option(
+        '--skip-dbt-compile',
+        'Skip `dbt compile` and deploy from the existing ./target/manifest.json',
+        false,
+    )
     .action(previewHandler);
 
 program
@@ -367,6 +372,11 @@ program
         '--start-of-week <number>',
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
         parseStartOfWeekArgument,
+    )
+    .option(
+        '--skip-dbt-compile',
+        'Skip `dbt compile` and deploy from the existing ./target/manifest.json',
+        false,
     )
     .action(startPreviewHandler);
 
@@ -487,6 +497,11 @@ program
     .option('--state <state>')
     .option('--full-refresh')
     .option('--verbose', undefined, false)
+    .option(
+        '--skip-dbt-compile',
+        'Skip `dbt compile` and deploy from the existing ./target/manifest.json',
+        false,
+    )
     .action(validateHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [7194](https://github.com/lightdash/lightdash/issues/7194).

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

This PR allows running `lightdash deploy` `lightdash validate`, `lightdash preview` and `lightdash start-preview` with the `--skip-dbt-compile` flag to perform the command without running `dbt compile` first, instead expecting an existing `./target/manifest.json` from which to build the Lightdash explores. 

This can be handy for teams running complex CI/CD workflows with dbt, to take advantage of already created artifacts.

<!-- Even better add a screenshot / gif / loom -->
<img width="773" alt="Screenshot 2023-11-30 at 12 40 23 PM" src="https://github.com/lightdash/lightdash/assets/17347282/f268bfbe-fed1-45b1-b4f7-4b7ee23edb92">
<img width="776" alt="Screenshot 2023-11-30 at 12 45 45 PM" src="https://github.com/lightdash/lightdash/assets/17347282/0acebbc2-a19e-4421-bb0f-e3cd3d968202">
<img width="762" alt="Screenshot 2023-11-30 at 12 47 09 PM" src="https://github.com/lightdash/lightdash/assets/17347282/84ce5e4a-c613-44ce-86b1-cec4e9d2dc62">

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
