### PR TITLE
refactor: remove explore from visualization provider

### DIFF
--- a/packages/backend/src/database/seeds/development/02_saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/02_saved_queries.ts
@@ -145,13 +145,13 @@ export async function seed(knex: Knex): Promise<void> {
             tableName: 'orders',
             metricQuery: {
                 exploreName: 'orders',
-                dimensions: ['orders_order_date'],
+                dimensions: ['orders_order_date_day'],
                 metrics: ['orders_unique_order_count'],
                 filters: {},
                 limit: 500,
                 sorts: [
                     {
-                        fieldId: 'orders_order_date',
+                        fieldId: 'orders_order_date_day',
                         descending: false,
                     },
                 ],
@@ -159,7 +159,7 @@ export async function seed(knex: Knex): Promise<void> {
                     {
                         name: 'cumulative_order_count',
                         displayName: 'Cumulative order count',
-                        sql: 'SUM(${orders.unique_order_count})\nOVER(ORDER BY ${orders.order_date})',
+                        sql: 'SUM(${orders.unique_order_count})\nOVER(ORDER BY ${orders.order_date_day})',
                     },
                 ],
             },
@@ -167,7 +167,7 @@ export async function seed(knex: Knex): Promise<void> {
                 type: ChartType.CARTESIAN,
                 config: {
                     layout: {
-                        xField: 'orders_order_date',
+                        xField: 'orders_order_date_day',
                         yField: [
                             'orders_unique_order_count',
                             'cumulative_order_count',
@@ -177,7 +177,7 @@ export async function seed(knex: Knex): Promise<void> {
                         series: [
                             {
                                 encode: {
-                                    xRef: { field: 'orders_order_date' },
+                                    xRef: { field: 'orders_order_date_day' },
                                     yRef: {
                                         field: 'orders_unique_order_count',
                                     },
@@ -187,7 +187,7 @@ export async function seed(knex: Knex): Promise<void> {
                             },
                             {
                                 encode: {
-                                    xRef: { field: 'orders_order_date' },
+                                    xRef: { field: 'orders_order_date_day' },
                                     yRef: { field: 'cumulative_order_count' },
                                 },
                                 type: CartesianSeriesType.LINE,
@@ -199,7 +199,7 @@ export async function seed(knex: Knex): Promise<void> {
             },
             tableConfig: {
                 columnOrder: [
-                    'orders_order_date',
+                    'orders_order_date_day',
                     'orders_unique_order_count',
                     'cumulative_order_count',
                 ],

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -156,14 +156,7 @@ const ValidDashboardChartTile: FC<{
 }> = ({
     tileUuid,
     isTitleHidden = false,
-    chartAndResults: {
-        chart,
-        explore,
-        metricQuery,
-        rows,
-        cacheMetadata,
-        fields,
-    },
+    chartAndResults: { chart, metricQuery, rows, cacheMetadata, fields },
     onSeriesContextMenu,
 }) => {
     const addResultsCacheTime = useDashboardContext(
@@ -198,7 +191,6 @@ const ValidDashboardChartTile: FC<{
             chartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
             resultsData={resultData}
-            explore={explore}
             isLoading={false}
             onSeriesContextMenu={onSeriesContextMenu}
             columnOrder={chart.tableConfig.columnOrder}
@@ -223,14 +215,7 @@ const ValidDashboardChartTileMinimal: FC<{
     chartAndResults: ApiChartAndResults;
 }> = ({
     tileUuid,
-    chartAndResults: {
-        chart,
-        metricQuery,
-        explore,
-        rows,
-        cacheMetadata,
-        fields,
-    },
+    chartAndResults: { chart, metricQuery, rows, cacheMetadata, fields },
     isTitleHidden = false,
 }) => {
     const { health } = useApp();
@@ -253,7 +238,6 @@ const ValidDashboardChartTileMinimal: FC<{
             initialPivotDimensions={chart.pivotConfig?.columns}
             resultsData={resultData}
             isLoading={false}
-            explore={explore}
             columnOrder={chart.tableConfig.columnOrder}
             pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
             savedChartUuid={chart.uuid}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -156,7 +156,6 @@ const VisualizationCard: FC<{
         <VisualizationProvider
             chartConfig={unsavedChartVersion.chartConfig}
             initialPivotDimensions={unsavedChartVersion.pivotConfig?.columns}
-            explore={explore}
             resultsData={queryResults}
             isLoading={isLoadingQueryResults}
             columnOrder={unsavedChartVersion.tableConfig.columnOrder}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
@@ -1,4 +1,4 @@
-import { ChartType } from '@lightdash/common';
+import { ChartType, ItemsMap } from '@lightdash/common';
 import { FC, useEffect } from 'react';
 import useCartesianChartConfig, {
     CartesianTypeOptions,
@@ -21,6 +21,7 @@ export const isCartesianVisualizationConfig = (
 
 type VisualizationCartesianConfigProps =
     VisualizationConfigCommon<VisualizationConfigCartesian> & {
+        itemsMap: ItemsMap | undefined;
         stacking: boolean | undefined;
         cartesianType: CartesianTypeOptions | undefined;
         columnOrder: string[];
@@ -31,7 +32,7 @@ type VisualizationCartesianConfigProps =
     };
 
 const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
-    explore,
+    itemsMap,
     resultsData,
     validPivotDimensions,
     columnOrder,
@@ -48,7 +49,7 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
         resultsData,
         setPivotDimensions,
         columnOrder,
-        explore,
+        itemsMap,
         stacking,
         cartesianType,
     });

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -35,7 +35,6 @@ type VisualizationConfigPieProps =
     };
 
 const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
-    explore,
     resultsData,
     initialChartConfig,
     onChartConfigChange,
@@ -54,7 +53,6 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     );
 
     const pieChartConfig = usePieChartConfig(
-        explore,
         resultsData,
         initialChartConfig,
         itemsMap,

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
@@ -19,7 +19,6 @@ export const isTableVisualizationConfig = (
 
 type VisualizationTableConfigProps =
     VisualizationConfigCommon<VisualizationConfigTable> & {
-        exploreName: string | undefined;
         itemsMap: ItemsMap | undefined;
         columnOrder: string[];
         validPivotDimensions: string[] | undefined;
@@ -30,7 +29,6 @@ type VisualizationTableConfigProps =
     };
 
 const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
-    exploreName,
     itemsMap,
     resultsData,
     columnOrder,
@@ -46,7 +44,6 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
     const tableConfig = useTableConfig(
         initialChartConfig,
         resultsData,
-        exploreName,
         itemsMap,
         columnOrder,
         validPivotDimensions,

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -217,6 +217,7 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.CARTESIAN:
             return (
                 <VisualizationCartesianConfig
+                    itemsMap={itemsMap}
                     resultsData={lastValidResultsData}
                     validPivotDimensions={validPivotDimensions}
                     columnOrder={isSqlRunner ? [] : defaultColumnOrder}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -4,7 +4,6 @@ import {
     ChartConfig,
     ChartType,
     DashboardFilters,
-    Explore,
     getCustomDimensionId,
     ItemsMap,
 } from '@lightdash/common';
@@ -83,7 +82,6 @@ export function useVisualizationContext(): VisualizationContext {
 }
 
 export type VisualizationConfigCommon<T extends VisualizationConfig> = {
-    explore?: Explore;
     resultsData: ApiQueryResults | undefined;
     initialChartConfig: T['chartConfig']['validConfig'] | undefined;
     onChartConfigChange?: (chartConfig: {
@@ -107,7 +105,6 @@ type Props = {
     onChartTypeChange?: (value: ChartType) => void;
     onChartConfigChange?: (value: ChartConfig) => void;
     onPivotDimensionsChange?: (value: string[] | undefined) => void;
-    explore: Explore | undefined;
     isSqlRunner?: boolean;
     pivotTableMaxColumnLimit: number;
     savedChartUuid?: string;
@@ -121,7 +118,6 @@ const VisualizationProvider: FC<Props> = ({
     resultsData,
     isLoading,
     columnOrder,
-    explore,
     isSqlRunner,
     pivotTableMaxColumnLimit,
     chartConfig,
@@ -221,7 +217,6 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.CARTESIAN:
             return (
                 <VisualizationCartesianConfig
-                    explore={isSqlRunner ? undefined : explore}
                     resultsData={lastValidResultsData}
                     validPivotDimensions={validPivotDimensions}
                     columnOrder={isSqlRunner ? [] : defaultColumnOrder}
@@ -243,7 +238,6 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.PIE:
             return (
                 <VisualizationPieConfig
-                    explore={explore}
                     itemsMap={itemsMap}
                     resultsData={lastValidResultsData}
                     initialChartConfig={chartConfig.config}
@@ -261,7 +255,6 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.BIG_NUMBER:
             return (
                 <VisualizationBigNumberConfig
-                    explore={explore}
                     itemsMap={itemsMap}
                     resultsData={lastValidResultsData}
                     initialChartConfig={chartConfig.config}
@@ -279,7 +272,6 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.TABLE:
             return (
                 <VisualizationTableConfig
-                    exploreName={explore?.name}
                     itemsMap={itemsMap}
                     resultsData={lastValidResultsData}
                     columnOrder={defaultColumnOrder}
@@ -303,7 +295,6 @@ const VisualizationProvider: FC<Props> = ({
         case ChartType.CUSTOM:
             return (
                 <VisualizationCustomConfig
-                    explore={explore}
                     resultsData={lastValidResultsData}
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -3,15 +3,13 @@ import { MenuItem2 } from '@blueprintjs/popover2';
 import { subject } from '@casl/ability';
 import {
     DashboardFilterRule,
-    Explore,
     fieldId,
     FilterOperator,
     friendlyName,
-    getFields,
-    getItemId,
     hasCustomDimension,
     isDimension,
     isField,
+    ItemsMap,
     ResultValue,
 } from '@lightdash/common';
 import { uuid4 } from '@sentry/utils';
@@ -32,9 +30,9 @@ import { useMetricQueryDataContext } from '../MetricQueryData/MetricQueryDataPro
 
 const DashboardCellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell'> & {
-        explore: Explore | undefined;
+        itemsMap: ItemsMap | undefined;
     }
-> = ({ cell, explore }) => {
+> = ({ cell, itemsMap }) => {
     const { showToastSuccess } = useToaster();
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
@@ -65,19 +63,15 @@ const DashboardCellContextMenu: FC<
               ]
             : [];
 
-    const fields = explore && getFields(explore);
-
     const possiblePivotFilters = (
         meta?.pivotReference?.pivotValues || []
     ).map<DashboardFilterRule>((pivot) => {
-        const pivotField = fields?.find(
-            (field) => getItemId(field) === pivot?.field,
-        );
+        const pivotField = itemsMap?.[pivot?.field];
         return {
             id: uuid4(),
             target: {
                 fieldId: pivot.field,
-                tableName: pivotField?.table || '',
+                tableName: isField(pivotField) ? pivotField?.table : '',
             },
             operator: FilterOperator.EQUALS,
             values: [pivot.value],

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -31,7 +31,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         isLoading,
         columnOrder,
         isSqlRunner,
-        explore,
+        itemsMap,
         visualizationConfig,
     } = useVisualizationContext();
 
@@ -135,7 +135,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         return (
                             <DashboardCellContextMenu
                                 {...props}
-                                explore={explore}
+                                itemsMap={itemsMap}
                             />
                         );
                     return <CellContextMenu {...props} />;

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ChartConfigTabs.tsx
@@ -1,12 +1,3 @@
-import {
-    convertAdditionalMetric,
-    fieldId,
-    getDimensions,
-    getMetrics,
-    isField,
-    Metric,
-    TableCalculation,
-} from '@lightdash/common';
 import { Tabs } from '@mantine/core';
 import { FC, memo, useMemo } from 'react';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
@@ -17,55 +8,9 @@ import LegendPanel from './Legend';
 import SeriesTab from './Series';
 
 const ChartConfigTabs: FC = memo(() => {
-    const { explore, resultsData, itemsMap } = useVisualizationContext();
-    const dimensionsInMetricQuery = explore
-        ? getDimensions(explore).filter((field) =>
-              resultsData?.metricQuery.dimensions.includes(fieldId(field)),
-          )
-        : [];
+    const { itemsMap } = useVisualizationContext();
 
-    const customDimensions = resultsData?.metricQuery.customDimensions || [];
-
-    const metricsAndTableCalculations: Array<Metric | TableCalculation> =
-        useMemo(() => {
-            return explore
-                ? [
-                      ...getMetrics(explore),
-                      ...(
-                          resultsData?.metricQuery.additionalMetrics || []
-                      ).reduce<Metric[]>((acc, additionalMetric) => {
-                          const table = explore.tables[additionalMetric.table];
-                          if (table) {
-                              const metric = convertAdditionalMetric({
-                                  additionalMetric,
-                                  table,
-                              });
-                              return [...acc, metric];
-                          }
-                          return acc;
-                      }, []),
-                      ...(resultsData?.metricQuery.tableCalculations || []),
-                  ].filter((item) => {
-                      if (isField(item)) {
-                          return resultsData?.metricQuery.metrics.includes(
-                              fieldId(item),
-                          );
-                      }
-                      return true;
-                  })
-                : [];
-        }, [
-            explore,
-            resultsData?.metricQuery.additionalMetrics,
-            resultsData?.metricQuery.metrics,
-            resultsData?.metricQuery.tableCalculations,
-        ]);
-
-    const items = [
-        ...dimensionsInMetricQuery,
-        ...customDimensions,
-        ...metricsAndTableCalculations,
-    ];
+    const items = useMemo(() => Object.values(itemsMap || {}), [itemsMap]);
 
     return (
         <Tabs defaultValue="layout" keepMounted={false}>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
@@ -10,8 +10,7 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 import ChartConfigTabs from './ChartConfigTabs';
 
 const ChartConfigPanel: React.FC = () => {
-    const { resultsData, itemsMap, visualizationConfig } =
-        useVisualizationContext();
+    const { resultsData, visualizationConfig } = useVisualizationContext();
 
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
 
@@ -20,7 +19,6 @@ const ChartConfigPanel: React.FC = () => {
     const disabled =
         !resultsData ||
         resultsData?.rows.length === 0 ||
-        !itemsMap ||
         !chartConfig.validConfig;
 
     return (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/index.tsx
@@ -10,7 +10,7 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 import ChartConfigTabs from './ChartConfigTabs';
 
 const ChartConfigPanel: React.FC = () => {
-    const { resultsData, explore, visualizationConfig } =
+    const { resultsData, itemsMap, visualizationConfig } =
         useVisualizationContext();
 
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
@@ -20,7 +20,7 @@ const ChartConfigPanel: React.FC = () => {
     const disabled =
         !resultsData ||
         resultsData?.rows.length === 0 ||
-        !explore ||
+        !itemsMap ||
         !chartConfig.validConfig;
 
     return (

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1,4 +1,4 @@
-import { CartesianSeriesType } from '@lightdash/common';
+import { CartesianSeriesType, getItemMap } from '@lightdash/common';
 import { renderHook } from '@testing-library/react-hooks';
 import useCartesianChartConfig from './useCartesianChartConfig';
 import {
@@ -55,7 +55,7 @@ describe('sortDimensions', () => {
         ];
         const sortedDimensions = sortDimensions(
             dimensionIds,
-            explore,
+            getItemMap(explore),
             columnOrder,
         );
         expect(sortedDimensions).toStrictEqual(dimensionIds);
@@ -74,7 +74,7 @@ describe('sortDimensions', () => {
         ];
         const sortedDimensions = sortDimensions(
             dimensionIds,
-            explore,
+            getItemMap(explore),
             columnOrder,
         );
         expect(sortedDimensions).toStrictEqual([
@@ -97,7 +97,7 @@ describe('sortDimensions', () => {
         ];
         const sortedDimensions = sortDimensions(
             dimensionIds,
-            explore,
+            getItemMap(explore),
             columnOrder,
         );
         expect(sortedDimensions).toStrictEqual([
@@ -112,7 +112,7 @@ describe('sortDimensions', () => {
         const columnOrder = ['dimension_string', 'dimension_timestamp'];
         const sortedDimensions = sortDimensions(
             dimensionIds,
-            explore,
+            getItemMap(explore),
             columnOrder,
         );
         expect(sortedDimensions).toStrictEqual([

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -5,11 +5,11 @@ import {
     CompleteCartesianChartLayout,
     EchartsGrid,
     EchartsLegend,
-    Explore,
     getCustomDimensionId,
     getSeriesId,
     isCompleteEchartsConfig,
     isCompleteLayout,
+    ItemsMap,
     MarkLineData,
     Series,
 } from '@lightdash/common';
@@ -40,7 +40,7 @@ type Args = {
         React.SetStateAction<string[] | undefined>
     >;
     columnOrder: string[];
-    explore: Explore | undefined;
+    itemsMap: ItemsMap | undefined;
     stacking: boolean | undefined;
     cartesianType: CartesianTypeOptions | undefined;
 };
@@ -114,7 +114,7 @@ const useCartesianChartConfig = ({
     resultsData,
     setPivotDimensions,
     columnOrder,
-    explore,
+    itemsMap,
     stacking,
     cartesianType,
 }: Args) => {
@@ -384,10 +384,10 @@ const useCartesianChartConfig = ({
     const sortedDimensions = useMemo(() => {
         return sortDimensions(
             resultsData?.metricQuery.dimensions || [],
-            explore,
+            itemsMap,
             columnOrder,
         );
-    }, [resultsData?.metricQuery.dimensions, explore, columnOrder]);
+    }, [resultsData?.metricQuery.dimensions, itemsMap, columnOrder]);
 
     const [
         availableFields,
@@ -543,7 +543,7 @@ const useCartesianChartConfig = ({
                     newYFields = [availableDimensions[1]];
                 }
 
-                if (explore !== undefined) setPivotDimensions(newPivotFields);
+                if (itemsMap !== undefined) setPivotDimensions(newPivotFields);
                 return {
                     ...prev,
                     xField: newXField,
@@ -558,7 +558,7 @@ const useCartesianChartConfig = ({
         availableTableCalculations,
         availableCustomDimensions,
         hasInitialValue,
-        explore,
+        itemsMap,
         setPivotDimensions,
         setType,
     ]);

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -2,10 +2,11 @@ import {
     ApiQueryResults,
     CartesianSeriesType,
     DimensionType,
-    Explore,
-    getDimensions,
+    getDimensionsFromItemsMap,
     getItemId,
     getSeriesId,
+    isDimension,
+    ItemsMap,
     Series,
 } from '@lightdash/common';
 import { getPivotedData } from '../plottedData/getPlottedData';
@@ -203,17 +204,18 @@ export const getSeriesGroupedByField = (series: Series[]) => {
 
 export const sortDimensions = (
     dimensionIds: string[],
-    explore: Explore | undefined,
+    itemsMap: ItemsMap | undefined,
     columnOrder: string[],
 ) => {
-    if (!explore) return dimensionIds;
+    if (!itemsMap) return dimensionIds;
 
     if (dimensionIds.length <= 1) return dimensionIds;
 
-    const dimensions = getDimensions(explore);
+    const dimensions = Object.values(getDimensionsFromItemsMap(itemsMap));
 
     const dateDimensions = dimensions.filter(
         (dimension) =>
+            isDimension(dimension) &&
             dimensionIds.includes(getItemId(dimension)) &&
             [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                 dimension.type,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -29,7 +29,6 @@ const createWorker = createWorkerFactory(
 const useTableConfig = (
     tableChartConfig: TableChart | undefined,
     resultsData: ApiQueryResults | undefined,
-    exploreName: string | undefined,
     itemsMap: ItemsMap | undefined,
     columnOrder: string[],
     pivotDimensions: string[] | undefined,
@@ -176,7 +175,7 @@ const useTableConfig = (
               }
             : {
                   metricQuery: resultsData?.metricQuery,
-                  explore: exploreName,
+                  explore: resultsData?.metricQuery.exploreName,
                   fieldIds: selectedItemIds,
                   itemsMap,
                   showColumnCalculation:

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -3,7 +3,6 @@ import {
     CustomDimension,
     Dimension,
     ECHARTS_DEFAULT_COLORS,
-    Explore,
     formatItemValue,
     isField,
     isMetric,
@@ -85,7 +84,6 @@ type PieChartConfig = {
 };
 
 export type PieChartConfigFn = (
-    explore: Explore | undefined,
     resultsData: ApiQueryResults | undefined,
     pieChartConfig: PieChart | undefined,
     itemsMap: ItemsMap | undefined,
@@ -94,7 +92,6 @@ export type PieChartConfigFn = (
 ) => PieChartConfig;
 
 const usePieChartConfig: PieChartConfigFn = (
-    explore,
     resultsData,
     pieChartConfig,
     itemsMap,
@@ -178,7 +175,7 @@ const usePieChartConfig: PieChartConfigFn = (
         return undefined;
     }, [itemsMap, metricId]);
 
-    const isLoading = !explore || !resultsData;
+    const isLoading = !resultsData;
 
     useEffect(() => {
         if (isLoading) return;

--- a/packages/frontend/src/hooks/useSqlQueryVisualization.ts
+++ b/packages/frontend/src/hooks/useSqlQueryVisualization.ts
@@ -199,7 +199,6 @@ const useSqlQueryVisualization = ({
 
     return {
         initialPivotDimensions: initialState?.pivotConfig?.columns,
-        explore,
         fieldsMap: { ...fields.sqlQueryDimensions, ...fields.sqlQueryMetrics },
         resultsData,
         columnOrder: [...dimensionKeys, ...metricKeys],

--- a/packages/frontend/src/pages/MetricFlow.tsx
+++ b/packages/frontend/src/pages/MetricFlow.tsx
@@ -328,7 +328,6 @@ const MetricFlowPage = () => {
                     onChartTypeChange={setChartType}
                     onPivotDimensionsChange={setPivotFields}
                     columnOrder={columnOrder}
-                    explore={explore}
                     isSqlRunner={true}
                     pivotTableMaxColumnLimit={
                         health.data.pivotTable.maxColumnLimit

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
-import { useExplore } from '../hooks/useExplore';
 import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
 import { useQueryResults } from '../hooks/useQueryResults';
 import { useSavedQuery } from '../hooks/useSavedQuery';
@@ -40,8 +39,6 @@ const MinimalExplorer: FC = () => {
         (context) => context.queryResults.isLoading,
     );
 
-    const { data: explore } = useExplore(savedChart?.tableName);
-
     if (!savedChart || health.isLoading || !health.data) {
         return null;
     }
@@ -51,7 +48,6 @@ const MinimalExplorer: FC = () => {
             minimal
             chartConfig={savedChart.chartConfig}
             initialPivotDimensions={savedChart.pivotConfig?.columns}
-            explore={explore}
             resultsData={queryResults}
             isLoading={isLoadingQueryResults}
             columnOrder={savedChart.tableConfig.columnOrder}

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -80,7 +80,6 @@ const SqlRunnerPage = () => {
     const { isLoading, mutate } = sqlQueryMutation;
     const {
         initialPivotDimensions,
-        explore,
         resultsData,
         columnOrder,
         createSavedChart,
@@ -257,7 +256,6 @@ const SqlRunnerPage = () => {
                     onChartTypeChange={setChartType}
                     onPivotDimensionsChange={setPivotFields}
                     columnOrder={columnOrder}
-                    explore={explore}
                     isSqlRunner={true}
                     pivotTableMaxColumnLimit={
                         health.data.pivotTable.maxColumnLimit


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8153<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


Main changes:
- remove explore from VisualizationProvider props
- remove explore, metrics, custom metrics, table calculation, explore name from the VisualizationProvider context
- refactor some stuff that was missed in the previous PRs
  - in some cases we just need to remove the explore code
  - in some cases we need to replace the explore with itemsMap

Tested: explore, saved chart, SQL runner, minimal dashboard, minimal chart

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
