### PR TITLE
feat: tile menus (mantine migrations part 2)

### DIFF
--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -105,7 +105,7 @@ describe('Download CSV on Dashboards', () => {
             cy.get('thead th').should('have.length', 6); // Table chart
             cy.contains('Days since').trigger('mouseenter');
 
-            cy.get('[icon="more"]').click();
+            cy.findByTestId('tile-icon-more').click();
             cy.findByText('Export CSV').click();
             cy.get('button').contains('Export CSV').click();
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1,4 +1,4 @@
-import { Menu, Tag } from '@blueprintjs/core';
+import { Tag } from '@blueprintjs/core';
 import {
     MenuItem2,
     Popover2,
@@ -29,8 +29,14 @@ import {
     ResultValue,
     SavedChart,
 } from '@lightdash/common';
-import { Box, Portal, Text, Tooltip } from '@mantine/core';
-import { IconAlertCircle, IconFilter, IconFolders } from '@tabler/icons-react';
+import { ActionIcon, Box, Menu, Portal, Text, Tooltip } from '@mantine/core';
+import {
+    IconAlertCircle,
+    IconFilter,
+    IconFolders,
+    IconTableExport,
+    IconTelescope,
+} from '@tabler/icons-react';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useParams } from 'react-router-dom';
@@ -468,6 +474,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 extraHeaderElement={
                     appliedFilterRules.length > 0 && (
                         <Tooltip
+                            arrowOffset={10}
                             label={
                                 <FilterWrapper>
                                     <FilterLabel>
@@ -484,7 +491,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                             withArrow
                             withinPortal
                         >
-                            <MantineIcon icon={IconFilter} />
+                            <ActionIcon size="sm">
+                                <MantineIcon icon={IconFilter} />
+                            </ActionIcon>
                         </Tooltip>
                     )
                 }
@@ -514,28 +523,36 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                 {userCanManageChart && (
                                     <EditChartMenuItem
                                         tile={props.tile}
-                                        isEditMode={isEditMode}
+                                        disabled={isEditMode}
                                     />
                                 )}
 
                                 {exploreFromHereUrl && (
                                     <LinkMenuItem
-                                        icon="series-search"
-                                        text="Explore from here"
+                                        icon={
+                                            <MantineIcon icon={IconTelescope} />
+                                        }
                                         disabled={isEditMode}
                                         href={exploreFromHereUrl}
-                                    />
+                                    >
+                                        Explore from here
+                                    </LinkMenuItem>
                                 )}
 
                                 {chart.chartConfig.type === ChartType.TABLE && (
-                                    <MenuItem2
-                                        icon="export"
-                                        text="Export CSV"
+                                    <Menu.Item
+                                        icon={
+                                            <MantineIcon
+                                                icon={IconTableExport}
+                                            />
+                                        }
                                         disabled={isEditMode}
                                         onClick={() =>
                                             setIsCSVExportModalOpen(true)
                                         }
-                                    />
+                                    >
+                                        Export CSV
+                                    </Menu.Item>
                                 )}
                                 {chart.chartConfig.type === ChartType.TABLE && (
                                     <ExportGoogleSheet
@@ -545,12 +562,15 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                 )}
 
                                 {chart.dashboardUuid && userCanManageChart && (
-                                    <MenuItem2
-                                        icon={<IconFolders size={16} />}
-                                        text="Move to space"
+                                    <Menu.Item
+                                        icon={
+                                            <MantineIcon icon={IconFolders} />
+                                        }
                                         onClick={() => setIsMovingChart(true)}
                                         disabled={isEditMode}
-                                    />
+                                    >
+                                        Move to space
+                                    </Menu.Item>
                                 )}
                             </Box>
                         </Tooltip>
@@ -821,7 +841,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = ({
     if (error !== null || !data)
         return (
             <TileBase
-                title={''}
+                title=""
                 isEditMode={isEditMode}
                 tile={tile}
                 extraMenuItems={
@@ -833,7 +853,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = ({
                             <Box>
                                 <EditChartMenuItem
                                     tile={tile}
-                                    isEditMode={isEditMode}
+                                    disabled={isEditMode}
                                 />
                             </Box>
                         </Tooltip>

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -1,15 +1,18 @@
 import { DashboardChartTile } from '@lightdash/common';
+import { IconFilePencil } from '@tabler/icons-react';
+import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useApp } from '../../providers/AppProvider';
 import { useDashboardContext } from '../../providers/DashboardProvider';
-import LinkMenuItem from '../common/LinkMenuItem';
+import LinkMenuItem, { LinkMenuItemProps } from '../common/LinkMenuItem';
+import MantineIcon from '../common/MantineIcon';
 
-function EditChartMenuItem(props: {
+type Props = LinkMenuItemProps & {
     tile: DashboardChartTile;
-    isEditMode: boolean;
-}) {
-    const { tile, isEditMode } = props;
+};
+
+const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
     const { user } = useApp();
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const filtersFromContext = useDashboardContext((c) => c.dashboardFilters);
@@ -30,9 +33,7 @@ function EditChartMenuItem(props: {
 
     return (
         <LinkMenuItem
-            icon="document-open"
-            text="Edit chart"
-            disabled={isEditMode}
+            icon={<MantineIcon icon={IconFilePencil} />}
             onClick={() => {
                 if (tile.properties.belongsToDashboard) {
                     storeDashboard(
@@ -46,8 +47,11 @@ function EditChartMenuItem(props: {
                 }
             }}
             href={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
-        />
+            {...props}
+        >
+            Edit chart
+        </LinkMenuItem>
     );
-}
+};
 
 export default EditChartMenuItem;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -1,15 +1,10 @@
-import {
-    Button,
-    Classes,
-    Menu,
-    MenuDivider,
-    PopoverPosition,
-} from '@blueprintjs/core';
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { Classes } from '@blueprintjs/core';
 import { Dashboard, DashboardTileTypes, isChartTile } from '@lightdash/common';
-import { Box, Group, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Box, Group, Menu, Text, Tooltip } from '@mantine/core';
 import { useHover, useToggle } from '@mantine/hooks';
+import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import { ReactNode, useState } from 'react';
+import MantineIcon from '../../common/MantineIcon';
 import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/DeleteChartTileThatBelongsToDashboardModal';
 import ChartUpdateModal from '../TileForms/ChartUpdateModal';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
@@ -141,71 +136,85 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                 {extraHeaderElement}
                                 {(isEditMode ||
                                     (!isEditMode && extraMenuItems)) && (
-                                    <Popover2
-                                        lazy
-                                        onOpening={() => toggleMenu(true)}
-                                        onClosed={() => toggleMenu(false)}
-                                        position={PopoverPosition.BOTTOM_RIGHT}
-                                        content={
-                                            <Menu>
-                                                {extraMenuItems}
-                                                {isEditMode &&
-                                                    extraMenuItems && (
-                                                        <MenuDivider />
-                                                    )}
-                                                {isEditMode && (
-                                                    <>
-                                                        {!belongsToDashboard && (
-                                                            <MenuItem2
-                                                                icon="edit"
-                                                                text="Edit tile content"
-                                                                onClick={() =>
-                                                                    setIsEditingTileContent(
-                                                                        true,
-                                                                    )
-                                                                }
-                                                            />
-                                                        )}
-                                                        {belongsToDashboard ? (
-                                                            <MenuItem2
-                                                                icon="delete"
-                                                                intent="danger"
-                                                                text="Delete chart"
-                                                                onClick={() =>
-                                                                    setIsDeletingChartThatBelongsToDashboard(
-                                                                        true,
-                                                                    )
-                                                                }
-                                                            />
-                                                        ) : (
-                                                            <>
-                                                                <MenuDivider />
-                                                                <MenuItem2
-                                                                    icon="delete"
-                                                                    intent="danger"
-                                                                    text="Remove tile"
-                                                                    onClick={() =>
-                                                                        onDelete(
-                                                                            tile,
-                                                                        )
+                                    <Menu
+                                        opened={isMenuOpen}
+                                        onOpen={() => toggleMenu(true)}
+                                        onClose={() => toggleMenu(false)}
+                                        shadow="md"
+                                        withArrow
+                                        position="bottom-end"
+                                        offset={4}
+                                        arrowOffset={10}
+                                    >
+                                        <Menu.Dropdown>
+                                            {extraMenuItems}
+                                            {isEditMode && extraMenuItems && (
+                                                <Menu.Divider />
+                                            )}
+                                            {isEditMode && (
+                                                <>
+                                                    {!belongsToDashboard && (
+                                                        <Menu.Item
+                                                            // FIXME: pick icon for this one
+                                                            icon={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconEdit
                                                                     }
                                                                 />
-                                                            </>
-                                                        )}
-                                                    </>
-                                                )}
-                                            </Menu>
-                                        }
-                                        renderTarget={({ ref, ...props }) => (
-                                            <Button
-                                                elementRef={ref}
-                                                minimal
-                                                small
-                                                icon="more"
-                                                {...props}
-                                            />
-                                        )}
-                                    />
+                                                            }
+                                                            onClick={() =>
+                                                                setIsEditingTileContent(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            Edit tile content
+                                                        </Menu.Item>
+                                                    )}
+                                                    {belongsToDashboard ? (
+                                                        <Menu.Item
+                                                            color="red"
+                                                            onClick={() =>
+                                                                setIsDeletingChartThatBelongsToDashboard(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            Delete chart
+                                                        </Menu.Item>
+                                                    ) : (
+                                                        <>
+                                                            <Menu.Divider />
+                                                            <Menu.Item
+                                                                color="red"
+                                                                icon={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconTrash
+                                                                        }
+                                                                    />
+                                                                }
+                                                                onClick={() =>
+                                                                    onDelete(
+                                                                        tile,
+                                                                    )
+                                                                }
+                                                            >
+                                                                Remove tile
+                                                            </Menu.Item>
+                                                        </>
+                                                    )}
+                                                </>
+                                            )}
+                                        </Menu.Dropdown>
+
+                                        <Menu.Target>
+                                            <ActionIcon size="sm">
+                                                <MantineIcon icon={IconDots} />
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                    </Menu>
                                 )}
                             </ButtonsWrapper>
                         ) : null}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -210,7 +210,10 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
                                         <Menu.Target>
                                             <ActionIcon size="sm">
-                                                <MantineIcon icon={IconDots} />
+                                                <MantineIcon
+                                                    data-testid="tile-icon-more"
+                                                    icon={IconDots}
+                                                />
                                             </ActionIcon>
                                         </Menu.Target>
                                     </Menu>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -155,7 +155,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                 <>
                                                     {!belongsToDashboard && (
                                                         <Menu.Item
-                                                            // FIXME: pick icon for this one
                                                             icon={
                                                                 <MantineIcon
                                                                     icon={

--- a/packages/frontend/src/components/common/LinkMenuItem.tsx
+++ b/packages/frontend/src/components/common/LinkMenuItem.tsx
@@ -1,14 +1,14 @@
-import { Menu, MenuItemProps } from '@mantine/core';
+import { Menu, MenuItemProps, UnstyledButton } from '@mantine/core';
 import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { EventData, useTracking } from '../../providers/TrackingProvider';
 
 export interface LinkMenuItemProps extends MenuItemProps {
-    href?: string;
     trackingEvent?: EventData;
     target?: React.HTMLAttributeAnchorTarget;
     forceRefresh?: boolean;
-    onClick?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+    href?: string;
+    disabled?: boolean;
 }
 
 const LinkMenuItem: FC<LinkMenuItemProps> = ({
@@ -16,35 +16,40 @@ const LinkMenuItem: FC<LinkMenuItemProps> = ({
     target,
     trackingEvent,
     forceRefresh = false,
-    onClick,
+    disabled = false,
+    children,
     ...rest
 }) => {
     const history = useHistory();
     const { track } = useTracking();
 
     return (
-        <Menu.Item
-            component="a"
-            {...rest}
-            href={href}
+        <UnstyledButton
             target={target}
-            onClick={(e) => {
-                if (
-                    !forceRefresh &&
-                    !e.ctrlKey &&
-                    !e.metaKey &&
-                    target !== '_blank' &&
-                    href
-                ) {
-                    e.preventDefault();
-                    history.push(href);
-                }
+            component="a"
+            href={disabled ? undefined : href}
+        >
+            <Menu.Item
+                {...rest}
+                disabled={disabled}
+                onClick={(e) => {
+                    if (
+                        !forceRefresh &&
+                        !e.ctrlKey &&
+                        !e.metaKey &&
+                        target !== '_blank' &&
+                        href
+                    ) {
+                        e.preventDefault();
+                        history.push(href);
+                    }
 
-                onClick?.(e);
-
-                if (trackingEvent) track(trackingEvent);
-            }}
-        />
+                    if (trackingEvent) track(trackingEvent);
+                }}
+            >
+                {children}
+            </Menu.Item>
+        </UnstyledButton>
     );
 };
 

--- a/packages/frontend/src/components/common/LinkMenuItem.tsx
+++ b/packages/frontend/src/components/common/LinkMenuItem.tsx
@@ -9,6 +9,7 @@ export interface LinkMenuItemProps extends MenuItemProps {
     forceRefresh?: boolean;
     href?: string;
     disabled?: boolean;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 const LinkMenuItem: FC<LinkMenuItemProps> = ({
@@ -17,6 +18,7 @@ const LinkMenuItem: FC<LinkMenuItemProps> = ({
     trackingEvent,
     forceRefresh = false,
     disabled = false,
+    onClick,
     children,
     ...rest
 }) => {
@@ -43,6 +45,8 @@ const LinkMenuItem: FC<LinkMenuItemProps> = ({
                         e.preventDefault();
                         history.push(href);
                     }
+
+                    onClick?.(e);
 
                     if (trackingEvent) track(trackingEvent);
                 }}

--- a/packages/frontend/src/components/common/LinkMenuItem.tsx
+++ b/packages/frontend/src/components/common/LinkMenuItem.tsx
@@ -1,13 +1,14 @@
-import { MenuItem2, MenuItem2Props } from '@blueprintjs/popover2';
+import { Menu, MenuItemProps } from '@mantine/core';
 import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { EventData, useTracking } from '../../providers/TrackingProvider';
 
-export interface LinkMenuItemProps extends MenuItem2Props {
+export interface LinkMenuItemProps extends MenuItemProps {
     href?: string;
     trackingEvent?: EventData;
     target?: React.HTMLAttributeAnchorTarget;
     forceRefresh?: boolean;
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }
 
 const LinkMenuItem: FC<LinkMenuItemProps> = ({
@@ -22,7 +23,8 @@ const LinkMenuItem: FC<LinkMenuItemProps> = ({
     const { track } = useTracking();
 
     return (
-        <MenuItem2
+        <Menu.Item
+            component="a"
             {...rest}
             href={href}
             target={target}

--- a/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
+++ b/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
@@ -1,7 +1,6 @@
-import { Spinner } from '@blueprintjs/core';
-import { MenuItem2 } from '@blueprintjs/popover2';
 import { ApiScheduledDownloadCsv } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Button, Loader, Menu } from '@mantine/core';
+import { IconShare2 } from '@tabler/icons-react';
 import { FC, memo, useState } from 'react';
 import { GSheetsIcon } from '../../../components/common/GSheetsIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -46,13 +45,19 @@ export const ExportToGoogleSheet: FC<ExportToGoogleSheetProps> = memo(
 
         if (asMenuItem) {
             return (
-                <MenuItem2
-                    icon={isExporting ? <Spinner size={16} /> : 'export'}
-                    text="Export Google Sheets"
+                <Menu.Item
+                    icon={
+                        isExporting ? (
+                            <Loader />
+                        ) : (
+                            <MantineIcon icon={IconShare2} />
+                        )
+                    }
                     disabled={isExporting || disabled}
-                    shouldDismissPopover={false}
                     onClick={() => setIsGoogleAuthQueryEnabled(true)}
-                />
+                >
+                    Export Google Sheets
+                </Menu.Item>
             );
         }
         return (


### PR DESCRIPTION
### Description:

migrates tile menus to mantine

![CleanShot 2023-12-08 at 20 22 52@2x](https://github.com/lightdash/lightdash/assets/962095/49cb1e2c-09cd-433a-a3cc-8862f0c66539)
![CleanShot 2023-12-08 at 20 22 12@2x](https://github.com/lightdash/lightdash/assets/962095/1fa9912e-4f2f-4bdd-9876-330e2732e708)
![CleanShot 2023-12-08 at 20 21 48@2x](https://github.com/lightdash/lightdash/assets/962095/e7fbcd1e-074a-4a19-9bfb-af0f4ae43fc6)



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
