### PR TITLE
chore: remove last blueprint collapse

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/FormSection.tsx
+++ b/packages/frontend/src/components/ReactHookForm/FormSection.tsx
@@ -1,4 +1,4 @@
-import { Collapse } from '@blueprintjs/core';
+import { Collapse } from '@mantine/core';
 import React, { FC } from 'react';
 
 interface FormSectionProps {
@@ -7,9 +7,7 @@ interface FormSectionProps {
 }
 
 const FormSection: FC<FormSectionProps> = ({ isOpen = true, children }) => (
-    <Collapse isOpen={isOpen} keepChildrenMounted>
-        {children}
-    </Collapse>
+    <Collapse in={isOpen}>{children}</Collapse>
 );
 
 export default FormSection;


### PR DESCRIPTION
### Description:

Remove the final blueprint collapse. I did check that the children stay mounted in the new one. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
