### PR TITLE
fix: only send org name if it didn't exist

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/index.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/index.tsx
@@ -54,7 +54,14 @@ const UserCompletionModal: FC = () => {
 
     const { isLoading, mutate, isSuccess } = useUserCompleteMutation();
 
-    const handleSubmit = form.onSubmit((data) => mutate(data));
+    const handleSubmit = form.onSubmit((data) => {
+        if (user.data?.organizationName) {
+            const { organizationName, ...rest } = data;
+            mutate(rest);
+        } else {
+            mutate(data);
+        }
+    });
 
     const { setFieldValue } = form;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8334 

### Description:

Only send `organizationName` if it didn't exist in the first place. 
User has to set it if there's no org set up 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
