### PR TITLE
fix: alignment fix for date zoom icon

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -12,7 +12,8 @@ const TILE_HEADER_MARGIN_BOTTOM = 12;
 export const HeaderContainer = styled.div<HeaderContainerProps>`
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
+    justify-content: space-between;
+    align-items: center;
     gap: 8px;
     height: ${TILE_HEADER_HEIGHT}px;
     margin-bottom: ${TILE_HEADER_MARGIN_BOTTOM}px;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8383 

### Description:
Just had to change the flex styles for the `HeaderContainer` that wrapped the icons.

1) Align items: center fixes the vertical alignment

Before:
![image](https://github.com/lightdash/lightdash/assets/85165953/b488d139-680e-4dbe-8653-4527301b7c3d)

After:
![image](https://github.com/lightdash/lightdash/assets/85165953/cb7ddd13-97e3-4e68-9b79-97b7d7856944)

2) Justify content: space-between makes sure the icons are on two ends of the tile.

Final Result (with missing title):
![image](https://github.com/lightdash/lightdash/assets/85165953/1643c59f-0c15-4a2c-8c50-7eab26e2aa2e)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
