### PR TITLE
feat: add edit title option for dashboard charts

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -173,24 +173,21 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                             )}
                                             {isEditMode && (
                                                 <>
-                                                    {!belongsToDashboard && (
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconEdit
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                setIsEditingTileContent(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Edit tile content
-                                                        </Menu.Item>
-                                                    )}
+                                                    <Menu.Item
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconEdit}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setIsEditingTileContent(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Edit title
+                                                    </Menu.Item>
+
                                                     {belongsToDashboard ? (
                                                         <Menu.Item
                                                             color="red"

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -6,7 +6,6 @@ import {
     Group,
     Modal,
     ModalProps,
-    Select,
     Stack,
     TextInput,
     Title,
@@ -44,7 +43,7 @@ const ChartUpdateModal = ({
         },
     });
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: savedCharts, isLoading } = useChartSummaries(projectUuid);
+    const { data: savedCharts } = useChartSummaries(projectUuid);
 
     const handleConfirm = form.onSubmit(
         ({
@@ -68,14 +67,14 @@ const ChartUpdateModal = ({
                         size="lg"
                         color="blue.8"
                     />
-                    <Title order={4}>Edit tile content</Title>
+                    <Title order={4}>Edit title</Title>
                 </Flex>
             }
             withCloseButton
             className="non-draggable"
             {...modalProps}
         >
-            <form onSubmit={handleConfirm} name="Edit tile content">
+            <form onSubmit={handleConfirm} name="Edit title">
                 <Stack spacing="md">
                     <Flex align="flex-end" gap="xs">
                         <TextInput
@@ -110,36 +109,7 @@ const ChartUpdateModal = ({
                             />
                         </ActionIcon>
                     </Flex>
-                    <Select
-                        styles={(theme) => ({
-                            separator: {
-                                position: 'sticky',
-                                top: 0,
-                                backgroundColor: 'white',
-                            },
-                            separatorLabel: {
-                                color: theme.colors.gray[6],
-                                fontWeight: 500,
-                            },
-                        })}
-                        id="savedChartUuid"
-                        name="savedChartUuid"
-                        label="Select chart"
-                        data={(savedCharts || []).map(
-                            ({ uuid, name, spaceName }) => {
-                                return {
-                                    value: uuid,
-                                    label: name,
-                                    group: spaceName,
-                                };
-                            },
-                        )}
-                        disabled={isLoading}
-                        withinPortal
-                        {...form.getInputProps('uuid')}
-                        searchable
-                        placeholder="Search..."
-                    />
+
                     <Group spacing="xs" position="right" mt="md">
                         <Button onClick={() => onClose?.()} variant="outline">
                             Cancel


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8363 

### Description:

- [X] Removed the functionality from edit tile content to change the chart shown within a tile (i.e. to swap a chart out for another chart)
- [X] Renamed edit tile content to edit title
- [X] Added the option to edit title in charts created from within dashboard

For outside charts (not created within dashboard):
![image](https://github.com/lightdash/lightdash/assets/85165953/0c12e8fb-c27c-48fc-b9ab-e84b90fd7b4c)

For charts created within dashboard:
![image](https://github.com/lightdash/lightdash/assets/85165953/63e8c0ce-5ffa-41fb-a3a2-27788e0328c9)

Edit title modal:
![image](https://github.com/lightdash/lightdash/assets/85165953/171cc2c1-02ee-4f71-b66a-c58196caf0fc)

I think that we can change the `isEditingTileContent` state name to `isEditingTitle` here. Would love to know if the reviewer also feels the same. Will update the PR accordingly.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
