### PR TITLE
fix: clear previous invite from add user modal

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -291,6 +291,7 @@ const UserManagementPanel: FC = () => {
                             Add user
                         </Button>
                         <InvitesModal
+                            key={`invite-modal-${showInviteModal}`}
                             opened={showInviteModal}
                             onClose={() => setShowInviteModal(false)}
                         />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8208 

### Description:

The previous invite was sticking around when the user invite modal was closed and re-opened. This clears the modal state when it is closed.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
