### PR TITLE
feat: scheduled delivery screenshot timeout

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -124,6 +124,7 @@ export type LightdashConfig = {
         enabled: boolean;
         concurrency: number;
         jobTimeout: number;
+        screenshotTimeout?: number;
     };
     logging: LoggingConfig;
 };
@@ -429,6 +430,9 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             jobTimeout: process.env.SCHEDULER_JOB_TIMEOUT
                 ? parseInt(process.env.SCHEDULER_JOB_TIMEOUT, 10)
                 : DEFAULT_JOB_TIMEOUT,
+            screenshotTimeout: process.env.SCHEDULER_SCREENSHOT_TIMEOUT
+                ? parseInt(process.env.SCHEDULER_SCREENSHOT_TIMEOUT, 10)
+                : undefined,
         },
         logging: {
             level: parseLoggingLevel(

--- a/packages/backend/src/routers/headlessBrowser.ts
+++ b/packages/backend/src/routers/headlessBrowser.ts
@@ -152,6 +152,16 @@ if (
                     elements.forEach((el) => el.parentNode.removeChild(el));
                 }, '.bp4-navbar');
             }
+
+            if (lightdashConfig.scheduler.screenshotTimeout) {
+                await new Promise((resolve) => {
+                    setTimeout(
+                        resolve,
+                        lightdashConfig.scheduler.screenshotTimeout,
+                    );
+                });
+            }
+
             const imageBuffer = await element.screenshot({
                 path: '/tmp/test-screenshot.png',
             });

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -459,6 +459,17 @@ export class UnfurlService {
                             pageMetrics.JSEventListeners,
                         timeout,
                     });
+
+                    if (this.lightdashConfig.scheduler.screenshotTimeout) {
+                        await new Promise((resolve) => {
+                            setTimeout(
+                                resolve,
+                                this.lightdashConfig.scheduler
+                                    .screenshotTimeout,
+                            );
+                        });
+                    }
+
                     const imageBuffer = (await element.screenshot({
                         path,
                     })) as Buffer;


### PR DESCRIPTION
closes: https://github.com/lightdash/lightdash/issues/6932

### Description:

introduces new env variable `SCHEDULER_SCREENSHOT_TIMEOUT` to delay taking a screenshot for instances with heavy dashboards. this is a temporary workaround for https://github.com/lightdash/lightdash/issues/6932



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
