### PR TITLE
refactor: expose items map in cartesian visualization

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -1,8 +1,7 @@
 import {
-    Field,
     getItemLabel,
     getItemLabelWithoutTableName,
-    TableCalculation,
+    ItemsMap,
 } from '@lightdash/common';
 import { google, sheets_v4 } from 'googleapis';
 import { lightdashConfig } from '../../config/lightdashConfig';
@@ -199,7 +198,7 @@ export class GoogleDriveClient {
         refreshToken: string,
         fileId: string,
         csvContent: Record<string, string>[],
-        itemMap: Record<string, Field | TableCalculation>,
+        itemMap: ItemsMap,
         showTableNames: boolean,
 
         tabName?: string,

--- a/packages/backend/src/services/CsvService/CsvService.mock.ts
+++ b/packages/backend/src/services/CsvService/CsvService.mock.ts
@@ -1,10 +1,4 @@
-import {
-    Field,
-    FieldType,
-    Format,
-    MetricQuery,
-    TableCalculation,
-} from '@lightdash/common';
+import { FieldType, Format, ItemsMap, MetricQuery } from '@lightdash/common';
 
 export const metricQuery: MetricQuery = {
     dimensions: ['column_number', 'column_date'],
@@ -23,7 +17,7 @@ export const metricQuery: MetricQuery = {
     additionalMetrics: [],
 };
 
-export const itemMap: Record<string, Field | TableCalculation> = {
+export const itemMap: ItemsMap = {
     column_number: {
         name: 'column_number',
         table: 'table',
@@ -44,10 +38,10 @@ export const itemMap: Record<string, Field | TableCalculation> = {
     column_date: {
         name: 'column_date',
         type: 'date',
-        displayName: 'column date',
+        hidden: false,
+        table: 'table',
         tableLabel: 'table',
         label: 'column date',
-
         fieldType: FieldType.DIMENSION,
         sql: '${TABLE}.column_date',
     },

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -7,7 +7,6 @@ import {
     DimensionType,
     DownloadCsvPayload,
     DownloadMetricCsv,
-    Field,
     ForbiddenError,
     formatItemValue,
     friendlyName,
@@ -22,12 +21,12 @@ import {
     isField,
     isMomentInput,
     isTableChartConfig,
+    ItemsMap,
     MetricQuery,
     SchedulerCsvOptions,
     SchedulerFilterRule,
     SchedulerFormat,
     SessionUser,
-    TableCalculation,
 } from '@lightdash/common';
 
 import { stringify } from 'csv-stringify';
@@ -160,7 +159,7 @@ export class CsvService {
 
     static convertRowToCsv(
         row: Record<string, any>,
-        itemMap: Record<string, Field | TableCalculation>,
+        itemMap: ItemsMap,
         onlyRaw: boolean,
         sortedFieldIds: string[],
     ) {
@@ -208,7 +207,7 @@ export class CsvService {
         rows: Record<string, any>[],
         onlyRaw: boolean,
         metricQuery: MetricQuery,
-        itemMap: Record<string, Field | TableCalculation>,
+        itemMap: ItemsMap,
         showTableNames: boolean,
         fileName: string,
         truncated: boolean,

--- a/packages/backend/src/services/ProjectService/formatRows.ts
+++ b/packages/backend/src/services/ProjectService/formatRows.ts
@@ -1,9 +1,14 @@
-import { Field, formatRows, TableCalculation } from '@lightdash/common';
+import {
+    Field,
+    formatRows,
+    ItemsMap,
+    TableCalculation,
+} from '@lightdash/common';
 import { parentPort, workerData } from 'worker_threads';
 
 type Args = {
     rows: Record<string, any>[];
-    itemMap: Record<string, Field | TableCalculation>;
+    itemMap: ItemsMap;
 };
 
 function run() {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -710,9 +710,7 @@ export const getResultValueArray = (
         }, {}),
     );
 
-export const getDateGroupLabel = (
-    axisItem: Field | TableCalculation | CustomDimension,
-) => {
+export const getDateGroupLabel = (axisItem: ItemsMap[string]) => {
     if (
         isDimension(axisItem) &&
         [DimensionType.DATE, DimensionType.TIMESTAMP].includes(axisItem.type) &&

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,6 +12,7 @@ import {
     CompiledField,
     CompiledMetric,
     CustomDimension,
+    Dimension,
     DimensionType,
     Field,
     FieldId,
@@ -26,6 +27,7 @@ import {
     AdditionalMetric,
     getCustomDimensionId,
     isAdditionalMetric,
+    isCustomDimension,
     MetricQuery,
 } from './types/metricQuery';
 import {
@@ -728,7 +730,7 @@ export const getAxisName = ({
     axisIndex,
     axisName,
     series,
-    items,
+    itemsMap,
 }: {
     isAxisTheSameForAllSeries: boolean;
     selectedAxisIndex: number;
@@ -736,12 +738,11 @@ export const getAxisName = ({
     axisIndex: number;
     axisName?: string;
     series?: Series[];
-    items: Array<Field | TableCalculation | CustomDimension>;
+    itemsMap: ItemsMap | undefined;
 }): string | undefined => {
-    const defaultItem = items.find(
-        (item) =>
-            getItemId(item) === (series || [])[0]?.encode[axisReference].field,
-    );
+    const defaultItem = itemsMap
+        ? itemsMap[(series || [])[0]?.encode[axisReference].field]
+        : undefined;
     const dateGroupName = defaultItem
         ? getDateGroupLabel(defaultItem)
         : undefined;
@@ -769,12 +770,17 @@ export function getFieldMap(
     );
 }
 
+export type ItemsMap = Record<
+    string,
+    Field | TableCalculation | CustomDimension | Metric
+>;
+
 export function getItemMap(
     explore: Explore,
     additionalMetrics: AdditionalMetric[] = [],
     tableCalculations: TableCalculation[] = [],
     customDimensions: CustomDimension[] = [],
-): Record<string, Field | TableCalculation> {
+): ItemsMap {
     const convertedAdditionalMetrics = (additionalMetrics || []).reduce<
         Metric[]
     >((acc, additionalMetric) => {
@@ -802,6 +808,20 @@ export function getItemMap(
     );
 }
 
+export function getDimensionsInItemMap(
+    itemsMap: ItemsMap,
+): Record<string, Dimension | CustomDimension> {
+    return Object.values(itemsMap).reduce((acc, item) => {
+        if (isDimension(item) || isCustomDimension(item)) {
+            return {
+                ...acc,
+                [fieldId(item)]: item,
+            };
+        }
+        return acc;
+    }, {});
+}
+
 export function itemsInMetricQuery(
     metricQuery: MetricQuery | undefined,
 ): string[] {
@@ -817,13 +837,13 @@ export function itemsInMetricQuery(
 
 export function formatRows(
     rows: { [col: string]: any }[],
-    itemMap: Record<string, Field | TableCalculation>,
+    itemsMap: ItemsMap,
 ): ResultRow[] {
     return rows.map((row) =>
         Object.keys(row).reduce<ResultRow>((acc, columnName) => {
             const col = row[columnName];
 
-            const item = itemMap[columnName];
+            const item = itemsMap[columnName];
             return {
                 ...acc,
                 [columnName]: {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,7 +12,6 @@ import {
     CompiledField,
     CompiledMetric,
     CustomDimension,
-    Dimension,
     DimensionType,
     Field,
     FieldId,
@@ -27,7 +26,6 @@ import {
     AdditionalMetric,
     getCustomDimensionId,
     isAdditionalMetric,
-    isCustomDimension,
     MetricQuery,
 } from './types/metricQuery';
 import {
@@ -804,20 +802,6 @@ export function getItemMap(
         }),
         {},
     );
-}
-
-export function getDimensionsInItemMap(
-    itemsMap: ItemsMap,
-): Record<string, Dimension | CustomDimension> {
-    return Object.values(itemsMap).reduce((acc, item) => {
-        if (isDimension(item) || isCustomDimension(item)) {
-            return {
-                ...acc,
-                [fieldId(item)]: item,
-            };
-        }
-        return acc;
-    }, {});
 }
 
 export function itemsInMetricQuery(

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -1,3 +1,4 @@
+import type { ItemsMap } from '..';
 import { CompileError } from './errors';
 import { MetricFilterRule } from './filter';
 import { TimeFrames } from './timeFrames';
@@ -98,7 +99,7 @@ export interface CustomDimension {
     customRange?: BinRange[];
 }
 
-export type Item = Field | TableCalculation | CustomDimension;
+export type Item = ItemsMap[string];
 
 export enum TableCalculationFormatType {
     DEFAULT = 'default',
@@ -289,7 +290,7 @@ export type FilterableItem =
     | TableCalculationField
     | TableCalculation;
 export const isFilterableItem = (
-    item: Field | Dimension | Metric | TableCalculationField | TableCalculation,
+    item: ItemsMap[string] | TableCalculationField,
 ): item is FilterableItem =>
     isDimension(item) ? isFilterableDimension(item) : true;
 

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -1,4 +1,4 @@
-import type { ItemsMap } from '..';
+import type { AdditionalMetric, ItemsMap } from '..';
 import { CompileError } from './errors';
 import { MetricFilterRule } from './filter';
 import { TimeFrames } from './timeFrames';
@@ -249,7 +249,9 @@ export interface CompiledDimension extends Dimension {
 
 export type CompiledField = CompiledDimension | CompiledMetric;
 
-export const isDimension = (field: any): field is Dimension =>
+export const isDimension = (
+    field: ItemsMap[string] | AdditionalMetric | undefined, // NOTE: `ItemsMap converts AdditionalMetric to Metric
+): field is Dimension =>
     isField(field) && field.fieldType === FieldType.DIMENSION;
 
 export interface CompiledMetric extends Metric {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import type { ItemsMap } from '..';
 import {
     ConditionalFormattingConfig,
     ConditionalFormattingConfigWithColorRange,
@@ -12,13 +13,11 @@ import {
     ConditionalRuleLabels,
 } from '../types/conditionalRule';
 import {
-    Field,
     FilterableItem,
     Format,
     isField,
     isFilterableItem,
     isTableCalculation,
-    TableCalculation,
     TableCalculationFormatType,
 } from '../types/field';
 import { FieldTarget } from '../types/filter';
@@ -57,9 +56,7 @@ export const createConditionalFormattingConfigWithColorRange = (
     },
 });
 
-export const hasPercentageFormat = (
-    field: Field | TableCalculation | undefined,
-) => {
+export const hasPercentageFormat = (field: ItemsMap[string] | undefined) => {
     if (!field) return false;
 
     return (
@@ -71,7 +68,7 @@ export const hasPercentageFormat = (
 
 const convertFormattedValue = (
     value: unknown,
-    field: Field | TableCalculation | undefined,
+    field: ItemsMap[string] | undefined,
 ) => {
     if (!field) return value;
 
@@ -83,7 +80,7 @@ const convertFormattedValue = (
 };
 
 export const hasMatchingConditionalRules = (
-    field: Field | TableCalculation,
+    field: ItemsMap[string],
     value: unknown,
     config: ConditionalFormattingConfig | undefined,
 ) => {
@@ -145,7 +142,7 @@ export const hasMatchingConditionalRules = (
 };
 
 export const getConditionalFormattingConfig = (
-    field: Field | TableCalculation | undefined,
+    field: ItemsMap[string] | undefined,
     value: unknown | undefined,
     conditionalFormattings: ConditionalFormattingConfig[] | undefined,
 ) => {
@@ -162,7 +159,7 @@ export const getConditionalFormattingConfig = (
 };
 
 export const getConditionalFormattingDescription = (
-    field: Field | TableCalculation | undefined,
+    field: ItemsMap[string] | undefined,
     conditionalFormattingConfig: ConditionalFormattingConfig | undefined,
     getConditionalRuleLabel: (
         rule: ConditionalFormattingWithConditionalOperator,
@@ -200,7 +197,7 @@ export const getConditionalFormattingDescription = (
 };
 
 export const getConditionalFormattingColor = (
-    field: Field | TableCalculation | undefined,
+    field: ItemsMap[string] | undefined,
     value: unknown,
     conditionalFormattingConfig: ConditionalFormattingConfig | undefined,
     getColorFromRange: (

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -24,10 +24,10 @@ import {
     isChartTile,
     isFilterableField,
     isTableChartConfig,
+    ItemsMap,
     PivotReference,
     ResultValue,
     SavedChart,
-    TableCalculation,
 } from '@lightdash/common';
 import { Box, Portal, Text, Tooltip } from '@mantine/core';
 import { IconFilter, IconFolders } from '@tabler/icons-react';
@@ -324,7 +324,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         DashboardFilterRule[]
     >([]);
     const [viewUnderlyingDataOptions, setViewUnderlyingDataOptions] = useState<{
-        item: Field | TableCalculation | undefined;
+        item: ItemsMap[string] | undefined;
         value: ResultValue;
         fieldValues: Record<string, ResultValue>;
         dimensions: string[];

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,4 +1,4 @@
-import { Field, getItemMap, TableCalculation } from '@lightdash/common';
+import { getItemMap } from '@lightdash/common';
 import { Box, Text } from '@mantine/core';
 import { FC, memo, useCallback, useMemo, useState } from 'react';
 
@@ -70,17 +70,16 @@ export const ExplorerResults = memo(() => {
         setIsExpandModalOpened(true);
     };
 
-    const itemsMap: Record<string, Field | TableCalculation> | undefined =
-        useMemo(() => {
-            if (exploreData) {
-                return getItemMap(
-                    exploreData,
-                    additionalMetrics,
-                    tableCalculations,
-                );
-            }
-            return undefined;
-        }, [exploreData, additionalMetrics, tableCalculations]);
+    const itemsMap = useMemo(() => {
+        if (exploreData) {
+            return getItemMap(
+                exploreData,
+                additionalMetrics,
+                tableCalculations,
+            );
+        }
+        return undefined;
+    }, [exploreData, additionalMetrics, tableCalculations]);
 
     const cellContextMenu = useCallback(
         (props) => (

--- a/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
+++ b/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
@@ -1,15 +1,14 @@
 import {
     DashboardFilters,
     Explore,
-    Field,
     formatItemValue,
     getItemId,
     hashFieldReference,
     isDimension,
+    ItemsMap,
     MetricQuery,
     PivotReference,
     ResultValue,
-    TableCalculation,
 } from '@lightdash/common';
 import { createContext, FC, useCallback, useContext, useState } from 'react';
 import { EChartSeries } from '../../hooks/echarts/useEchartsCartesianConfig';
@@ -17,7 +16,7 @@ import { useExplore } from '../../hooks/useExplore';
 import { EchartSeriesClickEvent } from '../SimpleChart';
 
 export type UnderlyingDataConfig = {
-    item: Field | TableCalculation | undefined;
+    item: ItemsMap[string] | undefined;
     value: ResultValue;
     fieldValues: Record<string, ResultValue>;
     dimensions?: string[];
@@ -26,7 +25,7 @@ export type UnderlyingDataConfig = {
 };
 
 export type DrillDownConfig = {
-    item: Field | TableCalculation;
+    item: ItemsMap[string];
     fieldValues: Record<string, ResultValue>;
     pivotReference?: PivotReference;
     dashboardFilters?: DashboardFilters;
@@ -50,7 +49,7 @@ type MetricQueryDataContext = {
 
 export const getDataFromChartClick = (
     e: EchartSeriesClickEvent,
-    itemsMap: Record<string, Field | TableCalculation>,
+    itemsMap: ItemsMap,
     series: EChartSeries[],
 ): UnderlyingDataConfig => {
     const pivotReference = series[e.seriesIndex]?.pivotReference;
@@ -70,7 +69,7 @@ export const getDataFromChartClick = (
         (item) => !isDimension(item),
     );
 
-    let selectedField: Field | TableCalculation | undefined = undefined;
+    let selectedField: ItemsMap[string] | undefined = undefined;
     if (selectedMetricsAndTableCalculations.length > 0) {
         selectedField = selectedMetricsAndTableCalculations[0];
     } else if (selectedFields.length > 0) {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
@@ -1,12 +1,9 @@
 import {
-    CustomDimension,
-    Field,
     getAxisName,
     getDateGroupLabel,
-    getItemId,
     getItemLabelWithoutTableName,
     isNumericItem,
-    TableCalculation,
+    ItemsMap,
 } from '@lightdash/common';
 import {
     Checkbox,
@@ -81,12 +78,11 @@ const AxisMinMax: FC<MinMaxProps> = ({ label, min, max, setMin, setMax }) => {
         </>
     );
 };
-
 type Props = {
-    items: (Field | TableCalculation | CustomDimension)[];
+    itemsMap: ItemsMap | undefined;
 };
 
-const AxesOptions: FC<Props> = ({ items }) => {
+const AxesOptions: FC<Props> = ({ itemsMap }) => {
     const { visualizationConfig } = useVisualizationContext();
 
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
@@ -103,9 +99,10 @@ const AxesOptions: FC<Props> = ({ items }) => {
         setInverseX,
     } = visualizationConfig.chartConfig;
 
-    const xAxisField = items.find(
-        (item) => getItemId(item) === dirtyLayout?.xField,
-    );
+    const xAxisField =
+        itemsMap && dirtyLayout?.xField
+            ? itemsMap[dirtyLayout?.xField]
+            : undefined;
 
     const selectedAxisInSeries = Array.from(
         new Set(
@@ -120,9 +117,8 @@ const AxesOptions: FC<Props> = ({ items }) => {
         dirtyEchartsConfig?.series || []
     ).reduce<[boolean, boolean]>(
         (acc, series) => {
-            const seriesField = items.find(
-                (item) => getItemId(item) === series.encode.yRef.field,
-            );
+            if (!itemsMap) return acc;
+            const seriesField = itemsMap[series.encode.yRef.field];
             if (isNumericItem(seriesField)) {
                 acc[series.yAxisIndex || 0] = true;
             }
@@ -183,7 +179,7 @@ const AxesOptions: FC<Props> = ({ items }) => {
                         axisReference: 'yRef',
                         axisIndex: 0,
                         series: dirtyEchartsConfig?.series,
-                        items,
+                        itemsMap,
                     })
                 }
                 onBlur={(e) => setYAxisName(0, e.currentTarget.value)}
@@ -216,7 +212,7 @@ const AxesOptions: FC<Props> = ({ items }) => {
                         axisReference: 'yRef',
                         axisIndex: 1,
                         series: dirtyEchartsConfig?.series,
-                        items,
+                        itemsMap,
                     })
                 }
                 onBlur={(e) => setYAxisName(1, e.currentTarget.value)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
@@ -17,7 +17,7 @@ import LegendPanel from './Legend';
 import SeriesTab from './Series';
 
 const ChartConfigTabs: FC = memo(() => {
-    const { explore, resultsData } = useVisualizationContext();
+    const { explore, resultsData, itemsMap } = useVisualizationContext();
     const dimensionsInMetricQuery = explore
         ? getDimensions(explore).filter((field) =>
               resultsData?.metricQuery.dimensions.includes(fieldId(field)),
@@ -93,7 +93,7 @@ const ChartConfigTabs: FC = memo(() => {
                 <SeriesTab items={items} />
             </Tabs.Panel>
             <Tabs.Panel value="axes">
-                <AxesOptions items={items} />
+                <AxesOptions itemsMap={itemsMap} />
             </Tabs.Panel>
             <Tabs.Panel value="legend">
                 <LegendPanel items={items} />

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -1,10 +1,5 @@
 import { subject } from '@casl/ability';
-import {
-    Field,
-    hasCustomDimension,
-    ResultValue,
-    TableCalculation,
-} from '@lightdash/common';
+import { hasCustomDimension, ItemsMap, ResultValue } from '@lightdash/common';
 import { Menu, MenuProps } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import { FC } from 'react';
@@ -22,7 +17,7 @@ type ValueCellMenuProps = {
 
     rowIndex?: number;
     colIndex?: number;
-    item?: Field | TableCalculation | undefined;
+    item?: ItemsMap[string] | undefined;
     getUnderlyingFieldValues?: (
         colIndex: number,
         rowIndex: number,

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1,6 +1,5 @@
 import {
     ConditionalFormattingConfig,
-    Field,
     fieldId,
     formatItemValue,
     getConditionalFormattingColor,
@@ -8,9 +7,9 @@ import {
     getConditionalFormattingDescription,
     isField,
     isNumericItem,
+    ItemsMap,
     PivotData,
     ResultValue,
-    TableCalculation,
 } from '@lightdash/common';
 import { BoxProps } from '@mantine/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -44,7 +43,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         conditionalFormattings: ConditionalFormattingConfig[];
         hideRowNumbers: boolean;
         getFieldLabel: (fieldId: string) => string | undefined;
-        getField: (fieldId: string) => Field | TableCalculation;
+        getField: (fieldId: string) => ItemsMap[string];
     };
 
 const PivotTable: FC<PivotTableProps> = ({

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -11,7 +11,6 @@ import {
     getAxisName,
     getDateGroupLabel,
     getDefaultSeriesColor,
-    getItemId,
     getItemLabelWithoutTableName,
     getResultValueArray,
     hashFieldReference,
@@ -806,40 +805,35 @@ const getEchartAxis = ({
     );
 
     const getAxisFormatter = (axisItem: ItemsMap[string] | undefined) => {
-        const field =
-            axisItem && getItemId(axisItem) && itemsMap[getItemId(axisItem)];
         const hasFormattingConfig =
-            isField(field) && (field.format || field.round || field.compact);
+            isField(axisItem) &&
+            (axisItem.format || axisItem.round || axisItem.compact);
         const axisMinInterval =
-            isDimension(field) &&
-            field.timeInterval &&
-            isTimeInterval(field.timeInterval) &&
-            timeFrameConfigs[field.timeInterval].getAxisMinInterval();
+            isDimension(axisItem) &&
+            axisItem.timeInterval &&
+            isTimeInterval(axisItem.timeInterval) &&
+            timeFrameConfigs[axisItem.timeInterval].getAxisMinInterval();
         const axisLabelFormatter =
-            isDimension(field) &&
-            field.timeInterval &&
-            isTimeInterval(field.timeInterval) &&
-            timeFrameConfigs[field.timeInterval].getAxisLabelFormatter();
+            isDimension(axisItem) &&
+            axisItem.timeInterval &&
+            isTimeInterval(axisItem.timeInterval) &&
+            timeFrameConfigs[axisItem.timeInterval].getAxisLabelFormatter();
         const axisConfig: Record<string, any> = {};
 
-        if (field && (hasFormattingConfig || axisMinInterval)) {
+        if (axisItem && (hasFormattingConfig || axisMinInterval)) {
             axisConfig.axisLabel = {
                 formatter: (value: any) => {
-                    return formatItemValue(field, value, true);
+                    return formatItemValue(axisItem, value, true);
                 },
             };
         } else if (axisLabelFormatter) {
             axisConfig.axisLabel = {
                 formatter: axisLabelFormatter,
             };
-        } else if (
-            field !== '' &&
-            field !== undefined &&
-            isTableCalculation(field)
-        ) {
+        } else if (axisItem !== undefined && isTableCalculation(axisItem)) {
             axisConfig.axisLabel = {
                 formatter: (value: any) => {
-                    return formatTableCalculationValue(field, value);
+                    return formatTableCalculationValue(axisItem, value);
                 },
             };
         }

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -398,7 +398,6 @@ const getMinAndMaxReferenceLines = (
             if (serieFieldId.field !== fieldId) return [];
 
             if (!serie.markLine) return [];
-            // TODO: check if correct because findItem can check for name
             const field = items[serieFieldId.field];
 
             const fieldType = isField(field) ? field.type : undefined;

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1222,11 +1222,11 @@ const useEchartsCartesianConfig = (
             isCompleteLayout(validCartesianConfig.layout)
         ) {
             const yFieldPivotedKeys = validCartesianConfig.layout.yField.filter(
-                (yField) => !itemsMap[yField],
+                (yField) => itemsMap[yField] && !isDimension(yField),
             );
             const yFieldNonPivotedKeys =
                 validCartesianConfig.layout.yField.filter(
-                    (yField) => itemsMap[yField],
+                    (yField) => itemsMap[yField] && isDimension(yField),
                 );
 
             return [

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2,10 +2,8 @@ import {
     ApiQueryResults,
     CartesianChart,
     CartesianSeriesType,
-    CustomDimension,
     DimensionType,
     ECHARTS_DEFAULT_COLORS,
-    Field,
     formatItemValue,
     formatTableCalculationValue,
     formatValue,
@@ -82,9 +80,7 @@ const getLabelFromField = (fields: ItemsMap, key: string | undefined) => {
     }
 };
 
-const getAxisTypeFromField = (
-    item?: Field | TableCalculation | CustomDimension,
-): string => {
+const getAxisTypeFromField = (item?: ItemsMap[string]): string => {
     if (item && isCustomDimension(item)) return 'category';
     if (item && isField(item)) {
         switch (item.type) {
@@ -116,7 +112,7 @@ const getAxisTypeFromField = (
 
 type GetAxisTypeArg = {
     validCartesianConfig: CartesianChart;
-    itemsMap: Record<string, Field | TableCalculation | CustomDimension>;
+    itemsMap: ItemsMap;
     topAxisXId?: string;
     bottomAxisXId?: string;
     rightAxisYId?: string;
@@ -810,9 +806,7 @@ const getEchartAxis = ({
         [true, true],
     );
 
-    const getAxisFormatter = (
-        axisItem: Field | TableCalculation | CustomDimension | undefined,
-    ) => {
+    const getAxisFormatter = (axisItem: ItemsMap[string] | undefined) => {
         const field =
             axisItem && getItemId(axisItem) && itemsMap[getItemId(axisItem)];
         const hasFormattingConfig =

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2,12 +2,10 @@ import {
     ApiQueryResults,
     CartesianChart,
     CartesianSeriesType,
-    convertAdditionalMetric,
     CustomDimension,
     DimensionType,
     ECHARTS_DEFAULT_COLORS,
     Field,
-    findItem,
     formatItemValue,
     formatTableCalculationValue,
     formatValue,
@@ -15,11 +13,9 @@ import {
     getAxisName,
     getDateGroupLabel,
     getDefaultSeriesColor,
-    getDimensions,
-    getFields,
+    getDimensionsInItemMap,
     getItemId,
     getItemLabelWithoutTableName,
-    getItemMap,
     getResultValueArray,
     hashFieldReference,
     isCompleteLayout,
@@ -29,7 +25,7 @@ import {
     isPivotReferenceWithValues,
     isTableCalculation,
     isTimeInterval,
-    Metric,
+    ItemsMap,
     MetricType,
     PivotReference,
     ResultRow,
@@ -74,11 +70,8 @@ type TooltipOption = Omit<TooltipComponentOption, 'formatter'> & {
 export const isLineSeriesOption = (obj: unknown): obj is LineSeriesOption =>
     typeof obj === 'object' && obj !== null && 'showSymbol' in obj;
 
-const getLabelFromField = (
-    fields: Array<Field | TableCalculation | CustomDimension>,
-    key: string | undefined,
-) => {
-    const item = findItem(fields, key);
+const getLabelFromField = (fields: ItemsMap, key: string | undefined) => {
+    const item = key ? fields[key] : undefined;
 
     if (item) {
         return getDateGroupLabel(item) || getItemLabelWithoutTableName(item);
@@ -123,7 +116,7 @@ const getAxisTypeFromField = (
 
 type GetAxisTypeArg = {
     validCartesianConfig: CartesianChart;
-    itemMap: Record<string, Field | TableCalculation | CustomDimension>;
+    itemsMap: Record<string, Field | TableCalculation | CustomDimension>;
     topAxisXId?: string;
     bottomAxisXId?: string;
     rightAxisYId?: string;
@@ -131,24 +124,24 @@ type GetAxisTypeArg = {
 };
 const getAxisType = ({
     validCartesianConfig,
-    itemMap,
+    itemsMap,
     topAxisXId,
     bottomAxisXId,
     rightAxisYId,
     leftAxisYId,
 }: GetAxisTypeArg) => {
     const topAxisType = getAxisTypeFromField(
-        topAxisXId ? itemMap[topAxisXId] : undefined,
+        topAxisXId ? itemsMap[topAxisXId] : undefined,
     );
     const bottomAxisType =
         bottomAxisXId === EMPTY_X_AXIS
             ? 'category'
             : getAxisTypeFromField(
-                  bottomAxisXId ? itemMap[bottomAxisXId] : undefined,
+                  bottomAxisXId ? itemsMap[bottomAxisXId] : undefined,
               );
     // horizontal bar chart needs the type 'category' in the left/right axis
     const defaultRightAxisType = getAxisTypeFromField(
-        rightAxisYId ? itemMap[rightAxisYId] : undefined,
+        rightAxisYId ? itemsMap[rightAxisYId] : undefined,
     );
     const rightAxisType =
         validCartesianConfig.layout.flipAxes &&
@@ -161,7 +154,7 @@ const getAxisType = ({
             ? 'category'
             : defaultRightAxisType;
     const defaultLeftAxisType = getAxisTypeFromField(
-        leftAxisYId ? itemMap[leftAxisYId] : undefined,
+        leftAxisYId ? itemsMap[leftAxisYId] : undefined,
     );
     const leftAxisType =
         validCartesianConfig.layout.flipAxes &&
@@ -272,23 +265,15 @@ export type EChartSeries = {
 const getFormattedValue = (
     value: any,
     key: string,
-    items: Array<Field | TableCalculation | CustomDimension>,
+    itemsMap: ItemsMap,
     convertToUTC: boolean = true,
 ): string => {
-    return formatItemValue(
-        items.find((item) => getItemId(item) === key),
-        value,
-        convertToUTC,
-    );
+    return formatItemValue(itemsMap[key], value, convertToUTC);
 };
 
 const valueFormatter =
-    (
-        yFieldId: string,
-        items: Array<Field | TableCalculation | CustomDimension>,
-    ) =>
-    (rawValue: any) => {
-        return getFormattedValue(rawValue, yFieldId, items);
+    (yFieldId: string, itemsMap: ItemsMap) => (rawValue: any) => {
+        return getFormattedValue(rawValue, yFieldId, itemsMap);
     };
 
 const removeEmptyProperties = <T = Record<any, any>>(obj: T | undefined) => {
@@ -397,7 +382,7 @@ const getMinAndMaxReferenceLines = (
     bottomAxisXId: string | undefined,
     resultsData: ApiQueryResults | undefined,
     series: Series[] | undefined,
-    items: Array<Field | TableCalculation | CustomDimension>,
+    items: ItemsMap,
 ) => {
     if (resultsData === undefined || series === undefined) return {};
     // Skip method if there are no reference lines
@@ -419,7 +404,8 @@ const getMinAndMaxReferenceLines = (
             if (serieFieldId.field !== fieldId) return [];
 
             if (!serie.markLine) return [];
-            const field = findItem(items, serieFieldId.field);
+            // TODO: check if correct because findItem can check for name
+            const field = items[serieFieldId.field];
 
             const fieldType = isField(field) ? field.type : undefined;
 
@@ -552,9 +538,7 @@ const getMinAndMaxReferenceLines = (
 };
 type GetPivotSeriesArg = {
     series: Series;
-    items: Array<Field | TableCalculation | CustomDimension>;
-    formats: Record<string, TableCalculation | Field> | undefined;
-
+    itemsMap: ItemsMap;
     cartesianChart: CartesianChart;
     flipAxes: boolean | undefined;
     yFieldHash: string;
@@ -565,16 +549,15 @@ type GetPivotSeriesArg = {
 const getPivotSeries = ({
     series,
     pivotReference,
-    items,
+    itemsMap,
     xFieldHash,
     yFieldHash,
     flipAxes,
-    formats,
     cartesianChart,
 }: GetPivotSeriesArg): EChartSeries => {
     const pivotLabel = pivotReference.pivotValues.reduce(
         (acc, { field, value }) => {
-            const formattedValue = getFormattedValue(value, field, items);
+            const formattedValue = getFormattedValue(value, field, itemsMap);
             return acc ? `${acc} - ${formattedValue}` : formattedValue;
         },
         '',
@@ -598,7 +581,7 @@ const getPivotSeries = ({
         dimensions: [
             {
                 name: xFieldHash,
-                displayName: getLabelFromField(items, xFieldHash),
+                displayName: getLabelFromField(itemsMap, xFieldHash),
             },
             {
                 name: yFieldHash,
@@ -606,23 +589,23 @@ const getPivotSeries = ({
                     cartesianChart.layout.yField &&
                     cartesianChart.layout.yField.length > 1
                         ? `[${pivotLabel}] ${getLabelFromField(
-                              items,
+                              itemsMap,
                               series.encode.yRef.field,
                           )}`
                         : pivotLabel,
             },
         ],
         tooltip: {
-            valueFormatter: valueFormatter(series.encode.yRef.field, items),
+            valueFormatter: valueFormatter(series.encode.yRef.field, itemsMap),
         },
         showSymbol: series.showSymbol ?? true,
         ...(series.label?.show && {
             label: {
                 ...series.label,
-                ...(formats &&
-                    formats[series.encode.yRef.field] && {
+                ...(itemsMap &&
+                    itemsMap[series.encode.yRef.field] && {
                         formatter: (value: any) => {
-                            const field = formats[series.encode.yRef.field];
+                            const field = itemsMap[series.encode.yRef.field];
                             if (isCustomDimension(field)) {
                                 return value;
                             }
@@ -650,10 +633,7 @@ const getPivotSeries = ({
 
 type GetSimpleSeriesArg = {
     series: Series;
-    items: Array<Field | TableCalculation | CustomDimension>;
-    formats:
-        | Record<string, TableCalculation | Field | CustomDimension>
-        | undefined;
+    itemsMap: ItemsMap;
     flipAxes: boolean | undefined;
     yFieldHash: string;
     xFieldHash: string;
@@ -664,8 +644,7 @@ const getSimpleSeries = ({
     flipAxes,
     yFieldHash,
     xFieldHash,
-    items,
-    formats,
+    itemsMap,
 }: GetSimpleSeriesArg) => ({
     ...series,
     xAxisIndex: flipAxes ? series.yAxisIndex : undefined,
@@ -684,24 +663,24 @@ const getSimpleSeries = ({
     dimensions: [
         {
             name: xFieldHash,
-            displayName: getLabelFromField(items, xFieldHash),
+            displayName: getLabelFromField(itemsMap, xFieldHash),
         },
         {
             name: yFieldHash,
-            displayName: getLabelFromField(items, yFieldHash),
+            displayName: getLabelFromField(itemsMap, yFieldHash),
         },
     ],
     tooltip: {
-        valueFormatter: valueFormatter(yFieldHash, items),
+        valueFormatter: valueFormatter(yFieldHash, itemsMap),
     },
     showSymbol: series.showSymbol ?? true,
     ...(series.label?.show && {
         label: {
             ...series.label,
-            ...(formats &&
-                formats[yFieldHash] && {
+            ...(itemsMap &&
+                itemsMap[yFieldHash] && {
                     formatter: (value: any) => {
-                        const field = formats[yFieldHash];
+                        const field = itemsMap[yFieldHash];
                         if (isCustomDimension(field)) {
                             return value;
                         }
@@ -727,10 +706,9 @@ const getSimpleSeries = ({
 });
 
 const getEchartsSeries = (
-    items: Array<Field | TableCalculation | CustomDimension>,
+    itemsMap: ItemsMap,
     cartesianChart: CartesianChart,
     pivotKeys: string[] | undefined,
-    formats: Record<string, TableCalculation | Field> | undefined,
 ): EChartSeries[] => {
     return (cartesianChart.eChartsConfig.series || [])
         .filter((s) => !s.hidden)
@@ -741,10 +719,9 @@ const getEchartsSeries = (
             if (pivotKeys && isPivotReferenceWithValues(series.encode.yRef)) {
                 return getPivotSeries({
                     series,
-                    items,
+                    itemsMap,
                     cartesianChart,
                     pivotReference: series.encode.yRef,
-                    formats,
                     flipAxes,
                     xFieldHash,
                     yFieldHash,
@@ -753,8 +730,7 @@ const getEchartsSeries = (
 
             return getSimpleSeries({
                 series,
-                items,
-                formats,
+                itemsMap,
                 flipAxes,
                 yFieldHash,
                 xFieldHash,
@@ -783,36 +759,26 @@ const calculateWidthText = (text: string | undefined): number => {
 };
 
 const getEchartAxis = ({
-    items,
+    itemsMap,
     validCartesianConfig,
     series,
     resultsData,
 }: {
     validCartesianConfig: CartesianChart;
-    items: Array<Field | TableCalculation | CustomDimension>;
+    itemsMap: ItemsMap;
     series: EChartSeries[];
     resultsData: ApiQueryResults | undefined;
 }) => {
-    const itemMap = items.reduce<
-        Record<string, Field | TableCalculation | CustomDimension>
-    >(
-        (acc, item) => ({
-            ...acc,
-            [getItemId(item)]: item,
-        }),
-        {},
-    );
-
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
         : validCartesianConfig.layout?.xField;
-    const xAxisItem = xAxisItemId ? itemMap[xAxisItemId] : undefined;
+    const xAxisItem = xAxisItemId ? itemsMap[xAxisItemId] : undefined;
 
     const yAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.xField
         : validCartesianConfig.layout?.yField?.[0];
 
-    const yAxisItem = yAxisItemId ? itemMap[yAxisItemId] : undefined;
+    const yAxisItem = yAxisItemId ? itemsMap[yAxisItemId] : undefined;
 
     const selectedAxisInSeries = Array.from(
         new Set(
@@ -848,9 +814,7 @@ const getEchartAxis = ({
         axisItem: Field | TableCalculation | CustomDimension | undefined,
     ) => {
         const field =
-            axisItem &&
-            getItemId(axisItem) &&
-            items.find((item) => getItemId(axisItem) === getItemId(item));
+            axisItem && getItemId(axisItem) && itemsMap[getItemId(axisItem)];
         const hasFormattingConfig =
             isField(field) && (field.format || field.round || field.compact);
         const axisMinInterval =
@@ -941,15 +905,17 @@ const getEchartAxis = ({
             );
     const rightYaxisGap = calculateWidthText(longestValueYAxisRight);
 
-    const rightAxisYField = rightAxisYId ? itemMap[rightAxisYId] : undefined;
-    const leftAxisYField = leftAxisYId ? itemMap[leftAxisYId] : undefined;
-    const topAxisXField = topAxisXId ? itemMap[topAxisXId] : undefined;
-    const bottomAxisXField = bottomAxisXId ? itemMap[bottomAxisXId] : undefined;
+    const rightAxisYField = rightAxisYId ? itemsMap[rightAxisYId] : undefined;
+    const leftAxisYField = leftAxisYId ? itemsMap[leftAxisYId] : undefined;
+    const topAxisXField = topAxisXId ? itemsMap[topAxisXId] : undefined;
+    const bottomAxisXField = bottomAxisXId
+        ? itemsMap[bottomAxisXId]
+        : undefined;
 
     const { bottomAxisType, topAxisType, rightAxisType, leftAxisType } =
         getAxisType({
             validCartesianConfig,
-            itemMap,
+            itemsMap,
             topAxisXId,
             bottomAxisXId,
             leftAxisYId,
@@ -969,7 +935,7 @@ const getEchartAxis = ({
         bottomAxisXId,
         resultsData,
         validCartesianConfig.eChartsConfig.series,
-        items,
+        itemsMap,
     );
 
     return {
@@ -983,7 +949,7 @@ const getEchartAxis = ({
                           axisIndex: 0,
                           axisReference: 'yRef',
                           axisName: xAxisConfiguration?.[0]?.name,
-                          items,
+                          itemsMap,
                           series: validCartesianConfig.eChartsConfig.series,
                       })
                     : xAxisConfiguration?.[0]?.name ||
@@ -1021,7 +987,7 @@ const getEchartAxis = ({
                           axisIndex: 1,
                           axisReference: 'yRef',
                           axisName: xAxisConfiguration?.[1]?.name,
-                          items,
+                          itemsMap,
                           series: validCartesianConfig.eChartsConfig.series,
                       })
                     : undefined,
@@ -1060,7 +1026,7 @@ const getEchartAxis = ({
                           axisIndex: 0,
                           axisReference: 'yRef',
                           axisName: yAxisConfiguration?.[0]?.name,
-                          items,
+                          itemsMap,
                           series: validCartesianConfig.eChartsConfig.series,
                       }),
                 min: !validCartesianConfig.layout.flipAxes
@@ -1097,7 +1063,7 @@ const getEchartAxis = ({
                           axisIndex: 1,
                           axisReference: 'yRef',
                           axisName: yAxisConfiguration?.[1]?.name,
-                          items,
+                          itemsMap,
                           series: validCartesianConfig.eChartsConfig.series,
                       }),
                 min: !validCartesianConfig.layout.flipAxes
@@ -1197,7 +1163,7 @@ const getStackTotalRows = (
 const getStackTotalSeries = (
     rows: ResultRow[],
     seriesWithStack: EChartSeries[],
-    items: Array<Field | TableCalculation | CustomDimension>,
+    itemsMap: ItemsMap,
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
 ) => {
@@ -1220,7 +1186,7 @@ const getStackTotalSeries = (
                             return getFormattedValue(
                                 stackTotal,
                                 fieldId,
-                                items,
+                                itemsMap,
                             );
                         }
                         return '';
@@ -1252,7 +1218,7 @@ const useEchartsCartesianConfig = (
     validCartesianConfigLegend?: LegendValues,
     isInDashboard?: boolean,
 ) => {
-    const { visualizationConfig, explore, pivotDimensions, resultsData } =
+    const { visualizationConfig, pivotDimensions, resultsData, itemsMap } =
         useVisualizationContext();
 
     const validCartesianConfig = useMemo(() => {
@@ -1264,17 +1230,16 @@ const useEchartsCartesianConfig = (
 
     const [pivotedKeys, nonPivotedKeys] = useMemo(() => {
         if (
-            resultsData &&
+            itemsMap &&
             validCartesianConfig &&
             isCompleteLayout(validCartesianConfig.layout)
         ) {
             const yFieldPivotedKeys = validCartesianConfig.layout.yField.filter(
-                (yField) =>
-                    !resultsData.metricQuery.dimensions.includes(yField),
+                (yField) => !itemsMap[yField],
             );
             const yFieldNonPivotedKeys =
-                validCartesianConfig.layout.yField.filter((yField) =>
-                    resultsData.metricQuery.dimensions.includes(yField),
+                validCartesianConfig.layout.yField.filter(
+                    (yField) => itemsMap[yField],
                 );
 
             return [
@@ -1283,7 +1248,7 @@ const useEchartsCartesianConfig = (
             ];
         }
         return [];
-    }, [validCartesianConfig, resultsData]);
+    }, [itemsMap, validCartesianConfig]);
 
     const { rows } = useMemo(() => {
         return getPlottedData(
@@ -1294,76 +1259,34 @@ const useEchartsCartesianConfig = (
         );
     }, [resultsData?.rows, pivotDimensions, pivotedKeys, nonPivotedKeys]);
 
-    const formats = useMemo(
-        () =>
-            explore
-                ? getItemMap(
-                      explore,
-                      resultsData?.metricQuery.additionalMetrics,
-                      resultsData?.metricQuery.tableCalculations,
-                  )
-                : undefined,
-        [explore, resultsData],
-    );
-
-    const items = useMemo(() => {
-        if (!explore || !resultsData) {
-            return [];
-        }
-        return [
-            ...getFields(explore),
-            ...(resultsData?.metricQuery.additionalMetrics || []).reduce<
-                Metric[]
-            >((acc, additionalMetric) => {
-                const table = explore.tables[additionalMetric.table];
-                if (table) {
-                    const metric = convertAdditionalMetric({
-                        additionalMetric,
-                        table,
-                    });
-                    return [...acc, metric];
-                }
-                return acc;
-            }, []),
-            ...(resultsData?.metricQuery.tableCalculations || []),
-            ...(resultsData?.metricQuery.customDimensions || []),
-        ];
-    }, [explore, resultsData]);
-
     const series = useMemo(() => {
-        if (!explore || !validCartesianConfig || !resultsData) {
+        if (!itemsMap || !validCartesianConfig || !resultsData) {
             return [];
         }
 
+        // TODO: do we need items and formats?
         return getEchartsSeries(
-            items,
+            itemsMap,
             validCartesianConfig,
             pivotDimensions,
-            formats,
         );
-    }, [
-        explore,
-        validCartesianConfig,
-        resultsData,
-        pivotDimensions,
-        formats,
-        items,
-    ]);
+    }, [validCartesianConfig, resultsData, itemsMap, pivotDimensions]);
 
     const axis = useMemo(() => {
-        if (!validCartesianConfig) {
+        if (!itemsMap || !validCartesianConfig) {
             return { xAxis: [], yAxis: [] };
         }
 
         return getEchartAxis({
-            items,
+            itemsMap,
             series,
             validCartesianConfig,
             resultsData,
         });
-    }, [items, series, validCartesianConfig, resultsData]);
+    }, [itemsMap, series, validCartesianConfig, resultsData]);
 
     const stackedSeries = useMemo(() => {
+        if (!itemsMap) return;
         const seriesWithValidStack = series.map<EChartSeries>((serie) => ({
             ...serie,
             stack: getValidStack(serie),
@@ -1373,7 +1296,7 @@ const useEchartsCartesianConfig = (
             ...getStackTotalSeries(
                 rows,
                 seriesWithValidStack,
-                items,
+                itemsMap,
                 validCartesianConfig?.layout.flipAxes,
                 validCartesianConfigLegend,
             ),
@@ -1381,7 +1304,7 @@ const useEchartsCartesianConfig = (
     }, [
         series,
         rows,
-        items,
+        itemsMap,
         validCartesianConfig?.layout.flipAxes,
         validCartesianConfigLegend,
     ]);
@@ -1404,6 +1327,7 @@ const useEchartsCartesianConfig = (
               )
             : allColors;
     }, [organizationData?.chartColors, validCartesianConfig]);
+
     const sortedResults = useMemo(() => {
         const results =
             validCartesianConfig?.layout?.xField === EMPTY_X_AXIS
@@ -1413,10 +1337,11 @@ const useEchartsCartesianConfig = (
                   }))
                 : getResultValueArray(rows, true);
         try {
-            if (!explore) return results;
-            const dimensions = getDimensions(explore);
-            const customDimensions =
-                resultsData?.metricQuery.customDimensions || [];
+            if (!itemsMap) return results;
+
+            // TODO: don't know if we need this. The type comes out nicely though
+            const dimensionsAndCustomDimensionsMap =
+                getDimensionsInItemMap(itemsMap);
 
             const xFieldId = validCartesianConfig?.layout?.xField;
             if (xFieldId === undefined) return results;
@@ -1425,9 +1350,7 @@ const useEchartsCartesianConfig = (
                 resultsData?.metricQuery.sorts?.[0]?.fieldId === xFieldId;
             if (alreadySorted) return results;
 
-            const xField = [...dimensions, ...customDimensions].find(
-                (dimension) => getItemId(dimension) === xFieldId,
-            );
+            const xField = dimensionsAndCustomDimensionsMap[xFieldId];
             const hasTotal = validCartesianConfig?.eChartsConfig?.series?.some(
                 (s) => s.stackLabel?.show,
             );
@@ -1479,12 +1402,11 @@ const useEchartsCartesianConfig = (
             return results;
         }
     }, [
-        rows,
-        resultsData?.metricQuery.sorts,
-        explore,
         validCartesianConfig?.layout?.xField,
         validCartesianConfig?.eChartsConfig?.series,
-        resultsData?.metricQuery.customDimensions,
+        rows,
+        itemsMap,
+        resultsData?.metricQuery.sorts,
     ]);
 
     const tooltip = useMemo<TooltipOption>(
@@ -1499,7 +1421,7 @@ const useEchartsCartesianConfig = (
                 label: { show: true },
             },
             formatter: (params) => {
-                if (!Array.isArray(params)) return '';
+                if (!Array.isArray(params) || !itemsMap) return '';
 
                 const tooltipRows = params
                     .map((param) => {
@@ -1525,7 +1447,7 @@ const useEchartsCartesianConfig = (
                                 <td style="text-align: right;"><b>${getFormattedValue(
                                     (value as Record<string, unknown>)[dim],
                                     dim.split('.')[0],
-                                    items,
+                                    itemsMap,
                                 )}</b></td>
                             </tr>
                         `;
@@ -1538,9 +1460,7 @@ const useEchartsCartesianConfig = (
                 const dimensionId = params[0].dimensionNames?.[0];
 
                 if (dimensionId !== undefined) {
-                    const field = items.find(
-                        (item) => getItemId(item) === dimensionId,
-                    );
+                    const field = itemsMap[dimensionId];
 
                     if (
                         isDimension(field) &&
@@ -1553,7 +1473,7 @@ const useEchartsCartesianConfig = (
                         const dateFormatted = getFormattedValue(
                             date,
                             dimensionId,
-                            items,
+                            itemsMap,
                             false,
                         );
                         return `${dateFormatted}<br/><table>${tooltipRows}</table>`;
@@ -1567,7 +1487,7 @@ const useEchartsCartesianConfig = (
                         const tooltipHeader = getFormattedValue(
                             params[0].axisValueLabel,
                             dimensionId,
-                            items,
+                            itemsMap,
                         );
 
                         return `${tooltipHeader}<br/><table>${tooltipRows}</table>`;
@@ -1576,7 +1496,7 @@ const useEchartsCartesianConfig = (
                 return `${params[0].axisValueLabel}<br/><table>${tooltipRows}</table>`;
             },
         }),
-        [items],
+        [itemsMap],
     );
 
     const eChartsOptions = useMemo(
@@ -1620,7 +1540,7 @@ const useEchartsCartesianConfig = (
     );
 
     if (
-        !explore ||
+        !itemsMap ||
         series.length <= 0 ||
         rows.length <= 0 ||
         !validCartesianConfig

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1221,12 +1221,15 @@ const useEchartsCartesianConfig = (
             isCompleteLayout(validCartesianConfig.layout)
         ) {
             const yFieldPivotedKeys = validCartesianConfig.layout.yField.filter(
-                (yField) => itemsMap[yField] && !isDimension(itemsMap[yField]),
+                (yField) =>
+                    !itemsMap[yField] ||
+                    (itemsMap[yField] && !isDimension(itemsMap[yField])),
             );
             const yFieldNonPivotedKeys =
                 validCartesianConfig.layout.yField.filter(
                     (yField) =>
-                        itemsMap[yField] && isDimension(itemsMap[yField]),
+                        !itemsMap[yField] ||
+                        (itemsMap[yField] && isDimension(itemsMap[yField])),
                 );
 
             return [

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1221,11 +1221,12 @@ const useEchartsCartesianConfig = (
             isCompleteLayout(validCartesianConfig.layout)
         ) {
             const yFieldPivotedKeys = validCartesianConfig.layout.yField.filter(
-                (yField) => itemsMap[yField] && !isDimension(yField),
+                (yField) => itemsMap[yField] && !isDimension(itemsMap[yField]),
             );
             const yFieldNonPivotedKeys =
                 validCartesianConfig.layout.yField.filter(
-                    (yField) => itemsMap[yField] && isDimension(yField),
+                    (yField) =>
+                        itemsMap[yField] && isDimension(itemsMap[yField]),
                 );
 
             return [

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1264,7 +1264,6 @@ const useEchartsCartesianConfig = (
             return [];
         }
 
-        // TODO: do we need items and formats?
         return getEchartsSeries(
             itemsMap,
             validCartesianConfig,
@@ -1339,7 +1338,6 @@ const useEchartsCartesianConfig = (
         try {
             if (!itemsMap) return results;
 
-            // TODO: don't know if we need this. The type comes out nicely though
             const dimensionsAndCustomDimensionsMap =
                 getDimensionsInItemMap(itemsMap);
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -11,7 +11,6 @@ import {
     getAxisName,
     getDateGroupLabel,
     getDefaultSeriesColor,
-    getDimensionsInItemMap,
     getItemId,
     getItemLabelWithoutTableName,
     getResultValueArray,
@@ -1332,9 +1331,6 @@ const useEchartsCartesianConfig = (
         try {
             if (!itemsMap) return results;
 
-            const dimensionsAndCustomDimensionsMap =
-                getDimensionsInItemMap(itemsMap);
-
             const xFieldId = validCartesianConfig?.layout?.xField;
             if (xFieldId === undefined) return results;
 
@@ -1342,7 +1338,7 @@ const useEchartsCartesianConfig = (
                 resultsData?.metricQuery.sorts?.[0]?.fieldId === xFieldId;
             if (alreadySorted) return results;
 
-            const xField = dimensionsAndCustomDimensionsMap[xFieldId];
+            const xField = itemsMap[xFieldId];
             const hasTotal = validCartesianConfig?.eChartsConfig?.series?.some(
                 (s) => s.stackLabel?.show,
             );
@@ -1371,6 +1367,7 @@ const useEchartsCartesianConfig = (
             if (
                 xField !== undefined &&
                 results.length >= 0 &&
+                isDimension(xField) &&
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                     xField.type,
                 )

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -1,11 +1,10 @@
 import {
     ApiQueryResults,
-    Field,
     formatItemValue,
     friendlyName,
     isField,
+    ItemsMap,
     ResultRow,
-    TableCalculation,
 } from '@lightdash/common';
 import {
     TableHeaderBoldLabel,
@@ -19,7 +18,7 @@ import {
 } from '../../components/common/Table/types';
 
 type Args = {
-    itemsMap: Record<string, Field | TableCalculation>;
+    itemsMap: ItemsMap;
     selectedItemIds: string[];
     resultsData: ApiQueryResults;
     isColumnVisible: (key: string) => boolean;
@@ -82,8 +81,9 @@ const getDataAndColumns = ({
                                 <TableHeaderBoldLabel>
                                     {item === undefined
                                         ? 'Undefined'
-                                        : item.displayName ||
-                                          friendlyName(item.name)}
+                                        : 'displayName' in item
+                                        ? item.displayName
+                                        : friendlyName(item.name)}
                                 </TableHeaderBoldLabel>
                             )}
                         </TableHeaderLabelContainer>

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -6,7 +6,6 @@ import {
     ComparisonFormatTypes,
     convertAdditionalMetric,
     Explore,
-    Field,
     fieldId,
     Format,
     formatTableCalculationValue,
@@ -19,8 +18,8 @@ import {
     isField,
     isNumericItem,
     isTableCalculation,
+    ItemsMap,
     Metric,
-    TableCalculation,
     valueIsNaN,
 } from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -46,7 +45,7 @@ const UNDEFINED = 'undefined';
 const formatComparisonValue = (
     format: ComparisonFormatTypes | undefined,
     comparisonDiff: ComparisonDiffTypes | undefined,
-    item: Field | TableCalculation | undefined,
+    item: ItemsMap[string] | undefined,
     value: number | string,
     bigNumberStyle: CompactOrAlias | undefined,
 ) => {
@@ -87,7 +86,7 @@ const formatComparisonValue = (
     }
 };
 
-const isNumber = (i: Field | TableCalculation | undefined, value: any) =>
+const isNumber = (i: ItemsMap[string] | undefined, value: any) =>
     isNumericItem(i) && !(value instanceof Date) && !valueIsNaN(value);
 
 const useBigNumberConfig = (

--- a/packages/frontend/src/hooks/useCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useCalculateTotal.ts
@@ -3,13 +3,12 @@ import {
     ApiError,
     CalculateTotalFromQuery,
     DashboardFilters,
-    Field,
     fieldId as getFieldId,
     isField,
     isMetric,
+    ItemsMap,
     MetricQuery,
     MetricQueryRequest,
-    TableCalculation,
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { useQuery } from 'react-query';
@@ -65,7 +64,7 @@ const calculateTotalFromSavedChart = async (
 
 const getCalculationColumnFields = (
     selectedItemIds: string[],
-    itemsMap: Record<string, Field | TableCalculation>,
+    itemsMap: ItemsMap,
 ) => {
     //This method will return the metric ids that need to be calculated in the backend
 
@@ -96,7 +95,7 @@ export const useCalculateTotal = ({
     savedChartUuid?: string;
     dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
-    itemsMap: Record<string, TableCalculation | Field>;
+    itemsMap: ItemsMap;
     fieldIds?: string[];
     showColumnCalculation?: boolean;
 }) => {

--- a/packages/frontend/src/hooks/useColumnTotals.ts
+++ b/packages/frontend/src/hooks/useColumnTotals.ts
@@ -8,6 +8,7 @@ import {
     isDimension,
     isTableCalculation,
     Item,
+    ItemsMap,
     MetricType,
     ResultRow,
     TableCalculation,
@@ -60,7 +61,7 @@ const getResultColumnTotals = (
 
 const getResultColumnTotalsFromItemsMap = (
     rows: ResultRow[],
-    itemsMap: Record<FieldId, Field | TableCalculation>,
+    itemsMap: ItemsMap,
 ): Record<FieldId, number | undefined> => {
     return getResultColumnTotals(
         rows,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -13,6 +13,7 @@ import {
     isField,
     isNumericItem,
     itemsInMetricQuery,
+    ItemsMap,
     TableCalculation,
 } from '@lightdash/common';
 import { useMemo } from 'react';
@@ -68,7 +69,7 @@ export const useColumns = (): TableColumn[] => {
     });
 
     const { activeItemsMap, invalidActiveItems } = useMemo<{
-        activeItemsMap: Record<string, Field | TableCalculation>;
+        activeItemsMap: ItemsMap;
         invalidActiveItems: string[];
     }>(() => {
         if (exploreData) {
@@ -80,7 +81,7 @@ export const useColumns = (): TableColumn[] => {
             );
 
             return Array.from(activeFields).reduce<{
-                activeItemsMap: Record<string, Field | TableCalculation>;
+                activeItemsMap: ItemsMap;
                 invalidActiveItems: string[];
             }>(
                 (acc, key) => {
@@ -149,7 +150,8 @@ export const useColumns = (): TableColumn[] => {
                                 </>
                             ) : (
                                 <TableHeaderBoldLabel>
-                                    {item.displayName ||
+                                    {('displayName' in item &&
+                                        item.displayName) ||
                                         friendlyName(item.name)}
                                 </TableHeaderBoldLabel>
                             )}

--- a/packages/frontend/src/types/table-core.d.ts
+++ b/packages/frontend/src/types/table-core.d.ts
@@ -1,4 +1,4 @@
-import { Field, PivotReference, TableCalculation } from '@lightdash/common';
+import { ItemsMap, PivotReference } from '@lightdash/common';
 import { MouseEventHandler } from 'react';
 import { Sort } from '../components/common/Table/types';
 
@@ -7,7 +7,7 @@ declare module '@tanstack/table-core' {
         isInvalidItem?: boolean;
         width?: number;
         draggable?: boolean;
-        item?: Field | TableCalculation;
+        item?: ItemsMap[string];
         pivotReference?: PivotReference;
         bgColor?: string;
         sort?: Sort;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8153 (first PR on cartesian config, will do more per config and remove unnecessary stuff as I progress)

### Description:

Adds `ItemsMap` type
We don't use `explore` anymore in `useEchartsCartesianConfig.ts`. Instead, we use `itemsMap` which includes all we need.
THe `itemsMap` is now initialised on the `VisualizationProvider`



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
