### PR TITLE
chore: mantine-fy dashboard update modal

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -199,7 +199,7 @@ const DashboardHeader = ({
                     {isUpdating && (
                         <DashboardUpdateModal
                             uuid={dashboardUuid}
-                            isOpen={isUpdating}
+                            opened={isUpdating}
                             onClose={() => setIsUpdating(false)}
                             onConfirm={() => setIsUpdating(false)}
                         />

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -203,7 +203,7 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                 case ResourceViewItemType.DASHBOARD:
                     return (
                         <DashboardUpdateModal
-                            isOpen
+                            opened
                             uuid={action.item.data.uuid}
                             onClose={handleReset}
                             onConfirm={handleReset}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8301 

### Description:

dashboard update modal

before

<img width="909" alt="Screenshot 2023-12-13 at 16 21 13" src="https://github.com/lightdash/lightdash/assets/7611706/041f6e99-4f90-4e4f-b419-728f809af780">

after

<img width="1232" alt="Screenshot 2023-12-13 at 16 20 38" src="https://github.com/lightdash/lightdash/assets/7611706/3534f188-11e5-4733-b06c-d12c8d038f09">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
