### PR TITLE
fix: add polling to send now messaging

### DIFF
--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -5,6 +5,7 @@ import {
     ApiSchedulerAndTargetsResponse,
     ApiSchedulerLogsResponse,
     ApiTestSchedulerResponse,
+    SchedulerJobStatus,
 } from '@lightdash/common';
 import {
     Body,
@@ -178,7 +179,11 @@ export class SchedulerController extends Controller {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: { status: await schedulerService.getJobStatus(jobId) },
+            results: {
+                status: (await schedulerService.getJobStatus(
+                    jobId,
+                )) as SchedulerJobStatus,
+            },
         };
     }
 

--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -177,12 +177,12 @@ export class SchedulerController extends Controller {
         @Request() req: express.Request,
     ): Promise<ApiJobStatusResponse> {
         this.setStatus(200);
+        const { status, details } = await schedulerService.getJobStatus(jobId);
         return {
             status: 'ok',
             results: {
-                status: (await schedulerService.getJobStatus(
-                    jobId,
-                )) as SchedulerJobStatus,
+                status: status as SchedulerJobStatus,
+                details,
             },
         };
     }

--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -200,9 +200,13 @@ export class SchedulerController extends Controller {
         @Body() body: any, // TODO: It should be CreateSchedulerAndTargets but tsoa returns an error
     ): Promise<ApiTestSchedulerResponse> {
         this.setStatus(200);
-        await schedulerService.sendScheduler(req.user!, body);
+
         return {
             status: 'ok',
+            results: {
+                jobId: (await schedulerService.sendScheduler(req.user!, body))
+                    .jobId,
+            },
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3842,7 +3842,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        status: { dataType: 'string', required: true },
+                        status: { ref: 'SchedulerJobStatus', required: true },
                     },
                     required: true,
                 },
