### PR TITLE
fix: close datezoom dropdown on click outside

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -49,7 +49,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                     variant="default"
                     loaderPosition="center"
                     disabled={isEditMode}
-                    onClick={() => {}}
                     sx={{
                         borderColor: dateZoomGranularity
                             ? theme.colors.blue['6']

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 export const DateZoom: FC<Props> = ({ isEditMode }) => {
     const theme = useMantineTheme();
-    const [isOpen, setIsOpen] = useState(false);
+    const [showOpenIcon, setShowOpenIcon] = useState(false);
 
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
@@ -37,10 +37,11 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
             withArrow
             closeOnItemClick
             closeOnClickOutside
-            opened={isOpen}
             offset={-1}
             position="bottom-end"
             disabled={isEditMode}
+            onOpen={() => setShowOpenIcon(true)}
+            onClose={() => setShowOpenIcon(false)}
         >
             <Menu.Target>
                 <Button
@@ -48,9 +49,7 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                     variant="default"
                     loaderPosition="center"
                     disabled={isEditMode}
-                    onClick={() => {
-                        setIsOpen((prev) => !prev);
-                    }}
+                    onClick={() => {}}
                     sx={{
                         borderColor: dateZoomGranularity
                             ? theme.colors.blue['6']
@@ -59,7 +58,9 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                     leftIcon={<MantineIcon icon={IconCalendarSearch} />}
                     rightIcon={
                         <MantineIcon
-                            icon={isOpen ? IconChevronUp : IconChevronDown}
+                            icon={
+                                showOpenIcon ? IconChevronUp : IconChevronDown
+                            }
                         />
                     }
                 >
@@ -87,7 +88,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                         });
 
                         setDateZoomGranularity(undefined);
-                        setIsOpen(false);
                     }}
                     bg={
                         dateZoomGranularity === undefined
@@ -118,7 +118,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                                 },
                             });
                             setDateZoomGranularity(granularity);
-                            setIsOpen(false);
                         }}
                         disabled={dateZoomGranularity === granularity}
                         bg={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8343 

### Description:

Date zoom dropdown was staying open when interacting with other things. This makes the drowdown state uncontrolled and just changes the icon when the menu is open.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
