### PR TITLE
fix: styles for errors on health endpoint

### DIFF
--- a/packages/frontend/src/hooks/health/useHealth.tsx
+++ b/packages/frontend/src/hooks/health/useHealth.tsx
@@ -25,7 +25,7 @@ const useHealth = () => {
             showToastError({
                 key: first,
                 subtitle: (
-                    <div>
+                    <div style={{ color: 'white' }}>
                         <b>{first}</b>
                         <p>{rest.join('\n')}</p>
                     </div>


### PR DESCRIPTION
### Description:

Health endpoint errors were showing with the wrong text color. This fixes the color. 

Before (BUG)
<img width="490" alt="Screenshot 2023-12-28 at 15 51 07" src="https://github.com/lightdash/lightdash/assets/1864179/a22ea030-0810-4ad4-8e8b-3256d8dca3f9">

After (fixed)
<img width="506" alt="Screenshot 2023-12-28 at 17 18 20" src="https://github.com/lightdash/lightdash/assets/1864179/20b1d585-4123-4dee-9bde-1f63e5256e7e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
