### PR TITLE
feat: visualization context menus to mantine

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1,9 +1,5 @@
-import { Menu, NonIdealState, Tag } from '@blueprintjs/core';
-import {
-    MenuItem2,
-    Popover2,
-    Popover2TargetProps,
-} from '@blueprintjs/popover2';
+import { NonIdealState, Tag } from '@blueprintjs/core';
+import { MenuItem2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     ApiChartAndResults,
@@ -29,10 +25,16 @@ import {
     ResultValue,
     SavedChart,
 } from '@lightdash/common';
-import { Box, Portal, Text, Tooltip } from '@mantine/core';
-import { IconFilter, IconFolders } from '@tabler/icons-react';
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
+import { Box, Menu, Portal, Text, Tooltip } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import {
+    IconChevronRight,
+    IconCopy,
+    IconFilter,
+    IconFolders,
+    IconStack,
+} from '@tabler/icons-react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { downloadCsv } from '../../api/csv';
@@ -271,6 +273,7 @@ interface DashboardChartTileMainProps
 
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { showToastSuccess } = useToaster();
+    const clipboard = useClipboard({ timeout: 200 });
     const { track } = useTracking();
     const {
         tile: {
@@ -312,24 +315,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { user } = useApp();
 
     const { openUnderlyingDataModal } = useMetricQueryDataContext();
-    const contextMenuRenderTarget = useCallback(
-        ({ ref }: Popover2TargetProps) => (
-            <Portal>
-                <div
-                    style={{ position: 'absolute', ...contextMenuTargetOffset }}
-                    ref={ref}
-                />
-            </Portal>
-        ),
-        [contextMenuTargetOffset],
-    );
-    const cancelContextMenu = React.useCallback(
-        (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(),
-        [],
-    );
-    const [dashboardTileFilterOptions, setDashboardFilterOptions] = useState<
-        DashboardFilterRule[]
-    >([]);
+
     const [viewUnderlyingDataOptions, setViewUnderlyingDataOptions] = useState<{
         item: ItemsMap[string] | undefined;
         value: ResultValue;
@@ -337,6 +323,85 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         dimensions: string[];
         pivotReference?: PivotReference;
     }>();
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (!viewUnderlyingDataOptions) return;
+
+        openUnderlyingDataModal({
+            ...viewUnderlyingDataOptions,
+        });
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                organizationId: user?.data?.organizationUuid,
+                userId: user?.data?.userUuid,
+                projectId: projectUuid,
+            },
+        });
+    }, [
+        track,
+        user,
+        projectUuid,
+        openUnderlyingDataModal,
+        viewUnderlyingDataOptions,
+    ]);
+
+    const handleCopyToClipboard = useCallback(() => {
+        if (!viewUnderlyingDataOptions) return;
+
+        const value = viewUnderlyingDataOptions.value.formatted;
+
+        showToastSuccess({
+            title: 'Copied to clipboard!',
+        });
+
+        clipboard.copy(value);
+    }, [viewUnderlyingDataOptions, clipboard, showToastSuccess]);
+
+    const handleAddFilter = useCallback(
+        (filter: DashboardFilterRule) => {
+            track({
+                name: EventName.ADD_FILTER_CLICKED,
+                properties: {
+                    mode: isEditMode ? 'edit' : 'viewer',
+                },
+            });
+
+            const fields = explore ? getFields(explore) : [];
+            const field = fields.find(
+                (f) => fieldId(f) === filter.target.fieldId,
+            );
+
+            track({
+                name: EventName.CROSS_FILTER_DASHBOARD_APPLIED,
+                properties: {
+                    fieldType: field?.type,
+                    projectId: projectUuid,
+                    dashboardId: dashboardUuid,
+                },
+            });
+
+            addDimensionDashboardFilter(filter, !isEditMode);
+        },
+        [
+            track,
+            isEditMode,
+            addDimensionDashboardFilter,
+            explore,
+            projectUuid,
+            dashboardUuid,
+        ],
+    );
+
+    const handleCancelContextMenu = useCallback(
+        (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(),
+        [],
+    );
+
+    const [dashboardTileFilterOptions, setDashboardFilterOptions] = useState<
+        DashboardFilterRule[]
+    >([]);
+
     const [isCSVExportModalOpen, setIsCSVExportModalOpen] = useState(false);
 
     const onSeriesContextMenu = useCallback(
@@ -571,159 +636,140 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 {...props}
             >
                 <>
-                    <Popover2
-                        content={
-                            <div onContextMenu={cancelContextMenu}>
-                                <Menu>
-                                    {viewUnderlyingDataOptions?.value && (
-                                        <CopyToClipboard
-                                            text={
-                                                viewUnderlyingDataOptions.value
-                                                    .formatted
-                                            }
-                                            onCopy={() => {
-                                                showToastSuccess({
-                                                    title: 'Copied to clipboard!',
-                                                });
-                                            }}
-                                        >
-                                            <MenuItem2
-                                                text="Copy value"
-                                                icon="duplicate"
-                                            />
-                                        </CopyToClipboard>
-                                    )}
-                                    <Can
-                                        I="view"
-                                        this={subject('UnderlyingData', {
-                                            organizationUuid:
-                                                user.data?.organizationUuid,
-                                            projectUuid: projectUuid,
-                                        })}
-                                    >
-                                        {' '}
-                                        {!hasCustomDimension(metricQuery) && (
-                                            <MenuItem2
-                                                text="View underlying data"
-                                                icon="layers"
-                                                onClick={() => {
-                                                    if (
-                                                        !viewUnderlyingDataOptions
-                                                    ) {
-                                                        return;
-                                                    }
-
-                                                    openUnderlyingDataModal({
-                                                        ...viewUnderlyingDataOptions,
-                                                    });
-                                                    track({
-                                                        name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                                        properties: {
-                                                            organizationId:
-                                                                user?.data
-                                                                    ?.organizationUuid,
-                                                            userId: user?.data
-                                                                ?.userUuid,
-                                                            projectId:
-                                                                projectUuid,
-                                                        },
-                                                    });
-                                                }}
-                                            />
-                                        )}
-                                    </Can>
-
-                                    <Can
-                                        I="manage"
-                                        this={subject('Explore', {
-                                            organizationUuid:
-                                                user.data?.organizationUuid,
-                                            projectUuid: projectUuid,
-                                        })}
-                                    >
-                                        <DrillDownMenuItem
-                                            {...viewUnderlyingDataOptions}
-                                            trackingData={{
-                                                organizationId:
-                                                    user.data?.organizationUuid,
-                                                userId: user.data?.userUuid,
-                                                projectId: projectUuid,
-                                            }}
-                                        />
-                                    </Can>
-                                    <MenuItem2
-                                        icon="filter"
-                                        text="Filter dashboard to..."
-                                    >
-                                        {dashboardTileFilterOptions.map(
-                                            (filter) => (
-                                                <MenuItem2
-                                                    key={filter.id}
-                                                    text={`${friendlyName(
-                                                        filter.target.fieldId,
-                                                    )} is ${
-                                                        filter.values &&
-                                                        filter.values[0]
-                                                    }`}
-                                                    onClick={() => {
-                                                        track({
-                                                            name: EventName.ADD_FILTER_CLICKED,
-                                                            properties: {
-                                                                mode: isEditMode
-                                                                    ? 'edit'
-                                                                    : 'viewer',
-                                                            },
-                                                        });
-
-                                                        const fields = explore
-                                                            ? getFields(explore)
-                                                            : [];
-                                                        const field =
-                                                            fields.find(
-                                                                (f) =>
-                                                                    fieldId(
-                                                                        f,
-                                                                    ) ===
-                                                                    filter
-                                                                        .target
-                                                                        .fieldId,
-                                                            );
-
-                                                        track({
-                                                            name: EventName.CROSS_FILTER_DASHBOARD_APPLIED,
-                                                            properties: {
-                                                                fieldType:
-                                                                    field?.type,
-                                                                projectId:
-                                                                    projectUuid,
-                                                                dashboardId:
-                                                                    dashboardUuid,
-                                                            },
-                                                        });
-
-                                                        addDimensionDashboardFilter(
-                                                            filter,
-                                                            !isEditMode,
-                                                        );
-                                                    }}
-                                                />
-                                            ),
-                                        )}
-                                    </MenuItem2>
-                                </Menu>
-                            </div>
-                        }
-                        enforceFocus={false}
-                        hasBackdrop={true}
-                        isOpen={contextMenuIsOpen}
-                        minimal={true}
+                    <Menu
+                        opened={contextMenuIsOpen}
                         onClose={() => setContextMenuIsOpen(false)}
-                        placement="right-start"
-                        positioningStrategy="fixed"
-                        rootBoundary={'viewport'}
-                        renderTarget={contextMenuRenderTarget}
-                        transitionDuration={100}
-                    />
+                        position="bottom-start"
+                        shadow="md"
+                        radius={0}
+                        offset={{
+                            crossAxis: 0,
+                            mainAxis: 0,
+                        }}
+                    >
+                        <Portal>
+                            <Menu.Target>
+                                <div
+                                    onContextMenu={handleCancelContextMenu}
+                                    style={{
+                                        position: 'absolute',
+                                        ...contextMenuTargetOffset,
+                                    }}
+                                />
+                            </Menu.Target>
+                        </Portal>
+
+                        <Menu.Dropdown>
+                            {viewUnderlyingDataOptions?.value && (
+                                <Menu.Item
+                                    icon={<MantineIcon icon={IconCopy} />}
+                                    onClick={handleCopyToClipboard}
+                                >
+                                    Copy value
+                                </Menu.Item>
+                            )}
+                            <Can
+                                I="view"
+                                this={subject('UnderlyingData', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid: projectUuid,
+                                })}
+                            >
+                                {!hasCustomDimension(metricQuery) && (
+                                    <Menu.Item
+                                        icon={<MantineIcon icon={IconStack} />}
+                                        onClick={handleViewUnderlyingData}
+                                    >
+                                        View underlying data
+                                    </Menu.Item>
+                                )}
+                            </Can>
+
+                            <Can
+                                I="manage"
+                                this={subject('Explore', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid: projectUuid,
+                                })}
+                            >
+                                <DrillDownMenuItem
+                                    {...viewUnderlyingDataOptions}
+                                    trackingData={{
+                                        organizationId:
+                                            user.data?.organizationUuid,
+                                        userId: user.data?.userUuid,
+                                        projectId: projectUuid,
+                                    }}
+                                />
+                            </Can>
+
+                            {dashboardTileFilterOptions.length > 0 && (
+                                <>
+                                    <Menu.Divider />
+
+                                    <Menu
+                                        withinPortal
+                                        trigger="hover"
+                                        offset={0}
+                                        radius={0}
+                                        position="right-start"
+                                        shadow="md"
+                                        closeOnItemClick
+                                    >
+                                        <Menu.Target>
+                                            <Menu.Item
+                                                icon={
+                                                    <MantineIcon
+                                                        icon={IconFilter}
+                                                    />
+                                                }
+                                                rightSection={
+                                                    <Box w={18} h={18} ml="lg">
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconChevronRight
+                                                            }
+                                                        />
+                                                    </Box>
+                                                }
+                                            >
+                                                Filter dashboard to...
+                                            </Menu.Item>
+                                        </Menu.Target>
+
+                                        <Menu.Dropdown>
+                                            {dashboardTileFilterOptions.map(
+                                                (filter) => (
+                                                    <Menu.Item
+                                                        key={filter.id}
+                                                        onClick={() =>
+                                                            handleAddFilter(
+                                                                filter,
+                                                            )
+                                                        }
+                                                    >
+                                                        {friendlyName(
+                                                            filter.target
+                                                                .fieldId,
+                                                        )}{' '}
+                                                        is{' '}
+                                                        <Text span fw={500}>
+                                                            {filter.values &&
+                                                                filter
+                                                                    .values[0]}
+                                                        </Text>
+                                                    </Menu.Item>
+                                                ),
+                                            )}
+                                        </Menu.Dropdown>
+                                    </Menu>
+                                </>
+                            )}
+                        </Menu.Dropdown>
+                    </Menu>
+
                     <ValidDashboardChartTile
                         tileUuid={tileUuid}
                         chartAndResults={chartAndResults}
