### PR TITLE
fix: add correct string for chart update modal

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
@@ -77,7 +77,7 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
                         label="Chart description"
                         placeholder="A few words to give your team some context"
                         disabled={isUpdating}
-                        {...form.getInputProps('descrition')}
+                        {...form.getInputProps('description')}
                     />
 
                     <Group position="right" mt="sm">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8385

### Description:

Fix `descrition` typo so the form text input for `chart description` can get populated on load if that data exists

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
