### PR TITLE
refactor: use itemsMap on visualisation provider pie chart

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -10,6 +10,7 @@ import { Explore, SummaryExplore } from './types/explore';
 import {
     CompiledField,
     CustomDimension,
+    Dimension,
     DimensionType,
     Field,
     FieldId,
@@ -17,6 +18,8 @@ import {
     FilterableField,
     friendlyName,
     isDimension,
+    isField,
+    isMetric,
     ItemsMap,
     Metric,
     TableCalculation,
@@ -25,6 +28,7 @@ import {
     AdditionalMetric,
     getCustomDimensionId,
     isAdditionalMetric,
+    isCustomDimension,
     MetricQuery,
 } from './types/metricQuery';
 import {
@@ -788,6 +792,27 @@ export function getItemMap(
         {},
     );
 }
+
+export const getDimensionsFromItemsMap = (itemsMap: ItemsMap) =>
+    Object.entries(itemsMap).reduce<
+        Record<string, Dimension | CustomDimension>
+    >((acc, [key, value]) => {
+        if (isDimension(value) || isCustomDimension(value)) {
+            return { ...acc, [key]: value };
+        }
+        return acc;
+    }, {});
+
+export const getMetricsFromItemsMap = (itemsMap: ItemsMap) =>
+    Object.entries(itemsMap).reduce<Record<string, Metric>>(
+        (acc, [key, value]) => {
+            if (isField(value) && isMetric(value)) {
+                return { ...acc, [key]: value };
+            }
+            return acc;
+        },
+        {},
+    );
 
 export function itemsInMetricQuery(
     metricQuery: MetricQuery | undefined,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -803,10 +803,13 @@ export const getDimensionsFromItemsMap = (itemsMap: ItemsMap) =>
         return acc;
     }, {});
 
-export const getMetricsFromItemsMap = (itemsMap: ItemsMap) =>
+export const getMetricsFromItemsMap = (
+    itemsMap: ItemsMap,
+    filter: (value: ItemsMap[string]) => boolean = () => true,
+) =>
     Object.entries(itemsMap).reduce<Record<string, Metric>>(
         (acc, [key, value]) => {
-            if (isField(value) && isMetric(value)) {
+            if (isField(value) && isMetric(value) && filter(value)) {
                 return { ...acc, [key]: value };
             }
             return acc;

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -57,6 +57,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
         explore,
         resultsData,
         initialChartConfig,
+        itemsMap,
         dimensions,
         metrics,
     );

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -4,6 +4,7 @@ import {
     Dimension,
     getDimensionsFromItemsMap,
     getMetricsFromItemsMap,
+    isNumericItem,
     ItemsMap,
     Metric,
 } from '@lightdash/common';
@@ -17,8 +18,8 @@ import {
 export type VisualizationConfigPie = {
     chartType: ChartType.PIE;
     chartConfig: ReturnType<typeof usePieChartConfig>;
-    dimensions: (Dimension | CustomDimension)[];
-    metrics: Metric[];
+    dimensions: Record<string, CustomDimension | Dimension>;
+    numericMetrics: Record<string, Metric>;
 };
 
 export const isPieVisualizationConfig = (
@@ -41,14 +42,13 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     itemsMap,
     children,
 }) => {
-    const { dimensions, metrics } = useMemo(
+    const { dimensions, numericMetrics } = useMemo(
         () => ({
-            dimensions: itemsMap
-                ? Object.values(getDimensionsFromItemsMap(itemsMap))
-                : [],
-            metrics: itemsMap
-                ? Object.values(getMetricsFromItemsMap(itemsMap))
-                : [],
+            dimensions: getDimensionsFromItemsMap(itemsMap ?? {}),
+            numericMetrics: getMetricsFromItemsMap(
+                itemsMap ?? {},
+                isNumericItem,
+            ),
         }),
         [itemsMap],
     );
@@ -59,7 +59,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
         initialChartConfig,
         itemsMap,
         dimensions,
-        metrics,
+        numericMetrics,
     );
 
     useEffect(() => {
@@ -76,7 +76,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
             chartType: ChartType.PIE,
             chartConfig: pieChartConfig,
             dimensions,
-            metrics,
+            numericMetrics,
         },
     });
 };

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -1,10 +1,4 @@
-import {
-    ChartType,
-    CustomDimension,
-    Dimension,
-    Metric,
-    TableCalculation,
-} from '@lightdash/common';
+import { ChartType, ItemsMap } from '@lightdash/common';
 import { FC, useEffect } from 'react';
 import usePieChartConfig from '../../hooks/usePieChartConfig';
 import {
@@ -25,28 +19,23 @@ export const isPieVisualizationConfig = (
 
 type VisualizationConfigPieProps =
     VisualizationConfigCommon<VisualizationConfigPie> & {
-        dimensions: Dimension[];
-        allNumericMetrics: (Metric | TableCalculation)[];
-        customDimensions: CustomDimension[];
+        // TODO: shared prop once all visualizations are converted
+        itemsMap: ItemsMap | undefined;
     };
 
 const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     explore,
     resultsData,
-    dimensions,
-    allNumericMetrics,
-    customDimensions,
     initialChartConfig,
     onChartConfigChange,
+    itemsMap,
     children,
 }) => {
     const pieChartConfig = usePieChartConfig(
         explore,
         resultsData,
         initialChartConfig,
-        dimensions,
-        allNumericMetrics,
-        customDimensions,
+        itemsMap,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -1,5 +1,13 @@
-import { ChartType, ItemsMap } from '@lightdash/common';
-import { FC, useEffect } from 'react';
+import {
+    ChartType,
+    CustomDimension,
+    Dimension,
+    getDimensionsFromItemsMap,
+    getMetricsFromItemsMap,
+    ItemsMap,
+    Metric,
+} from '@lightdash/common';
+import { FC, useEffect, useMemo } from 'react';
 import usePieChartConfig from '../../hooks/usePieChartConfig';
 import {
     VisualizationConfig,
@@ -9,6 +17,8 @@ import {
 export type VisualizationConfigPie = {
     chartType: ChartType.PIE;
     chartConfig: ReturnType<typeof usePieChartConfig>;
+    dimensions: (Dimension | CustomDimension)[];
+    metrics: Metric[];
 };
 
 export const isPieVisualizationConfig = (
@@ -31,11 +41,24 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     itemsMap,
     children,
 }) => {
+    const { dimensions, metrics } = useMemo(
+        () => ({
+            dimensions: itemsMap
+                ? Object.values(getDimensionsFromItemsMap(itemsMap))
+                : [],
+            metrics: itemsMap
+                ? Object.values(getMetricsFromItemsMap(itemsMap))
+                : [],
+        }),
+        [itemsMap],
+    );
+
     const pieChartConfig = usePieChartConfig(
         explore,
         resultsData,
         initialChartConfig,
-        itemsMap,
+        dimensions,
+        metrics,
     );
 
     useEffect(() => {
@@ -51,6 +74,8 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
         visualizationConfig: {
             chartType: ChartType.PIE,
             chartConfig: pieChartConfig,
+            dimensions,
+            metrics,
         },
     });
 };

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -5,15 +5,11 @@ import {
     ChartConfig,
     ChartType,
     convertAdditionalMetric,
-    CustomDimension,
     DashboardFilters,
-    Dimension,
     Explore,
     fieldId,
     getCustomDimensionId,
-    getDimensions,
     getMetrics,
-    isNumericItem,
     ItemsMap,
     Metric,
     TableCalculation,
@@ -68,11 +64,7 @@ type VisualizationContext = {
     columnOrder: string[];
     isSqlRunner: boolean;
     itemsMap: ItemsMap | undefined;
-    dimensions: Dimension[];
-    customDimensions: CustomDimension[];
     metrics: Metric[];
-    allMetrics: (Metric | TableCalculation)[];
-    allNumericMetrics: (Metric | TableCalculation)[];
     customMetrics: AdditionalMetric[];
     tableCalculations: TableCalculation[];
     visualizationConfig: VisualizationConfig;
@@ -176,23 +168,12 @@ const VisualizationProvider: FC<Props> = ({
     const [cartesianType, setCartesianType] = useState<CartesianTypeOptions>();
     // --
 
-    const dimensions = useMemo(() => {
-        if (!explore) return [];
-        return getDimensions(explore).filter((field) =>
-            resultsData?.metricQuery.dimensions.includes(fieldId(field)),
-        );
-    }, [explore, resultsData?.metricQuery.dimensions]);
-
     const metrics = useMemo(() => {
         if (!explore) return [];
         return getMetrics(explore).filter((field) =>
             resultsData?.metricQuery.metrics.includes(fieldId(field)),
         );
     }, [explore, resultsData?.metricQuery.metrics]);
-
-    const customDimensions = useMemo(() => {
-        return resultsData?.metricQuery.customDimensions || [];
-    }, [resultsData?.metricQuery.customDimensions]);
 
     const customMetrics = useMemo(() => {
         if (!explore) return [];
@@ -223,16 +204,6 @@ const VisualizationProvider: FC<Props> = ({
     const tableCalculations = useMemo(() => {
         return resultsData?.metricQuery.tableCalculations ?? [];
     }, [resultsData?.metricQuery.tableCalculations]);
-
-    const allMetrics = useMemo(
-        () => [...metrics, ...customMetrics, ...tableCalculations],
-        [metrics, customMetrics, tableCalculations],
-    );
-
-    const allNumericMetrics = useMemo(
-        () => allMetrics.filter((m) => isNumericItem(m)),
-        [allMetrics],
-    );
 
     // If we don't toggle any fields, (eg: when you `explore from here`) columnOrder on tableConfig might be empty
     // so we initialize it with the fields from resultData
@@ -287,13 +258,9 @@ const VisualizationProvider: FC<Props> = ({
         columnOrder,
         isSqlRunner: isSqlRunner ?? false,
         itemsMap,
-        dimensions,
         metrics,
         customMetrics,
-        customDimensions,
         tableCalculations,
-        allMetrics,
-        allNumericMetrics,
         setStacking,
         setCartesianType,
         onSeriesContextMenu,
@@ -328,10 +295,8 @@ const VisualizationProvider: FC<Props> = ({
             return (
                 <VisualizationPieConfig
                     explore={explore}
+                    itemsMap={itemsMap}
                     resultsData={lastValidResultsData}
-                    dimensions={dimensions}
-                    allNumericMetrics={allNumericMetrics}
-                    customDimensions={customDimensions}
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}
                 >

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -3,8 +3,6 @@ import {
     Dimension,
     fieldId,
     getCustomDimensionId,
-    getDimensionsFromItemsMap,
-    getMetricsFromItemsMap,
     isCustomDimension,
     isDimension,
     isField,
@@ -12,7 +10,6 @@ import {
 } from '@lightdash/common';
 import { Box, Button, Stack, Switch, Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
-import { useMemo } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigPie';
@@ -21,19 +18,9 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 const PieChartLayoutConfig: React.FC = () => {
     const { visualizationConfig, itemsMap } = useVisualizationContext();
 
-    const { dimensions, metrics } = useMemo(
-        () => ({
-            dimensions: itemsMap
-                ? Object.values(getDimensionsFromItemsMap(itemsMap))
-                : [],
-            metrics: itemsMap
-                ? Object.values(getMetricsFromItemsMap(itemsMap))
-                : [],
-        }),
-        [itemsMap],
-    );
-
     if (!isPieVisualizationConfig(visualizationConfig)) return null;
+
+    const { dimensions, metrics } = visualizationConfig;
 
     const {
         groupFieldIds,

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -1,27 +1,39 @@
 import {
+    CustomDimension,
+    Dimension,
     fieldId,
     getCustomDimensionId,
+    getDimensionsFromItemsMap,
+    getMetricsFromItemsMap,
     isCustomDimension,
+    isDimension,
     isField,
+    Metric,
 } from '@lightdash/common';
 import { Box, Button, Stack, Switch, Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
+import { useMemo } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigPie';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 
 const PieChartLayoutConfig: React.FC = () => {
-    const {
-        dimensions,
-        allNumericMetrics,
-        customDimensions,
-        visualizationConfig,
-    } = useVisualizationContext();
+    const { visualizationConfig, itemsMap } = useVisualizationContext();
+
+    const { dimensions, metrics } = useMemo(
+        () => ({
+            dimensions: itemsMap
+                ? Object.values(getDimensionsFromItemsMap(itemsMap))
+                : [],
+            metrics: itemsMap
+                ? Object.values(getMetricsFromItemsMap(itemsMap))
+                : [],
+        }),
+        [itemsMap],
+    );
 
     if (!isPieVisualizationConfig(visualizationConfig)) return null;
-
-    const allDimensions = [...dimensions, ...customDimensions];
 
     const {
         groupFieldIds,
@@ -40,22 +52,23 @@ const PieChartLayoutConfig: React.FC = () => {
         <Stack>
             <Stack spacing="xs">
                 {groupFieldIds.map((dimensionId, index) => {
-                    const selectedDimension = allDimensions.find(
-                        (d) =>
-                            (isCustomDimension(d)
-                                ? getCustomDimensionId(d)
-                                : fieldId(d)) === dimensionId,
-                    );
+                    if (!itemsMap || !dimensionId) return null;
 
+                    const dimension = itemsMap[dimensionId];
+
+                    const selectedDimension =
+                        isDimension(dimension) || isCustomDimension(dimension)
+                            ? dimension
+                            : undefined;
                     return (
-                        <FieldSelect
+                        <FieldSelect<CustomDimension | Dimension>
                             key={index}
-                            disabled={allDimensions.length === 0}
+                            disabled={dimensions.length === 0}
                             clearable={index !== 0}
                             label={index === 0 ? 'Group' : undefined}
                             placeholder="Select dimension"
                             item={selectedDimension}
-                            items={allDimensions}
+                            items={dimensions}
                             inactiveItemIds={groupFieldIds
                                 .filter((id): id is string => !!id)
                                 .filter((id) => id !== dimensionId)}
@@ -82,14 +95,14 @@ const PieChartLayoutConfig: React.FC = () => {
                 <Tooltip
                     disabled={
                         !(
-                            allDimensions.length === 0 ||
-                            groupFieldIds.length === allDimensions.length
+                            dimensions.length === 0 ||
+                            groupFieldIds.length === dimensions.length
                         )
                     }
                     label={
-                        allDimensions.length === 0
+                        dimensions.length === 0
                             ? 'You must select at least one dimension to create a pie chart'
-                            : allDimensions.length === groupFieldIds.length
+                            : dimensions.length === groupFieldIds.length
                             ? 'To add more groups you need to add more dimensions to your query'
                             : undefined
                     }
@@ -103,8 +116,8 @@ const PieChartLayoutConfig: React.FC = () => {
                             variant="outline"
                             onClick={groupAdd}
                             disabled={
-                                allDimensions.length === 0 ||
-                                groupFieldIds.length === allDimensions.length
+                                dimensions.length === 0 ||
+                                groupFieldIds.length === dimensions.length
                             }
                         >
                             Add Group
@@ -114,16 +127,16 @@ const PieChartLayoutConfig: React.FC = () => {
             </Stack>
 
             <Tooltip
-                disabled={allNumericMetrics.length > 0}
+                disabled={metrics && metrics.length > 0}
                 label="You must select at least one numeric metric to create a pie chart"
             >
                 <Box>
-                    <FieldSelect
+                    <FieldSelect<Metric>
                         label="Metric"
                         placeholder="Select metric"
-                        disabled={allNumericMetrics.length === 0}
+                        disabled={metrics.length === 0}
                         item={selectedMetric}
-                        items={allNumericMetrics}
+                        items={metrics}
                         onChange={(newField) => {
                             metricChange(
                                 newField && isField(newField)

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -20,7 +20,8 @@ const PieChartLayoutConfig: React.FC = () => {
 
     if (!isPieVisualizationConfig(visualizationConfig)) return null;
 
-    const { dimensions, metrics } = visualizationConfig;
+    const numericMetrics = Object.values(visualizationConfig.numericMetrics);
+    const dimensions = Object.values(visualizationConfig.dimensions);
 
     const {
         groupFieldIds,
@@ -114,16 +115,16 @@ const PieChartLayoutConfig: React.FC = () => {
             </Stack>
 
             <Tooltip
-                disabled={metrics && metrics.length > 0}
+                disabled={numericMetrics && numericMetrics.length > 0}
                 label="You must select at least one numeric metric to create a pie chart"
             >
                 <Box>
                     <FieldSelect<Metric>
                         label="Metric"
                         placeholder="Select metric"
-                        disabled={metrics.length === 0}
+                        disabled={numericMetrics.length === 0}
                         item={selectedMetric}
-                        items={metrics}
+                        items={numericMetrics}
                         onChange={(newField) => {
                             metricChange(
                                 newField && isField(newField)

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -14,7 +14,7 @@ export type PieSeriesDataPoint = NonNullable<
 };
 
 const useEchartsPieConfig = (isInDashboard: boolean) => {
-    const { visualizationConfig, explore } = useVisualizationContext();
+    const { visualizationConfig, itemsMap } = useVisualizationContext();
 
     const chartConfig = useMemo(() => {
         if (!isPieVisualizationConfig(visualizationConfig)) return;
@@ -166,7 +166,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         };
     }, [chartConfig, isInDashboard, pieSeriesOption]);
 
-    if (!explore) return;
+    if (!itemsMap) return;
     if (!eChartsOption || !pieSeriesOption) return;
 
     return { eChartsOption, pieSeriesOption };

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -9,7 +9,9 @@ import {
     getCustomDimensionId,
     isCustomDimension,
     isField,
+    isMetric,
     isNumericItem,
+    ItemsMap,
     Metric,
     PieChart,
     PieChartLegendPosition,
@@ -90,6 +92,7 @@ export type PieChartConfigFn = (
     explore: Explore | undefined,
     resultsData: ApiQueryResults | undefined,
     pieChartConfig: PieChart | undefined,
+    itemsMap: ItemsMap | undefined,
     dimensions: (Dimension | CustomDimension)[],
     metrics: Metric[],
 ) => PieChartConfig;
@@ -98,6 +101,7 @@ const usePieChartConfig: PieChartConfigFn = (
     explore,
     resultsData,
     pieChartConfig,
+    itemsMap,
     dimensions,
     metrics,
 ) => {
@@ -182,13 +186,14 @@ const usePieChartConfig: PieChartConfigFn = (
         [allNumericMetrics],
     );
 
-    const selectedMetric = useMemo(
-        () =>
-            allNumericMetrics.find(
-                (m) => isField(m) && fieldId(m) === metricId,
-            ),
-        [allNumericMetrics, metricId],
-    );
+    const selectedMetric = useMemo(() => {
+        if (!itemsMap || !metricId) return undefined;
+        const item = itemsMap[metricId];
+
+        if (isField(item) && isMetric(item)) return item;
+
+        return undefined;
+    }, [itemsMap, metricId]);
 
     const isLoading = !explore || !resultsData;
 

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -176,14 +176,15 @@ const usePieChartConfig: PieChartConfigFn = (
         [dimensions],
     );
 
-    const allNumericMetrics = useMemo(
-        () => metrics.filter(isNumericItem),
-        [metrics],
-    );
-
     const allNumericMetricIds = useMemo(
-        () => allNumericMetrics.map((m) => fieldId(m)),
-        [allNumericMetrics],
+        () =>
+            metrics.reduce<string[]>((acc, metric) => {
+                if (isNumericItem(metric)) {
+                    acc.push(fieldId(metric));
+                }
+                return acc;
+            }, []),
+        [metrics],
     );
 
     const selectedMetric = useMemo(() => {

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -4,13 +4,9 @@ import {
     Dimension,
     ECHARTS_DEFAULT_COLORS,
     Explore,
-    fieldId,
     formatItemValue,
-    getCustomDimensionId,
-    isCustomDimension,
     isField,
     isMetric,
-    isNumericItem,
     ItemsMap,
     Metric,
     PieChart,
@@ -93,8 +89,8 @@ export type PieChartConfigFn = (
     resultsData: ApiQueryResults | undefined,
     pieChartConfig: PieChart | undefined,
     itemsMap: ItemsMap | undefined,
-    dimensions: (Dimension | CustomDimension)[],
-    metrics: Metric[],
+    dimensions: Record<string, CustomDimension | Dimension>,
+    numericMetrics: Record<string, Metric>,
 ) => PieChartConfig;
 
 const usePieChartConfig: PieChartConfigFn = (
@@ -103,7 +99,7 @@ const usePieChartConfig: PieChartConfigFn = (
     pieChartConfig,
     itemsMap,
     dimensions,
-    metrics,
+    numericMetrics,
 ) => {
     const { data: org } = useOrganization();
 
@@ -166,25 +162,11 @@ const usePieChartConfig: PieChartConfigFn = (
         [org],
     );
 
-    const dimensionIds = useMemo(
-        () =>
-            dimensions.map((dimension) => {
-                if (isCustomDimension(dimension))
-                    return getCustomDimensionId(dimension);
-                return fieldId(dimension);
-            }),
-        [dimensions],
-    );
+    const dimensionIds = useMemo(() => Object.keys(dimensions), [dimensions]);
 
     const allNumericMetricIds = useMemo(
-        () =>
-            metrics.reduce<string[]>((acc, metric) => {
-                if (isNumericItem(metric)) {
-                    acc.push(fieldId(metric));
-                }
-                return acc;
-            }, []),
-        [metrics],
+        () => Object.keys(numericMetrics),
+        [numericMetrics],
     );
 
     const selectedMetric = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/8153

### Description:

Generate all `dimensions` and all `metrics` with `itemsMap` and utilise it where possible on Pie Charts. Now we don't do unnecessary loops for non-pie charts because that's been moved to the viz provider just for Pie charts. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
