### PR TITLE
fix: added missing param to 'getDashboardsContainingChart' endpoint

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboards.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboards.tsx
@@ -26,9 +26,10 @@ const getDashboards = async (
 const getDashboardsContainingChart = async (
     projectUuid: string,
     chartId: string,
+    includePrivate: boolean,
 ) =>
     lightdashApi<DashboardBasicDetails[]>({
-        url: `/projects/${projectUuid}/dashboards?chartUuid=${chartId}`,
+        url: `/projects/${projectUuid}/dashboards?chartUuid=${chartId}&includePrivate=${includePrivate}`,
         method: 'GET',
         body: undefined,
     });
@@ -57,11 +58,18 @@ export const useDashboards = (
 export const useDashboardsContainingChart = (
     projectUuid: string,
     chartId: string,
+    includePrivate = true,
 ) => {
     const setErrorResponse = useQueryError();
     return useQuery<DashboardBasicDetails[], ApiError>({
-        queryKey: ['dashboards-containing-chart', projectUuid, chartId],
-        queryFn: () => getDashboardsContainingChart(projectUuid, chartId),
+        queryKey: [
+            'dashboards-containing-chart',
+            projectUuid,
+            chartId,
+            includePrivate,
+        ],
+        queryFn: () =>
+            getDashboardsContainingChart(projectUuid, chartId, includePrivate),
         onError: (result) => setErrorResponse(result),
     });
 };


### PR DESCRIPTION
Closes: #8318 

### Description:
Added missing query param to "getDashboardsContainingChart" endpoint.  

![Screen Recording 2023-12-14 at 22 43 55](https://github.com/lightdash/lightdash/assets/9052608/d222e7cf-fbcf-474e-a19a-b7a9ab3edf06)

How to replicate the issue fixed in this PR:
1. User **X** (e.g: developer) from the organization creates a Private Space **Y**
2. User **X** creates a new dashboard **W** in Private Space **Y**
3. Admin user **Z** from organization adds a chart from a public space into dashboard **W**

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
