### PR TITLE
chore: remove description styled component

### DIFF
--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles.ts
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles.ts
@@ -1,8 +1,0 @@
-import { Colors } from '@blueprintjs/core';
-import styled from 'styled-components';
-
-export const Description = styled.p`
-    tex-align: left;
-    color: ${Colors.GRAY1};
-    font-size: small;
-`;

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Box, Stack, Title } from '@mantine/core';
+import { Box, Stack, Text, Title } from '@mantine/core';
 import {
     IconBuildingSkyscraper,
     IconCalendarStats,
@@ -33,7 +33,6 @@ import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel'
 import AppearancePanel from '../components/UserSettings/AppearancePanel';
 import DefaultProjectPanel from '../components/UserSettings/DefaultProjectPanel';
 import { DeleteOrganizationPanel } from '../components/UserSettings/DeleteOrganizationPanel';
-import { Description } from '../components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationPanel.styles';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
 import PasswordPanel from '../components/UserSettings/PasswordPanel';
 import ProfilePanel from '../components/UserSettings/ProfilePanel';
@@ -401,11 +400,11 @@ const Settings: FC = () => {
                                     <Title order={4}>
                                         Allowed email domains
                                     </Title>
-                                    <Description>
+                                    <Text ta="left" c="gray.6" fz="xs">
                                         Anyone with email addresses at these
                                         domains can automatically join the
                                         organization.
-                                    </Description>
+                                    </Text>
                                 </div>
                                 <AllowedDomainsPanel />
                             </SettingsGridCard>
@@ -413,13 +412,13 @@ const Settings: FC = () => {
                             <SettingsGridCard>
                                 <div>
                                     <Title order={4}>Default Project</Title>
-                                    <Description>
+                                    <Text ta="left" c="gray.6" fz="xs">
                                         This is the project users will see when
                                         they log in for the first time or from a
                                         new device. If a user does not have
                                         access, they will see their next
                                         accessible project.
-                                    </Description>
+                                    </Text>
                                 </div>
                                 <DefaultProjectPanel />
                             </SettingsGridCard>
@@ -428,12 +427,12 @@ const Settings: FC = () => {
                                 <SettingsGridCard>
                                     <div>
                                         <Title order={4}>Danger zone </Title>
-                                        <Description>
+                                        <Text ta="left" c="gray.6" fz="xs">
                                             This action deletes the whole
                                             workspace and all its content,
                                             including users. This action is not
                                             reversible.
-                                        </Description>
+                                        </Text>
                                     </div>
                                     <DeleteOrganizationPanel />
                                 </SettingsGridCard>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -400,7 +400,7 @@ const Settings: FC = () => {
                                     <Title order={4}>
                                         Allowed email domains
                                     </Title>
-                                    <Text ta="left" c="gray.6" fz="xs">
+                                    <Text c="gray.6" fz="xs">
                                         Anyone with email addresses at these
                                         domains can automatically join the
                                         organization.
@@ -412,7 +412,7 @@ const Settings: FC = () => {
                             <SettingsGridCard>
                                 <div>
                                     <Title order={4}>Default Project</Title>
-                                    <Text ta="left" c="gray.6" fz="xs">
+                                    <Text c="gray.6" fz="xs">
                                         This is the project users will see when
                                         they log in for the first time or from a
                                         new device. If a user does not have
@@ -427,7 +427,7 @@ const Settings: FC = () => {
                                 <SettingsGridCard>
                                     <div>
                                         <Title order={4}>Danger zone </Title>
-                                        <Text ta="left" c="gray.6" fz="xs">
+                                        <Text c="gray.6" fz="xs">
                                             This action deletes the whole
                                             workspace and all its content,
                                             including users. This action is not


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Small `Description` SC component

Before
<img width="942" alt="Screenshot 2023-12-12 at 18 36 47" src="https://github.com/lightdash/lightdash/assets/7611706/272f941e-6a3d-41bf-8e59-1ed3cb01f320">

After
<img width="902" alt="Screenshot 2023-12-12 at 18 36 39" src="https://github.com/lightdash/lightdash/assets/7611706/3f8be1bb-61d3-45ec-ae7a-07f7c1c7a23f">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
