### PR TITLE
refactor: dont request explore in dashboard page

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -887,6 +887,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = ({
         <MetricQueryDataProvider
             metricQuery={data?.metricQuery}
             tableName={data?.chart.tableName || ''}
+            explore={data?.explore}
         >
             {minimal ? (
                 <DashboardChartTileMinimal

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -2,6 +2,7 @@ import { ProjectType } from '@lightdash/common';
 import { Stack } from '@mantine/core';
 import { FC, memo } from 'react';
 import { useParams } from 'react-router-dom';
+import { useExplore } from '../../hooks/useExplore';
 import { useProjects } from '../../hooks/useProjects';
 import { useExplorerContext } from '../../providers/ExplorerProvider';
 import { CustomVisualizationProvider } from '../CustomVisualization';
@@ -32,11 +33,13 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 project.projectUuid === projectUuid &&
                 project.type === ProjectType.PREVIEW,
         );
+        const { data: explore } = useExplore(unsavedChartVersionTableName);
 
         return (
             <MetricQueryDataProvider
                 metricQuery={unsavedChartVersionMetricQuery}
                 tableName={unsavedChartVersionTableName}
+                explore={explore}
             >
                 <Stack sx={{ flexGrow: 1 }}>
                     {!hideHeader && <ExplorerHeader />}

--- a/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
+++ b/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
@@ -11,7 +11,6 @@ import {
 } from '@lightdash/common';
 import { createContext, FC, useCallback, useContext, useState } from 'react';
 import { EChartSeries } from '../../hooks/echarts/useEchartsCartesianConfig';
-import { useExplore } from '../../hooks/useExplore';
 import { EchartSeriesClickEvent } from '../SimpleChart';
 
 export type UnderlyingDataConfig = {
@@ -96,11 +95,13 @@ const Context = createContext<MetricQueryDataContext | undefined>(undefined);
 
 type Props = {
     tableName: string;
+    explore: Explore | undefined;
     metricQuery: MetricQuery | undefined;
 };
 
 const MetricQueryDataProvider: FC<Props> = ({
     tableName,
+    explore,
     metricQuery,
     children,
 }) => {
@@ -111,7 +112,6 @@ const MetricQueryDataProvider: FC<Props> = ({
         useState<boolean>(false);
     const [isDrillDownModalOpen, setIsDrillDownModalOpen] =
         useState<boolean>(false);
-    const { data: explore } = useExplore(tableName);
 
     const openDrillDownModal = useCallback(
         (config: DrillDownConfig) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

In the dashboard page, use explore from chart results for the MetricQueryDataProvider.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