@@ -733,6 +779,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     />
                 </>
             </TileBase>
+
             {chart.spaceUuid && (
                 <MoveChartThatBelongsToDashboardModal
                     className={'non-draggable'}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -348,14 +348,10 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
 
     const handleCopyToClipboard = useCallback(() => {
         if (!viewUnderlyingDataOptions) return;
-
         const value = viewUnderlyingDataOptions.value.formatted;
 
-        showToastSuccess({
-            title: 'Copied to clipboard!',
-        });
-
         clipboard.copy(value);
+        showToastSuccess({ title: 'Copied to clipboard!' });
     }, [viewUnderlyingDataOptions, clipboard, showToastSuccess]);
 
     const handleAddFilter = useCallback(
@@ -639,9 +635,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     <Menu
                         opened={contextMenuIsOpen}
                         onClose={() => setContextMenuIsOpen(false)}
-                        position="bottom-start"
+                        withinPortal
+                        closeOnItemClick
+                        closeOnEscape
                         shadow="md"
                         radius={0}
+                        position="bottom-start"
                         offset={{
                             crossAxis: 0,
                             mainAxis: 0,
@@ -710,13 +709,14 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                     <Menu.Divider />
 
                                     <Menu
-                                        withinPortal
                                         trigger="hover"
-                                        offset={0}
-                                        radius={0}
-                                        position="right-start"
-                                        shadow="md"
+                                        withinPortal
                                         closeOnItemClick
+                                        closeOnEscape
+                                        shadow="md"
+                                        radius={0}
+                                        offset={0}
+                                        position="right-start"
                                     >
                                         <Menu.Target>
                                             <Menu.Item

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,5 +1,3 @@
-import { Menu, MenuDivider } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     Field,
@@ -11,9 +9,11 @@ import {
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
+import { Menu, Text } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy, IconEye, IconFilter, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash-es/mapValues';
-import { FC } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
+import { FC, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useFilters } from '../../../hooks/useFilters';
@@ -21,6 +21,7 @@ import { useApp } from '../../../providers/AppProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { Can } from '../../common/Authorization';
+import MantineIcon from '../../common/MantineIcon';
 import { CellContextMenuProps } from '../../common/Table/types';
 import DrillDownMenuItem from '../../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../../MetricQueryData/MetricQueryDataProvider';
@@ -37,13 +38,62 @@ const CellContextMenu: FC<
         useMetricQueryDataContext();
     const { track } = useTracking();
     const { showToastSuccess } = useToaster();
+    const clipboard = useClipboard();
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
-    const value: ResultValue = cell.getValue()?.value || {};
-    const fieldValues = mapValues(cell.row.original, (v) => v?.value) || {};
+    const value: ResultValue = useMemo(
+        () => cell.getValue()?.value || {},
+        [cell],
+    );
+
+    const fieldValues = useMemo(
+        () => mapValues(cell.row.original, (v) => v?.value) || {},
+        [cell.row.original],
+    );
+
+    const handleCopyToClipboard = useCallback(() => {
+        clipboard.copy(value.formatted);
+
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [value, clipboard, showToastSuccess]);
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (meta?.item === undefined) return;
+
+        openUnderlyingDataModal({
+            item: meta.item,
+            value,
+            fieldValues,
+        });
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                organizationId: user?.data?.organizationUuid,
+                userId: user?.data?.userUuid,
+                projectId: projectUuid,
+            },
+        });
+    }, [
+        openUnderlyingDataModal,
+        meta,
+        value,
+        fieldValues,
+        track,
+        user,
+        projectUuid,
+    ]);
+
+    const handleFilterByValue = useCallback(() => {
+        if (!isField(item) || !isFilterableField(item)) return;
+
+        track({
+            name: EventName.ADD_FILTER_CLICKED,
+        });
+        addFilter(item, value.raw === undefined ? null : value.raw, true);
+    }, [track, addFilter, item, value]);
 
     let parseResult: null | object = null;
     if (
@@ -59,7 +109,7 @@ const CellContextMenu: FC<
     }
 
     return (
-        <Menu style={{ maxWidth: 500 }}>
+        <Menu>
             {!!value.raw && isField(item) && (
                 <UrlMenuItems
                     urls={item.urls}
@@ -68,21 +118,18 @@ const CellContextMenu: FC<
                 />
             )}
 
-            {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}
+            {isField(item) && (item.urls || []).length > 0 && <Menu.Divider />}
 
-            <CopyToClipboard
-                text={value.formatted}
-                onCopy={() => {
-                    showToastSuccess({ title: 'Copied to clipboard!' });
-                }}
+            <Menu.Item
+                icon={<MantineIcon icon={IconCopy} />}
+                onClick={handleCopyToClipboard}
             >
-                <MenuItem2 text="Copy value" icon="duplicate" />
-            </CopyToClipboard>
+                Copy value
+            </Menu.Item>
 
             {parseResult !== null && (
-                <MenuItem2
-                    text="Expand"
-                    icon="eye-open"
+                <Menu.Item
+                    icon={<MantineIcon icon={IconEye} />}
                     onClick={() =>
                         onExpand(
                             item && 'displayName' in item
@@ -91,7 +138,9 @@ const CellContextMenu: FC<
                             parseResult || {},
                         )
                     }
-                />
+                >
+                    Expand
+                </Menu.Item>
             )}
 
             {item &&
@@ -105,28 +154,15 @@ const CellContextMenu: FC<
                             projectUuid: projectUuid,
                         })}
                     >
-                        <MenuItem2
-                            text="View underlying data"
-                            icon="layers"
-                            onClick={() => {
-                                openUnderlyingDataModal({
-                                    item: meta.item,
-                                    value,
-                                    fieldValues,
-                                });
-                                track({
-                                    name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                    properties: {
-                                        organizationId:
-                                            user?.data?.organizationUuid,
-                                        userId: user?.data?.userUuid,
-                                        projectId: projectUuid,
-                                    },
-                                });
-                            }}
-                        />
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconStack} />}
+                            onClick={handleViewUnderlyingData}
+                        >
+                            View underlying data
+                        </Menu.Item>
                     </Can>
                 )}
