### PR TITLE
feat: date filters for current date

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -40,6 +40,7 @@ export const ExpectedNumberFilterSQL: Record<FilterOperator, string | null> = {
     [FilterOperator.IN_THE_CURRENT]: null,
     [FilterOperator.IN_THE_NEXT]: null,
     [FilterOperator.IN_BETWEEN]: null,
+    [FilterOperator.PRESENT]: null,
 };
 
 export const InTheCurrentFilterBase = {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -276,6 +276,11 @@ export const renderDateFilterSql = (
                 startDate,
             )} AND (${dimensionSql}) <= ${castValue(endDate)})`;
         }
+        case FilterOperator.PRESENT: {
+            return `(${dimensionSql}) = ${castValue(
+                dateFormatter(new Date()),
+            )}`;
+        }
         default:
             throw Error(
                 `No function implemented to render sql for filter type ${filterType} on dimension of date type`,

--- a/packages/common/src/types/conditionalRule.ts
+++ b/packages/common/src/types/conditionalRule.ts
@@ -16,6 +16,7 @@ export enum ConditionalOperator {
     IN_THE_NEXT = 'inTheNext',
     IN_THE_CURRENT = 'inTheCurrent',
     IN_BETWEEN = 'inBetween',
+    PRESENT = 'present',
 }
 
 export type ConditionalRule<O = ConditionalOperator, V = unknown> = {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -122,6 +122,7 @@ export const hasMatchingConditionalRules = (
                 case ConditionalOperator.IN_THE_NEXT:
                 case ConditionalOperator.IN_THE_CURRENT:
                 case ConditionalOperator.IN_BETWEEN:
+                case ConditionalOperator.PRESENT:
                     throw new Error('Not implemented');
                 default:
                     return assertUnreachable(

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -24,6 +24,7 @@ export const isFilterConfigurationApplyButtonEnabled = (
     switch (filterRule.operator) {
         case FilterOperator.NULL:
         case FilterOperator.NOT_NULL:
+        case FilterOperator.PRESENT:
             return true;
         case FilterOperator.EQUALS:
         case FilterOperator.NOT_EQUALS:

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -39,6 +39,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     switch (rule.operator) {
         case FilterOperator.NULL:
         case FilterOperator.NOT_NULL:
+        case FilterOperator.PRESENT:
             return <span style={{ width: '100%' }} />;
         case FilterOperator.STARTS_WITH:
         case FilterOperator.ENDS_WITH:

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -46,6 +46,7 @@ const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.IN_THE_NEXT]: 'in the next',
     [FilterOperator.IN_THE_CURRENT]: 'in the current',
     [FilterOperator.IN_BETWEEN]: 'is between',
+    [FilterOperator.PRESENT]: 'is the current',
 };
 
 const getFilterOptions = <T extends FilterOperator>(
@@ -56,10 +57,12 @@ const getFilterOptions = <T extends FilterOperator>(
         label: filterOperatorLabel[operator],
     }));
 
-const timeFilterOptions: Array<{
+const getTimeFilterOptions = (
+    timeInterval: string | undefined,
+): Array<{
     value: FilterOperator;
     label: string;
-}> = [
+}> => [
     ...getFilterOptions([
         FilterOperator.NULL,
         FilterOperator.NOT_NULL,
@@ -70,6 +73,17 @@ const timeFilterOptions: Array<{
         FilterOperator.IN_THE_NEXT,
         FilterOperator.IN_THE_CURRENT,
     ]),
+    ...(timeInterval
+        ? [
+              {
+                  value: FilterOperator.PRESENT,
+                  label:
+                      timeInterval === 'DAY'
+                          ? 'is today'
+                          : `is this ${timeInterval.toLowerCase()}`,
+              },
+          ]
+        : []),
     { value: FilterOperator.LESS_THAN, label: 'is before' },
     { value: FilterOperator.LESS_THAN_OR_EQUAL, label: 'is on or before' },
     { value: FilterOperator.GREATER_THAN, label: 'is after' },
@@ -88,6 +102,7 @@ export type FilterInputsProps<T extends ConditionalRule> = {
 
 export const getFilterOperatorOptions = (
     filterType: FilterType,
+    timeInterval?: string,
 ): Array<{ value: FilterOperator; label: string }> => {
     switch (filterType) {
         case FilterType.STRING:
@@ -111,7 +126,7 @@ export const getFilterOperatorOptions = (
                 FilterOperator.GREATER_THAN,
             ]);
         case FilterType.DATE:
-            return timeFilterOptions;
+            return getTimeFilterOptions(timeInterval);
         case FilterType.BOOLEAN:
             return getFilterOptions([
                 FilterOperator.NULL,
@@ -188,6 +203,7 @@ const getValueAsString = (
                 case FilterOperator.LESS_THAN_OR_EQUAL:
                 case FilterOperator.GREATER_THAN:
                 case FilterOperator.GREATER_THAN_OR_EQUAL:
+                case FilterOperator.PRESENT:
                     return values
                         ?.map((value) => {
                             if (

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -46,8 +46,13 @@ const FilterRuleForm: FC<Props> = ({
     }, [activeField]);
 
     const filterOperatorOptions = useMemo(() => {
+        if (activeField?.type === 'date')
+            return getFilterOperatorOptions(
+                filterType,
+                activeField.timeInterval || 'DAY',
+            );
         return getFilterOperatorOptions(filterType);
-    }, [filterType]);
+    }, [filterType, activeField]);
 
     const onFieldChange = useCallback(
         (fieldId: string) => {

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -38,6 +38,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.IN_THE_NEXT:
                 case FilterOperator.IN_THE_CURRENT:
                 case FilterOperator.IN_BETWEEN:
+                case FilterOperator.PRESENT:
                     throw new Error('Not implemented');
                 default:
                     return assertUnreachable(operator, 'unknown operator');
@@ -64,6 +65,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.IN_THE_NEXT:
                 case FilterOperator.IN_THE_CURRENT:
                 case FilterOperator.IN_BETWEEN:
+                case FilterOperator.PRESENT:
                     throw new Error('Not implemented');
                 default:
                     return assertUnreachable(operator, 'unknown operator');
@@ -88,6 +90,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.IN_THE_CURRENT:
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
+                case FilterOperator.PRESENT:
                     return '';
                 case FilterOperator.STARTS_WITH:
                 case FilterOperator.ENDS_WITH:
@@ -118,6 +121,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.IN_THE_NEXT:
                 case FilterOperator.IN_THE_CURRENT:
                 case FilterOperator.IN_BETWEEN:
+                case FilterOperator.PRESENT:
                     throw new Error('Not implemented');
                 default:
                     return assertUnreachable(operator, 'unknown operator');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8137 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This adds a filter for `is today` and other current date intervals as well (this week, this month, this quarter, this year), because the sql generation for other date filters is generated when this one is implemented. 

Geting the time interval from `activeField.timeInterval` in `filterOperatorOptions` gives a typescript error for some reason.

Could use help with tests.

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 02-12-23 10:47:33.webm](https://github.com/lightdash/lightdash/assets/76876702/7210ae59-bb70-4082-9a66-92fe9492d2d0)



### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
