### PR TITLE
fix: get base dimension type when date zooming

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -773,6 +773,7 @@ export class ProjectService {
                 const dimWithGranularityOverride =
                     createDimensionWithGranularity(
                         dimToOverride.name,
+                        dimToOverride.type,
                         baseTimeDimension,
                         explore,
                         warehouseClient,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -773,7 +773,6 @@ export class ProjectService {
                 const dimWithGranularityOverride =
                     createDimensionWithGranularity(
                         dimToOverride.name,
-                        dimToOverride.type,
                         baseTimeDimension,
                         explore,
                         warehouseClient,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,7 +11,6 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
-    DimensionType,
     friendlyName,
     isNonAggregateMetric,
     Metric,
@@ -535,7 +534,6 @@ export class ExploreCompiler {
 
 export const createDimensionWithGranularity = (
     dimensionName: string,
-    dimensionType: DimensionType,
     baseTimeDimension: CompiledDimension,
     explore: Explore,
     warehouseClient: WarehouseClient,
@@ -547,10 +545,9 @@ export const createDimensionWithGranularity = (
         {
             ...baseTimeDimension,
             name: dimensionName,
-            type:
-                dimensionType === DimensionType.DATE
-                    ? DimensionType.DATE
-                    : DimensionType.TIMESTAMP,
+            type: timeFrameConfigs[newTimeInterval].getDimensionType(
+                baseTimeDimension.type,
+            ),
             timeInterval: newTimeInterval,
             label: `${baseTimeDimension.label} ${timeFrameConfigs[
                 newTimeInterval

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -11,6 +11,7 @@ import {
     CompiledDimension,
     CompiledMetric,
     Dimension,
+    DimensionType,
     friendlyName,
     isNonAggregateMetric,
     Metric,
@@ -534,6 +535,7 @@ export class ExploreCompiler {
 
 export const createDimensionWithGranularity = (
     dimensionName: string,
+    dimensionType: DimensionType,
     baseTimeDimension: CompiledDimension,
     explore: Explore,
     warehouseClient: WarehouseClient,
@@ -545,6 +547,10 @@ export const createDimensionWithGranularity = (
         {
             ...baseTimeDimension,
             name: dimensionName,
+            type:
+                dimensionType === DimensionType.DATE
+                    ? DimensionType.DATE
+                    : DimensionType.TIMESTAMP,
             timeInterval: newTimeInterval,
             label: `${baseTimeDimension.label} ${timeFrameConfigs[
                 newTimeInterval


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

When overriding a dimension with a selected granularity, also try to get its base dimension's `type`. If that's `date` then set it as date. If not, then `timestamp`. 

This ensures that users don't see these `unformatted` x axis labels:

<img width="919" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/e1b3c3d1-1c07-4c76-bbc8-0f8dbbd8ac1c">


To reproduce (with jaffle shop) 
* create a chart with dimension : customers created date week + metric unique customer count
Date zoom to `Month`
in `/charts-and-results` `fields` property, the value `type` of the dimension (with the different SQL) should be: `date` and not `timestamp` - this was happening because we were getting the `type` from the `baseTimeDimension`, which was `timestamp`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