+
             <Can
                 I="manage"
                 this={subject('Explore', {
@@ -135,20 +171,15 @@ const CellContextMenu: FC<
                 })}
             >
                 {isEditMode && isField(item) && isFilterableField(item) && (
-                    <MenuItem2
-                        icon="filter"
-                        text={`Filter by "${value.formatted}"`}
-                        onClick={() => {
-                            track({
-                                name: EventName.ADD_FILTER_CLICKED,
-                            });
-                            addFilter(
-                                item,
-                                value.raw === undefined ? null : value.raw,
-                                true,
-                            );
-                        }}
-                    />
+                    <Menu.Item
+                        icon={<MantineIcon icon={IconFilter} />}
+                        onClick={handleFilterByValue}
+                    >
+                        Filter by{' '}
+                        <Text span fw={500}>
+                            {value.formatted}
+                        </Text>
+                    </Menu.Item>
                 )}
 
                 <DrillDownMenuItem

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -56,7 +56,6 @@ const CellContextMenu: FC<
 
     const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);
-
         showToastSuccess({ title: 'Copied to clipboard!' });
     }, [value, clipboard, showToastSuccess]);
 
@@ -109,7 +108,7 @@ const CellContextMenu: FC<
     }
 
     return (
-        <Menu>
+        <>
             {!!value.raw && isField(item) && (
                 <UrlMenuItems
                     urls={item.urls}
@@ -117,16 +116,13 @@ const CellContextMenu: FC<
                     itemsMap={itemsMap}
                 />
             )}
-
             {isField(item) && (item.urls || []).length > 0 && <Menu.Divider />}
-
             <Menu.Item
                 icon={<MantineIcon icon={IconCopy} />}
                 onClick={handleCopyToClipboard}
             >
                 Copy value
             </Menu.Item>
-
             {parseResult !== null && (
                 <Menu.Item
                     icon={<MantineIcon icon={IconEye} />}
@@ -142,7 +138,6 @@ const CellContextMenu: FC<
                     Expand
                 </Menu.Item>
             )}
-
             {item &&
                 !isDimension(item) &&
                 !isCustomDimension(item) &&
@@ -162,7 +157,6 @@ const CellContextMenu: FC<
                         </Menu.Item>
                     </Can>
                 )}
