### PR TITLE
feat: change copy on sign-in-with-microsoft button

### DIFF
--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -123,7 +123,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
-                    providerName="Azure AD"
+                    providerName="Microsoft"
                     logo="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAACCSURBVEiJ7ZSxDcJAEATnTxd8CBlNkJK/CFwAETW4QV4EbsEd0ASBg5eOFlZIDizdxrs7J5205Xu/vYAJQVGsPecLwKL4gW5q+Z+abMdyABKQgASAR7GmmsfYVgcGyBm/Pt76OdvgczoDVY54CXm4iOoNKljImeM/OQEJOAig79jff9AUF4fE3EHkAAAAAElFTkSuQmCC"
                     {...props}
                 />


### PR DESCRIPTION
Azure AD is mostly an internal name and the product has also been renamed. "Sign in with Microsoft" is more recognisable to end users