### PR TITLE
chore: mantine-fy chart delete modal

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -670,7 +670,7 @@ const SavedChartsHeader: FC = () => {
             {isDeleteDialogOpen && savedChart?.uuid && (
                 <ChartDeleteModal
                     uuid={savedChart.uuid}
-                    isOpen={isDeleteDialogOpen}
+                    opened={isDeleteDialogOpen}
                     onClose={() => setIsDeleteDialogOpen(false)}
                     onConfirm={() => {
                         history.listen((location, action) => {

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -233,7 +233,7 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                 case ResourceViewItemType.CHART:
                     return (
                         <ChartDeleteModal
-                            isOpen
+                            opened
                             uuid={action.item.data.uuid}
                             onClose={handleReset}
                             onConfirm={handleReset}

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -1,11 +1,16 @@
 import {
+    Alert,
+    Anchor,
     Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    DialogProps,
-} from '@blueprintjs/core';
-import { Anchor } from '@mantine/core';
+    Group,
+    List,
+    Modal,
+    ModalProps,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
 import { FC } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
@@ -13,8 +18,9 @@ import {
     useSavedQuery,
     useSavedQueryDeleteMutation,
 } from '../../../hooks/useSavedQuery';
+import MantineIcon from '../MantineIcon';
 
-interface ChartDeleteModalProps extends DialogProps {
+interface ChartDeleteModalProps extends ModalProps {
     uuid: string;
     onConfirm?: () => void;
 }
@@ -46,54 +52,60 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
     };
 
     return (
-        <Dialog lazy title="Delete Chart" icon="trash" {...modalProps}>
-            <DialogBody>
-                <p>
+        <Modal title={<Title order={4}>Delete Chart</Title>} {...modalProps}>
+            <Stack spacing="lg" pt="sm">
+                <Text>
                     Are you sure you want to delete the chart{' '}
-                    <b>"{chart.name}"</b>?
-                </p>
+                    <Text span fw={600}>
+                        "{chart.name}"
+                    </Text>
+                    ?
+                </Text>
 
                 {relatedDashboards.length > 0 && (
                     <>
-                        <b>
-                            This action will remove a chart tile from{' '}
-                            {relatedDashboards.length} dashboard
-                            {relatedDashboards.length > 1 ? 's' : ''}:
-                        </b>
-
-                        <ul>
-                            {relatedDashboards.map((dashboard) => (
-                                <li key={dashboard.uuid}>
-                                    <Anchor
-                                        component={Link}
-                                        target="_blank"
-                                        to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}
-                                    >
-                                        {dashboard.name}
-                                    </Anchor>
-                                </li>
-                            ))}
-                        </ul>
+                        <Alert
+                            icon={<MantineIcon icon={IconAlertCircle} />}
+                            title={
+                                <Text fw={600}>
+                                    This action will remove a chart tile from{' '}
+                                    {relatedDashboards.length} dashboard
+                                    {relatedDashboards.length > 1 ? 's' : ''}:
+                                </Text>
+                            }
+                        >
+                            <List fz="sm">
+                                {relatedDashboards.map((dashboard) => (
+                                    <List.Item key={dashboard.uuid}>
+                                        <Anchor
+                                            component={Link}
+                                            target="_blank"
+                                            to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}
+                                        >
+                                            {dashboard.name}
+                                        </Anchor>
+                                    </List.Item>
+                                ))}
+                            </List>
+                        </Alert>
                     </>
                 )}
-            </DialogBody>
 
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={modalProps.onClose}>Cancel</Button>
+                <Group position="right" mt="sm">
+                    <Button variant="outline" onClick={modalProps.onClose}>
+                        Cancel
+                    </Button>
 
-                        <Button
-                            loading={isDeleting}
-                            intent="danger"
-                            onClick={handleConfirm}
-                        >
-                            Delete
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                    <Button
+                        loading={isDeleting}
+                        color="red"
+                        onClick={handleConfirm}
+                    >
+                        Delete
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/8301

### Description:

Before

<img width="1357" alt="Screenshot 2023-12-13 at 15 25 11" src="https://github.com/lightdash/lightdash/assets/7611706/592646dc-7f09-4ada-b5f4-1e85b7c3484a">


After

<img width="1118" alt="Screenshot 2023-12-13 at 15 45 04" src="https://github.com/lightdash/lightdash/assets/7611706/77284d88-0ce4-4722-b8c2-ec6bda368b30">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
