### PR TITLE
fix: explore filter showing value with is null operator

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -1,4 +1,5 @@
 import {
+    ConditionalOperator,
     countTotalFilterRules,
     Field,
     fieldId,
@@ -88,7 +89,14 @@ const FiltersCard: FC = memo(() => {
                 return (
                     <div key={field.name}>
                         {filterRuleLabels.field}: {filterRuleLabels.operator}{' '}
-                        <FilterValues>{filterRuleLabels.value}</FilterValues>
+                        {filterRule.operator !== ConditionalOperator.NULL &&
+                        filterRule.operator !== ConditionalOperator.NOT_NULL ? (
+                            <FilterValues>
+                                {filterRuleLabels.value}
+                            </FilterValues>
+                        ) : (
+                            ''
+                        )}
                     </div>
                 );
             }


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/7466

### Description:

![CleanShot 2023-12-01 at 15 05 15@2x](https://github.com/lightdash/lightdash/assets/962095/d5ed6305-cbcf-47a2-9077-5334907dbb9a)
![CleanShot 2023-12-01 at 15 05 20@2x](https://github.com/lightdash/lightdash/assets/962095/0c5d1b10-7db7-413a-a3ab-695452b603b4)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
