### PR TITLE
fix: remove extra tooltip on dashboard title

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -91,7 +91,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
                     >
                         <Tooltip
-                            disabled={!description || !!titleLeftIcon}
+                            disabled={!description}
                             label={description}
                             multiline
                             position="top-start"
@@ -101,34 +101,24 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             <TitleWrapper $hovered={titleHovered}>
                                 <Group spacing="xs">
                                     {titleLeftIcon}
-                                    <Tooltip
-                                        disabled={
-                                            !description || !titleLeftIcon
-                                        }
-                                        label={description}
-                                        multiline
-                                        position="top-start"
-                                        withinPortal
-                                        maw={400}
-                                    >
-                                        {!hideTitle ? (
-                                            belongsToDashboard ? (
-                                                <Text fw={600} size="md">
-                                                    {title}
-                                                </Text>
-                                            ) : (
-                                                <TileTitleLink
-                                                    ref={titleRef}
-                                                    href={titleHref}
-                                                    $hovered={titleHovered}
-                                                    target="_blank"
-                                                    className="non-draggable"
-                                                >
-                                                    {title}
-                                                </TileTitleLink>
-                                            )
-                                        ) : null}
-                                    </Tooltip>
+
+                                    {!hideTitle ? (
+                                        belongsToDashboard ? (
+                                            <Text fw={600} size="md">
+                                                {title}
+                                            </Text>
+                                        ) : (
+                                            <TileTitleLink
+                                                ref={titleRef}
+                                                href={titleHref}
+                                                $hovered={titleHovered}
+                                                target="_blank"
+                                                className="non-draggable"
+                                            >
+                                                {title}
+                                            </TileTitleLink>
+                                        )
+                                    ) : null}
                                 </Group>
                             </TitleWrapper>
                         </Tooltip>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Dashboards don't load when there's 2 tooltips (one nested) and when one is `disabled` when the other isn't.

Removing the extra tooltip that was to fix this: https://github.com/lightdash/lightdash/pull/8144#issuecomment-1831969506 
But will work on a different solution on another PR.

error for reference: 

![image](https://github.com/lightdash/lightdash/assets/7611706/977961a5-b0e8-427c-bae6-e36fead1cd05)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
