### PR TITLE
feat: customise width and preview dashboard exports

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -97,7 +97,7 @@
         "pg": "^8.11.3",
         "pg-connection-string": "^2.5.0",
         "posthog-node": "^3.1.3",
-        "puppeteer": "^21.3.1",
+        "puppeteer": "^21.6.1",
         "redoc-express": "^1.0.0",
         "simple-git": "^3.16.0",
         "slackify-markdown": "^4.4.0",

--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -164,12 +164,12 @@ export class SlackService {
                     const authUserUuid =
                         await this.slackAuthenticationModel.getUserUuid(teamId);
 
-                    const { imageUrl } = await unfurlService.unfurlImage(
-                        details.minimalUrl,
-                        details.pageType,
+                    const { imageUrl } = await unfurlService.unfurlImage({
+                        url: details.minimalUrl,
+                        lightdashPage: details.pageType,
                         imageId,
                         authUserUuid,
-                    );
+                    });
 
                     if (imageUrl) {
                         await SlackService.sendUnfurl(

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -179,6 +179,7 @@ dashboardRouter.post(
             const results = await unfurlService.exportDashboard(
                 req.params.dashboardUuid,
                 req.body.queryFilters,
+                req.body.gridWidth,
                 req.user!,
             );
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -171,13 +171,13 @@ export const getNotificationPageData = async (
             const imageOptions = isSchedulerImageOptions(scheduler.options)
                 ? scheduler.options
                 : undefined;
-            const unfurlImage = await unfurlService.unfurlImage(
-                minimalUrl,
-                pageType,
+            const unfurlImage = await unfurlService.unfurlImage({
+                url: minimalUrl,
+                lightdashPage: pageType,
                 imageId,
-                userUuid,
-                imageOptions?.withPdf,
-            );
+                authUserUuid: userUuid,
+                withPdf: imageOptions?.withPdf,
+            });
             if (unfurlImage.imageUrl === undefined) {
                 throw new Error('Unable to unfurl image');
             }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -225,23 +225,32 @@ export class UnfurlService {
         return path;
     }
 
-    async unfurlImage(
-        url: string,
-        lightdashPage: LightdashPage,
-        imageId: string,
-        authUserUuid: string,
-        withPdf: boolean = false,
-    ): Promise<{ imageUrl?: string; pdfPath?: string }> {
+    async unfurlImage({
+        url,
+        lightdashPage,
+        imageId,
+        authUserUuid,
+        gridWidth,
+        withPdf = false,
+    }: {
+        url: string;
+        lightdashPage: LightdashPage;
+        imageId: string;
+        authUserUuid: string;
+        gridWidth?: number | undefined;
+        withPdf?: boolean;
+    }): Promise<{ imageUrl?: string; pdfPath?: string }> {
         const cookie = await this.getUserCookie(authUserUuid);
         const details = await this.unfurlDetails(url);
-        const buffer = await this.saveScreenshot(
+        const buffer = await this.saveScreenshot({
             imageId,
             cookie,
             url,
             lightdashPage,
-            details?.chartType,
-            details?.organizationUuid,
-        );
+            chartType: details?.chartType,
+            organizationUuid: details?.organizationUuid,
+            gridWidth,
+        });
 
         let imageUrl;
         let pdfPath;
@@ -263,6 +272,7 @@ export class UnfurlService {
     async exportDashboard(
         dashboardUuid: string,
         queryFilters: string,
+        gridWidth: number | undefined,
         user: SessionUser,
     ): Promise<string> {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
@@ -281,26 +291,36 @@ export class UnfurlService {
         ) {
             throw new ForbiddenError();
         }
-        const unfurlImage = await this.unfurlImage(
-            minimalUrl,
-            pageType,
-            `slack-image_${snakeCaseName(name)}_${useNanoid()}`, // In order to use local images from slackRouter, image needs to start with slack-image
-            user.userUuid,
-        );
+        const unfurlImage = await this.unfurlImage({
+            url: minimalUrl,
+            lightdashPage: pageType,
+            imageId: `slack-image_${snakeCaseName(name)}_${useNanoid()}`,
+            authUserUuid: user.userUuid,
+            gridWidth,
+        });
         if (unfurlImage.imageUrl === undefined) {
             throw new Error('Unable to unfurl image');
         }
         return unfurlImage.imageUrl;
     }
 
-    private async saveScreenshot(
-        imageId: string,
-        cookie: string,
-        url: string,
-        lightdashPage: LightdashPage,
-        chartType?: string,
-        organizationUuid?: string,
-    ): Promise<Buffer | undefined> {
+    private async saveScreenshot({
+        imageId,
+        cookie,
+        url,
+        lightdashPage,
+        chartType,
+        organizationUuid,
+        gridWidth = undefined,
+    }: {
+        imageId: string;
+        cookie: string;
+        url: string;
+        lightdashPage: LightdashPage;
+        chartType?: string;
+        organizationUuid?: string;
+        gridWidth?: number | undefined;
+    }): Promise<Buffer | undefined> {
         if (this.lightdashConfig.headlessBrowser?.host === undefined) {
             Logger.error(
                 `Can't get screenshot if HEADLESS_BROWSER_HOST env variable is not defined`,
@@ -332,7 +352,10 @@ export class UnfurlService {
                     if (chartType === ChartType.BIG_NUMBER) {
                         await page.setViewport(bigNumberViewport);
                     } else {
-                        await page.setViewport(viewport);
+                        await page.setViewport({
+                            ...viewport,
+                            width: gridWidth ?? viewport.width,
+                        });
                     }
                     await page.on('requestfailed', (request) => {
                         Logger.warn(
@@ -470,9 +493,11 @@ export class UnfurlService {
                         });
                     }
 
-                    const imageBuffer = (await element.screenshot({
+                    const imageBuffer = await page.screenshot({
                         path,
-                    })) as Buffer;
+                        fullPage: true,
+                        captureBeyondViewport: true,
+                    });
 
                     return imageBuffer;
                 } catch (e) {

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -1,0 +1,237 @@
+import { Dashboard } from '@lightdash/common';
+import {
+    Button,
+    Center,
+    Divider,
+    Flex,
+    Group,
+    Image,
+    LoadingOverlay,
+    Modal,
+    Select,
+    Skeleton,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import {
+    IconEye,
+    IconEyeClosed,
+    IconEyeCog,
+    IconFileExport,
+} from '@tabler/icons-react';
+import { FC, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
+import CollapsableCard from '../CollapsableCard';
+import MantineIcon from '../MantineIcon';
+
+type Props = {
+    gridWidth: number;
+    dashboard: Dashboard;
+};
+
+const CUSTOM_WIDTH_OPTIONS = [
+    {
+        label: 'Small (1000px)',
+        value: '1000',
+    },
+    {
+        label: 'Medium (1200px)',
+        value: '1200',
+    },
+    {
+        label: 'Large (1400px)',
+        value: '1400',
+    },
+];
+
+const PreviewAndCustomize: FC<Props> = ({ gridWidth, dashboard }) => {
+    const [isOpenImage, setIsOpenImage] = useState(false);
+    const location = useLocation();
+    const { mutate: exportDashboard, isLoading, data } = useExportDashboard();
+    const [previewChoice, setPreviewChoice] = useState('current');
+    const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
+
+    return (
+        <>
+            <CollapsableCard
+                isOpen={isCustomizeOpen}
+                title="Customize"
+                headerElement={
+                    <Text fz="xs" c="gray.6">
+                        your dashboard before exporting (with preview)
+                    </Text>
+                }
+                onToggle={() => {
+                    setIsCustomizeOpen(!isCustomizeOpen);
+                }}
+            >
+                <Stack spacing="lg" p="md">
+                    <Group position="center" align="flex-end">
+                        <Select
+                            label="Use custom width"
+                            withinPortal
+                            data={CUSTOM_WIDTH_OPTIONS.concat([
+                                {
+                                    label: `Current view: ${gridWidth}px`,
+                                    value: 'current',
+                                },
+                            ])}
+                            defaultValue="current"
+                            onChange={(value) => {
+                                if (!value) return;
+                                setPreviewChoice(value);
+                            }}
+                        />
+
+                        <Button
+                            variant="default"
+                            leftIcon={<MantineIcon icon={IconEye} />}
+                            onClick={() => {
+                                exportDashboard({
+                                    dashboard,
+                                    gridWidth:
+                                        previewChoice === 'current'
+                                            ? gridWidth
+                                            : parseInt(previewChoice),
+                                    queryFilters: location.search,
+                                    isPreview: true,
+                                });
+                            }}
+                        >
+                            Generate preview
+                        </Button>
+                    </Group>
+
+                    <Center h={400}>
+                        <LoadingOverlay visible={isLoading} />
+                        <Image
+                            src={data}
+                            onClick={() => {
+                                if (data) setIsOpenImage(true);
+                            }}
+                            width={400}
+                            height={400}
+                            style={{
+                                objectPosition: 'top',
+                                cursor: data ? 'pointer' : 'default',
+                            }}
+                            withPlaceholder
+                            placeholder={
+                                isLoading ? (
+                                    <Skeleton w={400} h={400} />
+                                ) : (
+                                    <Flex
+                                        gap="md"
+                                        align="center"
+                                        direction="column"
+                                    >
+                                        <MantineIcon
+                                            icon={IconEyeClosed}
+                                            size={30}
+                                        />
+
+                                        <Text>No preview yet</Text>
+                                    </Flex>
+                                )
+                            }
+                        />
+                    </Center>
+                    <Button
+                        m="auto"
+                        leftIcon={<MantineIcon icon={IconEyeCog} />}
+                        onClick={() => {
+                            exportDashboard({
+                                dashboard,
+                                gridWidth:
+                                    previewChoice === 'current'
+                                        ? gridWidth
+                                        : parseInt(previewChoice),
+                                queryFilters: location.search,
+                            });
+                        }}
+                    >
+                        Export with current selection
+                    </Button>
+                </Stack>
+            </CollapsableCard>
+
+            <Modal
+                fullScreen
+                onClose={() => setIsOpenImage(false)}
+                opened={isOpenImage}
+            >
+                <Image
+                    src={data}
+                    onClick={() => {
+                        setIsOpenImage(false);
+                    }}
+                    width="100%"
+                    height="100%"
+                    style={{
+                        cursor: 'pointer',
+                    }}
+                />
+            </Modal>
+        </>
+    );
+};
+
+export const DashboardExportModal: FC<Props> = ({ gridWidth, dashboard }) => {
+    const location = useLocation();
+    const [isOpen, setIsOpen] = useState(true);
+    const { mutate: exportDashboard, isLoading } = useExportDashboard();
+
+    return (
+        <>
+            <Modal
+                size="xl"
+                yOffset="3vh"
+                opened={isOpen}
+                onClose={() => {
+                    setIsOpen(false);
+                }}
+                title={<Title order={5}>Export dashboard</Title>}
+                styles={{
+                    body: {
+                        padding: 0,
+                    },
+                }}
+            >
+                <Stack>
+                    <Button
+                        loading={isLoading}
+                        m="auto"
+                        onClick={() => {
+                            exportDashboard({
+                                dashboard,
+                                gridWidth: undefined,
+                                queryFilters: location.search,
+                            });
+                        }}
+                        leftIcon={<MantineIcon icon={IconFileExport} />}
+                    >
+                        Export now
+                    </Button>
+
+                    <Divider label="OR" labelPosition="center" />
+
+                    <PreviewAndCustomize
+                        gridWidth={gridWidth}
+                        dashboard={dashboard}
+                    />
+
+                    <Group position="left" pb="md" px="md">
+                        <Button
+                            variant="outline"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Cancel
+                        </Button>
+                    </Group>
+                </Stack>
+            </Modal>
+        </>
+    );
+};

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -244,27 +244,20 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                             <Button
                                 loading={exportDashboardMutation.isLoading}
                                 onClick={() => {
-                                    if (previewChoice) {
-                                        if (exportDashboardMutation.data)
-                                            return window.open(
-                                                exportDashboardMutation.data,
-                                                '_blank',
-                                            );
-                                        exportDashboardMutation.mutate({
-                                            dashboard,
-                                            gridWidth:
-                                                previewChoice === 'current'
-                                                    ? gridWidth
-                                                    : parseInt(previewChoice),
-                                            queryFilters: location.search,
-                                        });
-                                    } else {
-                                        exportDashboardMutation.mutate({
-                                            dashboard,
-                                            gridWidth: undefined,
-                                            queryFilters: location.search,
-                                        });
-                                    }
+                                    if (
+                                        previewChoice &&
+                                        previews[previewChoice]
+                                    )
+                                        return window.open(
+                                            exportDashboardMutation.data,
+                                            '_blank',
+                                        );
+
+                                    exportDashboardMutation.mutate({
+                                        dashboard,
+                                        gridWidth: undefined,
+                                        queryFilters: location.search,
+                                    });
                                 }}
                                 leftIcon={
                                     <MantineIcon

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -210,6 +210,23 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
     const location = useLocation();
     const exportDashboardMutation = useExportDashboard();
 
+    const handleExportClick = useCallback(() => {
+        if (previewChoice && previews[previewChoice])
+            return window.open(exportDashboardMutation.data, '_blank');
+
+        exportDashboardMutation.mutate({
+            dashboard,
+            gridWidth: undefined,
+            queryFilters: location.search,
+        });
+    }, [
+        dashboard,
+        exportDashboardMutation,
+        location.search,
+        previewChoice,
+        previews,
+    ]);
+
     return (
         <>
             <Modal
@@ -243,22 +260,7 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                         <Group spacing="xs">
                             <Button
                                 loading={exportDashboardMutation.isLoading}
-                                onClick={() => {
-                                    if (
-                                        previewChoice &&
-                                        previews[previewChoice]
-                                    )
-                                        return window.open(
-                                            exportDashboardMutation.data,
-                                            '_blank',
-                                        );
-
-                                    exportDashboardMutation.mutate({
-                                        dashboard,
-                                        gridWidth: undefined,
-                                        queryFilters: location.search,
-                                    });
-                                }}
+                                onClick={handleExportClick}
                                 leftIcon={
                                     <MantineIcon
                                         icon={

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -118,29 +118,32 @@ export const useExportDashboard = () => {
         {
             mutationKey: ['export_dashboard'],
             onMutate: (data) => {
-                if (data.isPreview) return;
                 showToastInfo({
                     key: 'dashboard_export_toast',
-                    title: `${data.dashboard.name} is being exported. This might take a few seconds.`,
+                    title: data.isPreview
+                        ? `Generating preview for ${data.dashboard.name}`
+                        : `${data.dashboard.name} is being exported. This might take a few seconds.`,
                     autoClose: false,
                     loading: true,
                 });
             },
             onSuccess: async (url, data) => {
                 if (url) {
-                    if (data.isPreview) return;
-                    window.open(url, '_blank');
+                    if (!data.isPreview) window.open(url, '_blank');
                     showToastSuccess({
                         key: 'dashboard_export_toast',
-                        title: `Success! ${data.dashboard.name} was exported.`,
+                        title: data.isPreview
+                            ? 'Success!'
+                            : `Success! ${data.dashboard.name} was exported.`,
                     });
                 }
             },
             onError: (error, data) => {
-                if (data.isPreview) return;
                 showToastError({
                     key: 'dashboard_export_toast',
-                    title: `Failed to export ${data.dashboard.name}`,
+                    title: data.isPreview
+                        ? `Failed to generate preview for ${data.dashboard.name}`
+                        : `Failed to export ${data.dashboard.name}`,
                     subtitle: error.error.message,
                 });
             },

--- a/packages/frontend/src/hooks/dashboard/useDashboard.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.tsx
@@ -62,11 +62,15 @@ const postDashboardsAvailableFilters = async (
         body: JSON.stringify(savedChartUuidsAndTileUuids),
     });
 
-const exportDashboard = async (id: string, queryFilters: string) =>
+const exportDashboard = async (
+    id: string,
+    gridWidth: number | undefined,
+    queryFilters: string,
+) =>
     lightdashApi<string>({
         url: `/dashboards/${id}/export`,
         method: 'POST',
-        body: JSON.stringify({ queryFilters }),
+        body: JSON.stringify({ queryFilters, gridWidth }),
     });
 
 export const useDashboardsAvailableFilters = (
@@ -94,35 +98,54 @@ export const useDashboardQuery = (
 };
 
 export const useExportDashboard = () => {
-    const { showToastSuccess, showToastError, showToastPrimary } = useToaster();
+    const { showToastSuccess, showToastError, showToastInfo } = useToaster();
     return useMutation<
         string,
         ApiError,
-        { dashboard: Dashboard; queryFilters: string }
-    >((data) => exportDashboard(data.dashboard.uuid, data.queryFilters), {
-        mutationKey: ['export_dashboard'],
-        onMutate: (data) => {
-            showToastPrimary({
-                key: 'dashboard_export_toast',
-                title: `${data.dashboard.name} is being exported. This might take a few seconds.`,
-                autoClose: false,
-            });
+        {
+            dashboard: Dashboard;
+            gridWidth: number | undefined;
+            queryFilters: string;
+            isPreview?: boolean;
+        }
+    >(
+        (data) =>
+            exportDashboard(
+                data.dashboard.uuid,
+                data.gridWidth,
+                data.queryFilters,
+            ),
+        {
+            mutationKey: ['export_dashboard'],
+            onMutate: (data) => {
+                if (data.isPreview) return;
+                showToastInfo({
+                    key: 'dashboard_export_toast',
+                    title: `${data.dashboard.name} is being exported. This might take a few seconds.`,
+                    autoClose: false,
+                    loading: true,
+                });
+            },
+            onSuccess: async (url, data) => {
+                if (url) {
+                    if (data.isPreview) return;
+                    window.open(url, '_blank');
+                    showToastSuccess({
+                        key: 'dashboard_export_toast',
+                        title: `Success! ${data.dashboard.name} was exported.`,
+                    });
+                }
+            },
+            onError: (error, data) => {
+                if (data.isPreview) return;
+                showToastError({
+                    key: 'dashboard_export_toast',
+                    title: `Failed to export ${data.dashboard.name}`,
+                    subtitle: error.error.message,
+                });
+            },
         },
-        onSuccess: async (url, data) => {
-            if (url) window.open(url, '_blank');
-            showToastSuccess({
-                key: 'dashboard_export_toast',
-                title: `Success! ${data.dashboard.name} was exported.`,
-            });
-        },
-        onError: (error, data) => {
-            showToastError({
-                key: 'dashboard_export_toast',
-                title: `Failed to export ${data.dashboard.name}`,
-                subtitle: error.error.message,
-            });
-        },
-    });
+    );
 };
 
 export const useUpdateDashboard = (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -651,6 +651,8 @@ const Dashboard: FC = () => {
                 )}
                 {isExportDashboardModalOpen && (
                     <DashboardExportModal
+                        opened={isExportDashboardModalOpen}
+                        onClose={() => setIsExportDashboardModalOpen(false)}
                         dashboard={dashboard}
                         gridWidth={gridWidth}
                     />

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -19,12 +19,13 @@ import React, {
     useState,
 } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { useIntersection } from 'react-use';
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import DashboardDeleteModal from '../components/common/modal/DashboardDeleteModal';
+import { DashboardExportModal } from '../components/common/modal/DashboardExportModal';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import DashboardFilter from '../components/DashboardFilter';
@@ -37,7 +38,6 @@ import { DateZoom } from '../features/dateZoom';
 import {
     appendNewTilesToBottom,
     useDuplicateDashboardMutation,
-    useExportDashboard,
     useMoveDashboardMutation,
     useUpdateDashboard,
 } from '../hooks/dashboard/useDashboard';
@@ -188,8 +188,6 @@ const Dashboard: FC = () => {
     const { mutate: duplicateDashboard } = useDuplicateDashboardMutation({
         showRedirectButton: true,
     });
-    const { mutate: exportDashboard } = useExportDashboard();
-    const location = useLocation();
 
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
@@ -250,6 +248,8 @@ const Dashboard: FC = () => {
         clearIsEditingDashboardChart,
         showToastError,
     ]);
+
+    const [gridWidth, setGridWidth] = useState(0);
 
     useEffect(() => {
         if (isSuccess) {
@@ -408,9 +408,13 @@ const Dashboard: FC = () => {
         setIsDeleteModalOpen(true);
     };
 
+    const [isExportDashboardModalOpen, setIsExportDashboardModalOpen] =
+        useState(false);
+
     const handleExportDashboard = () => {
         if (!dashboard) return;
-        exportDashboard({ dashboard, queryFilters: location.search });
+
+        setIsExportDashboardModalOpen(true);
     };
 
     const [isSaveWarningModalOpen, setIsSaveWarningModalOpen] =
@@ -603,6 +607,7 @@ const Dashboard: FC = () => {
                     {...getResponsiveGridLayoutProps()}
                     onDragStop={handleUpdateTiles}
                     onResizeStop={handleUpdateTiles}
+                    onWidthChange={(cw) => setGridWidth(cw)}
                     layouts={layouts}
                 >
                     {sortedTiles?.map((tile, idx) => {
@@ -644,10 +649,17 @@ const Dashboard: FC = () => {
                         }}
                     />
                 )}
+                {isExportDashboardModalOpen && (
+                    <DashboardExportModal
+                        dashboard={dashboard}
+                        gridWidth={gridWidth}
+                    />
+                )}
             </Page>
         </>
     );
 };
+
 const DashboardPage: FC = () => {
     useProfiler('Dashboard');
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,10 +4485,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@puppeteer/browsers@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.7.1.tgz#04f1e3aec4b87f50a7acc8f64be2149bda014f0a"
-  integrity sha512-nIb8SOBgDEMFY2iS2MdnUZOg2ikcYchRrBoF+wtdjieRFKR2uGRipHY/oFLo+2N6anDualyClPzGywTHRGrLfw==
+"@puppeteer/browsers@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.9.0.tgz#dfd0aad0bdc039572f1b57648f189525d627b7ff"
+  integrity sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==
   dependencies:
     debug "4.3.4"
     extract-zip "2.0.1"
@@ -4496,7 +4496,7 @@
     proxy-agent "6.3.1"
     tar-fs "3.0.4"
     unbzip2-stream "1.4.3"
-    yargs "17.7.1"
+    yargs "17.7.2"
 
 "@radix-ui/number@1.0.0":
   version "1.0.0"
@@ -8161,10 +8161,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromium-bidi@0.4.27:
-  version "0.4.27"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.27.tgz#6b12b9cb4d43f66803258cb3b2c4a857e5911cc7"
-  integrity sha512-8Irq0FbKYN8Xmj8M62kta6wk5MyDKeYIFtNavxQ2M3xf2v5MCC4ntf+FxitQu1iHaQvGU6t5O+Nrep0RNNS0EQ==
+chromium-bidi@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.5.1.tgz#390c1af350c4887824a33d82190de1cc5c5680fc"
+  integrity sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==
   dependencies:
     mitt "3.0.1"
     urlpattern-polyfill "9.0.0"
@@ -9374,10 +9374,10 @@ detective-typescript@^9.1.1:
     node-source-walk "^5.0.1"
     typescript "^4.9.5"
 
-devtools-protocol@0.0.1179426:
-  version "0.0.1179426"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1179426.tgz#c4c3ee671efae868395569123002facbbbffa267"
-  integrity sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg==
+devtools-protocol@0.0.1203626:
+  version "0.0.1203626"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz#4366a4c81a7e0d4fd6924e9182c67f1e5941e820"
+  integrity sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==
 
 diff-match-patch@^1.0.5:
   version "1.0.5"
@@ -16476,26 +16476,26 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@21.3.1:
-  version "21.3.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-21.3.1.tgz#806c317c36f543b2f2c7362a5c1c3c64e5c57fc5"
-  integrity sha512-3VrCDEAHk0hPvE8qtfKgsT8CzRuaQrDQGXdCOuMFJM7Ap+ghpQzhPa9H3DE3gZgwDvC5Jt7SxUkAWLCeNbD0xw==
+puppeteer-core@21.6.1:
+  version "21.6.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-21.6.1.tgz#10eccb4dc3167c8c26bc21122fabb45a9fda9ca7"
+  integrity sha512-0chaaK/RL9S1U3bsyR4fUeUfoj51vNnjWvXgG6DcsyMjwYNpLcAThv187i1rZCo7QhJP0wZN8plQkjNyrq2h+A==
   dependencies:
-    "@puppeteer/browsers" "1.7.1"
-    chromium-bidi "0.4.27"
+    "@puppeteer/browsers" "1.9.0"
+    chromium-bidi "0.5.1"
     cross-fetch "4.0.0"
     debug "4.3.4"
-    devtools-protocol "0.0.1179426"
-    ws "8.14.1"
+    devtools-protocol "0.0.1203626"
+    ws "8.15.1"
 
-puppeteer@^21.3.1:
-  version "21.3.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-21.3.1.tgz#0196d6f9fcdd6c2f97948d64f2dd7ee8187174b1"
-  integrity sha512-MhDvA+BYmzx+9vHJ/ZtknhlPbSPjTlHQnW1QYfkGpBcGW2Yy6eMahjkNuhAzN29H9tb47IcT0QsVcUy3Txx+SA==
+puppeteer@^21.6.1:
+  version "21.6.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-21.6.1.tgz#2ec0878906ff90b3a424f19e5eb006592abe25b6"
+  integrity sha512-O+pbc61oj8ln6m8EJKncrsQFmytgRyFYERtk190PeLbJn5JKpmmynn2p1PiFrlhCitAQXLJ0MOy7F0TeyCRqBg==
   dependencies:
-    "@puppeteer/browsers" "1.7.1"
+    "@puppeteer/browsers" "1.9.0"
     cosmiconfig "8.3.6"
-    puppeteer-core "21.3.1"
+    puppeteer-core "21.6.1"
 
 pure-color@^1.2.0:
   version "1.3.0"
@@ -20363,10 +20363,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.14.1:
-  version "8.14.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.1.tgz#4b9586b4f70f9e6534c7bb1d3dc0baa8b8cf01e0"
-  integrity sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==
+ws@8.15.1:
+  version "8.15.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.15.1.tgz#271ba33a45ca0cc477940f7f200cd7fba7ee1997"
+  integrity sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==
 
 ws@^5.2.3:
   version "5.2.3"
@@ -20459,10 +20459,10 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@17.7.1:
-  version "17.7.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
-  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+yargs@17.7.2, yargs@^17.7.2, yargs@~17.7.2:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"
@@ -20514,19 +20514,6 @@ yargs@^17.1.1, yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yargs@^17.7.2, yargs@~17.7.2:
-  version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Consequence of investigation: #8276 

### Description:

Feature: 
* Allow dashboard `export now` - default behaviour
* Provide customisation section. Users can: change the width + preview what their dashboard would look like



**Demo (most recent):**


https://github.com/lightdash/lightdash/assets/7611706/8cf98155-f5b1-4ae9-8dd1-52fb612ae725



**Demo (outdated):**


https://github.com/lightdash/lightdash/assets/7611706/b1470203-2d27-4511-9e53-478603281009



Added a loading spinner to the notification for `exporting in progress` 

Notes:
* upgrade `puppeteer`
* convert some long-args-methods to one single object
* use `page.screenshot` instead - worked great on `dashboards` and `charts` exports



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
