### PR TITLE
fix: bignumber comparison negative percent values

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -33,7 +33,7 @@ const calculateComparisonValue = (
     const rawValue = a - b;
     switch (format) {
         case ComparisonFormatTypes.PERCENTAGE:
-            return rawValue / b;
+            return rawValue / Math.abs(b);
         case ComparisonFormatTypes.RAW:
             return rawValue;
         default:


### PR DESCRIPTION
Closes: #8157 

### Description:

raw comparison
![CleanShot 2023-12-01 at 11 54 19@2x](https://github.com/lightdash/lightdash/assets/962095/ac172922-59a1-4acc-9914-3a80e2e525db)

with percentage
![CleanShot 2023-12-01 at 11 54 26@2x](https://github.com/lightdash/lightdash/assets/962095/7c66b4c7-6a30-48d9-b504-fb658305962f)

with percentage inverse sort
![CleanShot 2023-12-01 at 11 55 11@2x](https://github.com/lightdash/lightdash/assets/962095/fab5c2f3-9647-4825-875e-54fc86e10b85)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
