### PR TITLE
chore: remove blueprint from react hook form directory

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/FromGroup.styles.ts
+++ b/packages/frontend/src/components/ReactHookForm/FromGroup.styles.ts
@@ -1,7 +1,0 @@
-import { Colors } from '@blueprintjs/core';
-import styled from 'styled-components';
-
-export const LabelInfoToggleButton = styled.div`
-    cursor: pointer;
-    color: ${Colors.GRAY5};
-`;

--- a/packages/frontend/src/components/ReactHookForm/Input.tsx
+++ b/packages/frontend/src/components/ReactHookForm/Input.tsx
@@ -1,10 +1,9 @@
-import { InputGroup } from '@blueprintjs/core';
+import { TextInput } from '@mantine/core';
 import React, { FC } from 'react';
 import InputWrapper, { InputWrapperProps } from './InputWrapper';
 
 type FieldProps = {
-    rightElement?: React.ComponentProps<typeof InputGroup>['rightElement'];
-    readOnly?: React.ComponentProps<typeof InputGroup>['readOnly'];
+    rightElement?: React.ReactNode;
 };
 const Input: FC<Omit<InputWrapperProps, 'render'> & FieldProps> = ({
     rightElement,
@@ -13,7 +12,7 @@ const Input: FC<Omit<InputWrapperProps, 'render'> & FieldProps> = ({
     <InputWrapper
         {...rest}
         render={(props, { field }) => (
-            <InputGroup {...props} {...field} rightElement={rightElement} />
+            <TextInput {...props} {...field} rightSection={rightElement} />
         )}
     />
 );

--- a/packages/frontend/src/components/ReactHookForm/InputWrapper.tsx
+++ b/packages/frontend/src/components/ReactHookForm/InputWrapper.tsx
@@ -1,10 +1,11 @@
-import { FormGroup, Icon } from '@blueprintjs/core';
 import { ErrorMessage } from '@hookform/error-message';
 import { ArgumentsOf } from '@lightdash/common';
+import { ActionIcon, Group, Stack, Text } from '@mantine/core';
+import { IconHelpCircle } from '@tabler/icons-react';
 import React, { FC, ReactElement, useState } from 'react';
 import { Controller, get, useFormContext } from 'react-hook-form';
+import MantineIcon from '../common/MantineIcon';
 import DocumentationHelpButton from '../DocumentationHelpButton';
-import { LabelInfoToggleButton } from './FromGroup.styles';
 import './InputWrapper.css';
 
 interface InputProps {
@@ -15,7 +16,6 @@ interface InputProps {
 
 export interface InputWrapperProps {
     name: string;
-    inline?: boolean;
     label?: string;
     disabled?: boolean;
     placeholder?: string;
@@ -35,7 +35,6 @@ export interface InputWrapperProps {
 }
 
 const InputWrapper: FC<InputWrapperProps> = ({
-    inline,
     name,
     defaultValue,
     documentationUrl,
@@ -57,39 +56,28 @@ const InputWrapper: FC<InputWrapperProps> = ({
     const [isLabelInfoOpen, setIsLabelInfoOpen] = useState<boolean>(false);
     const error = get(errors, name);
     return (
-        <FormGroup
-            inline={inline}
-            className={`input-wrapper ${className}`}
-            label={label}
-            labelFor={id}
-            subLabel={isLabelInfoOpen && labelHelp}
-            labelInfo={
-                <>
-                    <span style={{ flex: 1 }}>{requiredLabel}</span>
-                    {documentationUrl && !labelHelp && (
-                        <DocumentationHelpButton href={documentationUrl} />
-                    )}
-                    {labelHelp && (
-                        <LabelInfoToggleButton
-                            onClick={(e) => {
-                                e.preventDefault();
-                                setIsLabelInfoOpen(!isLabelInfoOpen);
-                            }}
-                        >
-                            <Icon icon="help" intent="none" iconSize={15} />
-                        </LabelInfoToggleButton>
-                    )}
-                </>
-            }
-            intent={get(errors, name) ? 'danger' : 'none'}
-            helperText={
-                error ? (
-                    <ErrorMessage errors={errors} name={name} as="p" />
-                ) : (
-                    helperText
-                )
-            }
-        >
+        <Stack className={`input-wrapper ${className}`} spacing="two">
+            <Group spacing="xs" position="apart">
+                <Text fw={450}>
+                    {label} <span style={{ flex: 1 }}>{requiredLabel}</span>
+                </Text>
+
+                {documentationUrl && !labelHelp && (
+                    <DocumentationHelpButton href={documentationUrl} />
+                )}
+                {labelHelp && (
+                    <ActionIcon
+                        onClick={(e) => {
+                            e.preventDefault();
+                            setIsLabelInfoOpen(!isLabelInfoOpen);
+                        }}
+                    >
+                        <MantineIcon icon={IconHelpCircle} />
+                    </ActionIcon>
+                )}
+            </Group>
+            {isLabelInfoOpen && <Text>{labelHelp}</Text>}
+
             <Controller
                 control={control}
                 name={name}
@@ -99,7 +87,8 @@ const InputWrapper: FC<InputWrapperProps> = ({
                     render({ id, ...rest }, controllerProps)
                 }
             />
-        </FormGroup>
+            {error && <ErrorMessage errors={errors} name={name} as="p" />}
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/ReactHookForm/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/MultiKeyValuePairsInput.tsx
@@ -11,7 +11,6 @@ import { useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import MantineIcon from '../common/MantineIcon';
 import DocumentationHelpButton from '../DocumentationHelpButton';
-import { LabelInfoToggleButton } from './FromGroup.styles';
 
 type Props = {
     name: string;
@@ -51,15 +50,14 @@ export const MultiKeyValuePairsInput = ({
                     )}
 
                     {labelHelp && (
-                        <LabelInfoToggleButton
+                        <ActionIcon
                             onClick={(e) => {
                                 e.preventDefault();
-
                                 setIsLabelInfoOpen(!isLabelInfoOpen);
                             }}
                         >
-                            <MantineIcon icon={IconHelpCircle} size="sm" />
-                        </LabelInfoToggleButton>
+                            <MantineIcon icon={IconHelpCircle} />
+                        </ActionIcon>
                     )}
                 </>
             }

--- a/packages/frontend/src/components/ReactHookForm/PasswordInput.tsx
+++ b/packages/frontend/src/components/ReactHookForm/PasswordInput.tsx
@@ -1,6 +1,7 @@
-import { Button, InputGroup } from '@blueprintjs/core';
-import { Tooltip } from '@mantine/core';
+import { ActionIcon, TextInput, Tooltip } from '@mantine/core';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { FC, useState } from 'react';
+import MantineIcon from '../common/MantineIcon';
 import InputWrapper, { InputWrapperProps } from './InputWrapper';
 
 const PasswordInput: FC<Omit<InputWrapperProps, 'render'>> = (props) => {
@@ -9,27 +10,28 @@ const PasswordInput: FC<Omit<InputWrapperProps, 'render'>> = (props) => {
         <InputWrapper
             {...props}
             render={(inputProps, { field }) => (
-                <InputGroup
+                <TextInput
                     {...inputProps}
                     className="sentry-block ph-no-capture"
                     placeholder={
                         inputProps.placeholder || 'Enter your password...'
                     }
                     type={showPassword ? 'text' : 'password'}
-                    rightElement={
+                    rightSection={
                         <Tooltip
                             label={`${showPassword ? 'Hide' : 'Show'} Password`}
                             disabled={inputProps.disabled}
                         >
-                            <Button
-                                minimal
+                            <ActionIcon
                                 disabled={inputProps.disabled}
-                                icon={showPassword ? 'eye-off' : 'eye-open'}
-                                intent="warning"
                                 onClick={() =>
                                     setShowPassword((prevState) => !prevState)
                                 }
-                            />
+                            >
+                                <MantineIcon
+                                    icon={showPassword ? IconEyeOff : IconEye}
+                                />
+                            </ActionIcon>
                         </Tooltip>
                     }
                     {...field}


### PR DESCRIPTION
### Description:

Remove blueprint from ReactHookForm directory. This one is a bit confusing. The good news is there components are barely used. The bad news is you can't really test the DBT Cloud form. But it's deprecated and I did test it. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
