### PR TITLE
fix: upgrade package libcurl4 to fix CVE-2023-23914

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -18,6 +18,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     && apt-get clean
 
+# Install security updates
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list
+RUN apt-get update && apt-get -t bullseye-backports install -y \
+    libcurl3-gnutls=7.88.1-10+deb12u3~bpo11+1
+
+RUN echo "deb http://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list.d/backports.list
+RUN apt-get update && apt-get install -y  \
+    zlib1g=1:1.2.13.dfsg-1
+
 # Installing multiple versions of dbt
 # dbt 1.4 is the default
 RUN python3 -m venv /usr/local/dbt1.4


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->


curl@7.74.0-1.3 -> 7.88

https://www.cve.org/CVERecord?id=CVE-2023-23914

![image](https://github.com/lightdash/lightdash/assets/1983672/4376171f-2a69-4250-8679-e19213e034bf)

zlib has not released any version to fix this issue https://github.com/madler/zlib/issues/868 

![Screenshot from 2023-12-21 13-40-13](https://github.com/lightdash/lightdash/assets/1983672/0ab95c8b-a731-4c78-9fd4-bd31846ee591)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
