### PR TITLE
chore: mantine-fy tile-related modals

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -120,15 +120,18 @@ const AddTileButton: FC<Props> = ({ onAddTiles, disabled }) => {
                 />
             )}
 
-            <TileAddModal
-                isOpen={!!addTileType}
-                type={addTileType}
-                onClose={() => setAddTileType(undefined)}
-                onConfirm={(tile) => {
-                    onAddTile(tile);
-                    setAddTileType(undefined);
-                }}
-            />
+            {addTileType === DashboardTileTypes.MARKDOWN ||
+            addTileType === DashboardTileTypes.LOOM ? (
+                <TileAddModal
+                    opened={!!addTileType}
+                    type={addTileType}
+                    onClose={() => setAddTileType(undefined)}
+                    onConfirm={(tile) => {
+                        onAddTile(tile);
+                        setAddTileType(undefined);
+                    }}
+                />
+            ) : null}
         </>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -251,7 +251,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         ) : (
                             <TileUpdateModal
                                 className="non-draggable"
-                                isOpen={isEditingTileContent}
+                                opened={isEditingTileContent}
                                 tile={tile}
                                 onClose={() => setIsEditingTileContent(false)}
                                 onConfirm={(newTile) => {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -1,5 +1,5 @@
 import { DashboardMarkdownTileProperties } from '@lightdash/common';
-import { Input, Stack, TextInput } from '@mantine/core';
+import { Stack, TextInput } from '@mantine/core';
 import { UseFormReturnType } from '@mantine/form';
 import MDEditor from '@uiw/react-md-editor';
 
@@ -14,16 +14,15 @@ const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => (
             placeholder="Tile title"
             {...form.getInputProps('title')}
         />
-        <Input.Wrapper label="Content">
-            <MDEditor
-                preview="edit"
-                height={400}
-                overflow={false}
-                style={{ marginTop: '6px' }}
-                value={form.values.content}
-                onChange={(v) => form.setFieldValue('content', v || '')}
-            />
-        </Input.Wrapper>
+
+        <MDEditor
+            preview="edit"
+            maxHeight={300}
+            minHeight={100}
+            visibleDragbar
+            overflow={false}
+            {...form.getInputProps('content')}
+        />
     </Stack>
 );
 

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
@@ -6,15 +6,7 @@ import {
     DashboardTileTypes,
     defaultTileSize,
 } from '@lightdash/common';
-import {
-    Button,
-    Flex,
-    Group,
-    Modal,
-    ModalProps,
-    Stack,
-    Title,
-} from '@mantine/core';
+import { Button, Group, Modal, ModalProps, Stack, Title } from '@mantine/core';
 import { useForm, UseFormReturnType } from '@mantine/form';
 import { IconMarkdown, IconVideo } from '@tabler/icons-react';
 import { FC, useState } from 'react';
@@ -87,7 +79,7 @@ export const TileAddModal: FC<AddProps> = ({
     return (
         <Modal
             title={
-                <Flex gap="xs" align="center">
+                <Group spacing="xs">
                     <MantineIcon
                         size="lg"
                         color="blue.8"
@@ -98,7 +90,7 @@ export const TileAddModal: FC<AddProps> = ({
                         }
                     />
                     <Title order={4}>Add {type} tile</Title>
-                </Flex>
+                </Group>
             }
             {...modalProps}
             size="xl"

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
@@ -1,11 +1,4 @@
 import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    DialogProps,
-} from '@blueprintjs/core';
-import {
     assertUnreachable,
     Dashboard,
     DashboardLoomTileProperties,
@@ -13,21 +6,30 @@ import {
     DashboardTileTypes,
     defaultTileSize,
 } from '@lightdash/common';
+import {
+    Button,
+    Flex,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Title,
+} from '@mantine/core';
 import { useForm, UseFormReturnType } from '@mantine/form';
+import { IconMarkdown, IconVideo } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { v4 as uuid4 } from 'uuid';
-import ChartTileForm from './ChartTileForm';
+import MantineIcon from '../../common/MantineIcon';
 import LoomTileForm, { getLoomId } from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
 
 type Tile = Dashboard['tiles'][number];
 type TileProperties = Tile['properties'];
 
-interface AddProps extends DialogProps {
-    type?: DashboardTileTypes;
-    onClose?: () => void;
+type AddProps = ModalProps & {
+    type: DashboardTileTypes.LOOM | DashboardTileTypes.MARKDOWN;
     onConfirm: (tile: Tile) => void;
-}
+};
 
 export const TileAddModal: FC<AddProps> = ({
     type,
@@ -83,17 +85,28 @@ export const TileAddModal: FC<AddProps> = ({
     };
 
     return (
-        <Dialog
-            lazy
-            title="Add tile to dashboard"
+        <Modal
+            title={
+                <Flex gap="xs" align="center">
+                    <MantineIcon
+                        size="lg"
+                        color="blue.8"
+                        icon={
+                            type === DashboardTileTypes.MARKDOWN
+                                ? IconMarkdown
+                                : IconVideo
+                        }
+                    />
+                    <Title order={4}>Add {type} tile</Title>
+                </Flex>
+            }
             {...modalProps}
+            size="xl"
             onClose={handleClose}
         >
             <form onSubmit={handleConfirm}>
-                <DialogBody>
-                    {type === DashboardTileTypes.SAVED_CHART ? (
-                        <ChartTileForm />
-                    ) : type === DashboardTileTypes.MARKDOWN ? (
+                <Stack spacing="lg" pt="sm">
+                    {type === DashboardTileTypes.MARKDOWN ? (
                         <MarkdownTileForm
                             form={
                                 form as UseFormReturnType<
@@ -113,26 +126,20 @@ export const TileAddModal: FC<AddProps> = ({
                     ) : (
                         assertUnreachable(type, 'Tile type not supported')
                     )}
-                </DialogBody>
 
-                <DialogFooter
-                    actions={
-                        <>
-                            {errorMessage}
+                    {errorMessage}
 
-                            <Button onClick={handleClose}>Cancel</Button>
+                    <Group position="right" mt="sm">
+                        <Button variant="outline" onClick={handleClose}>
+                            Cancel
+                        </Button>
 
-                            <Button
-                                intent="primary"
-                                type="submit"
-                                disabled={!form.isValid()}
-                            >
-                                Add
-                            </Button>
-                        </>
-                    }
-                />
+                        <Button type="submit" disabled={!form.isValid()}>
+                            Add
+                        </Button>
+                    </Group>
+                </Stack>
             </form>
-        </Dialog>
+        </Modal>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -5,15 +5,7 @@ import {
     DashboardMarkdownTileProperties,
     DashboardTileTypes,
 } from '@lightdash/common';
-import {
-    Button,
-    Flex,
-    Group,
-    Modal,
-    ModalProps,
-    Stack,
-    Title,
-} from '@mantine/core';
+import { Button, Group, Modal, ModalProps, Stack, Title } from '@mantine/core';
 import { useForm, UseFormReturnType } from '@mantine/form';
 import { IconMarkdown, IconVideo } from '@tabler/icons-react';
 import produce from 'immer';
@@ -69,7 +61,7 @@ const TileUpdateModal = <T extends Tile>({
         <Modal
             size="xl"
             title={
-                <Flex gap="xs" align="center">
+                <Group spacing="xs">
                     <MantineIcon
                         size="lg"
                         color="blue.8"
@@ -80,7 +72,7 @@ const TileUpdateModal = <T extends Tile>({
                         }
                     />
                     <Title order={4}>Edit {tile.type} tile</Title>
-                </Flex>
+                </Group>
             }
             {...modalProps}
             onClose={() => onClose?.()}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -1,19 +1,23 @@
 import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    DialogProps,
-} from '@blueprintjs/core';
-import {
     assertUnreachable,
     Dashboard,
     DashboardLoomTileProperties,
     DashboardMarkdownTileProperties,
     DashboardTileTypes,
 } from '@lightdash/common';
+import {
+    Button,
+    Flex,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Title,
+} from '@mantine/core';
 import { useForm, UseFormReturnType } from '@mantine/form';
+import { IconMarkdown, IconVideo } from '@tabler/icons-react';
 import produce from 'immer';
+import MantineIcon from '../../common/MantineIcon';
 import ChartTileForm from './ChartTileForm';
 import LoomTileForm, { getLoomId } from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
@@ -21,9 +25,8 @@ import MarkdownTileForm from './MarkdownTileForm';
 type Tile = Dashboard['tiles'][number];
 type TileProperties = Tile['properties'];
 
-interface TileUpdateModalProps<T> extends DialogProps {
+interface TileUpdateModalProps<T> extends ModalProps {
     tile: T;
-    onClose?: () => void;
     onConfirm?: (tile: T) => void;
 }
 
@@ -63,15 +66,27 @@ const TileUpdateModal = <T extends Tile>({
     });
 
     return (
-        <Dialog
-            lazy
-            title="Edit tile content"
+        <Modal
+            size="xl"
+            title={
+                <Flex gap="xs" align="center">
+                    <MantineIcon
+                        size="lg"
+                        color="blue.8"
+                        icon={
+                            tile.type === DashboardTileTypes.MARKDOWN
+                                ? IconMarkdown
+                                : IconVideo
+                        }
+                    />
+                    <Title order={4}>Edit {tile.type} tile</Title>
+                </Flex>
+            }
             {...modalProps}
             onClose={() => onClose?.()}
-            backdropClassName="non-draggable"
         >
             <form onSubmit={handleConfirm}>
-                <DialogBody>
+                <Stack spacing="lg" pt="sm">
                     {tile.type === DashboardTileTypes.SAVED_CHART ? (
                         <ChartTileForm />
                     ) : tile.type === DashboardTileTypes.MARKDOWN ? (
@@ -94,25 +109,19 @@ const TileUpdateModal = <T extends Tile>({
                     ) : (
                         assertUnreachable(tile, 'Tile type not supported')
                     )}
-                </DialogBody>
 
-                <DialogFooter
-                    actions={
-                        <>
-                            <Button onClick={() => onClose?.()}>Cancel</Button>
+                    <Group position="right" mt="sm">
+                        <Button variant="outline" onClick={() => onClose?.()}>
+                            Cancel
+                        </Button>
 
-                            <Button
-                                intent="primary"
-                                type="submit"
-                                disabled={!form.isValid()}
-                            >
-                                Save
-                            </Button>
-                        </>
-                    }
-                />
+                        <Button type="submit" disabled={!form.isValid()}>
+                            Save
+                        </Button>
+                    </Group>
+                </Stack>
             </form>
-        </Dialog>
+        </Modal>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8301 

### Description:

More modals...

On dashboard tiles:
* create
* update


https://github.com/lightdash/lightdash/assets/7611706/cd7e3974-a1b0-456d-9b13-97bc47f00f05


**note**
we had references to `chart` modal form `TileUpdateModal.tsx` and `TileAddModal.tsx` but it would never be reached (because we were rendering separately the markdown+loom vs charts)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
