### PR TITLE
chore: group management page

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserManagementPanel/index.tsx
@@ -306,7 +306,7 @@ const UserManagementPanel: FC = () => {
 
             <Tabs defaultValue={'users'}>
                 {groupManagementEnabled && (
-                    <Tabs.List>
+                    <Tabs.List mb="xs">
                         <Tabs.Tab value="users">Users</Tabs.Tab>
                         <Tabs.Tab value="groups">Groups</Tabs.Tab>
                     </Tabs.List>
@@ -315,7 +315,7 @@ const UserManagementPanel: FC = () => {
                     {isLoadingUsers ? (
                         <LoadingState title="Loading users" />
                     ) : (
-                        <Stack spacing="xs" mt="xs">
+                        <Stack spacing="xs">
                             {user.data?.ability?.can(
                                 'create',
                                 'InviteLink',

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -1,0 +1,20 @@
+import { ApiError, Group } from '@lightdash/common';
+import { useQuery } from 'react-query';
+import { lightdashApi } from '../api';
+import useQueryError from './useQueryError';
+
+const getOrganizationGroupsQuery = async () =>
+    lightdashApi<Group[]>({
+        url: `/org/groups`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useOrganizationGroups = () => {
+    const setErrorResponse = useQueryError();
+    return useQuery<Group[], ApiError>({
+        queryKey: ['organization_groups'],
+        queryFn: getOrganizationGroupsQuery,
+        onError: (result) => setErrorResponse(result),
+    });
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
     IconUsers,
     IconUserShield,
 } from '@tabler/icons-react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { FC } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { Can } from '../components/common/Authorization';
@@ -50,6 +51,10 @@ import { EventName, PageName } from '../types/Events';
 import ProjectSettings from './ProjectSettings';
 
 const Settings: FC = () => {
+    // TODO: this is a feature flag while we are building groups.
+    // Remove this when groups are ready to be released.
+    const groupManagementEnabled = useFeatureFlagEnabled('group-management');
+
     const {
         health: {
             data: health,
@@ -182,7 +187,11 @@ const Settings: FC = () => {
                                     'OrganizationMemberProfile',
                                 ) && (
                                     <RouterNavLink
-                                        label="User management"
+                                        label={
+                                            groupManagementEnabled
+                                                ? 'Users and groups'
+                                                : 'User management'
+                                        }
                                         to="/generalSettings/userManagement"
                                         exact
                                         icon={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8418 

### Description:

Add a group management tab to the users page. Behind a feature flag. For now it only lists groups. CRUD to come. 

Here's what it looks like with the flag ON:
<img width="910" alt="Screenshot 2023-12-27 at 15 45 02" src="https://github.com/lightdash/lightdash/assets/1864179/233b0adc-a76c-40e4-94bd-93bc1fb39eb1">
<img width="895" alt="Screenshot 2023-12-27 at 15 45 06" src="https://github.com/lightdash/lightdash/assets/1864179/2670db87-321b-4e88-9c8e-95cd365fc84a">

And with the flag OFF (groups disabled)
<img width="884" alt="Screenshot 2023-12-27 at 15 46 36" src="https://github.com/lightdash/lightdash/assets/1864179/85b0ce4e-27d6-440f-8284-bdbcc9531def">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
