### PR TITLE
fix: disabled style on explores link button

### DIFF
--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -32,10 +32,11 @@ const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
             variant="default"
             onClick={handleCopyClick}
             disabled={isDisabled}
+            color="gray"
         >
             <MantineIcon
                 icon={clipboard.copied ? IconCheck : IconLink}
-                color={clipboard.copied ? 'green' : 'black'}
+                color={clipboard.copied ? 'green' : undefined}
             />
         </ActionIcon>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8353 

### Description:

Quick style fix. The icon button is still a little different from the others because of a mantine default, but it's better. 

Old:
<img width="329" alt="Screenshot 2023-12-21 at 11 26 07" src="https://github.com/lightdash/lightdash/assets/1864179/951752fb-3c2d-426b-bedd-586d3ad16698">

New:
<img width="357" alt="Screenshot 2023-12-21 at 11 25 56" src="https://github.com/lightdash/lightdash/assets/1864179/de275e2f-fe75-4355-8048-8d1c7deb412e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
