### PR TITLE
feat: add healthcheck to dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -164,5 +164,10 @@ ENV LIGHTDASH_CONFIG_FILE /usr/app/lightdash.yml
 COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
 
 EXPOSE 8080
+
+# Healthcheck for backend service
+HEALTHCHECK --interval=30s --timeout=3s --retries=5 \
+  CMD curl -f http://localhost/:8080 || exit 1
+
 ENTRYPOINT ["/usr/bin/prod-entrypoint.sh"]
 CMD ["yarn", "workspace", "backend", "start"]

--- a/dockerfile
+++ b/dockerfile
@@ -167,7 +167,7 @@ EXPOSE 8080
 
 # Healthcheck for backend service
 HEALTHCHECK --interval=30s --timeout=3s --retries=5 \
-  CMD curl -f http://localhost/:8080 || exit 1
+  CMD curl -f http://localhost:8080/api/v1/health || exit 1
 
 ENTRYPOINT ["/usr/bin/prod-entrypoint.sh"]
 CMD ["yarn", "workspace", "backend", "start"]


### PR DESCRIPTION
### Description:

This change will introduce an additional statement in the Dockerfile to implement a health check, ensuring the proper functioning of the backend service. I wasn't entirely certain if this was something we wanted to include, and I'm open to discussing the details.

I'd love to hear your thoughts and suggestions on this! 😄

**Current Proposal**

The idea is to use curl to check the response from `http://localhost:8080/api/v1/health`. If the request is unsuccessful, we `EXIT` with a `1` error code, prompting Docker to consider the container as unhealthy.

We can also consider additional options, such as `interval`, `timeout`, and `retries`. With this configuration, we maintain performance by limiting requests to every 30 seconds and ensuring that the service is marked as broken after 5 retries.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
