### PR TITLE
fix: remove granularity from explore from here

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -290,10 +290,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         (c) => c.addDimensionDashboardFilter,
     );
 
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
-    );
-
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
 
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
@@ -458,10 +454,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
             chartWithDashboardFilters.projectUuid,
             chartWithDashboardFilters,
-            dateZoomGranularity,
         );
         return `${pathname}?${search}`;
-    }, [chartWithDashboardFilters, dateZoomGranularity]);
+    }, [chartWithDashboardFilters]);
 
     const userCanManageChart = user.data?.ability?.can('manage', 'SavedChart');
 

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -16,14 +16,13 @@ import useToaster from './toaster/useToaster';
 export const getExplorerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
     createSavedChart: CreateSavedChartVersion,
-    dateZoomGranularity?: DateGranularity,
 ): { pathname: string; search: string } => {
     const newParams = new URLSearchParams();
     newParams.set(
         'create_saved_chart_version',
         JSON.stringify(createSavedChart),
     );
-    if (dateZoomGranularity) newParams.set('dateZoom', dateZoomGranularity);
+
     return {
         pathname: `/projects/${projectUuid}/tables/${createSavedChart.tableName}`,
         search: newParams.toString(),
@@ -103,7 +102,6 @@ export const useExplorerRoute = () => {
                         ...unsavedChartVersion,
                         metricQuery: queryResultsData.metricQuery,
                     },
-                    dateZoom,
                 ),
             );
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8257 

### Description:

Remove `dateZoom` from `explore from here` URL, meaning that users won't see the date zoom value applied when `explore from here` from a dashboard tile

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
