### PR TITLE
fix(dashboard): hide table sorting in minimal dashboard

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -121,7 +121,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                     show: showColumnCalculation,
                 }}
                 headerContextMenu={(props) => {
-                    if (isDashboard && tileUuid)
+                    if (!minimal && isDashboard && tileUuid)
                         return (
                             <DashboardHeaderContextMenu
                                 {...props}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Small bug where we show the menu options to sort table results in the minimal page.

Before:
<img width="1485" alt="Screenshot 2023-12-15 at 14 22 39" src="https://github.com/lightdash/lightdash/assets/9117144/a88345b6-41a6-4764-8d39-5521355584b8">

After:
<img width="1485" alt="Screenshot 2023-12-15 at 14 23 44" src="https://github.com/lightdash/lightdash/assets/9117144/2e703e67-bfdb-4020-b18b-716bfa9b938b">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
