### PR TITLE
refactor: return color palette with chart

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3253,6 +3253,11 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                colorPalette: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
                 dashboardName: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3686,6 +3686,12 @@
             },
             "SavedChart": {
                 "properties": {
+                    "colorPalette": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "dashboardName": {
                         "type": "string",
                         "nullable": true
@@ -3766,6 +3772,7 @@
                     }
                 },
                 "required": [
+                    "colorPalette",
                     "dashboardName",
                     "dashboardUuid",
                     "pinnedListOrder",
@@ -5471,7 +5478,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.897.0",
+        "version": "0.907.2",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -6,8 +6,8 @@ import {
     ChartVersionSummary,
     CreateSavedChart,
     CreateSavedChartVersion,
-    CustomDimension,
     DBFieldTypes,
+    ECHARTS_DEFAULT_COLORS,
     getChartKind,
     getChartType,
     getCustomDimensionId,
@@ -38,7 +38,6 @@ import {
     CreateDbSavedChartVersionSort,
     DBFilteredAdditionalMetrics,
     DbSavedChartAdditionalMetricInsert,
-    DbSavedChartCustomDimension,
     DbSavedChartCustomDimensionInsert,
     DbSavedChartTableCalculationInsert,
     InsertChart,
@@ -603,6 +602,7 @@ export class SavedChartModel {
                         space_uuid: string;
                         spaceName: string;
                         dashboardName: string | null;
+                        chart_colors: string[] | null;
                     })[]
                 >([
                     `${ProjectTableName}.project_uuid`,
@@ -621,6 +621,7 @@ export class SavedChartModel {
                     'saved_queries_versions.chart_config',
                     'saved_queries_versions.pivot_dimensions',
                     `${OrganizationTableName}.organization_uuid`,
+                    `${OrganizationTableName}.chart_colors`,
                     `${UserTableName}.user_uuid`,
                     `${UserTableName}.first_name`,
                     `${UserTableName}.last_name`,
@@ -825,6 +826,7 @@ export class SavedChartModel {
                 pinnedListOrder: null,
                 dashboardUuid: savedQuery.dashboard_uuid,
                 dashboardName: savedQuery.dashboardName,
+                colorPalette: savedQuery.chart_colors ?? ECHARTS_DEFAULT_COLORS,
             };
         } finally {
             span?.finish();

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -130,6 +130,7 @@ export const chart: SavedChart = {
     pinnedListOrder: null,
     dashboardUuid: dashboard.uuid,
     dashboardName: dashboard.name,
+    colorPalette: [],
 };
 
 export const dashboardsDetails: DashboardBasicDetails[] = [

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -155,6 +155,7 @@ export const chart: SavedChart = {
     spaceName: 'space name',
     pinnedListUuid: null,
     pinnedListOrder: null,
+    colorPalette: [],
 };
 
 export const chartWithJoinedField: SavedChart = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -305,6 +305,7 @@ export type SavedChart = {
     pinnedListOrder: number | null;
     dashboardUuid: string | null;
     dashboardName: string | null;
+    colorPalette: string[];
 };
 
 type CreateChartBase = Pick<
@@ -345,6 +346,7 @@ export type CreateSavedChartVersion = Omit<
     | 'firstViewedAt'
     | 'dashboardUuid'
     | 'dashboardName'
+    | 'colorPalette'
 >;
 
 export type UpdateSavedChart = Partial<

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -202,6 +202,7 @@ const ValidDashboardChartTile: FC<{
             savedChartUuid={chart.uuid}
             dashboardFilters={dashboardFilters}
             invalidateCache={invalidateCache}
+            colorPalette={chart.colorPalette}
         >
             <LightdashVisualization
                 isDashboard
@@ -246,6 +247,7 @@ const ValidDashboardChartTileMinimal: FC<{
             pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
             savedChartUuid={chart.uuid}
             dashboardFilters={dashboardFilters}
+            colorPalette={chart.colorPalette}
         >
             <LightdashVisualization
                 isDashboard

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,4 +1,8 @@
-import { getHiddenTableFields, NotFoundError } from '@lightdash/common';
+import {
+    ECHARTS_DEFAULT_COLORS,
+    getHiddenTableFields,
+    NotFoundError,
+} from '@lightdash/common';
 import { FC, memo, useCallback, useMemo, useState } from 'react';
 
 import { useDisclosure } from '@mantine/hooks';
@@ -6,6 +10,7 @@ import { downloadCsv } from '../../../api/csv';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
 import { useApp } from '../../../providers/AppProvider';
 import {
@@ -31,6 +36,7 @@ const VisualizationCard: FC<{
     isProjectPreview?: boolean;
 }> = memo(({ projectUuid: fallBackUUid, isProjectPreview }) => {
     const { health } = useApp();
+    const { data: org } = useOrganization();
 
     const savedChart = useExplorerContext(
         (context) => context.state.savedChart,
@@ -165,6 +171,7 @@ const VisualizationCard: FC<{
             onChartConfigChange={setChartConfig}
             onChartTypeChange={setChartType}
             onPivotDimensionsChange={setPivotFields}
+            colorPalette={org?.chartColors ?? ECHARTS_DEFAULT_COLORS}
         >
             <CollapsableCard
                 title="Charts"

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -32,6 +32,7 @@ type VisualizationConfigPieProps =
     VisualizationConfigCommon<VisualizationConfigPie> & {
         // TODO: shared prop once all visualizations are converted
         itemsMap: ItemsMap | undefined;
+        colorPalette: string[];
     };
 
 const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
@@ -39,6 +40,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     initialChartConfig,
     onChartConfigChange,
     itemsMap,
+    colorPalette,
     children,
 }) => {
     const { dimensions, numericMetrics } = useMemo(
@@ -58,6 +60,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
         itemsMap,
         dimensions,
         numericMetrics,
+        colorPalette,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -67,6 +67,7 @@ type VisualizationContext = {
     ) => void;
     setChartType: (value: ChartType) => void;
     setPivotDimensions: (value: string[] | undefined) => void;
+    colorPalette: string[];
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);
@@ -110,6 +111,7 @@ type Props = {
     savedChartUuid?: string;
     dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
+    colorPalette: string[];
 };
 
 const VisualizationProvider: FC<Props> = ({
@@ -129,6 +131,7 @@ const VisualizationProvider: FC<Props> = ({
     savedChartUuid,
     dashboardFilters,
     invalidateCache,
+    colorPalette,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -211,6 +214,7 @@ const VisualizationProvider: FC<Props> = ({
         onSeriesContextMenu,
         setChartType,
         setPivotDimensions,
+        colorPalette,
     };
 
     switch (chartConfig.type) {
@@ -243,6 +247,7 @@ const VisualizationProvider: FC<Props> = ({
                     resultsData={lastValidResultsData}
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}
+                    colorPalette={colorPalette}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -1,7 +1,6 @@
 import {
     CompiledDimension,
     CustomDimension,
-    ECHARTS_DEFAULT_COLORS,
     Field,
     fieldId as getFieldId,
     formatDate,
@@ -29,7 +28,6 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
-import { useOrganization } from '../../../../hooks/organization/useOrganization';
 import FieldSelect from '../../../common/FieldSelect';
 import FilterDatePicker from '../../../common/Filters/FilterInputs/FilterDatePicker';
 import FilterMonthAndYearPicker from '../../../common/Filters/FilterInputs/FilterMonthAndYearPicker';
@@ -172,13 +170,7 @@ export const ReferenceLine: FC<Props> = ({
     updateReferenceLine,
     removeReferenceLine,
 }) => {
-    const { visualizationConfig } = useVisualizationContext();
-    const { data: org } = useOrganization();
-
-    const defaultColors = useMemo(
-        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
-        [org],
-    );
+    const { visualizationConfig, colorPalette } = useVisualizationContext();
 
     const isCartesianChart =
         isCartesianVisualizationConfig(visualizationConfig);
@@ -347,8 +339,8 @@ export const ReferenceLine: FC<Props> = ({
                         withinPortal={false}
                         withEyeDropper={false}
                         format="hex"
-                        swatches={defaultColors}
-                        swatchesPerRow={defaultColors.length}
+                        swatches={colorPalette}
+                        swatchesPerRow={colorPalette.length}
                         onChange={(color) => {
                             setLineColor(color);
                             if (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -23,6 +23,7 @@ import {
 import React, { FC } from 'react';
 import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 import MantineIcon from '../../../common/MantineIcon';
+import { useVisualizationContext } from '../../../LightdashVisualization/VisualizationProvider';
 import ColorSelector from '../../ColorSelector';
 
 type Props = {
@@ -52,6 +53,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
     toggleIsOpen,
     dragHandleProps,
 }) => {
+    const { colorPalette } = useVisualizationContext();
     const type =
         series.type === CartesianSeriesType.LINE && !!series.areaStyle
             ? CartesianSeriesType.AREA
@@ -88,6 +90,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                 )}
                 <ColorSelector
                     color={series.color || fallbackColor}
+                    swatches={colorPalette}
                     onColorChange={(color) => {
                         updateSingleSeries({
                             ...series,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -19,7 +19,6 @@ import {
 } from 'react-beautiful-dnd';
 import { createPortal } from 'react-dom';
 import { getSeriesGroupedByField } from '../../../../hooks/cartesianChartConfig/utils';
-import { useOrganization } from '../../../../hooks/organization/useOrganization';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/VisualizationConfigCartesian';
 import { useVisualizationContext } from '../../../LightdashVisualization/VisualizationProvider';
 import BasicSeriesConfiguration from './BasicSeriesConfiguration';
@@ -43,8 +42,7 @@ type Props = {
 };
 
 const SeriesTab: FC<Props> = ({ items }) => {
-    const { visualizationConfig } = useVisualizationContext();
-    const { data: orgData } = useOrganization({ refetchOnMount: false });
+    const { visualizationConfig, colorPalette } = useVisualizationContext();
 
     const isCartesianChart =
         isCartesianVisualizationConfig(visualizationConfig);
@@ -65,12 +63,11 @@ const SeriesTab: FC<Props> = ({ items }) => {
                 (sum, series, index) => ({
                     ...sum,
                     [getSeriesId(series)]:
-                        (orgData?.chartColors && orgData?.chartColors[index]) ||
-                        getDefaultSeriesColor(index),
+                        colorPalette[index] || getDefaultSeriesColor(index),
                 }),
                 {},
             );
-    }, [chartConfig, orgData]);
+    }, [chartConfig, colorPalette]);
 
     const getSeriesColor = useCallback(
         (seriesId: string) => {

--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -1,4 +1,3 @@
-import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
 import {
     ColorPicker as MantineColorPicker,
     ColorSwatch,
@@ -8,14 +7,13 @@ import {
 } from '@mantine/core';
 import { IconHash } from '@tabler/icons-react';
 import { FC } from 'react';
-import { useOrganization } from '../../hooks/organization/useOrganization';
 import { isHexCodeColor } from '../../utils/colorUtils';
 import MantineIcon from '../common/MantineIcon';
 
 interface Props {
     color?: string;
     defaultColor?: string;
-    swatches?: string[];
+    swatches: string[];
     onColorChange: (newColor: string) => void;
 }
 
@@ -25,9 +23,6 @@ const ColorSelector: FC<Props> = ({
     swatches,
     onColorChange,
 }) => {
-    const { data } = useOrganization();
-
-    swatches = data?.chartColors || ECHARTS_DEFAULT_COLORS;
     const isValidHexColor = color && isHexCodeColor(color);
 
     return (

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
@@ -247,7 +247,7 @@ const GroupItem = forwardRef<HTMLDivElement, StackProps & GroupItemProps>(
 );
 
 const PieChartSeriesConfig: FC = () => {
-    const { visualizationConfig } = useVisualizationContext();
+    const { visualizationConfig, colorPalette } = useVisualizationContext();
 
     const isPieChartConfig = isPieVisualizationConfig(visualizationConfig);
 
@@ -269,7 +269,6 @@ const PieChartSeriesConfig: FC = () => {
     if (!isPieChartConfig) return null;
 
     const {
-        defaultColors,
         valueLabel,
         valueLabelChange,
         showValue,
@@ -359,7 +358,7 @@ const PieChartSeriesConfig: FC = () => {
                                                           }
                                                         : {}
                                                 }
-                                                swatches={defaultColors}
+                                                swatches={colorPalette}
                                                 defaultColor={
                                                     groupColorDefaults[
                                                         groupLabel

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormatting.tsx
@@ -8,7 +8,6 @@ import {
     createConditionalFormatingRule,
     createConditionalFormattingConfigWithColorRange,
     createConditionalFormattingConfigWithSingleColor,
-    ECHARTS_DEFAULT_COLORS,
     FilterableItem,
     getConditionalFormattingConfigType,
     getItemId,
@@ -38,7 +37,6 @@ import {
 } from '@tabler/icons-react';
 import produce from 'immer';
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
 import FieldSelect from '../../common/FieldSelect';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
@@ -46,6 +44,7 @@ import ConditionalFormattingRule from './ConditionalFormattingRule';
 
 interface ConditionalFormattingProps {
     isDefaultOpen?: boolean;
+    colorPalette: string[];
     index: number;
     fields: FilterableItem[];
     value: ConditionalFormattingConfig;
@@ -60,22 +59,16 @@ const ConditionalFormattingRuleLabels = {
 
 const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
     isDefaultOpen = true,
+    colorPalette,
     index: configIndex,
     fields,
     value,
     onChange,
     onRemove,
 }) => {
-    const { data: org } = useOrganization();
-
     const [isAddingRule, setIsAddingRule] = useState(false);
     const [isOpen, setIsOpen] = useState(isDefaultOpen);
     const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
-
-    const defaultColors = useMemo(
-        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
-        [org],
-    );
 
     const field = useMemo(
         () => fields.find((f) => getItemId(f) === config?.target?.fieldId),
@@ -113,14 +106,14 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                 case ConditionalFormattingConfigType.Single:
                     return handleChange(
                         createConditionalFormattingConfigWithSingleColor(
-                            defaultColors[0],
+                            colorPalette[0],
                             config.target,
                         ),
                     );
                 case ConditionalFormattingConfigType.Range:
                     return handleChange(
                         createConditionalFormattingConfigWithColorRange(
-                            defaultColors[0],
+                            colorPalette[0],
                             config.target,
                         ),
                     );
@@ -131,7 +124,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                     );
             }
         },
-        [handleChange, config, defaultColors],
+        [handleChange, config, colorPalette],
     );
 
     const handleAddRule = useCallback(() => {
@@ -318,8 +311,8 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                     withinPortal={false}
                                     withEyeDropper={false}
                                     format="hex"
-                                    swatches={defaultColors}
-                                    swatchesPerRow={defaultColors.length}
+                                    swatches={colorPalette}
+                                    swatchesPerRow={colorPalette.length}
                                     label="Select color"
                                     value={config.color}
                                     onChange={handleChangeSingleColor}
@@ -372,8 +365,8 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                     withinPortal={false}
                                     withEyeDropper={false}
                                     format="hex"
-                                    swatches={defaultColors}
-                                    swatchesPerRow={defaultColors.length}
+                                    swatches={colorPalette}
+                                    swatchesPerRow={colorPalette.length}
                                     label="Start color"
                                     value={config.color.start}
                                     onChange={(newStartColor) =>
@@ -387,8 +380,8 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                     withinPortal={false}
                                     withEyeDropper={false}
                                     format="hex"
-                                    swatches={defaultColors}
-                                    swatchesPerRow={defaultColors.length}
+                                    swatches={colorPalette}
+                                    swatchesPerRow={colorPalette.length}
                                     label="End color"
                                     value={config.color.end}
                                     onChange={(newEndColor) =>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -1,6 +1,5 @@
 import {
     createConditionalFormattingConfigWithSingleColor,
-    ECHARTS_DEFAULT_COLORS,
     FilterableItem,
     getItemId,
     isFilterableItem,
@@ -10,28 +9,20 @@ import { Button, Stack } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import produce from 'immer';
 import { useCallback, useMemo, useState } from 'react';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
 import MantineIcon from '../../common/MantineIcon';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigTable';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
 import ConditionalFormatting from './ConditionalFormatting';
 
 const ConditionalFormattingList = ({}) => {
-    const { data: org } = useOrganization();
-
     const [isAddingNew, setIsAddingNew] = useState(false);
-    const { itemsMap, resultsData, visualizationConfig } =
+    const { itemsMap, resultsData, visualizationConfig, colorPalette } =
         useVisualizationContext();
 
     const chartConfig = useMemo(() => {
         if (!isTableVisualizationConfig(visualizationConfig)) return undefined;
         return visualizationConfig.chartConfig;
     }, [visualizationConfig]);
-
-    const defaultColors = useMemo(
-        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
-        [org],
-    );
 
     const activeFields = useMemo(() => {
         if (!resultsData) return new Set<string>();
@@ -76,12 +67,12 @@ const ConditionalFormattingList = ({}) => {
             produce(activeConfigs, (draft) => {
                 draft.push(
                     createConditionalFormattingConfigWithSingleColor(
-                        defaultColors[0],
+                        colorPalette[0],
                     ),
                 );
             }),
         );
-    }, [chartConfig, activeConfigs, defaultColors]);
+    }, [chartConfig, activeConfigs, colorPalette]);
 
     const handleRemove = useCallback(
         (index) => {
@@ -118,6 +109,7 @@ const ConditionalFormattingList = ({}) => {
             {activeConfigs.map((conditionalFormatting, index) => (
                 <ConditionalFormatting
                     key={index}
+                    colorPalette={colorPalette}
                     isDefaultOpen={activeConfigs.length === 1 || isAddingNew}
                     index={index}
                     fields={visibleActiveNumericFields}

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3,7 +3,6 @@ import {
     CartesianChart,
     CartesianSeriesType,
     DimensionType,
-    ECHARTS_DEFAULT_COLORS,
     formatItemValue,
     formatTableCalculationValue,
     formatValue,
@@ -43,7 +42,6 @@ import { isCartesianVisualizationConfig } from '../../components/LightdashVisual
 import { useVisualizationContext } from '../../components/LightdashVisualization/VisualizationProvider';
 import { defaultGrid } from '../../components/VisualizationConfigs/ChartConfigPanel/Grid';
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
-import { useOrganization } from '../organization/useOrganization';
 import getPlottedData from '../plottedData/getPlottedData';
 
 // NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
@@ -1218,15 +1216,18 @@ const useEchartsCartesianConfig = (
     validCartesianConfigLegend?: LegendValues,
     isInDashboard?: boolean,
 ) => {
-    const { visualizationConfig, pivotDimensions, resultsData, itemsMap } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        pivotDimensions,
+        resultsData,
+        itemsMap,
+        colorPalette,
+    } = useVisualizationContext();
 
     const validCartesianConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
-
-    const { data: organizationData } = useOrganization();
 
     const [pivotedKeys, nonPivotedKeys] = useMemo(() => {
         if (
@@ -1313,8 +1314,6 @@ const useEchartsCartesianConfig = (
     ]);
 
     const colors = useMemo<string[]>(() => {
-        const allColors =
-            organizationData?.chartColors || ECHARTS_DEFAULT_COLORS;
         //Do not use colors from hidden series
         return validCartesianConfig?.eChartsConfig.series
             ? validCartesianConfig.eChartsConfig.series.reduce<string[]>(
@@ -1322,14 +1321,15 @@ const useEchartsCartesianConfig = (
                       if (!serie.hidden)
                           return [
                               ...acc,
-                              allColors[index] || getDefaultSeriesColor(index),
+                              colorPalette[index] ||
+                                  getDefaultSeriesColor(index),
                           ];
                       else return acc;
                   },
                   [],
               )
-            : allColors;
-    }, [organizationData?.chartColors, validCartesianConfig]);
+            : colorPalette;
+    }, [colorPalette, validCartesianConfig]);
 
     const sortedResults = useMemo(() => {
         const results =

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -2,7 +2,6 @@ import {
     ApiQueryResults,
     CustomDimension,
     Dimension,
-    ECHARTS_DEFAULT_COLORS,
     formatItemValue,
     isField,
     isMetric,
@@ -24,7 +23,6 @@ import pick from 'lodash-es/pick';
 import pickBy from 'lodash-es/pickBy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isHexCodeColor } from '../utils/colorUtils';
-import { useOrganization } from './organization/useOrganization';
 
 type PieChartConfig = {
     validConfig: PieChart;
@@ -51,8 +49,6 @@ type PieChartConfig = {
     isValueLabelOverriden: boolean;
     isShowValueOverriden: boolean;
     isShowPercentageOverriden: boolean;
-
-    defaultColors: string[];
 
     sortedGroupLabels: string[];
     groupLabelOverrides: Record<string, string>;
@@ -89,6 +85,7 @@ export type PieChartConfigFn = (
     itemsMap: ItemsMap | undefined,
     dimensions: Record<string, CustomDimension | Dimension>,
     numericMetrics: Record<string, Metric>,
+    colorPalette: string[],
 ) => PieChartConfig;
 
 const usePieChartConfig: PieChartConfigFn = (
@@ -97,9 +94,8 @@ const usePieChartConfig: PieChartConfigFn = (
     itemsMap,
     dimensions,
     numericMetrics,
+    colorPalette,
 ) => {
-    const { data: org } = useOrganization();
-
     const [groupFieldIds, setGroupFieldIds] = useState(
         pieChartConfig?.groupFieldIds ?? [],
     );
@@ -152,11 +148,6 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const [legendPosition, setLegendPosition] = useState(
         pieChartConfig?.legendPosition ?? PieChartLegendPositionDefault,
-    );
-
-    const defaultColors = useMemo(
-        () => org?.chartColors ?? ECHARTS_DEFAULT_COLORS,
-        [org],
     );
 
     const dimensionIds = useMemo(() => Object.keys(dimensions), [dimensions]);
@@ -294,10 +285,10 @@ const usePieChartConfig: PieChartConfigFn = (
         return Object.fromEntries(
             groupLabels.map((name, index) => [
                 name,
-                defaultColors[index % defaultColors.length],
+                colorPalette[index % colorPalette.length],
             ]),
         );
-    }, [groupLabels, defaultColors]);
+    }, [groupLabels, colorPalette]);
 
     const handleGroupChange = useCallback(
         (prevDimensionId: string, newDimensionId: string) => {
@@ -474,8 +465,6 @@ const usePieChartConfig: PieChartConfigFn = (
         isValueLabelOverriden,
         isShowValueOverriden,
         isShowPercentageOverriden,
-
-        defaultColors,
 
         sortedGroupLabels,
         groupLabelOverrides,

--- a/packages/frontend/src/pages/MetricFlow.tsx
+++ b/packages/frontend/src/pages/MetricFlow.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
 import {
     Badge,
     Button,
@@ -32,6 +33,7 @@ import useMetricFlowVisualization from '../features/metricFlow/hooks/useMetricFl
 import convertFieldMapToTableColumns from '../features/metricFlow/utils/convertFieldMapToTableColumns';
 import convertMetricFlowFieldsToExplore from '../features/metricFlow/utils/convertMetricFlowFieldsToExplore';
 import convertMetricFlowQueryResultsToResultsData from '../features/metricFlow/utils/convertMetricFlowQueryResultsToResultsData';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useApp } from '../providers/AppProvider';
@@ -41,6 +43,7 @@ const MOCK_TABLE_NAME = 'metricflow';
 const MetricFlowPage = () => {
     const { showToastError } = useToaster();
     const { user, health } = useApp();
+    const { data: org } = useOrganization();
     const { activeProjectUuid } = useActiveProjectUuid();
     const [selectedMetrics, setSelectedMetrics] = useState<Record<string, {}>>(
         {},
@@ -332,6 +335,7 @@ const MetricFlowPage = () => {
                     pivotTableMaxColumnLimit={
                         health.data.pivotTable.maxColumnLimit
                     }
+                    colorPalette={org?.chartColors ?? ECHARTS_DEFAULT_COLORS}
                 >
                     <CollapsableCard
                         title="Charts"

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -53,6 +53,7 @@ const MinimalExplorer: FC = () => {
             columnOrder={savedChart.tableConfig.columnOrder}
             pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
             savedChartUuid={savedChart.uuid}
+            colorPalette={savedChart.colorPalette}
         >
             <MantineProvider inherit theme={themeOverride}>
                 <StyledLightdashVisualization

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartType,
+    ECHARTS_DEFAULT_COLORS,
     getCustomLabelsFromTableConfig,
     NotFoundError,
 } from '@lightdash/common';
@@ -29,6 +30,7 @@ import RunSqlQueryButton from '../components/SqlRunner/RunSqlQueryButton';
 import SqlRunnerLoadingSkeleton from '../components/SqlRunner/SqlRunerLoadingSkeleton';
 import SqlRunnerInput from '../components/SqlRunner/SqlRunnerInput';
 import SqlRunnerResultsTable from '../components/SqlRunner/SqlRunnerResultsTable';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import { useProjectCatalog } from '../hooks/useProjectCatalog';
 import {
     ProjectCatalogTreeNode,
@@ -56,6 +58,7 @@ enum SqlRunnerCards {
 
 const SqlRunnerPage = () => {
     const { user, health } = useApp();
+    const { data: org } = useOrganization();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const initialState = useSqlRunnerUrlState();
     const sqlQueryMutation = useSqlQueryMutation();
@@ -260,6 +263,7 @@ const SqlRunnerPage = () => {
                     pivotTableMaxColumnLimit={
                         health.data.pivotTable.maxColumnLimit
                     }
+                    colorPalette={org?.chartColors ?? ECHARTS_DEFAULT_COLORS}
                 >
                     <CollapsableCard
                         title="Charts"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Stop requesting the organization color palette inside visualization components. This data is now available in the visualization provider.
We now return the color palette when fetching a chart.
There are 3 places where still need to fetch the org since we don't have a saved chart:
- dbt semantic layer (aka metricflow)
- SQL runner
- explore page

Affected features:
- cartesian charts - series colors + reference lines
- pie chart - series colors
- table chart - conditional formatting

<img width="1275" alt="Screenshot 2023-12-15 at 12 48 42" src="https://github.com/lightdash/lightdash/assets/9117144/bb4f2490-4bd9-4703-a331-842b965f9db0">
<img width="1274" alt="Screenshot 2023-12-15 at 12 54 55" src="https://github.com/lightdash/lightdash/assets/9117144/d8dd4937-bd7b-4f85-a9ed-5f2a2b96ad22">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