@@ -3857,6 +3857,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        jobId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3842,6 +3842,14 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        details: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'Record_string.any_' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         status: { ref: 'SchedulerJobStatus', required: true },
                     },
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4375,7 +4375,7 @@
                     "results": {
                         "properties": {
                             "status": {
-                                "type": "string"
+                                "$ref": "#/components/schemas/SchedulerJobStatus"
                             }
                         },
                         "required": ["status"],
@@ -4392,13 +4392,22 @@
             },
             "ApiTestSchedulerResponse": {
                 "properties": {
+                    "results": {
+                        "properties": {
+                            "jobId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["jobId"],
+                        "type": "object"
+                    },
                     "status": {
                         "type": "string",
                         "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ShareUrl": {
@@ -5478,7 +5487,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.907.2",
+        "version": "0.909.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4374,11 +4374,19 @@
                 "properties": {
                     "results": {
                         "properties": {
+                            "details": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Record_string.any_"
+                                    }
+                                ],
+                                "nullable": true
+                            },
                             "status": {
                                 "$ref": "#/components/schemas/SchedulerJobStatus"
                             }
                         },
-                        "required": ["status"],
+                        "required": ["details", "status"],
                         "type": "object"
                     },
                     "status": {
@@ -5487,7 +5495,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.909.0",
+        "version": "0.911.1",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -25,7 +25,10 @@ import {
 } from '../../analytics/LightdashAnalytics';
 import { schedulerClient, slackClient } from '../../clients/clients';
 import { LightdashConfig } from '../../config/parseConfig';
-import { getSchedulerTargetType } from '../../database/entities/scheduler';
+import {
+    getSchedulerTargetType,
+    SchedulerLogDb,
+} from '../../database/entities/scheduler';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
@@ -298,9 +301,12 @@ export class SchedulerService {
         return schedulerLogs;
     }
 
-    async getJobStatus(jobId: string): Promise<string> {
+    async getJobStatus(
+        jobId: string,
+    ): Promise<Pick<SchedulerLogDb, 'status' | 'details'>> {
         const job = await this.schedulerModel.getJobStatus(jobId);
-        return job.status;
+
+        return { status: job.status, details: job.details };
     }
 
     async sendScheduler(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -328,12 +328,10 @@ export class SchedulerService {
             .map((target) => target.channel);
         await slackClient.joinChannels(user.organizationUuid, slackChannels);
 
-        schedulerClient.addScheduledDeliveryJob(
+        return schedulerClient.addScheduledDeliveryJob(
             new Date(),
             scheduler,
             undefined,
         );
-
-        return 'ok';
     }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -55,6 +55,7 @@ import { ShareUrl } from './types/share';
 import { SlackSettings } from './types/slackSettings';
 
 import { Email } from './types/api/email';
+import { ApiSuccessEmpty } from './types/api/success';
 import { EmailStatusExpiring } from './types/email';
 import { FieldValueSearchResult } from './types/fieldMatch';
 import { DashboardFilters } from './types/filter';
@@ -553,7 +554,8 @@ type ApiResults =
     | ApiJobScheduledResponse['results']
     | ApiSshKeyPairResponse['results']
     | MostPopularAndRecentlyUpdated
-    | ApiCalculateTotalResponse['results'];
+    | ApiCalculateTotalResponse['results']
+    | ApiSuccessEmpty;
 
 export type ApiResponse = {
     status: 'ok';

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -367,6 +367,6 @@ export type ApiJobScheduledResponse = {
 export type ApiJobStatusResponse = {
     status: 'ok';
     results: {
-        status: string;
+        status: SchedulerJobStatus;
     };
 };

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -368,5 +368,6 @@ export type ApiJobStatusResponse = {
     status: 'ok';
     results: {
         status: SchedulerJobStatus;
+        details: Record<string, any> | null;
     };
 };

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -245,6 +245,9 @@ export type ApiSchedulerLogsResponse = {
 };
 export type ApiTestSchedulerResponse = {
     status: 'ok';
+    results: {
+        jobId: string;
+    };
 };
 
 // Scheduler task types

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -718,6 +718,10 @@ const SchedulerForm: FC<Props> = ({
             <SchedulersModalFooter
                 confirmText={confirmText}
                 onBack={onBack}
+                canSendNow={Boolean(
+                    form.values.slackTargets.length ||
+                        form.values.emailTargets.length,
+                )}
                 onSendNow={handleSendNow}
                 loading={loading}
             />

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -78,7 +78,7 @@ const CreateStateContent: FC<{
     };
     const { data: user } = useUser(true);
     const { track } = useTracking();
-    const { mutate: sendNow, isFetching: isFetchingSendNow } =
+    const { mutate: sendNow, isLoading: isLoadingSendNow } =
         useSendNowScheduler();
 
     const handleSendNow = useCallback(
@@ -109,7 +109,7 @@ const CreateStateContent: FC<{
 
     return (
         <>
-            <LoadingOverlay visible={isFetchingSendNow} overlayBlur={1} />
+            <LoadingOverlay visible={isLoadingSendNow} overlayBlur={1} />
             <SchedulerForm
                 disabled={createMutation.isLoading}
                 resource={
@@ -154,7 +154,7 @@ const UpdateStateContent: FC<{
     const { data: user } = useUser(true);
     const { track } = useTracking();
 
-    const { mutate: sendNow, isFetching: isFetchingSendNow } =
+    const { mutate: sendNow, isLoading: isLoadingSendNow } =
         useSendNowScheduler();
 
     const handleSendNow = useCallback(
@@ -195,7 +195,7 @@ const UpdateStateContent: FC<{
     }
     return (
         <>
-            <LoadingOverlay visible={isFetchingSendNow} overlayBlur={1} />
+            <LoadingOverlay visible={isLoadingSendNow} overlayBlur={1} />
             <SchedulerForm
                 resource={
                     scheduler.data &&

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -101,6 +101,8 @@ const CreateStateContent: FC<{
             track({
                 name: EventName.SCHEDULER_SEND_NOW_BUTTON,
             });
+
+            // TODO: here
             sendNow(unsavedScheduler);
         },
         [isChart, resourceUuid, track, sendNow, user],

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
@@ -7,6 +7,7 @@ interface FooterProps {
     confirmText?: string;
     onBack?: () => void;
     onSendNow?: () => void;
+    canSendNow?: boolean;
     onCancel?: () => void;
     onConfirm?: () => void;
     loading?: boolean;
@@ -17,6 +18,7 @@ const SchedulersModalFooter = ({
     onBack,
     onCancel,
     onSendNow,
+    canSendNow,
     onConfirm,
     loading,
 }: FooterProps) => {
@@ -54,7 +56,7 @@ const SchedulersModalFooter = ({
                         variant="light"
                         leftIcon={<MantineIcon icon={IconSend} />}
                         onClick={onSendNow}
-                        disabled={loading}
+                        disabled={loading || !canSendNow}
                     >
                         Send now
                     </Button>

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -197,7 +197,7 @@ export const useSendNowScheduler = () => {
         },
     );
 
-    const isFetching = useMemo(
+    const isLoading = useMemo(
         () =>
             sendNowMutation.isLoading ||
             scheduledDeliveryJobStatus?.status === SchedulerJobStatus.STARTED,
@@ -206,6 +206,6 @@ export const useSendNowScheduler = () => {
 
     return {
         ...sendNowMutation,
-        isFetching,
+        isLoading,
     };
 };

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -138,7 +138,11 @@ export const useSendNowScheduler = () => {
         },
         {
             refetchInterval: (data) => {
-                if (data?.status === SchedulerJobStatus.COMPLETED) return false;
+                if (
+                    data?.status === SchedulerJobStatus.COMPLETED ||
+                    data?.status === SchedulerJobStatus.ERROR
+                )
+                    return false;
 
                 return 2000;
             },
@@ -167,6 +171,9 @@ export const useSendNowScheduler = () => {
                 if (data?.status === SchedulerJobStatus.ERROR) {
                     showToastError({
                         title: 'Failed to send scheduled delivery',
+                        ...(data?.details?.error && {
+                            subtitle: data.details.error,
+                        }),
                     });
                     return setTimeout(
                         () =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8358 

### Description:

Disable `Send now` if no targets (email or slack)
Add Loading Overlay if processing `Send Now`
Display notifications when:
* Job Started
* When Scheduled delivery is being processed
* Send success and error notifications for each job status (`COMPLETED` `ERROR`)

Improve types and API responses


https://github.com/lightdash/lightdash/assets/7611706/f1e23db9-c503-4ed6-9f9e-51399af9e625



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
