### PR TITLE
fix: empty location in BigQuery causes an error

### DIFF
--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -39,7 +39,7 @@ export const convertBigquerySchema = async (
         priority: target.priority,
         keyfileContents: await getBigqueryCredentials(target),
         retries: target.retries,
-        location: target.location,
         maximumBytesBilled: target.maximum_bytes_billed,
+        location: target.location || undefined,
     };
 };

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -101,6 +101,8 @@ const BigQueryForm: FC<{
                         validate: {
                             hasNoWhiteSpaces: hasNoWhiteSpaces('Location'),
                         },
+                        setValueAs: (value) =>
+                            value === '' ? undefined : value,
                     })}
                     disabled={disabled}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8306 

### Description:

We were setting location to the empty string when it wasn't set in the big query form. This keeps it as undefined, which I believe is the desired behavior, but I'm not sure how to make sure this works for the customer case. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
