### PR TITLE
feat: add line numbers to sql panel

### DIFF
--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -33,7 +33,7 @@ export const RenderedSql = () => {
     }
 
     return (
-        <Prism m="sm" language="sql">
+        <Prism m="sm" language="sql" withLineNumbers>
             {data || ''}
         </Prism>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8289 

### Description:
Luckily, Mantine has an inbuilt prop `withLineNumbers` that displays the line numbers in a `Prism`.

Before:
![image](https://github.com/lightdash/lightdash/assets/85165953/7d84ed19-1580-44e8-9362-22c5919445a4)

After:
![image](https://github.com/lightdash/lightdash/assets/85165953/0720256f-3e99-4e7d-8b4f-10ae920154b2)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
