### PR TITLE
fix: discard explores with duplicate name

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,6 +4,7 @@
     "main": "dist/index",
     "license": "MIT",
     "devDependencies": {
+        "@tsoa/cli": "^4.1.3",
         "@types/bcrypt": "^5.0.0",
         "@types/connect-flash": "^0.0.37",
         "@types/cookie-parser": "^1.4.2",
@@ -11,6 +12,7 @@
         "@types/express-session": "^1.17.4",
         "@types/fs-extra": "^9.0.13",
         "@types/js-yaml": "^4.0.1",
+        "@types/lodash": "^4.14.202",
         "@types/morgan": "^1.9.2",
         "@types/node-fetch": "^2.5.10",
         "@types/nodemailer": "^6.4.4",
@@ -23,8 +25,7 @@
         "@types/pg": "^8.10.7",
         "copyfiles": "^2.4.1",
         "jest-fetch-mock": "^3.0.3",
-        "knex-mock-client": "^1.11.0",
-        "@tsoa/cli": "^4.1.3"
+        "knex-mock-client": "^1.11.0"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.272.0",
@@ -78,6 +79,7 @@
         "graphql-request": "^5.0.0",
         "js-yaml": "^4.1.0",
         "knex": "^2.4.2",
+        "lodash": "^4.17.21",
         "marked": "^9.0.3",
         "moment": "^2.29.4",
         "nanoid": "^3.1.31",

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -484,3 +484,24 @@ export const exploreWithMetricFilters: Explore = {
     ],
     targetDatabase: SupportedDbtAdapter.POSTGRES,
 };
+
+export const exploresWithSameName: Explore[] = [
+    {
+        name: 'payments',
+        tags: [],
+        label: 'Payments V1',
+        tables: {},
+        baseTable: 'payments_v1',
+        joinedTables: [],
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
+    },
+    {
+        name: 'payments',
+        tags: [],
+        label: 'Payments V2',
+        tables: {},
+        baseTable: 'payments_v2',
+        joinedTables: [],
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
+    },
+];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8066 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

In this PR I'm avoiding this error by discarding/ignoring models with duplicate names. It will only use the first model for each name.

This fix is focused on not throwing an error to unblock users that deploy their project via the UI which deploys all their models. We can open a new ticket to support multiple models with the same name but that hasn't been requested by users.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
