### PR TITLE
feat: add search to user management table

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -11,10 +11,12 @@ import {
     Flex,
     Group,
     Modal,
+    Paper,
     Select,
     Stack,
     Table,
     Text,
+    TextInput,
     Title,
     Tooltip,
 } from '@mantine/core';
@@ -263,7 +265,8 @@ const UserManagementPanel: FC = () => {
     const { classes } = useTableStyles();
     const { user } = useApp();
     const [showInviteModal, setShowInviteModal] = useState(false);
-    const { data: organizationUsers, isLoading } = useOrganizationUsers();
+    const [search, setSearch] = useState('');
+    const { data: organizationUsers, isLoading } = useOrganizationUsers(search);
 
     if (user.data?.ability.cannot('view', 'OrganizationMemberProfile')) {
         return <ForbiddenPanel />;
@@ -303,6 +306,14 @@ const UserManagementPanel: FC = () => {
                 <LoadingState title="Loading users" />
             ) : (
                 <SettingsCard shadow="none" p={0}>
+                    <Paper p="sm">
+                        <TextInput
+                            size="xs"
+                            placeholder="Search users by name, email, or role"
+                            onChange={(e) => setSearch(e.target.value)}
+                            value={search}
+                        />
+                    </Paper>
                     <Table className={classes.root}>
                         <thead>
                             <tr>
@@ -319,17 +330,31 @@ const UserManagementPanel: FC = () => {
                             </tr>
                         </thead>
                         <tbody>
-                            {organizationUsers?.map((orgUser) => (
-                                <UserListItem
-                                    key={orgUser.email}
-                                    user={orgUser}
-                                    disabled={
-                                        user.data?.userUuid ===
-                                            orgUser.userUuid ||
-                                        organizationUsers.length <= 1
-                                    }
-                                />
-                            ))}
+                            {organizationUsers && organizationUsers.length ? (
+                                organizationUsers.map((orgUser) => (
+                                    <UserListItem
+                                        key={orgUser.email}
+                                        user={orgUser}
+                                        disabled={
+                                            user.data?.userUuid ===
+                                                orgUser.userUuid ||
+                                            organizationUsers.length <= 1
+                                        }
+                                    />
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan={3}>
+                                        <Text
+                                            c="gray.6"
+                                            fs="italic"
+                                            ta="center"
+                                        >
+                                            No users found
+                                        </Text>
+                                    </td>
+                                </tr>
+                            )}
                         </tbody>
                     </Table>
                 </SettingsCard>

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -3,6 +3,7 @@ import {
     OrganizationMemberProfile,
     OrganizationMemberProfileUpdate,
 } from '@lightdash/common';
+import Fuse from 'fuse.js';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import { useApp } from '../providers/AppProvider';
@@ -30,12 +31,24 @@ const updateUser = async (id: string, data: OrganizationMemberProfileUpdate) =>
         body: JSON.stringify(data),
     });
 
-export const useOrganizationUsers = () => {
+export const useOrganizationUsers = (searchInput: string) => {
     const setErrorResponse = useQueryError();
     return useQuery<OrganizationMemberProfile[], ApiError>({
         queryKey: ['organization_users'],
         queryFn: getOrganizationUsersQuery,
         onError: (result) => setErrorResponse(result),
+        select: (data) => {
+            if (searchInput) {
+                return new Fuse(Object.values(data), {
+                    keys: ['firstName', 'lastName', 'email', 'role'],
+                    ignoreLocation: true,
+                    threshold: 0.3,
+                })
+                    .search(searchInput)
+                    .map((result) => result.item);
+            }
+            return data;
+        },
     });
 };
 

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -31,7 +31,7 @@ const updateUser = async (id: string, data: OrganizationMemberProfileUpdate) =>
         body: JSON.stringify(data),
     });
 
-export const useOrganizationUsers = (searchInput: string) => {
+export const useOrganizationUsers = (searchInput?: string) => {
     const setErrorResponse = useQueryError();
     return useQuery<OrganizationMemberProfile[], ApiError>({
         queryKey: ['organization_users'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8413 

### Description:

Can search now by: 
* first name
* last name
* email
* role

with fuse.js (same way we do for explores)

Ideally we want the `users` query to accept a query param but this works as a v1 for now (we would like as well to support pagination which can be done on a separate ticket)


Demo:


https://github.com/lightdash/lightdash/assets/7611706/4fc2c5dd-0ef7-4fe5-801c-3400382429f1



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
