### PR TITLE
feat: move run query button back to the top of the page

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -1,11 +1,8 @@
-import { Alert, Box, Skeleton, Stack } from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Skeleton, Stack } from '@mantine/core';
 import { FC, memo } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
-import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
-import { RefreshButton } from '../../RefreshButton';
 import ExploreTree from '../ExploreTree';
 
 const LoadingSkeleton = () => (
@@ -43,12 +40,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     );
     const toggleActiveField = useExplorerContext(
         (context) => context.actions.toggleActiveField,
-    );
-    const showLimitWarning = useExplorerContext(
-        (context) =>
-            context.queryResults.data &&
-            context.queryResults.data.rows.length >=
-                context.state.unsavedChartVersion.metricQuery.limit,
     );
     const { data, status } = useExplore(activeTableName);
 
@@ -96,20 +87,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                 onSelectedFieldChange={toggleActiveField}
                 customDimensions={customDimensions}
             />
-            <Box py="md">
-                {showLimitWarning && (
-                    <Alert
-                        icon={<MantineIcon icon={IconAlertCircle} />}
-                        color="orange"
-                        title="Results may be incomplete"
-                        mb="md"
-                    >
-                        The number of results returned is the same or more than
-                        the limit you've set
-                    </Alert>
-                )}
-                <RefreshButton />
-            </Box>
         </>
     );
 });

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -54,6 +54,7 @@ const ExplorerHeader: FC = memo(() => {
                 <Box>
                     <RefreshDbtButton />
                 </Box>
+
                 <Group spacing="xs">
                     {showLimitWarning && (
                         <Tooltip
@@ -70,16 +71,17 @@ const ExplorerHeader: FC = memo(() => {
                                     />
                                 }
                                 color="yellow"
-                                variant={'outline'}
-                                sx={{
-                                    textTransform: 'none',
-                                }}
+                                variant="outline"
+                                tt="none"
+                                sx={{ cursor: 'help' }}
                             >
                                 Results may be incomplete
                             </Badge>
                         </Tooltip>
                     )}
-                    <RefreshButton size={'xs'} />
+
+                    <RefreshButton size="xs" />
+
                     {!savedChart && (
                         <Can I="manage" a="SavedChart">
                             <SaveChartButton isExplorer />

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,10 +1,13 @@
-import { Box, Group } from '@mantine/core';
+import { Badge, Box, Group, Tooltip } from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
 import { FC, memo, useEffect } from 'react';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { Can } from '../../common/Authorization';
+import MantineIcon from '../../common/MantineIcon';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
+import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import SaveChartButton from '../SaveChartButton';
 
@@ -17,6 +20,15 @@ const ExplorerHeader: FC = memo(() => {
     );
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
+    );
+    const showLimitWarning = useExplorerContext(
+        (context) =>
+            context.queryResults.data &&
+            context.queryResults.data.rows.length >=
+                context.state.unsavedChartVersion.metricQuery.limit,
+    );
+    const limit = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery.limit,
     );
 
     const { getHasDashboardChanges } = useDashboardStorage();
@@ -43,6 +55,31 @@ const ExplorerHeader: FC = memo(() => {
                     <RefreshDbtButton />
                 </Box>
                 <Group spacing="xs">
+                    {showLimitWarning && (
+                        <Tooltip
+                            width={400}
+                            label={`Query limit of ${limit} reached. There may be additional results that have not been displayed. To see more, increase the query limit or try narrowing filters.`}
+                            multiline
+                            position={'bottom'}
+                        >
+                            <Badge
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconAlertCircle}
+                                        size={'sm'}
+                                    />
+                                }
+                                color="yellow"
+                                variant={'outline'}
+                                sx={{
+                                    textTransform: 'none',
+                                }}
+                            >
+                                Results may be incomplete
+                            </Badge>
+                        </Tooltip>
+                    )}
+                    <RefreshButton size={'xs'} />
                     {!savedChart && (
                         <Can I="manage" a="SavedChart">
                             <SaveChartButton isExplorer />

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,12 +1,10 @@
-import { Alert, Stack, Text } from '@mantine/core';
+import { Stack } from '@mantine/core';
 import { FC, memo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ProjectType } from '@lightdash/common';
-import { IconAlertCircle } from '@tabler/icons-react';
 import { useProjects } from '../../hooks/useProjects';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
-import MantineIcon from '../common/MantineIcon';
 import { CustomVisualizationProvider } from '../CustomVisualization';
 import DrillDownModal from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
@@ -27,15 +25,6 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const unsavedChartVersionMetricQuery = useExplorerContext(
             (context) => context.state.unsavedChartVersion.metricQuery,
         );
-        const showLimitWarning = useExplorerContext(
-            (context) =>
-                context.queryResults.data &&
-                context.queryResults.data.rows.length >=
-                    context.state.unsavedChartVersion.metricQuery.limit,
-        );
-        const limit = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.metricQuery.limit,
-        );
         const { projectUuid } = useParams<{ projectUuid: string }>();
 
         const { data: projects } = useProjects({ refetchOnMount: false });
@@ -52,22 +41,6 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             >
                 <Stack sx={{ flexGrow: 1 }}>
                     {!hideHeader && <ExplorerHeader />}
-
-                    {showLimitWarning && (
-                        <Alert
-                            icon={<MantineIcon icon={IconAlertCircle} />}
-                            color="yellow"
-                            title="Results may be incomplete"
-                            variant={'outline'}
-                        >
-                            <Text color="gray.6">
-                                Query limit of {limit} reached. There may be
-                                additional results that have not been displayed.
-                                To see more, increase the query limit or try
-                                narrowing filters.
-                            </Text>
-                        </Alert>
-                    )}
 
                     <FiltersCard />
 

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,10 +1,12 @@
-import { Stack } from '@mantine/core';
+import { Alert, Stack, Text } from '@mantine/core';
 import { FC, memo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ProjectType } from '@lightdash/common';
+import { IconAlertCircle } from '@tabler/icons-react';
 import { useProjects } from '../../hooks/useProjects';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
+import MantineIcon from '../common/MantineIcon';
 import { CustomVisualizationProvider } from '../CustomVisualization';
 import DrillDownModal from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
@@ -25,6 +27,15 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const unsavedChartVersionMetricQuery = useExplorerContext(
             (context) => context.state.unsavedChartVersion.metricQuery,
         );
+        const showLimitWarning = useExplorerContext(
+            (context) =>
+                context.queryResults.data &&
+                context.queryResults.data.rows.length >=
+                    context.state.unsavedChartVersion.metricQuery.limit,
+        );
+        const limit = useExplorerContext(
+            (context) => context.state.unsavedChartVersion.metricQuery.limit,
+        );
         const { projectUuid } = useParams<{ projectUuid: string }>();
 
         const { data: projects } = useProjects({ refetchOnMount: false });
@@ -41,6 +52,22 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             >
                 <Stack sx={{ flexGrow: 1 }}>
                     {!hideHeader && <ExplorerHeader />}
+
+                    {showLimitWarning && (
+                        <Alert
+                            icon={<MantineIcon icon={IconAlertCircle} />}
+                            color="yellow"
+                            title="Results may be incomplete"
+                            variant={'outline'}
+                        >
+                            <Text color="gray.6">
+                                Query limit of {limit} reached. There may be
+                                additional results that have not been displayed.
+                                To see more, increase the query limit or try
+                                narrowing filters.
+                            </Text>
+                        </Alert>
+                    )}
 
                     <FiltersCard />
 

--- a/packages/frontend/src/components/LimitButton/LimitForm.tsx
+++ b/packages/frontend/src/components/LimitButton/LimitForm.tsx
@@ -50,6 +50,7 @@ const LimitForm = forwardRef<HTMLFormElement, LimitFormProps>(
                     />
 
                     <Button
+                        size={'xs'}
                         type="submit"
                         disabled={!form.isValid()}
                         sx={{ alignSelf: 'flex-end' }}

--- a/packages/frontend/src/components/LimitButton/index.tsx
+++ b/packages/frontend/src/components/LimitButton/index.tsx
@@ -30,11 +30,11 @@ const LimitButton: FC<Props> = memo(
                 withinPortal
                 disabled={disabled}
                 opened={opened}
-                position="top"
+                position="bottom-end"
                 withArrow
                 shadow="md"
-                arrowSize={10}
                 offset={2}
+                arrowOffset={10}
             >
                 <Popover.Target>
                     <Button
@@ -43,7 +43,7 @@ const LimitButton: FC<Props> = memo(
                         disabled={disabled}
                         onClick={opened ? undefined : open}
                     >
-                        <MantineIcon icon={IconChevronDown} size="lg" />
+                        <MantineIcon icon={IconChevronDown} size="sm" />
                     </Button>
                 </Popover.Target>
 

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -8,10 +8,12 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useHotkeys, useOs } from '@mantine/hooks';
+import { IconPlayerPlay } from '@tabler/icons-react';
 import { FC, memo, useCallback } from 'react';
 import { useExplorerContext } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import { EventName } from '../types/Events';
+import MantineIcon from './common/MantineIcon';
 import LimitButton from './LimitButton';
 
 export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
@@ -67,8 +69,10 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                 disabled={isLoading || !isValidQuery}
             >
                 <Button
+                    pr="xxs"
                     size={size}
                     disabled={!isValidQuery}
+                    leftIcon={<MantineIcon icon={IconPlayerPlay} />}
                     loading={isLoading}
                     onClick={onClick}
                     sx={{ flex: 1 }}
@@ -76,6 +80,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                     Run query ({limit})
                 </Button>
             </Tooltip>
+
             <LimitButton
                 disabled={!isValidQuery}
                 size={size}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Based on user feedback we moved the run query button back to the top and made the limit warning much smaller.

![Screenshot 2023-12-05 at 13 57 01](https://github.com/lightdash/lightdash/assets/9117144/fec82f6b-45e4-4d83-9b42-07c0d8e0e866)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
