### PR TITLE
feat: mantine tooltips in table headers

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,9 +1,8 @@
-import { Tooltip2 } from '@blueprintjs/popover2';
 import { isField } from '@lightdash/common';
+import { Tooltip } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import React, { FC } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
-
 import {
     TABLE_HEADER_BG,
     Th,
@@ -75,10 +74,11 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                                                         }),
                                                     }}
                                                 >
-                                                    <Tooltip2
-                                                        lazy
-                                                        fill
-                                                        content={
+                                                    <Tooltip
+                                                        withinPortal
+                                                        maw={400}
+                                                        multiline
+                                                        label={
                                                             meta?.item &&
                                                             isField(meta?.item)
                                                                 ? meta.item
@@ -92,15 +92,18 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                                                             snapshot.isDragging
                                                         }
                                                     >
-                                                        {header.isPlaceholder
-                                                            ? null
-                                                            : flexRender(
-                                                                  header.column
-                                                                      .columnDef
-                                                                      .header,
-                                                                  header.getContext(),
-                                                              )}
-                                                    </Tooltip2>
+                                                        <span>
+                                                            {header.isPlaceholder
+                                                                ? null
+                                                                : flexRender(
+                                                                      header
+                                                                          .column
+                                                                          .columnDef
+                                                                          .header,
+                                                                      header.getContext(),
+                                                                  )}
+                                                        </span>
+                                                    </Tooltip>
                                                 </ThLabelContainer>
 
                                                 {HeaderContextMenu && (

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -1,5 +1,3 @@
-import { Icon } from '@blueprintjs/core';
-import { Tooltip2 } from '@blueprintjs/popover2';
 import {
     AdditionalMetric,
     CustomDimension,
@@ -16,7 +14,10 @@ import {
     ItemsMap,
     TableCalculation,
 } from '@lightdash/common';
+import { Group, Tooltip } from '@mantine/core';
+import { IconExclamationCircle } from '@tabler/icons-react';
 import { useMemo } from 'react';
+import MantineIcon from '../components/common/MantineIcon';
 import {
     TableHeaderBoldLabel,
     TableHeaderLabelContainer,
@@ -188,23 +189,25 @@ export const useColumns = (): TableColumn[] => {
                     {
                         id: fieldId,
                         header: () => (
-                            <TableHeaderLabelContainer>
-                                <Tooltip2
-                                    content="This field was not found in the dbt project."
+                            <Group ff="Inter" spacing="two">
+                                <Tooltip
+                                    withinPortal
+                                    label="This field was not found in the dbt project."
                                     position="top"
                                 >
-                                    <Icon
-                                        icon="warning-sign"
-                                        intent="warning"
+                                    <MantineIcon
+                                        display="inline"
+                                        icon={IconExclamationCircle}
+                                        color="yellow"
                                     />
-                                </Tooltip2>
+                                </Tooltip>
 
                                 <TableHeaderBoldLabel
                                     style={{ marginLeft: 10 }}
                                 >
                                     {fieldId}
                                 </TableHeaderBoldLabel>
-                            </TableHeaderLabelContainer>
+                            </Group>
                         ),
                         cell: (info) => info.getValue()?.value.formatted || '-',
                         meta: {


### PR DESCRIPTION
### Description:

restore https://github.com/lightdash/lightdash/pull/8258
this disappeared somehow either from a revert or a bad merge

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
