### PR TITLE
fix: call subpopover handlers on close of autocomplete

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -34,6 +34,8 @@ const FilterStringAutoComplete: FC<Props> = ({
     disabled,
     onChange,
     placeholder,
+    onDropdownOpen,
+    onDropdownClose,
     ...rest
 }) => {
     const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
@@ -199,7 +201,17 @@ const FilterStringAutoComplete: FC<Props> = ({
             }
             data={data}
             value={values}
-            onDropdownClose={handleResetSearch}
+            onDropdownOpen={() => {
+                if (onDropdownOpen) {
+                    onDropdownOpen();
+                }
+            }}
+            onDropdownClose={() => {
+                handleResetSearch();
+                if (onDropdownClose) {
+                    onDropdownClose();
+                }
+            }}
             onChange={handleChange}
             onCreate={handleAdd}
             onKeyDown={handleKeyDown}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -201,16 +201,10 @@ const FilterStringAutoComplete: FC<Props> = ({
             }
             data={data}
             value={values}
-            onDropdownOpen={() => {
-                if (onDropdownOpen) {
-                    onDropdownOpen();
-                }
-            }}
+            onDropdownOpen={onDropdownOpen}
             onDropdownClose={() => {
                 handleResetSearch();
-                if (onDropdownClose) {
-                    onDropdownClose();
-                }
+                onDropdownClose?.();
             }}
             onChange={handleChange}
             onCreate={handleAdd}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

To reproduce: 
* click on saved filter which is a `FilterStringAutoComplete`
* click on dropdown
* click outside to close dropdown
* click outside again to close main popover 

tldr; `onDropdownClose` and `onDropdownOpen` were being passed but then overridden 


https://github.com/lightdash/lightdash/assets/7611706/e3a873ca-137e-4553-a324-130be8508ef5



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
