### PR TITLE
fix: sort alignment on email error message

### DIFF
--- a/packages/frontend/src/components/UserSettings/InvitesModal/index.tsx
+++ b/packages/frontend/src/components/UserSettings/InvitesModal/index.tsx
@@ -73,7 +73,10 @@ const InvitesModal: FC<{
                         handleSubmit(values),
                     )}
                 >
-                    <Group align="flex-end" spacing="xs">
+                    <Group
+                        spacing="xs"
+                        align={form.errors.email ? 'center' : 'end'}
+                    >
                         <TextInput
                             name="email"
                             label="Enter user email address"
@@ -83,7 +86,10 @@ const InvitesModal: FC<{
                             w="43%"
                             {...form.getInputProps('email')}
                         />
-                        <Group spacing="xs">
+                        <Group
+                            spacing="xs"
+                            align={form.errors.email ? 'center' : 'end'}
+                        >
                             {user.data?.ability?.can(
                                 'manage',
                                 'Organization',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8195

### Description:

The issue seemed to be because of the flex-end here.
https://github.com/lightdash/lightdash/blob/78633f90cf541f84b81480c65913f2eff328295d/packages/frontend/src/components/UserSettings/InvitesModal/index.tsx#L76

When we have an email error message, it increases the height of `TextInput`. Subsequently, the height of the Group also increases and it aligns itself to the end of it vertically. So a conditional bottom padding to the Group fixes this.

_Note: This may cause an extra padding at the bottom if we don't have all the inputs in the same line (but this shouldn't happen ideally)._ 

We don't need this fix in the `ProjectAccess` section as we are using a `Select` for the email there.

Before:
![image](https://github.com/lightdash/lightdash/assets/85165953/fdc57e1f-873a-46b9-baff-89345adb80df)

After:
Without Error -
![image](https://github.com/lightdash/lightdash/assets/85165953/3de053f5-68fd-479b-8666-3da4e9fe9dc3)

With Error - 
![image](https://github.com/lightdash/lightdash/assets/85165953/fa9f6948-9b35-4a3c-92c2-3bf35603192d)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
