### PR TITLE
fix: chat history returns at least 1 old version

### DIFF
--- a/packages/backend/src/models/SavedChartModel.mock.ts
+++ b/packages/backend/src/models/SavedChartModel.mock.ts
@@ -1,0 +1,142 @@
+import {
+    ConditionalOperator,
+    CreateBigqueryCredentials,
+    DbtCloudIDEProjectConfig,
+    DbtProjectType,
+    DefaultSupportedDbtVersion,
+    DimensionType,
+    Explore,
+    FieldType,
+    LightdashMode,
+    MetricFilterRule,
+    MetricType,
+    OrderFieldsByStrategy,
+    Project,
+    ProjectType,
+    SupportedDbtAdapter,
+    TablesConfiguration,
+    TableSelectionType,
+    WarehouseTypes,
+} from '@lightdash/common';
+import { LightdashConfig } from '../config/parseConfig';
+
+export const lightdashConfigMock: LightdashConfig = {
+    mode: LightdashMode.DEFAULT,
+    version: '1.0',
+    lightdashSecret: 'secret',
+    secureCookies: true,
+    cookiesMaxAgeHours: undefined,
+    trustProxy: true,
+    rudder: {
+        writeKey: '',
+        dataPlaneUrl: '',
+    },
+    sentry: {
+        dsn: '',
+        release: '',
+        environment: '',
+    },
+    auth: {
+        disablePasswordAuthentication: false,
+        google: {
+            oauth2ClientId: undefined,
+            oauth2ClientSecret: undefined,
+            loginPath: '',
+            callbackPath: '',
+            googleDriveApiKey: undefined,
+            enabled: false,
+        },
+        okta: {
+            loginPath: '',
+            callbackPath: '',
+            oauth2ClientSecret: undefined,
+            oauth2ClientId: undefined,
+            oauth2Issuer: undefined,
+            authorizationServerId: undefined,
+            oktaDomain: undefined,
+        },
+        oneLogin: {
+            loginPath: '',
+            callbackPath: '',
+            oauth2ClientSecret: undefined,
+            oauth2ClientId: undefined,
+            oauth2Issuer: undefined,
+        },
+        azuread: {
+            loginPath: '',
+            callbackPath: '',
+            oauth2ClientSecret: undefined,
+            oauth2ClientId: undefined,
+            oauth2TenantId: '',
+        },
+    },
+    posthog: {
+        projectApiKey: '',
+        apiHost: '',
+    },
+    intercom: {
+        appId: '',
+        apiBase: '',
+    },
+    smtp: undefined,
+    siteUrl: '',
+    staticIp: '',
+    database: {
+        connectionUri: undefined,
+        maxConnections: undefined,
+        minConnections: undefined,
+    },
+    allowMultiOrgs: false,
+    maxPayloadSize: '5mb',
+    query: {
+        maxLimit: 5000,
+        csvCellsLimit: 100000,
+    },
+    scheduler: {
+        enabled: false,
+        concurrency: 1,
+        jobTimeout: 1,
+    },
+    logging: {
+        level: 'info',
+        format: 'pretty',
+        outputs: ['console'],
+        consoleFormat: undefined,
+        consoleLevel: undefined,
+        fileFormat: undefined,
+        filePath: '',
+        fileLevel: undefined,
+    },
+    chart: {
+        versionHistory: { daysLimit: 3 },
+    },
+    customVisualizations: {
+        enabled: false,
+    },
+    pivotTable: {
+        maxColumnLimit: 60,
+    },
+    resultsCache: {
+        enabled: false,
+        cacheStateTimeSeconds: 86400,
+        s3: {},
+    },
+};
+
+type VersionSummaryRow = {
+    saved_query_uuid: string;
+    saved_queries_version_uuid: string;
+    created_at: Date;
+    user_uuid: string | null;
+    first_name: string | null;
+    last_name: string | null;
+};
+
+export const chartSummary: VersionSummaryRow = {
+    saved_query_uuid: 'chart_uuid',
+    saved_queries_version_uuid: 'version_uuid',
+    created_at: new Date(),
+    user_uuid: null,
+    first_name: null,
+    last_name: null,
+};

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,0 +1,150 @@
+import knex from 'knex';
+import {
+    FunctionQueryMatcher,
+    getTracker,
+    MockClient,
+    RawQuery,
+    Tracker,
+} from 'knex-mock-client';
+
+import {
+    SavedChartsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
+import { SavedChartModel } from './SavedChartModel';
+import { chartSummary, lightdashConfigMock } from './SavedChartModel.mock';
+
+function queryMatcher(
+    tableName: string,
+    params: any[] = [],
+): FunctionQueryMatcher {
+    return ({ sql, bindings }: RawQuery) =>
+        sql.includes(tableName) &&
+        params.length === bindings.length &&
+        params.reduce(
+            (valid, arg, index) => valid && bindings[index] === arg,
+            true,
+        );
+}
+
+describe('getLatestVersionSummaries', () => {
+    const model = new SavedChartModel({
+        database: knex({ client: MockClient, dialect: 'pg' }),
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+    afterEach(() => {
+        tracker.reset();
+    });
+    test('Should return recent chart version', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([chartSummary]);
+
+        const response = await model.getLatestVersionSummaries('chartUuid');
+        expect(response).toHaveLength(1);
+        expect(response[0].chartUuid).toEqual(chartSummary.saved_query_uuid);
+    });
+
+    test('Should return all recent chart versions', async () => {
+        const now = new Date();
+        const dateDaysAgo = (days: number) =>
+            new Date(new Date().setDate(new Date().getDate() - days));
+
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: 'version1',
+                created_at: new Date(),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: 'version2',
+                created_at: new Date(),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: 'version3',
+                created_at: new Date(),
+            },
+        ]);
+
+        const response = await model.getLatestVersionSummaries('chartUuid');
+        expect(response).toHaveLength(3);
+        const versionIds = response.map((r) => r.versionUuid);
+
+        expect(versionIds).toEqual(['version1', 'version2', 'version3']);
+    });
+
+    test('Should not old chart versions', async () => {
+        const dateDaysAgo = (days: number) =>
+            new Date(new Date().setDate(new Date().getDate() - days));
+
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: 'now',
+                created_at: new Date(),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '1_day_ago',
+                created_at: dateDaysAgo(1),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '2_days_ago',
+                created_at: dateDaysAgo(2),
+            },
+
+            // Old versions (greather than 3 days)
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '3_days_ago',
+                created_at: dateDaysAgo(3),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '4_days_ago',
+                created_at: dateDaysAgo(4),
+            },
+        ]);
+
+        const response = await model.getLatestVersionSummaries('chartUuid');
+        expect(response).toHaveLength(3);
+        const versionIds = response.map((r) => r.versionUuid);
+
+        expect(versionIds).toEqual(['now', '1_day_ago', '2_days_ago']);
+    });
+
+    test('Should get at least 1 old version if there are no more recent versions', async () => {
+        const dateDaysAgo = (days: number) =>
+            new Date(new Date().setDate(new Date().getDate() - days));
+
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: 'now',
+                created_at: new Date(),
+            },
+            // Old versions (greather than 3 days)
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '3_days_ago',
+                created_at: dateDaysAgo(3),
+            },
+            {
+                ...chartSummary,
+                saved_queries_version_uuid: '4_days_ago',
+                created_at: dateDaysAgo(4),
+            },
+        ]);
+
+        const response = await model.getLatestVersionSummaries('chartUuid');
+        expect(response).toHaveLength(2);
+        const versionIds = response.map((r) => r.versionUuid);
+
+        expect(versionIds).toEqual(['now', '3_days_ago']);
+    });
+});

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,31 +1,9 @@
 import knex from 'knex';
