### PR TITLE
fix: dashboard tile menu zindex

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -137,6 +137,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                 {(isEditMode ||
                                     (!isEditMode && extraMenuItems)) && (
                                     <Menu
+                                        withinPortal
                                         opened={isMenuOpen}
                                         onOpen={() => toggleMenu(true)}
                                         onClose={() => toggleMenu(false)}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -209,7 +209,13 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                         </Menu.Dropdown>
 
                                         <Menu.Target>
-                                            <ActionIcon size="sm">
+                                            <ActionIcon
+                                                size="sm"
+                                                style={{
+                                                    position: 'relative',
+                                                    zIndex: 1,
+                                                }}
+                                            >
                                                 <MantineIcon
                                                     data-testid="tile-icon-more"
                                                     icon={IconDots}


### PR DESCRIPTION
Closes:

### Description:

![CleanShot 2023-12-18 at 13 56 52@2x](https://github.com/lightdash/lightdash/assets/962095/1b79fea4-3cf0-4968-b829-7a193efdfa14)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
