### PR TITLE
feat: apply date zoom without time intervals dimensions

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1273,17 +1273,6 @@ export class ProjectService {
                     span.setAttribute('warehouse', warehouseConnection?.type);
                 }
 
-                const itemMap = await wrapOtelSpan(
-                    'ProjectService.runQueryAndFormatRows.getItemMap',
-                    {},
-                    async () =>
-                        getItemMap(
-                            explore,
-                            metricQuery.additionalMetrics,
-                            metricQuery.tableCalculations,
-                        ),
-                );
-
                 // If there are more than 500 rows, we need to format them in a background job
                 const formattedRows = await wrapOtelSpan(
                     'ProjectService.runQueryAndFormatRows.formatRows',
@@ -1311,12 +1300,12 @@ export class ProjectService {
                                               {
                                                   workerData: {
                                                       rows,
-                                                      itemMap,
+                                                      fields,
                                                   },
                                               },
                                           ),
                                       )
-                                    : formatRows(rows, itemMap);
+                                    : formatRows(rows, fields);
                             },
                         ),
                 );

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -300,16 +300,17 @@ export const convertTable = (
                 extraDimensions = intervals.reduce(
                     (acc, interval) => ({
                         ...acc,
-                        [`${column.name}_${interval}`]: convertDimension(
-                            index,
-                            adapterType,
-                            model,
-                            tableLabel,
-                            column,
-                            undefined,
-                            interval,
-                            startOfWeek,
-                        ),
+                        [`${column.name}_${interval.toLowerCase()}`]:
+                            convertDimension(
+                                index,
+                                adapterType,
+                                model,
+                                tableLabel,
+                                column,
+                                undefined,
+                                interval,
+                                startOfWeek,
+                            ),
                     }),
                     {},
                 );

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -30,3 +30,14 @@ export enum DateGranularity {
     QUARTER = 'Quarter',
     YEAR = 'Year',
 }
+
+export const dateGranularityToTimeFrameMap: Record<
+    DateGranularity,
+    TimeFrames
+> = {
+    [DateGranularity.DAY]: TimeFrames.DAY,
+    [DateGranularity.WEEK]: TimeFrames.WEEK,
+    [DateGranularity.MONTH]: TimeFrames.MONTH,
+    [DateGranularity.QUARTER]: TimeFrames.QUARTER,
+    [DateGranularity.YEAR]: TimeFrames.YEAR,
+};

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -1,4 +1,6 @@
+import { Explore } from '../types/explore';
 import {
+    CompiledDimension,
     CustomDimension,
     DimensionType,
     Field,
@@ -108,3 +110,20 @@ export const isDateItem = (
     }
     return true;
 };
+
+export const replaceDimensionInExplore = (
+    explore: Explore,
+    dimension: CompiledDimension,
+) => ({
+    ...explore,
+    tables: {
+        ...explore.tables,
+        [dimension.table]: {
+            ...explore.tables[dimension.table],
+            dimensions: {
+                ...explore.tables[dimension.table].dimensions,
+                [dimension.name]: dimension,
+            },
+        },
+    },
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8105 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before:
We would find the dimension with the correct time interval in the explore and use it. 
This meant updating the metric query, chart config and results with the new column id.
Now:
We replace the label and SQL of the dimensions used, keeping the existing column id. 


When date dimension has `time_intervals: OFF` 


https://github.com/lightdash/lightdash/assets/9117144/bf2ce3ab-555e-458f-852e-11a21b1a7ef6



When chart has multiple date columns, including the date column for the same granularity.


https://github.com/lightdash/lightdash/assets/9117144/219b705a-0efd-47c7-ae3c-da08eb67500a




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