-import {
-    FunctionQueryMatcher,
-    getTracker,
-    MockClient,
-    RawQuery,
-    Tracker,
-} from 'knex-mock-client';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 
-import {
-    SavedChartsTableName,
-    SavedChartVersionsTableName,
-} from '../database/entities/savedCharts';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SavedChartModel } from './SavedChartModel';
 import { chartSummary, lightdashConfigMock } from './SavedChartModel.mock';
-
-function queryMatcher(
-    tableName: string,
-    params: any[] = [],
-): FunctionQueryMatcher {
-    return ({ sql, bindings }: RawQuery) =>
-        sql.includes(tableName) &&
-        params.length === bindings.length &&
-        params.reduce(
-            (valid, arg, index) => valid && bindings[index] === arg,
-            true,
-        );
-}
 
 describe('getLatestVersionSummaries', () => {
     const model = new SavedChartModel({
@@ -48,10 +26,6 @@ describe('getLatestVersionSummaries', () => {
     });
 
     test('Should return all recent chart versions', async () => {
-        const now = new Date();
-        const dateDaysAgo = (days: number) =>
-            new Date(new Date().setDate(new Date().getDate() - days));
-
         tracker.on.select(SavedChartsTableName).responseOnce([
             {
                 ...chartSummary,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -360,19 +360,6 @@ export class SavedChartModel {
         };
     }
 
-    private getLastVersionUuidQuery(chartUuid: string) {
-        return this.database(SavedChartVersionsTableName)
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartVersionsTableName}.saved_query_id`,
-                `${SavedChartsTableName}.saved_query_id`,
-            )
-            .select('saved_queries_version_uuid')
-            .where(`${SavedChartsTableName}.saved_query_uuid`, chartUuid)
-            .limit(1)
-            .orderBy(`${SavedChartVersionsTableName}.created_at`, 'desc');
-    }
-
     private getVersionSummaryQuery() {
         return this.database(SavedChartVersionsTableName)
             .leftJoin(
@@ -416,24 +403,31 @@ export class SavedChartModel {
     async getLatestVersionSummaries(
         chartUuid: string,
     ): Promise<ChartVersionSummary[]> {
-        const getLastVersionUuidSubQuery =
-            this.getLastVersionUuidQuery(chartUuid);
         const { daysLimit } = this.lightdashConfig.chart.versionHistory;
         const chartVersions = await this.getVersionSummaryQuery()
             .where(`${SavedChartsTableName}.saved_query_uuid`, chartUuid)
-            .andWhere(function whereRecentVersionsOrCurrentVersion() {
-                // get all versions from the last X days + the current version ( in case is older than X days )
-                this.whereRaw(
-                    `${SavedChartVersionsTableName}.created_at >= DATE(current_timestamp - interval '?? days')`,
-                    [daysLimit],
-                ).orWhere(
-                    `${SavedChartVersionsTableName}.saved_queries_version_uuid`,
-                    getLastVersionUuidSubQuery,
-                );
-            })
             .orderBy(`${SavedChartVersionsTableName}.created_at`, 'asc');
 
-        return chartVersions.map(SavedChartModel.convertVersionSummary);
+        return chartVersions
+            .reduce<VersionSummaryRow[]>((acc, version) => {
+                // Get days since version.created_at
+                const daysSince = Math.floor(
+                    (new Date().getTime() -
+                        new Date(version.created_at).getTime()) /
+                        (1000 * 3600 * 24),
+                );
+
+                if (acc.length < 2) {
+                    // Return current version and the previous version regardless of daysLimit
+                    return [...acc, version];
+                }
+                if (daysSince < daysLimit) {
+                    return [...acc, version];
+                }
+
+                return acc;
+            }, [])
+            .map(SavedChartModel.convertVersionSummary);
     }
 
     async create(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8227

### Description:
<!-- Add a description of the changes proposed in the pull request. -->


After:


With Old version
![Screenshot from 2023-12-07 12-13-19](https://github.com/lightdash/lightdash/assets/1983672/97f5a867-df18-4091-921a-14fcb960a650)


New versions override old version 

![Screenshot from 2023-12-07 12-13-48](https://github.com/lightdash/lightdash/assets/1983672/6c521760-d3eb-454a-9fc0-ab84ba2fdc43)

![Screenshot from 2023-12-07 12-14-11](https://github.com/lightdash/lightdash/assets/1983672/a061f076-5b1a-4b79-8142-5eda66b6e1f4)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
