### PR TITLE
fix: recheck if scheduler filter should be disabled

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -34,8 +34,8 @@ import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 import {
     getFilterRuleRevertableObject,
-    isFilterConfigRevertButtonEnabled,
-    isFilterConfigurationApplyButtonEnabled,
+    hasSavedFilterValueChanged,
+    isFilterEnabled,
 } from './utils';
 
 export enum FilterTabs {
@@ -101,10 +101,7 @@ const FilterConfiguration: FC<Props> = ({
     const isFilterModified = useMemo(() => {
         if (!originalFilterRule || !draftFilterRule) return false;
 
-        return isFilterConfigRevertButtonEnabled(
-            originalFilterRule,
-            draftFilterRule,
-        );
+        return hasSavedFilterValueChanged(originalFilterRule, draftFilterRule);
     }, [originalFilterRule, draftFilterRule]);
 
     const handleChangeField = (newField: FilterableField) => {
@@ -236,7 +233,7 @@ const FilterConfiguration: FC<Props> = ({
         ],
     );
 
-    const isApplyDisabled = !isFilterConfigurationApplyButtonEnabled(
+    const isApplyDisabled = !isFilterEnabled(
         draftFilterRule,
         isEditMode,
         isCreatingNew,

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -6,7 +6,7 @@ import {
 import produce from 'immer';
 import isEqual from 'lodash-es/isEqual';
 
-export const isFilterConfigurationApplyButtonEnabled = (
+export const isFilterEnabled = (
     filterRule?: DashboardFilterRule,
     isEditMode?: boolean,
     isCreatingNew?: boolean,
@@ -64,7 +64,7 @@ export const getFilterRuleRevertableObject = (
     };
 };
 
-export const isFilterConfigRevertButtonEnabled = (
+export const hasSavedFilterValueChanged = (
     originalFilterRule: DashboardFilterRule,
     filterRule: DashboardFilterRule,
 ) => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -210,8 +210,6 @@ const updateFilters = (
     originalFilter: DashboardFilterRule,
     schedulerFilters: SchedulerFilterRule[] | undefined,
 ): SchedulerFilterRule[] | undefined => {
-    console.log('updateFilters');
-
     if (
         schedulerFilters &&
         // Check if filters are the same, regardless of disabled state (accepts any value)
@@ -220,8 +218,6 @@ const updateFilters = (
             { ...schedulerFilter, disabled: undefined },
         )
     ) {
-        console.log('reverted');
-
         return schedulerFilters.filter((f) => f.id !== schedulerFilter.id);
     }
 
@@ -235,8 +231,6 @@ const updateFilters = (
             : originalFilter;
 
     if (hasFilterChanged(filterToCompareAgainst, schedulerFilter)) {
-        console.log('changed');
-
         if (schedulerFilters && isExistingFilter) {
             return schedulerFilters.map((f) =>
                 f.id === schedulerFilter.id
@@ -247,17 +241,6 @@ const updateFilters = (
                     : f,
             );
         }
-
-        console.log({
-            changingDisabled: !(
-                filterToCompareAgainst.disabled &&
-                filterToCompareAgainst.disabled === true
-            ),
-            booleanInside:
-                filterToCompareAgainst.disabled &&
-                filterToCompareAgainst.disabled === true,
-            filterToCompareAgainst,
-        });
 
         return [
             ...(schedulerFilters ?? []),

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -31,7 +31,10 @@ import {
     useFiltersContext,
 } from '../../../components/common/Filters/FiltersProvider';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { isFilterConfigRevertButtonEnabled as hasSavedFilterValueChanged } from '../../../components/DashboardFilter/FilterConfiguration/utils';
+import {
+    hasSavedFilterValueChanged,
+    isFilterEnabled,
+} from '../../../components/DashboardFilter/FilterConfiguration/utils';
 import { useProject } from '../../../hooks/useProject';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 
@@ -207,6 +210,8 @@ const updateFilters = (
     originalFilter: DashboardFilterRule,
     schedulerFilters: SchedulerFilterRule[] | undefined,
 ): SchedulerFilterRule[] | undefined => {
+    console.log('updateFilters');
+
     if (
         schedulerFilters &&
         // Check if filters are the same, regardless of disabled state (accepts any value)
@@ -215,6 +220,8 @@ const updateFilters = (
             { ...schedulerFilter, disabled: undefined },
         )
     ) {
+        console.log('reverted');
+
         return schedulerFilters.filter((f) => f.id !== schedulerFilter.id);
     }
 
@@ -228,11 +235,29 @@ const updateFilters = (
             : originalFilter;
 
     if (hasFilterChanged(filterToCompareAgainst, schedulerFilter)) {
+        console.log('changed');
+
         if (schedulerFilters && isExistingFilter) {
             return schedulerFilters.map((f) =>
-                f.id === schedulerFilter.id ? schedulerFilter : f,
+                f.id === schedulerFilter.id
+                    ? {
+                          ...schedulerFilter,
+                          disabled: !isFilterEnabled(schedulerFilter),
+                      }
+                    : f,
             );
         }
+
+        console.log({
+            changingDisabled: !(
+                filterToCompareAgainst.disabled &&
+                filterToCompareAgainst.disabled === true
+            ),
+            booleanInside:
+                filterToCompareAgainst.disabled &&
+                filterToCompareAgainst.disabled === true,
+            filterToCompareAgainst,
+        });
 
         return [
             ...(schedulerFilters ?? []),

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -28,7 +28,7 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 import { createContext, useContextSelector } from 'use-context-selector';
 import { FieldsWithSuggestions } from '../components/common/Filters/FiltersProvider';
-import { isFilterConfigRevertButtonEnabled as hasSavedFilterValueChanged } from '../components/DashboardFilter/FilterConfiguration/utils';
+import { hasSavedFilterValueChanged } from '../components/DashboardFilter/FilterConfiguration/utils';
 import {
     useDashboardQuery,
     useDashboardsAvailableFilters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8267

### Description:

To reproduce: 
1. Add **saved filter**, type string for example: payment method is bank transfer
2. On scheduler
3. Override payment method filter, but first: remove `bank transfer`, and then add `card` -> the `disabled: true` attribute was added when removing the initial value, and then wouldn't be inverted when readding values. 

This PR now checks if that should be actually `disabled`. 

Also, renames some utils to make them more generic so it's easier to share across different parts of the app 👍 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
