### PR TITLE
fix: props missing from gsheets api

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -216,6 +216,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                tableCalculations: { ref: 'FilterGroupResponse' },
                 metrics: { ref: 'FilterGroupResponse' },
                 dimensions: { ref: 'FilterGroupResponse' },
             },
@@ -458,11 +459,32 @@ const models: TsoaRoute.Models = {
         additionalProperties: false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_CompiledDimension.label-or-name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricQueryResponse: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                metadata: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        hasADateDimension: {
+                            ref: 'Pick_CompiledDimension.label-or-name_',
+                            required: true,
+                        },
+                    },
+                },
                 customDimensions: {
                     dataType: 'array',
                     array: { dataType: 'refObject', ref: 'CustomDimension' },
@@ -2237,18 +2259,6 @@ const models: TsoaRoute.Models = {
     DateGranularity: {
         dataType: 'refEnum',
         enums: ['Day', 'Week', 'Month', 'Quarter', 'Year'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CompiledDimension.label-or-name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string', required: true },
-                label: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricQueryRequest: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -176,6 +176,9 @@
             },
             "FiltersResponse": {
                 "properties": {
+                    "tableCalculations": {
+                        "$ref": "#/components/schemas/FilterGroupResponse"
+                    },
                     "metrics": {
                         "$ref": "#/components/schemas/FilterGroupResponse"
                     },
@@ -471,8 +474,30 @@
                 "type": "object",
                 "additionalProperties": false
             },
+            "Pick_CompiledDimension.label-or-name_": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["label", "name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
             "MetricQueryResponse": {
                 "properties": {
+                    "metadata": {
+                        "properties": {
+                            "hasADateDimension": {
+                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
+                            }
+                        },
+                        "required": ["hasADateDimension"],
+                        "type": "object"
+                    },
                     "customDimensions": {
                         "items": {
                             "$ref": "#/components/schemas/CustomDimension"
@@ -2557,19 +2582,6 @@
             "DateGranularity": {
                 "enum": ["Day", "Week", "Month", "Quarter", "Year"],
                 "type": "string"
-            },
-            "Pick_CompiledDimension.label-or-name_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "label": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name", "label"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "MetricQueryRequest": {
                 "properties": {
@@ -5439,7 +5451,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.885.3",
+        "version": "0.891.1",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -100,6 +100,7 @@ type FilterGroupResponse =
 export type FiltersResponse = {
     dimensions?: FilterGroupResponse;
     metrics?: FilterGroupResponse;
+    tableCalculations?: FilterGroupResponse;
 };
 export type MetricQueryResponse = {
     dimensions: FieldId[]; // Dimensions to group by in the explore
@@ -110,6 +111,9 @@ export type MetricQueryResponse = {
     tableCalculations: TableCalculation[]; // calculations to append to results
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     customDimensions?: CustomDimension[];
+    metadata?: {
+        hasADateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+    };
 };
 
 export const countCustomDimensionsInMetricQuery = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

A couple of the newer props, `tableCalculations` and `metadata`, were missing from the types used by the gsheets export endpoint, causing a validation error. 

I tested this and it fixes the error. But I don't know a lot about these props and I'm happy to change this if another approach is needed. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