-
             <Can
                 I="manage"
                 this={subject('Explore', {
@@ -192,7 +186,7 @@ const CellContextMenu: FC<
                     }}
                 />
             </Can>
-        </Menu>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -38,7 +38,7 @@ const CellContextMenu: FC<
         useMetricQueryDataContext();
     const { track } = useTracking();
     const { showToastSuccess } = useToaster();
-    const clipboard = useClipboard();
+    const clipboard = useClipboard({ timeout: 2000 });
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const { user } = useApp();

--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -12,7 +12,7 @@ import {
     TableCalculation,
 } from '@lightdash/common';
 import { Box, Menu, Tooltip } from '@mantine/core';
-import { IconExclamationCircle } from '@tabler/icons-react';
+import { IconExclamationCircle, IconLink } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import { FC, useMemo } from 'react';
 import { useTracking } from '../../../providers/TrackingProvider';
@@ -77,14 +77,11 @@ const UrlMenuItem: FC<{
 
     return (
         <Menu.Item
-            key={`url_entry_${urlConfig.label}`}
-            icon="open-application"
+            icon={<MantineIcon icon={IconLink} />}
             rightSection={
                 error && (
                     <Tooltip label={error} position="right">
                         <Box>
-                            {/* Icon */}
-                            {/* <Icon icon="issue" /> */}
                             <MantineIcon icon={IconExclamationCircle} />
                         </Box>
                     </Tooltip>

--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -1,5 +1,3 @@
-import { Icon } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import {
     Field,
     FieldUrl,
@@ -13,11 +11,13 @@ import {
     ResultValue,
     TableCalculation,
 } from '@lightdash/common';
-import { Box, Tooltip } from '@mantine/core';
+import { Box, Menu, Tooltip } from '@mantine/core';
+import { IconExclamationCircle } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import { FC, useMemo } from 'react';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
+import MantineIcon from '../../common/MantineIcon';
 
 const UrlMenuItem: FC<{
     urlConfig: FieldUrl;
@@ -76,15 +76,16 @@ const UrlMenuItem: FC<{
     const error: string | undefined = validationError || renderError;
 
     return (
-        <MenuItem2
+        <Menu.Item
             key={`url_entry_${urlConfig.label}`}
             icon="open-application"
-            text={urlConfig.label}
-            labelElement={
+            rightSection={
                 error && (
                     <Tooltip label={error} position="right">
                         <Box>
-                            <Icon icon="issue" />
+                            {/* Icon */}
+                            {/* <Icon icon="issue" /> */}
+                            <MantineIcon icon={IconExclamationCircle} />
                         </Box>
                     </Tooltip>
                 )
@@ -96,7 +97,9 @@ const UrlMenuItem: FC<{
                 });
                 window.open(url, '_blank');
             }}
-        />
+        >
+            {urlConfig.label}
+        </Menu.Item>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -76,27 +76,36 @@ const UrlMenuItem: FC<{
     const error: string | undefined = validationError || renderError;
 
     return (
-        <Menu.Item
-            icon={<MantineIcon icon={IconLink} />}
-            rightSection={
-                error && (
-                    <Tooltip label={error} position="right">
-                        <Box>
-                            <MantineIcon icon={IconExclamationCircle} />
-                        </Box>
-                    </Tooltip>
-                )
-            }
-            disabled={!url}
-            onClick={() => {
-                track({
-                    name: EventName.GO_TO_LINK_CLICKED,
-                });
-                window.open(url, '_blank');
-            }}
+        <Tooltip
+            withinPortal
+            maw={300}
+            multiline
+            disabled={!error}
+            label={error}
+            position="bottom"
         >
-            {urlConfig.label}
-        </Menu.Item>
+            <Box>
+                <Menu.Item
+                    icon={<MantineIcon icon={IconLink} />}
+                    rightSection={
+                        error && (
+                            <Box ml="sm">
+                                <MantineIcon icon={IconExclamationCircle} />
+                            </Box>
+                        )
+                    }
+                    disabled={!url}
+                    onClick={() => {
+                        track({
+                            name: EventName.GO_TO_LINK_CLICKED,
+                        });
+                        window.open(url, '_blank');
+                    }}
+                >
+                    {urlConfig.label}
+                </Menu.Item>
+            </Box>
+        </Tooltip>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -77,15 +77,12 @@ export const SeriesContextMenu: FC<{
         }
     }, [echartSeriesClickEvent, explore, metricQuery, series]);
 
-    const handleCopy = useCallback(() => {
+    const handleCopyToClipboard = useCallback(() => {
         if (underlyingData === undefined) return;
         const value = underlyingData.value.formatted;
 
         clipboard.copy(value);
-
-        showToastSuccess({
-            title: 'Copied to clipboard!',
-        });
+        showToastSuccess({ title: 'Copied to clipboard!' });
     }, [underlyingData, clipboard, showToastSuccess]);
 
     const handleViewUnderlyingData = useCallback(() => {
@@ -125,9 +122,12 @@ export const SeriesContextMenu: FC<{
         <Menu
             opened={contextMenuIsOpen}
             onClose={onClose}
-            position="right-start"
+            withinPortal
+            closeOnItemClick
+            closeOnEscape
             shadow="md"
             radius={0}
+            position="right-start"
             offset={{
                 mainAxis: 0,
                 crossAxis: 0,
@@ -149,7 +149,7 @@ export const SeriesContextMenu: FC<{
                 {underlyingData?.value && (
                     <Menu.Item
                         icon={<MantineIcon icon={IconCopy} />}
-                        onClick={handleCopy}
+                        onClick={handleCopyToClipboard}
                     >
                         Copy value
                     </Menu.Item>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -1,21 +1,9 @@
-import { Menu } from '@blueprintjs/core';
-import {
-    MenuItem2,
-    Popover2,
-    Popover2TargetProps,
-} from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import { getItemMap, hasCustomDimension } from '@lightdash/common';
-import { Portal } from '@mantine/core';
-import React, {
-    FC,
-    memo,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
+import { Menu, Portal } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy, IconStack } from '@tabler/icons-react';
+import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -25,6 +13,7 @@ import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { Can } from '../../common/Authorization';
+import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../../MetricQueryData/DrillDownMenuItem';
 import {
@@ -39,6 +28,9 @@ export const SeriesContextMenu: FC<{
     series: EChartSeries[] | undefined;
 }> = memo(({ echartSeriesClickEvent, dimensions, series }) => {
     const { showToastSuccess } = useToaster();
+    const clipboard = useClipboard({ timeout: 200 });
+    const { track } = useTracking();
+    const { user } = useApp();
 
     const tableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
@@ -55,8 +47,6 @@ export const SeriesContextMenu: FC<{
         top: number;
     }>();
 
-    const { track } = useTracking();
-    const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
     useEffect(() => {
@@ -87,27 +77,44 @@ export const SeriesContextMenu: FC<{
         }
     }, [echartSeriesClickEvent, explore, metricQuery, series]);
 
-    const onViewUnderlyingData = useCallback(() => {
-        if (underlyingData !== undefined) {
-            openUnderlyingDataModal({
-                ...underlyingData,
-                dimensions,
-            });
-        }
-    }, [openUnderlyingDataModal, dimensions, underlyingData]);
-    const contextMenuRenderTarget = useCallback(
-        ({ ref }: Popover2TargetProps) => (
-            <Portal>
-                <div
-                    style={{ position: 'absolute', ...contextMenuTargetOffset }}
-                    ref={ref}
-                />
-            </Portal>
-        ),
-        [contextMenuTargetOffset],
-    );
+    const handleCopy = useCallback(() => {
+        if (underlyingData === undefined) return;
+        const value = underlyingData.value.formatted;
 
-    const cancelContextMenu = useCallback(
+        clipboard.copy(value);
+
+        showToastSuccess({
+            title: 'Copied to clipboard!',
+        });
+    }, [underlyingData, clipboard, showToastSuccess]);
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (underlyingData === undefined) return;
+
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                organizationId: user?.data?.organizationUuid,
+                userId: user?.data?.userUuid,
+                projectId: projectUuid,
+            },
+        });
+
+        openUnderlyingDataModal({
+            ...underlyingData,
+            dimensions,
+        });
+    }, [
+        underlyingData,
+        dimensions,
+        openUnderlyingDataModal,
+        track,
+        user?.data?.organizationUuid,
+        user?.data?.userUuid,
+        projectUuid,
+    ]);
+
+    const handleCancelContextMenu = useCallback(
         (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(),
         [],
     );
@@ -115,79 +122,73 @@ export const SeriesContextMenu: FC<{
     const onClose = useCallback(() => setContextMenuIsOpen(false), []);
 
     return (
-        <Popover2
-            content={
-                <div onContextMenu={cancelContextMenu}>
-                    <Menu>
-                        <Can
-                            I="view"
-                            this={subject('UnderlyingData', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid: projectUuid,
-                            })}
-                        >
-                            {!hasCustomDimension(metricQuery) && (
-                                <MenuItem2
-                                    text={`View underlying data`}
-                                    icon={'layers'}
-                                    onClick={() => {
-                                        onViewUnderlyingData();
-                                        track({
-                                            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                            properties: {
-                                                organizationId:
-                                                    user?.data
-                                                        ?.organizationUuid,
-                                                userId: user?.data?.userUuid,
-                                                projectId: projectUuid,
-                                            },
-                                        });
-                                    }}
-                                />
-                            )}
-                        </Can>
-                        {underlyingData?.value && (
-                            <CopyToClipboard
-                                text={underlyingData.value.formatted}
-                                onCopy={() => {
-                                    showToastSuccess({
-                                        title: 'Copied to clipboard!',
-                                    });
-                                }}
-                            >
-                                <MenuItem2 text="Copy value" icon="duplicate" />
-                            </CopyToClipboard>
-                        )}
-                        <Can
-                            I="view"
-                            this={subject('Explore', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid: projectUuid,
-                            })}
-                        >
-                            <DrillDownMenuItem
-                                {...underlyingData}
-                                trackingData={{
-                                    organizationId:
-                                        user?.data?.organizationUuid,
-                                    userId: user?.data?.userUuid,
-                                    projectId: projectUuid,
-                                }}
-                            />
-                        </Can>
-                    </Menu>
-                </div>
-            }
-            enforceFocus={false}
-            hasBackdrop={true}
-            isOpen={contextMenuIsOpen}
-            minimal={true}
+        <Menu
+            opened={contextMenuIsOpen}
             onClose={onClose}
-            placement="right-start"
-            positioningStrategy="fixed"
-            rootBoundary={'viewport'}
-            renderTarget={contextMenuRenderTarget}
-            transitionDuration={100}
-        />
+            position="right-start"
+            shadow="md"
+            radius={0}
+            offset={{
+                mainAxis: 0,
+                crossAxis: 0,
+            }}
+        >
+            <Portal>
+                <Menu.Target>
+                    <div
+                        onContextMenu={handleCancelContextMenu}
+                        style={{
+                            position: 'absolute',
+                            ...contextMenuTargetOffset,
+                        }}
+                    />
+                </Menu.Target>
+            </Portal>
+
+            <Menu.Dropdown>
+                {underlyingData?.value && (
+                    <Menu.Item
+                        icon={<MantineIcon icon={IconCopy} />}
+                        onClick={handleCopy}
+                    >
+                        Copy value
+                    </Menu.Item>
+                )}
+
+                <Can
+                    I="view"
+                    this={subject('UnderlyingData', {
+                        organizationUuid: user.data?.organizationUuid,
+                        projectUuid: projectUuid,
+                    })}
+                >
+                    {!hasCustomDimension(metricQuery) && (
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconStack} />}
+                            onClick={handleViewUnderlyingData}
+                        >
+                            View underlying data
+                        </Menu.Item>
+                    )}
+                </Can>
+
+                <Can
+                    I="view"
+                    this={subject('Explore', {
+                        organizationUuid: user.data?.organizationUuid,
+                        projectUuid: projectUuid,
+                    })}
+                >
+                    <DrillDownMenuItem
+                        {...underlyingData}
+                        trackingData={{
+                            organizationId: user?.data?.organizationUuid,
+                            userId: user?.data?.userUuid,
+                            projectId: projectUuid,
+                        }}
+                    />
+                </Can>
+            </Menu.Dropdown>
+        </Menu>
     );
 });

--- a/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
+++ b/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
@@ -1,20 +1,45 @@
 import { FieldUrl, isField, ResultValue } from '@lightdash/common';
-import { FC } from 'react';
+import { Menu } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy } from '@tabler/icons-react';
+import { FC, useCallback, useMemo } from 'react';
+import useToaster from '../../hooks/toaster/useToaster';
+import MantineIcon from '../common/MantineIcon';
 import { CellContextMenuProps } from '../common/Table/types';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 
 const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
-    const meta = cell.column.columnDef.meta;
-    const item = meta?.item;
-    const value: ResultValue = cell.getValue()?.value || {};
+    const clipboard = useClipboard({ timeout: 2000 });
+    const { showToastSuccess } = useToaster();
 
-    const urls: FieldUrl[] | undefined =
-        value.raw && isField(item) ? item.urls : undefined;
+    const item = useMemo(() => cell.column.columnDef.meta?.item, [cell]);
+    const value: ResultValue = useMemo(
+        () => cell.getValue()?.value || {},
+        [cell],
+    );
 
-    if (!urls) {
-        return null;
-    }
-    return <UrlMenuItems urls={urls} cell={cell} />;
+    const handleCopyToClipboard = useCallback(() => {
+        clipboard.copy(value.formatted);
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [value, clipboard, showToastSuccess]);
+
+    const urls: FieldUrl[] | undefined = useMemo(
+        () => (value.raw && isField(item) ? item.urls : undefined),
+        [value, item],
+    );
+
+    return (
+        <>
+            <UrlMenuItems urls={urls} cell={cell} />
+            {urls && urls.length > 0 && <Menu.Divider />}
+            <Menu.Item
+                icon={<MantineIcon icon={IconCopy} />}
+                onClick={handleCopyToClipboard}
+            >
+                Copy value
+            </Menu.Item>
+        </>
+    );
 };
 
 export default CellContextMenu;

--- a/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
+++ b/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
@@ -1,4 +1,3 @@
-import { Menu } from '@blueprintjs/core';
 import { FieldUrl, isField, ResultValue } from '@lightdash/common';
 import { FC } from 'react';
 import { CellContextMenuProps } from '../common/Table/types';
@@ -15,11 +14,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     if (!urls) {
         return null;
     }
-    return (
-        <Menu>
-            <UrlMenuItems urls={urls} cell={cell} />
-        </Menu>
-    );
+    return <UrlMenuItems urls={urls} cell={cell} />;
 };
 
 export default CellContextMenu;

--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -4,7 +4,7 @@ import {
     isField,
     isMetric,
 } from '@lightdash/common';
-import { Menu } from '@mantine/core';
+import { Menu, Text } from '@mantine/core';
 import { IconArrowBarToDown } from '@tabler/icons-react';
 import { FC, useCallback, useMemo } from 'react';
 import { useTracking } from '../../providers/TrackingProvider';
@@ -85,7 +85,10 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
                 icon={<MantineIcon icon={IconArrowBarToDown} />}
                 onClick={handleDrillInto}
             >
-                Drill into "{value}"
+                Drill into{' '}
+                <Text span fw={500}>
+                    {value}
+                </Text>
             </Menu.Item>
         );
     }

--- a/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
+++ b/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
@@ -132,13 +132,15 @@ const PieChartContextMenu: FC<PieChartContextMenuProps> = ({
             opened={opened}
             onOpen={onOpen}
             onClose={onClose}
-            withArrow
             withinPortal
             shadow="md"
-            position="bottom-end"
-            radius="xs"
+            closeOnItemClick
+            closeOnEscape
+            radius={0}
+            position="right-start"
             offset={{
-                mainAxis: 10,
+                mainAxis: 0,
+                crossAxis: 0,
             }}
         >
             <Portal>
@@ -154,7 +156,7 @@ const PieChartContextMenu: FC<PieChartContextMenuProps> = ({
                     icon={<MantineIcon icon={IconCopy} />}
                     onClick={handleCopy}
                 >
-                    Copy
+                    Copy value
                 </Menu.Item>
 
                 {canViewUnderlyingData && !hasCustomDimension(metricQuery) ? (

--- a/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
+++ b/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { hasCustomDimension, ResultRow, ResultValue } from '@lightdash/common';
-import { Box, Menu, MenuProps, Portal } from '@mantine/core';
+import { Box, Menu, MenuProps, Portal, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import { FC } from 'react';
@@ -171,7 +171,10 @@ const PieChartContextMenu: FC<PieChartContextMenuProps> = ({
                         icon={<MantineIcon icon={IconArrowBarToDown} />}
                         onClick={handleOpenDrillIntoModal}
                     >
-                        Drill into "{value.formatted}"
+                        Drill into{' '}
+                        <Text span fw={500}>
+                            {value.formatted}
+                        </Text>
                     </Menu.Item>
                 ) : null}
             </Menu.Dropdown>

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -52,13 +52,10 @@ const BigNumberContextMenu: FC<{}> = ({ children }) => {
         }
     }, [fieldValues, visualizationConfig, isBigNumber]);
 
-    const handleCopy = () => {
-        if (value) {
-            clipboard.copy(value.formatted);
-            showToastSuccess({
-                title: 'Copied to clipboard!',
-            });
-        }
+    const handleCopyToClipboard = () => {
+        if (!value) return;
+        clipboard.copy(value.formatted);
+        showToastSuccess({ title: 'Copied to clipboard!' });
     };
 
     const handleViewUnderlyingData = useCallback(() => {
@@ -132,7 +129,7 @@ const BigNumberContextMenu: FC<{}> = ({ children }) => {
                 {value && (
                     <Menu.Item
                         icon={<MantineIcon icon={IconCopy} />}
-                        onClick={handleCopy}
+                        onClick={handleCopyToClipboard}
                     >
                         Copy value
                     </Menu.Item>

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -120,8 +120,10 @@ const BigNumberContextMenu: FC<{}> = ({ children }) => {
             withinPortal
             shadow="md"
             position="bottom"
-            radius="xs"
-            offset={-5}
+            closeOnItemClick
+            closeOnEscape
+            radius={0}
+            offset={-2}
         >
             <Menu.Target>{children}</Menu.Target>
 

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { hasCustomDimension, ResultValue } from '@lightdash/common';
-import { Menu } from '@mantine/core';
+import { Menu, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash-es/mapValues';
@@ -167,7 +167,10 @@ const BigNumberContextMenu: FC<{}> = ({ children }) => {
                             icon={<MantineIcon icon={IconArrowBarToDown} />}
                             onClick={handleOpenDrillIntoModal}
                         >
-                            Drill into "{value.formatted}"
+                            Drill into{' '}
+                            <Text span fw={500}>
+                                {value.formatted}
+                            </Text>
                         </Menu.Item>
                     </Can>
                 )}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,5 +1,3 @@
-import { Menu, MenuDivider } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     hasCustomDimension,
@@ -8,15 +6,18 @@ import {
     isField,
     ResultValue,
 } from '@lightdash/common';
+import { Menu } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash-es/mapValues';
-import React, { FC } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
+import { FC, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useApp } from '../../providers/AppProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import { Can } from '../common/Authorization';
+import MantineIcon from '../common/MantineIcon';
 import { CellContextMenuProps } from '../common/Table/types';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
@@ -29,29 +30,64 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
-    const value: ResultValue = cell.getValue()?.value || {};
-    const fieldValues = mapValues(cell.row.original, (v) => v?.value) || {};
+    const value: ResultValue = useMemo(
+        () => cell.getValue()?.value || {},
+        [cell],
+    );
+    const fieldValues = useMemo(
+        () => mapValues(cell.row.original, (v) => v?.value) || {},
+        [cell],
+    );
 
     const { track } = useTracking();
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const clipboard = useClipboard({ timeout: 200 });
+
+    const handleCopy = useCallback(() => {
+        clipboard.copy(value.formatted);
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [clipboard, showToastSuccess, value.formatted]);
+
+    const handleViewUnderlyingData = useCallback(() => {
+        openUnderlyingDataModal({
+            item,
+            value,
+            fieldValues,
+        });
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                organizationId: user?.data?.organizationUuid,
+                userId: user?.data?.userUuid,
+                projectId: projectUuid,
+            },
+        });
+    }, [
+        fieldValues,
+        item,
+        openUnderlyingDataModal,
+        projectUuid,
+        track,
+        user?.data?.organizationUuid,
+        user?.data?.userUuid,
+        value,
+    ]);
 
     return (
-        <Menu>
+        <>
             {item && value.raw && isField(item) && (
                 <UrlMenuItems urls={item.urls} cell={cell} />
             )}
 
-            {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}
+            {isField(item) && (item.urls || []).length > 0 && <Menu.Divider />}
 
-            <CopyToClipboard
-                text={value.formatted}
-                onCopy={() => {
-                    showToastSuccess({ title: 'Copied to clipboard!' });
-                }}
+            <Menu.Item
+                icon={<MantineIcon icon={IconCopy} size="md" fillOpacity={0} />}
+                onClick={handleCopy}
             >
-                <MenuItem2 text="Copy value" icon="duplicate" />
-            </CopyToClipboard>
+                Copy value
+            </Menu.Item>
 
             {item &&
                 !isDimension(item) &&
@@ -64,28 +100,15 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                             projectUuid: projectUuid,
                         })}
                     >
-                        <MenuItem2
-                            text="View underlying data"
-                            icon="layers"
-                            onClick={() => {
-                                openUnderlyingDataModal({
-                                    item: meta.item,
-                                    value,
-                                    fieldValues,
-                                });
-                                track({
-                                    name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                    properties: {
-                                        organizationId:
-                                            user?.data?.organizationUuid,
-                                        userId: user?.data?.userUuid,
-                                        projectId: projectUuid,
-                                    },
-                                });
-                            }}
-                        />
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconStack} size="md" />}
+                            onClick={handleViewUnderlyingData}
+                        >
+                            View underlying data
+                        </Menu.Item>
                     </Can>
                 )}
+
             <Can
                 I="manage"
                 this={subject('Explore', {
@@ -104,7 +127,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                     }}
                 />
             </Can>
-        </Menu>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -44,7 +44,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const clipboard = useClipboard({ timeout: 200 });
 
-    const handleCopy = useCallback(() => {
+    const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);
         showToastSuccess({ title: 'Copied to clipboard!' });
     }, [clipboard, showToastSuccess, value.formatted]);
@@ -84,7 +84,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
             <Menu.Item
                 icon={<MantineIcon icon={IconCopy} size="md" fillOpacity={0} />}
-                onClick={handleCopy}
+                onClick={handleCopyToClipboard}
             >
                 Copy value
             </Menu.Item>

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -1,5 +1,3 @@
-import { Menu, MenuDivider } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     DashboardFilterRule,
@@ -14,10 +12,17 @@ import {
     isField,
     ResultValue,
 } from '@lightdash/common';
+import { Box, Menu } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
 import { uuid4 } from '@sentry/utils';
+import {
+    IconChevronRight,
+    IconCopy,
+    IconFilter,
+    IconStack,
+} from '@tabler/icons-react';
 import mapValues from 'lodash-es/mapValues';
-import { FC } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
+import { FC, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useApp } from '../../providers/AppProvider';
@@ -25,6 +30,7 @@ import { useDashboardContext } from '../../providers/DashboardProvider';
 import { useTracking } from '../../providers/TrackingProvider';
 import { EventName } from '../../types/Events';
 import { Can } from '../common/Authorization';
+import MantineIcon from '../common/MantineIcon';
 import { CellContextMenuProps } from '../common/Table/types';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
@@ -36,6 +42,7 @@ const DashboardCellContextMenu: FC<
     }
 > = ({ cell, explore }) => {
     const { showToastSuccess } = useToaster();
+    const clipboard = useClipboard({ timeout: 200 });
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
 
@@ -46,8 +53,15 @@ const DashboardCellContextMenu: FC<
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
-    const value: ResultValue = cell.getValue()?.value || {};
-    const fieldValues = mapValues(cell.row.original, (v) => v?.value) || {};
+    const value: ResultValue = useMemo(
+        () => cell.getValue()?.value || {},
+        [cell],
+    );
+
+    const fieldValues = useMemo(
+        () => mapValues(cell.row.original, (v) => v?.value) || {},
+        [cell.row.original],
+    );
 
     const filterField =
         isDimension(item) && !item.hidden
@@ -93,22 +107,54 @@ const DashboardCellContextMenu: FC<
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
+    const handleCopyToClipboard = useCallback(() => {
+        clipboard.copy(value.formatted);
+
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [value, clipboard, showToastSuccess]);
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (meta === undefined) return;
+
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                organizationId: user?.data?.organizationUuid,
+                userId: user?.data?.userUuid,
+                projectId: projectUuid,
+            },
+        });
+
+        openUnderlyingDataModal({
+            item: meta.item,
+            value,
+            fieldValues,
+            pivotReference: meta?.pivotReference,
+        });
+    }, [
+        track,
+        user,
+        projectUuid,
+        openUnderlyingDataModal,
+        meta,
+        value,
+        fieldValues,
+    ]);
+
     return (
         <Menu>
             {item && value.raw && isField(item) && (
                 <UrlMenuItems urls={item.urls} cell={cell} />
             )}
 
-            {isField(item) && (item.urls || []).length > 0 && <MenuDivider />}
+            {isField(item) && (item.urls || []).length > 0 && <Menu.Divider />}
 
-            <CopyToClipboard
-                text={value.formatted}
-                onCopy={() => {
-                    showToastSuccess({ title: 'Copied to clipboard!' });
-                }}
+            <Menu.Item
+                icon={<MantineIcon icon={IconCopy} />}
+                onClick={handleCopyToClipboard}
             >
-                <MenuItem2 text="Copy value" icon="duplicate" />
-            </CopyToClipboard>
+                Copy value
+            </Menu.Item>
 
             {item && !isDimension(item) && !hasCustomDimension(metricQuery) && (
                 <Can
@@ -118,27 +164,12 @@ const DashboardCellContextMenu: FC<
                         projectUuid: projectUuid,
                     })}
                 >
-                    <MenuItem2
-                        text="View underlying data"
-                        icon="layers"
-                        onClick={() => {
-                            track({
-                                name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
-                                properties: {
-                                    organizationId:
-                                        user?.data?.organizationUuid,
-                                    userId: user?.data?.userUuid,
-                                    projectId: projectUuid,
-                                },
-                            });
-                            openUnderlyingDataModal({
-                                item: meta.item,
-                                value,
-                                fieldValues,
-                                pivotReference: meta?.pivotReference,
-                            });
-                        }}
-                    />
+                    <Menu.Item
+                        icon={<MantineIcon icon={IconStack} />}
+                        onClick={handleViewUnderlyingData}
+                    >
+                        View underlying data
+                    </Menu.Item>
                 </Can>
             )}
 
@@ -162,21 +193,49 @@ const DashboardCellContextMenu: FC<
             </Can>
 
             {filters.length > 0 && (
-                <MenuItem2 icon="filter" text="Filter dashboard to...">
-                    {filters.map((filter) => {
-                        return (
-                            <MenuItem2
-                                key={filter.id}
-                                text={`${friendlyName(
-                                    filter.target.fieldId,
-                                )} is ${filter.values && filter.values[0]}`}
-                                onClick={() => {
-                                    addDimensionDashboardFilter(filter, true);
-                                }}
-                            />
-                        );
-                    })}
-                </MenuItem2>
+                <>
+                    <Menu.Divider />
+
+                    <Menu
+                        withinPortal
+                        trigger="hover"
+                        offset={0}
+                        radius={0}
+                        position="right-start"
+                        shadow="md"
+                        closeOnItemClick
+                    >
+                        <Menu.Target>
+                            <Menu.Item
+                                icon={<MantineIcon icon={IconFilter} />}
+                                rightSection={
+                                    <Box w={18} h={18} ml="lg">
+                                        <MantineIcon icon={IconChevronRight} />
+                                    </Box>
+                                }
+                            >
+                                Filter dashboard to...
+                            </Menu.Item>
+                        </Menu.Target>
+
+                        <Menu.Dropdown>
+                            {filters.map((filter) => (
+                                <Menu.Item
+                                    key={filter.id}
+                                    onClick={() =>
+                                        addDimensionDashboardFilter(
+                                            filter,
+                                            true,
+                                        )
+                                    }
+                                >
+                                    {friendlyName(filter.target.fieldId)} is{' '}
+                                    {filter.values && filter.values[0]}
+                                </Menu.Item>
+                            ))}
+                        </Menu.Dropdown>
+                    </Menu>
+                </>
             )}
         </Menu>
     );

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -109,7 +109,6 @@ const DashboardCellContextMenu: FC<
 
     const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);
-
         showToastSuccess({ title: 'Copied to clipboard!' });
     }, [value, clipboard, showToastSuccess]);
 
@@ -142,7 +141,7 @@ const DashboardCellContextMenu: FC<
     ]);
 
     return (
-        <Menu>
+        <>
             {item && value.raw && isField(item) && (
                 <UrlMenuItems urls={item.urls} cell={cell} />
             )}
@@ -197,13 +196,14 @@ const DashboardCellContextMenu: FC<
                     <Menu.Divider />
 
                     <Menu
-                        withinPortal
                         trigger="hover"
                         offset={0}
+                        withinPortal
+                        closeOnItemClick
+                        closeOnEscape
+                        shadow="md"
                         radius={0}
                         position="right-start"
-                        shadow="md"
-                        closeOnItemClick
                     >
                         <Menu.Target>
                             <Menu.Item
@@ -237,7 +237,7 @@ const DashboardCellContextMenu: FC<
                     </Menu>
                 </>
             )}
-        </Menu>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/common/PivotTable/TotalCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/TotalCellMenu.tsx
@@ -21,9 +21,11 @@ const TotalCellMenu: FC<TotalCellMenuProps> = ({
             onOpen={onOpen}
             onClose={onClose}
             withinPortal
+            closeOnItemClick
+            closeOnEscape
             shadow="md"
-            position="bottom-end"
             radius={0}
+            position="bottom-end"
             offset={{
                 mainAxis: 0,
                 crossAxis: 0,

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -141,9 +141,11 @@ const ValueCellMenu: FC<ValueCellMenuProps> = ({
             onOpen={onOpen}
             onClose={onClose}
             withinPortal
+            closeOnItemClick
+            closeOnEscape
             shadow="md"
-            position="bottom-end"
             radius={0}
+            position="bottom-end"
             offset={{
                 mainAxis: 0,
                 crossAxis: 0,

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { hasCustomDimension, ItemsMap, ResultValue } from '@lightdash/common';
-import { Menu, MenuProps } from '@mantine/core';
+import { Menu, MenuProps, Text } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
@@ -195,7 +195,10 @@ const ValueCellMenu: FC<ValueCellMenuProps> = ({
                                 }
                                 onClick={handleOpenDrillIntoModal}
                             >
-                                Drill into "{value.formatted}"
+                                Drill into{' '}
+                                <Text span fw={500}>
+                                    {value.formatted}
+                                </Text>
                             </Menu.Item>
                         ) : null}
                     </>

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -1,8 +1,7 @@
-import { mergeRefs, Position } from '@blueprintjs/core';
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { ResultRow } from '@lightdash/common';
+import { Menu, Tooltip } from '@mantine/core';
 import { Cell } from '@tanstack/react-table';
-import { FC } from 'react';
+import { FC, useCallback } from 'react';
 import { CSSProperties } from 'styled-components';
 import RichBodyCell from './ScrollableTable/RichBodyCell';
 import { Td } from './Table.styles';
@@ -52,68 +51,70 @@ const BodyCell: FC<CommonBodyCellProps> = ({
 
     const hasContextMenu = hasData && !!CellContextMenu;
 
-    const handleSelect = () => {
+    const handleSelect = useCallback(() => {
         if (!hasContextMenu) return;
         onSelect();
-    };
+    }, [hasContextMenu, onSelect]);
 
-    const handleDeselect = () => {
+    const handleDeselect = useCallback(() => {
         onDeselect();
-    };
+    }, [onDeselect]);
 
     return (
-        <Popover2
-            isOpen={selected}
-            lazy
-            minimal
-            position={Position.BOTTOM_RIGHT}
-            hasBackdrop
-            backdropProps={{ onClick: handleDeselect }}
-            onOpening={() => handleSelect()}
+        <Menu
+            withinPortal
+            opened={selected}
+            // backdropProps={{ onClick: handleDeselect }}
+            onOpen={() => handleSelect()}
             onClose={() => handleDeselect()}
-            content={
-                CellContextMenu && (
+            shadow="md"
+            position="bottom-end"
+            radius={0}
+            offset={{
+                mainAxis: 0,
+                crossAxis: 0,
+            }}
+        >
+            {CellContextMenu && (
+                <Menu.Dropdown>
                     <CellContextMenu
                         cell={cell as Cell<ResultRow, ResultRow[0]>}
                     />
-                )
-            }
-            renderTarget={({ ref: ref2, ...popoverProps }) => (
-                <Tooltip2
-                    lazy
-                    position={Position.TOP}
-                    disabled={!tooltipContent || minimal}
-                    content={tooltipContent}
-                    renderTarget={({ ref: ref1, ...tooltipProps }) => (
-                        <Td
-                            ref={mergeRefs(ref1, ref2)}
-                            {...(tooltipProps as any)}
-                            {...popoverProps}
-                            className={className}
-                            style={style}
-                            $rowIndex={index}
-                            $isSelected={selected}
-                            $isLargeText={isLargeText}
-                            $isMinimal={minimal}
-                            $isInteractive={hasContextMenu}
-                            $isCopying={copying}
-                            $backgroundColor={backgroundColor}
-                            $fontColor={fontColor}
-                            $hasData={hasContextMenu}
-                            $isNaN={!hasData || !isNumericItem}
-                            onClick={selected ? handleDeselect : handleSelect}
-                            onKeyDown={onKeyDown}
-                        >
-                            <RichBodyCell
-                                cell={cell as Cell<ResultRow, ResultRow[0]>}
-                            >
-                                {children}
-                            </RichBodyCell>
-                        </Td>
-                    )}
-                />
+                </Menu.Dropdown>
             )}
-        />
+
+            <Menu.Target>
+                <Tooltip
+                    withinPortal
+                    position="top"
+                    disabled={!tooltipContent || minimal}
+                    label={tooltipContent}
+                >
+                    <Td
+                        className={className}
+                        style={style}
+                        $rowIndex={index}
+                        $isSelected={selected}
+                        $isLargeText={isLargeText}
+                        $isMinimal={minimal}
+                        $isInteractive={hasContextMenu}
+                        $isCopying={copying}
+                        $backgroundColor={backgroundColor}
+                        $fontColor={fontColor}
+                        $hasData={hasContextMenu}
+                        $isNaN={!hasData || !isNumericItem}
+                        onClick={selected ? handleDeselect : handleSelect}
+                        onKeyDown={onKeyDown}
+                    >
+                        <RichBodyCell
+                            cell={cell as Cell<ResultRow, ResultRow[0]>}
+                        >
+                            {children}
+                        </RichBodyCell>
+                    </Td>
+                </Tooltip>
+            </Menu.Target>
+        </Menu>
     );
 };
 

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -66,6 +66,8 @@ const BodyCell: FC<CommonBodyCellProps> = ({
             opened={selected}
             onOpen={() => handleSelect()}
             onClose={() => handleDeselect()}
+            closeOnItemClick
+            closeOnEscape
             shadow="md"
             position="bottom-end"
             radius={0}

--- a/packages/frontend/src/components/common/Table/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/BodyCell.tsx
@@ -64,7 +64,6 @@ const BodyCell: FC<CommonBodyCellProps> = ({
         <Menu
             withinPortal
             opened={selected}
-            // backdropProps={{ onClick: handleDeselect }}
             onOpen={() => handleSelect()}
             onClose={() => handleDeselect()}
             shadow="md"

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -10,11 +10,14 @@ interface ScrollableTableProps {
 }
 
 const ScrollableTable: FC<ScrollableTableProps> = ({ minimal = true }) => {
-    const { footer } = useTableContext();
+    const { footer, selectedCell } = useTableContext();
     const tableContainerRef = useRef<HTMLDivElement>(null);
 
     return (
-        <TableScrollableWrapper ref={tableContainerRef}>
+        <TableScrollableWrapper
+            ref={tableContainerRef}
+            $enableScroll={!selectedCell}
+        >
             <Table $showFooter={!!footer?.show}>
                 <TableHeader minimal={minimal} />
                 <TableBody

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -9,12 +9,12 @@ export const TABLE_HEADER_BG = '#f8f9fa';
 // Needed for virtualization. Matches value from Pivot table.
 export const ROW_HEIGHT_PX = 34;
 
-export const TableScrollableWrapper = styled.div`
+export const TableScrollableWrapper = styled.div<{ $enableScroll: boolean }>`
     display: flex;
     flex-direction: column;
 
     position: relative;
-    overflow: auto;
+    overflow: ${({ $enableScroll }) => ($enableScroll ? 'auto' : 'hidden')};
     min-width: 100%;
 `;
 

--- a/scripts/count-blueprint-imports.ts
+++ b/scripts/count-blueprint-imports.ts
@@ -3,8 +3,6 @@ import * as ts from 'typescript';
 
 const INITIAL_BLUEPRINT_IMPORTS_BEFORE_REFACTOR = 993;
 
-const isVerbose = process.argv.includes('--verbose');
-
 const countImportsInAFile = (
     file: string,
     targetLibrary: string,

--- a/scripts/count-blueprint-imports.ts
+++ b/scripts/count-blueprint-imports.ts
@@ -3,6 +3,8 @@ import * as ts from 'typescript';
 
 const INITIAL_BLUEPRINT_IMPORTS_BEFORE_REFACTOR = 993;
 
+const isVerbose = process.argv.includes('--verbose');
+
 const countImportsInAFile = (
     file: string,
     targetLibrary: string,


### PR DESCRIPTION
### Description:

migrates viz context menus to mantine (table + charts)

![CleanShot 2023-12-06 at 20 31 10@2x](https://github.com/lightdash/lightdash/assets/962095/3bf89306-0c84-40ac-b82c-576b76730f86)
![CleanShot 2023-12-06 at 20 31 18@2x](https://github.com/lightdash/lightdash/assets/962095/2ef9af7d-4829-4d2d-b452-460bbc554a93)
![CleanShot 2023-12-06 at 20 31 25@2x](https://github.com/lightdash/lightdash/assets/962095/ff06908f-e269-4600-b55e-d34fe5d84337)
![CleanShot 2023-12-06 at 20 31 34@2x](https://github.com/lightdash/lightdash/assets/962095/2af0e0c3-d008-45a7-9f29-b025b5dfd55a)
![CleanShot 2023-12-06 at 20 34 03@2x](https://github.com/lightdash/lightdash/assets/962095/f0f2eadc-3244-4714-8acd-ae288c60d093)
![CleanShot 2023-12-06 at 20 32 59@2x](https://github.com/lightdash/lightdash/assets/962095/e9dd6f12-ff2e-488e-b413-c743cafc0cd5)
![CleanShot 2023-12-06 at 20 32 43@2x](https://github.com/lightdash/lightdash/assets/962095/9fbe2830-cfea-4aae-87a1-f1d65761498d)
![CleanShot 2023-12-06 at 20 34 57@2x](https://github.com/lightdash/lightdash/assets/962095/3bedabfa-dce5-4a17-a76a-52bfed6b5af4)
![CleanShot 2023-12-06 at 20 34 53@2x](https://github.com/lightdash/lightdash/assets/962095/1949dacb-acb7-46f9-950b-3b5db36083f8)
![CleanShot 2023-12-06 at 21 44 34@2x](https://github.com/lightdash/lightdash/assets/962095/85b90cb7-0dfa-4f5d-97b7-495c816c95e3)
![CleanShot 2023-12-06 at 21 38 04@2x](https://github.com/lightdash/lightdash/assets/962095/71448f91-fbfa-424b-b538-c15222f91f48)
![CleanShot 2023-12-06 at 19 42 29@2x](https://github.com/lightdash/lightdash/assets/962095/65089958-8b44-429b-a9be-a070ba5725f1)
![CleanShot 2023-12-06 at 19 44 26@2x](https://github.com/lightdash/lightdash/assets/962095/11b1171e-78b0-4d17-8290-265b0020566c)



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
