### PR TITLE
fix: default big number field to metric

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -8,8 +8,10 @@ import {
     formatTableCalculationValue,
     formatValue,
     friendlyName,
+    getItemId,
     getItemLabel,
     isField,
+    isMetric,
     isNumericItem,
     isTableCalculation,
     ItemsMap,
@@ -82,15 +84,27 @@ const formatComparisonValue = (
 const isNumber = (i: ItemsMap[string] | undefined, value: any) =>
     isNumericItem(i) && !(value instanceof Date) && !valueIsNaN(value);
 
+const getItemPriority = (item: ItemsMap[string]): number => {
+    if (isField(item) && isMetric(item)) {
+        return 1;
+    }
+    if (isTableCalculation(item)) {
+        return 2;
+    }
+    return 3;
+};
+
 const useBigNumberConfig = (
     bigNumberConfigData: BigNumber | undefined,
     resultsData: ApiQueryResults | undefined,
     itemsMap: ItemsMap | undefined,
 ) => {
-    const availableFieldsIds = useMemo(
-        () => Object.keys(itemsMap ?? {}),
-        [itemsMap],
-    );
+    const availableFieldsIds = useMemo(() => {
+        const itemsSortedByType = Object.values(itemsMap || {}).sort((a, b) => {
+            return getItemPriority(a) - getItemPriority(b);
+        });
+        return itemsSortedByType.map(getItemId);
+    }, [itemsMap]);
 
     const [selectedField, setSelectedField] = useState<string | undefined>();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before: 
Big number defaults to the first field available.

Now:
Big number defaults to metric > table calculation > dimensions.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
