### PR TITLE
chore: fix 'tick' text as icon

### DIFF
--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -75,7 +75,6 @@ const ProjectSwitcher = () => {
         setLastProjectMutation(project.projectUuid);
 
         showToastSuccess({
-            icon: 'tick',
             title: `You are now viewing ${project.name}`,
             action:
                 !isHomePage && shouldSwapProjectRoute


### PR DESCRIPTION
### Description:

Fix text showing up instead of icon

Before:
<img width="486" alt="Screenshot 2023-12-19 at 16 37 17" src="https://github.com/lightdash/lightdash/assets/1864179/3e878a17-722e-4bcd-8569-487de44efccf">

After:
<img width="459" alt="Screenshot 2023-12-19 at 17 15 29" src="https://github.com/lightdash/lightdash/assets/1864179/9a243970-4af4-478f-b0a9-1528881dd625">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
