### PR TITLE
feat: add preview choice to dashboard scheduled deliveries

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -26,6 +26,7 @@ export type SchedulerDb = {
     dashboard_uuid: string | null;
     options: Record<string, any>;
     filters: string | null;
+    custom_viewport_width: number | null;
 };
 
 export type ChartSchedulerDb = SchedulerDb & {
@@ -68,6 +69,7 @@ export type SchedulerTable = Knex.CompositeTableType<
         | 'format'
         | 'options'
         | 'filters'
+        | 'custom_viewport_width'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20231229105147_add-custom-viewport-width-to-scheduler-table.ts
+++ b/packages/backend/src/database/migrations/20231229105147_add-custom-viewport-width-to-scheduler-table.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const SchedulerTableName = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.integer('custom_viewport_width').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (
+        await knex.schema.hasColumn(SchedulerTableName, 'custom_viewport_width')
+    ) {
+        await knex.schema.alterTable(SchedulerTableName, (table) => {
+            table.dropColumn('custom_viewport_width');
+        });
+    }
+}

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -66,6 +66,7 @@ export class SchedulerModel {
             format: scheduler.format,
             options: scheduler.options,
             filters: scheduler.filters,
+            customViewportWidth: scheduler.custom_viewport_width,
         } as Scheduler;
     }
 
@@ -218,6 +219,11 @@ export class SchedulerModel {
                         newScheduler.filters
                             ? JSON.stringify(newScheduler.filters)
                             : null,
+                    custom_viewport_width:
+                        isDashboardScheduler(newScheduler) &&
+                        newScheduler.customViewportWidth
+                            ? newScheduler.customViewportWidth
+                            : null,
                 })
                 .returning('*');
             const targetPromises = newScheduler.targets.map(async (target) => {
@@ -257,6 +263,11 @@ export class SchedulerModel {
                     filters:
                         'filters' in scheduler && scheduler.filters
                             ? JSON.stringify(scheduler.filters)
+                            : null,
+                    custom_viewport_width:
+                        'customViewportWidth' in scheduler &&
+                        scheduler.customViewportWidth
+                            ? scheduler.customViewportWidth
                             : null,
                 })
                 .where('scheduler_uuid', scheduler.schedulerUuid);

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -177,6 +177,11 @@ export const getNotificationPageData = async (
                 imageId,
                 authUserUuid: userUuid,
                 withPdf: imageOptions?.withPdf,
+                gridWidth:
+                    isDashboardScheduler(scheduler) &&
+                    scheduler.customViewportWidth
+                        ? scheduler.customViewportWidth
+                        : undefined,
             });
             if (unfurlImage.imageUrl === undefined) {
                 throw new Error('Unable to unfurl image');

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -90,6 +90,7 @@ export type DashboardScheduler = SchedulerBase & {
     savedChartUuid: null;
     dashboardUuid: string;
     filters?: SchedulerFilterRule[];
+    customViewportWidth?: number;
 };
 
 export type Scheduler = ChartScheduler | DashboardScheduler;
@@ -156,7 +157,7 @@ export type UpdateSchedulerAndTargets = Pick<
     Scheduler,
     'schedulerUuid' | 'name' | 'message' | 'cron' | 'format' | 'options'
 > &
-    Pick<DashboardScheduler, 'filters'> & {
+    Pick<DashboardScheduler, 'filters' | 'customViewportWidth'> & {
         targets: Array<
             | CreateSchedulerTarget
             | UpdateSchedulerSlackTarget

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -1,28 +1,9 @@
-import { ApiError, Dashboard } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Card,
-    Flex,
-    Group,
-    Image,
-    LoadingOverlay,
-    Modal,
-    ModalProps,
-    Radio,
-    Stack,
-    Text,
-    Title,
-} from '@mantine/core';
-import {
-    IconEye,
-    IconEyeClosed,
-    IconEyeCog,
-    IconFileExport,
-} from '@tabler/icons-react';
-import { Dispatch, FC, SetStateAction, useCallback, useState } from 'react';
-import { UseMutationResult } from 'react-query';
+import { Dashboard } from '@lightdash/common';
+import { Button, Group, Modal, ModalProps, Stack, Title } from '@mantine/core';
+import { IconEyeCog, IconFileExport } from '@tabler/icons-react';
+import { FC, useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { PreviewAndCustomizeScreenshot } from '../../../features/preview';
 import { CUSTOM_WIDTH_OPTIONS } from '../../../features/scheduler/constants';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
 import MantineIcon from '../MantineIcon';
@@ -32,34 +13,35 @@ type Props = {
     dashboard: Dashboard;
 };
 
-type PreviewAndCustomizeProps = Props & {
-    exportDashboardMutation: UseMutationResult<
-        string,
-        ApiError,
-        {
-            dashboard: Dashboard;
-            gridWidth: number | undefined;
-            queryFilters: string;
-            isPreview?: boolean | undefined;
-        }
-    >;
-    previews: Record<string, string>;
-    setPreviews: Dispatch<SetStateAction<Record<string, string>>>;
-    previewChoice: string;
-    setPreviewChoice: Dispatch<SetStateAction<string>>;
-};
-
-const PreviewAndCustomize: FC<PreviewAndCustomizeProps> = ({
+export const DashboardExportModal: FC<Props & ModalProps> = ({
+    opened,
+    onClose,
     gridWidth,
     dashboard,
-    exportDashboardMutation,
-    previews,
-    setPreviews,
-    previewChoice,
-    setPreviewChoice,
 }) => {
+    const [previews, setPreviews] = useState<Record<string, string>>({});
+    const [previewChoice, setPreviewChoice] = useState<
+        typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined
+    >(CUSTOM_WIDTH_OPTIONS[1].value);
     const location = useLocation();
-    const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+    const exportDashboardMutation = useExportDashboard();
+
+    const handleExportClick = useCallback(() => {
+        if (previewChoice && previews[previewChoice])
+            return window.open(exportDashboardMutation.data, '_blank');
+
+        exportDashboardMutation.mutate({
+            dashboard,
+            gridWidth: undefined,
+            queryFilters: location.search,
+        });
+    }, [
+        dashboard,
+        exportDashboardMutation,
+        location.search,
+        previewChoice,
+        previews,
+    ]);
 
     const handlePreviewClick = useCallback(async () => {
         const url = await exportDashboardMutation.mutateAsync({
@@ -81,139 +63,6 @@ const PreviewAndCustomize: FC<PreviewAndCustomizeProps> = ({
     ]);
 
     return (
-        <Box p="md">
-            <LoadingOverlay visible={exportDashboardMutation.isLoading} />
-
-            <Stack spacing="md" px="md" py="md">
-                <Flex align="flex-start" justify="space-between">
-                    <Radio.Group
-                        name="customWidth"
-                        label="Custom width configuration"
-                        defaultValue=""
-                        onChange={(value) => {
-                            setPreviewChoice(value);
-                        }}
-                        value={previewChoice}
-                    >
-                        <Flex direction="column" gap="sm" pt="sm">
-                            {CUSTOM_WIDTH_OPTIONS.concat([
-                                {
-                                    label: `Current view (${gridWidth}px)`,
-                                    value: gridWidth.toString(),
-                                },
-                            ]).map((option) => (
-                                <Radio
-                                    key={option.value}
-                                    value={option.value}
-                                    label={option.label}
-                                    checked={previewChoice === option.value}
-                                />
-                            ))}
-                        </Flex>
-                    </Radio.Group>
-
-                    <Stack>
-                        <Card withBorder p={0}>
-                            <Image
-                                src={previewChoice && previews[previewChoice]}
-                                onClick={() => {
-                                    if (
-                                        previewChoice &&
-                                        previews[previewChoice]
-                                    )
-                                        setIsImageModalOpen(true);
-                                }}
-                                width={400}
-                                height={400}
-                                style={{
-                                    objectPosition: 'top',
-                                    cursor:
-                                        previewChoice && previews[previewChoice]
-                                            ? 'pointer'
-                                            : 'default',
-                                }}
-                                withPlaceholder
-                                placeholder={
-                                    <Flex
-                                        gap="md"
-                                        align="center"
-                                        direction="column"
-                                    >
-                                        <MantineIcon
-                                            icon={IconEyeClosed}
-                                            size={30}
-                                        />
-
-                                        <Text>No preview yet</Text>
-                                    </Flex>
-                                }
-                            />
-                        </Card>
-                        <Button
-                            mx="auto"
-                            display="block"
-                            size="xs"
-                            variant="default"
-                            leftIcon={<MantineIcon icon={IconEye} />}
-                            disabled={!previewChoice}
-                            onClick={handlePreviewClick}
-                        >
-                            Generate preview
-                        </Button>
-                    </Stack>
-                </Flex>
-            </Stack>
-
-            <Modal
-                fullScreen
-                onClose={() => setIsImageModalOpen(false)}
-                opened={isImageModalOpen}
-            >
-                <Image
-                    src={exportDashboardMutation.data}
-                    onClick={() => {
-                        setIsImageModalOpen(false);
-                    }}
-                    width="100%"
-                    height="100%"
-                    style={{
-                        cursor: 'pointer',
-                    }}
-                />
-            </Modal>
-        </Box>
-    );
-};
-
-export const DashboardExportModal: FC<Props & ModalProps> = ({
-    opened,
-    onClose,
-    gridWidth,
-    dashboard,
-}) => {
-    const [previews, setPreviews] = useState<Record<string, string>>({});
-    const [previewChoice, setPreviewChoice] = useState<string>('1400');
-    const location = useLocation();
-    const exportDashboardMutation = useExportDashboard();
-
-    const handleExportClick = useCallback(() => {
-        if (previewChoice && previews[previewChoice])
-            return window.open(exportDashboardMutation.data, '_blank');
-
-        exportDashboardMutation.mutate({
-            dashboard,
-            gridWidth: undefined,
-            queryFilters: location.search,
-        });
-    }, [
-        dashboard,
-        exportDashboardMutation,
-        location.search,
-        previewChoice,
-        previews,
-    ]);
-
-    return (
         <>
             <Modal
                 size="xl"
@@ -228,14 +77,14 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                 }}
             >
                 <Stack>
-                    <PreviewAndCustomize
-                        gridWidth={gridWidth}
-                        dashboard={dashboard}
-                        exportDashboardMutation={exportDashboardMutation}
+                    <PreviewAndCustomizeScreenshot
+                        containerWidth={gridWidth}
+                        exportMutation={exportDashboardMutation}
                         previews={previews}
                         setPreviews={setPreviews}
                         previewChoice={previewChoice}
                         setPreviewChoice={setPreviewChoice}
+                        onPreviewClick={handlePreviewClick}
                     />
 
                     <Group position="right" pb="md" px="md" spacing="lg">

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -23,6 +23,7 @@ import {
 import { Dispatch, FC, SetStateAction, useCallback, useState } from 'react';
 import { UseMutationResult } from 'react-query';
 import { useLocation } from 'react-router-dom';
+import { CUSTOM_WIDTH_OPTIONS } from '../../../features/scheduler/constants';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
 import MantineIcon from '../MantineIcon';
 
@@ -30,21 +31,6 @@ type Props = {
     gridWidth: number;
     dashboard: Dashboard;
 };
-
-const CUSTOM_WIDTH_OPTIONS = [
-    {
-        label: 'Small (1000px)',
-        value: '1000',
-    },
-    {
-        label: 'Medium (1400px)',
-        value: '1400',
-    },
-    {
-        label: 'Large (1500px)',
-        value: '1500',
-    },
-];
 
 type PreviewAndCustomizeProps = Props & {
     exportDashboardMutation: UseMutationResult<

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -1,5 +1,13 @@
 import { Dashboard } from '@lightdash/common';
-import { Button, Group, Modal, ModalProps, Stack, Title } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Title,
+} from '@mantine/core';
 import { IconEyeCog, IconFileExport } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -77,15 +85,17 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                 }}
             >
                 <Stack>
-                    <PreviewAndCustomizeScreenshot
-                        containerWidth={gridWidth}
-                        exportMutation={exportDashboardMutation}
-                        previews={previews}
-                        setPreviews={setPreviews}
-                        previewChoice={previewChoice}
-                        setPreviewChoice={setPreviewChoice}
-                        onPreviewClick={handlePreviewClick}
-                    />
+                    <Box p="md">
+                        <PreviewAndCustomizeScreenshot
+                            containerWidth={gridWidth}
+                            exportMutation={exportDashboardMutation}
+                            previews={previews}
+                            setPreviews={setPreviews}
+                            previewChoice={previewChoice}
+                            setPreviewChoice={setPreviewChoice}
+                            onPreviewClick={handlePreviewClick}
+                        />
+                    </Box>
 
                     <Group position="right" pb="md" px="md" spacing="lg">
                         <Button variant="outline" onClick={onClose}>

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -1,0 +1,165 @@
+import { ApiError, Dashboard } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Card,
+    Flex,
+    Image,
+    LoadingOverlay,
+    Modal,
+    Radio,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconEye, IconEyeClosed } from '@tabler/icons-react';
+import { Dispatch, FC, SetStateAction, useState } from 'react';
+import { UseMutationResult } from 'react-query';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { CUSTOM_WIDTH_OPTIONS } from '../../scheduler/constants';
+
+type PreviewAndCustomizeScreenshotProps = {
+    containerWidth?: number | undefined;
+    exportMutation: UseMutationResult<
+        string,
+        ApiError,
+        {
+            dashboard: Dashboard;
+            gridWidth: number | undefined;
+            queryFilters: string;
+            isPreview?: boolean | undefined;
+        }
+    >;
+    previews: Record<string, string>;
+    setPreviews: Dispatch<SetStateAction<Record<string, string>>>;
+    previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;
+    setPreviewChoice: Dispatch<
+        SetStateAction<typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined>
+    >;
+    onPreviewClick?: () => Promise<void>;
+};
+
+export const PreviewAndCustomizeScreenshot: FC<
+    PreviewAndCustomizeScreenshotProps
+> = ({
+    containerWidth,
+    exportMutation,
+    previews,
+    previewChoice,
+    setPreviewChoice,
+    onPreviewClick,
+}) => {
+    const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+
+    return (
+        <Box>
+            <LoadingOverlay visible={exportMutation.isLoading} />
+
+            <Stack spacing="md" px="md" py="md">
+                <Flex align="flex-start" justify="space-between">
+                    <Radio.Group
+                        name="customWidth"
+                        label="Custom width configuration"
+                        defaultValue=""
+                        onChange={(value) => {
+                            setPreviewChoice(value);
+                        }}
+                        value={previewChoice}
+                    >
+                        <Flex direction="column" gap="sm" pt="sm">
+                            {CUSTOM_WIDTH_OPTIONS.concat(
+                                containerWidth
+                                    ? [
+                                          {
+                                              label: `Current view (${containerWidth}px)`,
+                                              value: containerWidth.toString(),
+                                          },
+                                      ]
+                                    : [],
+                            ).map((option) => (
+                                <Radio
+                                    key={option.value}
+                                    value={option.value}
+                                    label={option.label}
+                                    checked={previewChoice === option.value}
+                                />
+                            ))}
+                        </Flex>
+                    </Radio.Group>
+
+                    <Stack>
+                        <Card withBorder p={0}>
+                            <Image
+                                src={previewChoice && previews[previewChoice]}
+                                onClick={() => {
+                                    if (
+                                        previewChoice &&
+                                        previews[previewChoice]
+                                    )
+                                        setIsImageModalOpen(true);
+                                }}
+                                width={400}
+                                height={400}
+                                styles={{
+                                    root: {
+                                        objectPosition: 'top',
+                                        cursor:
+                                            previewChoice &&
+                                            previews[previewChoice]
+                                                ? 'pointer'
+                                                : 'default',
+                                    },
+                                }}
+                                withPlaceholder
+                                placeholder={
+                                    <Flex
+                                        gap="md"
+                                        align="center"
+                                        direction="column"
+                                    >
+                                        <MantineIcon
+                                            icon={IconEyeClosed}
+                                            size={30}
+                                        />
+
+                                        <Text>No preview yet</Text>
+                                    </Flex>
+                                }
+                            />
+                        </Card>
+                        <Button
+                            mx="auto"
+                            display="block"
+                            size="xs"
+                            variant="default"
+                            leftIcon={<MantineIcon icon={IconEye} />}
+                            disabled={!previewChoice}
+                            onClick={onPreviewClick}
+                        >
+                            Generate preview
+                        </Button>
+                    </Stack>
+                </Flex>
+            </Stack>
+
+            <Modal
+                fullScreen
+                onClose={() => setIsImageModalOpen(false)}
+                opened={isImageModalOpen}
+            >
+                <Image
+                    src={exportMutation.data}
+                    onClick={() => {
+                        setIsImageModalOpen(false);
+                    }}
+                    width="100%"
+                    height="100%"
+                    styles={{
+                        root: {
+                            cursor: 'pointer',
+                        },
+                    }}
+                />
+            </Modal>
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -54,7 +54,7 @@ export const PreviewAndCustomizeScreenshot: FC<
         <Box>
             <LoadingOverlay visible={exportMutation.isLoading} />
 
-            <Stack spacing="md" px="md" py="md">
+            <Stack spacing="md">
                 <Flex align="flex-start" justify="space-between">
                     <Radio.Group
                         name="customWidth"
@@ -97,8 +97,8 @@ export const PreviewAndCustomizeScreenshot: FC<
                                     )
                                         setIsImageModalOpen(true);
                                 }}
-                                width={400}
-                                height={400}
+                                width={350}
+                                height={350}
                                 styles={{
                                     root: {
                                         objectPosition: 'top',

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -32,9 +32,9 @@ type PreviewAndCustomizeScreenshotProps = {
     previews: Record<string, string>;
     setPreviews: Dispatch<SetStateAction<Record<string, string>>>;
     previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;
-    setPreviewChoice: Dispatch<
-        SetStateAction<typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined>
-    >;
+    setPreviewChoice: (
+        prev: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined,
+    ) => void;
     onPreviewClick?: () => Promise<void>;
 };
 

--- a/packages/frontend/src/features/preview/index.ts
+++ b/packages/frontend/src/features/preview/index.ts
@@ -1,0 +1,1 @@
+export * from './components/PreviewAndCustomizeScreenshot';

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -50,6 +50,7 @@ import SlackSvg from '../../../svgs/slack.svg?react';
 import { isInvalidCronExpression } from '../../../utils/fieldValidators';
 import SchedulerFilters from './SchedulerFilters';
 import SchedulersModalFooter from './SchedulerModalFooter';
+import { SchedulerPreview } from './SchedulerPreview';
 
 export enum Limit {
     TABLE = 'table',
@@ -83,6 +84,7 @@ const DEFAULT_VALUES = {
     emailTargets: [] as string[],
     slackTargets: [] as string[],
     filters: undefined,
+    customViewportWidth: undefined,
 };
 
 const getFormValuesFromScheduler = (schedulerData: SchedulerAndTargets) => {
@@ -128,6 +130,7 @@ const getFormValuesFromScheduler = (schedulerData: SchedulerAndTargets) => {
         slackTargets: slackTargets,
         ...(isDashboardScheduler(schedulerData) && {
             filters: schedulerData.filters,
+            customViewportWidth: schedulerData.customViewportWidth,
         }),
     };
 };
@@ -257,6 +260,7 @@ const SchedulerForm: FC<Props> = ({
                 targets,
                 ...(resource?.type === 'dashboard' && {
                     filters: values.filters,
+                    customViewportWidth: values.customViewportWidth,
                 }),
             };
         },
@@ -343,6 +347,7 @@ const SchedulerForm: FC<Props> = ({
                         <Tabs.Tab value="filters">Filters</Tabs.Tab>
                     ) : null}
                     <Tabs.Tab value="customization">Customization</Tabs.Tab>
+                    <Tabs.Tab value="preview">Preview</Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="setup" mt="md">
@@ -713,6 +718,23 @@ const SchedulerForm: FC<Props> = ({
                         }
                     />
                 </Tabs.Panel>
+                {isDashboard && dashboard ? (
+                    <Tabs.Panel value="preview" p="md">
+                        <Text c="gray.7" m="md">
+                            Preview your scheduled delivery
+                        </Text>
+                        <SchedulerPreview
+                            schedulerFilters={form.values.filters}
+                            dashboard={dashboard}
+                            onChange={(customViewportWidth) => {
+                                form.setFieldValue(
+                                    'customViewportWidth',
+                                    parseInt(customViewportWidth),
+                                );
+                            }}
+                        />
+                    </Tabs.Panel>
+                ) : null}
             </Tabs>
 
             <SchedulersModalFooter

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -358,11 +358,16 @@ const SchedulerForm: FC<Props> = ({
                         <Tabs.Tab value="filters">Filters</Tabs.Tab>
                     ) : null}
                     <Tabs.Tab value="customization">Customization</Tabs.Tab>
-                    {form.values.format === SchedulerFormat.IMAGE && (
-                        <Tabs.Tab value="preview">
-                            Preview and change layout
-                        </Tabs.Tab>
-                    )}
+
+                    <Tabs.Tab
+                        disabled={
+                            form.values.format !== SchedulerFormat.IMAGE ||
+                            !isDashboard
+                        }
+                        value="preview"
+                    >
+                        Preview and Size
+                    </Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="setup" mt="md">

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -330,17 +330,6 @@ const SchedulerForm: FC<Props> = ({
         }
     }, [form, onSendNow]);
 
-    const { setFieldValue } = form;
-    const handleOnCustomViewportWidthChange = useCallback(
-        (customViewportWidth) => {
-            setFieldValue(
-                'customViewportWidth',
-                customViewportWidth ? parseInt(customViewportWidth) : undefined,
-            );
-        },
-        [setFieldValue],
-    );
-
     const isAddSlackDisabled = disabled || slackState !== SlackStates.SUCCESS;
     const isAddEmailDisabled = disabled || !health.data?.hasEmailClient;
     const isImageDisabled = !health.data?.hasHeadlessBrowser;
@@ -747,7 +736,14 @@ const SchedulerForm: FC<Props> = ({
                             customViewportWidth={
                                 form.values.customViewportWidth
                             }
-                            onChange={handleOnCustomViewportWidthChange}
+                            onChange={(customViewportWidth) => {
+                                form.setFieldValue(
+                                    'customViewportWidth',
+                                    customViewportWidth
+                                        ? parseInt(customViewportWidth)
+                                        : undefined,
+                                );
+                            }}
                         />
                     </Tabs.Panel>
                 ) : null}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -284,8 +284,6 @@ const SchedulerForm: FC<Props> = ({
         enabled: isDashboard,
     });
 
-    console.log('form', form.values.customViewportWidth);
-
     const slackQuery = useGetSlack();
     const slackState = useMemo(() => {
         if (slackQuery.isLoading) {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -284,6 +284,8 @@ const SchedulerForm: FC<Props> = ({
         enabled: isDashboard,
     });
 
+    console.log('form', form.values.customViewportWidth);
+
     const slackQuery = useGetSlack();
     const slackState = useMemo(() => {
         if (slackQuery.isLoading) {
@@ -329,6 +331,17 @@ const SchedulerForm: FC<Props> = ({
             form.validate();
         }
     }, [form, onSendNow]);
+
+    const { setFieldValue } = form;
+    const handleOnCustomViewportWidthChange = useCallback(
+        (customViewportWidth) => {
+            setFieldValue(
+                'customViewportWidth',
+                customViewportWidth ? parseInt(customViewportWidth) : undefined,
+            );
+        },
+        [setFieldValue],
+    );
 
     const isAddSlackDisabled = disabled || slackState !== SlackStates.SUCCESS;
     const isAddEmailDisabled = disabled || !health.data?.hasEmailClient;
@@ -730,12 +743,10 @@ const SchedulerForm: FC<Props> = ({
                         <SchedulerPreview
                             schedulerFilters={form.values.filters}
                             dashboard={dashboard}
-                            onChange={(customViewportWidth) => {
-                                form.setFieldValue(
-                                    'customViewportWidth',
-                                    parseInt(customViewportWidth),
-                                );
-                            }}
+                            customViewportWidth={
+                                form.values.customViewportWidth
+                            }
+                            onChange={handleOnCustomViewportWidthChange}
                         />
                     </Tabs.Panel>
                 ) : null}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -627,7 +627,6 @@ const SchedulerForm: FC<Props> = ({
                                         <SlackSvg
                                             style={{
                                                 margin: '5px 2px',
-
                                                 width: '20px',
                                                 height: '20px',
                                             }}
@@ -721,28 +720,27 @@ const SchedulerForm: FC<Props> = ({
                 ) : null}
 
                 <Tabs.Panel value="customization">
-                    <Text m="md">Customize delivery message body</Text>
+                    <Stack p="md">
+                        <Text fw={600}>Customize delivery message body</Text>
 
-                    <MDEditor
-                        preview="edit"
-                        commands={[
-                            commands.bold,
-                            commands.italic,
-                            commands.strikethrough,
-                            commands.divider,
-                            commands.link,
-                        ]}
-                        value={form.values.message}
-                        onChange={(value) =>
-                            form.setFieldValue('message', value || '')
-                        }
-                    />
+                        <MDEditor
+                            preview="edit"
+                            commands={[
+                                commands.bold,
+                                commands.italic,
+                                commands.strikethrough,
+                                commands.divider,
+                                commands.link,
+                            ]}
+                            value={form.values.message}
+                            onChange={(value) =>
+                                form.setFieldValue('message', value || '')
+                            }
+                        />
+                    </Stack>
                 </Tabs.Panel>
                 {isDashboard && dashboard ? (
-                    <Tabs.Panel value="preview" p="md">
-                        <Text c="gray.7" m="md">
-                            Preview your scheduled delivery
-                        </Text>
+                    <Tabs.Panel value="preview">
                         <SchedulerPreview
                             schedulerFilters={form.values.filters}
                             dashboard={dashboard}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -347,7 +347,11 @@ const SchedulerForm: FC<Props> = ({
                         <Tabs.Tab value="filters">Filters</Tabs.Tab>
                     ) : null}
                     <Tabs.Tab value="customization">Customization</Tabs.Tab>
-                    <Tabs.Tab value="preview">Preview</Tabs.Tab>
+                    {form.values.format === SchedulerFormat.IMAGE && (
+                        <Tabs.Tab value="preview">
+                            Preview and change layout
+                        </Tabs.Tab>
+                    )}
                 </Tabs.List>
 
                 <Tabs.Panel value="setup" mt="md">

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -4,7 +4,10 @@ import {
     DashboardScheduler,
     SchedulerFilterRule,
 } from '@lightdash/common';
+import { Group, Stack, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { FC, useCallback, useEffect, useState } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
 import { PreviewAndCustomizeScreenshot } from '../../preview';
 import { CUSTOM_WIDTH_OPTIONS } from '../constants';
@@ -75,13 +78,29 @@ export const SchedulerPreview: FC<Props> = ({
     }, [onChange, previewChoice]);
 
     return (
-        <PreviewAndCustomizeScreenshot
-            exportMutation={exportDashboardMutation}
-            previews={previews}
-            setPreviews={setPreviews}
-            previewChoice={previewChoice}
-            setPreviewChoice={setPreviewChoice}
-            onPreviewClick={handlePreviewClick}
-        />
+        <Stack p="md">
+            <Group spacing="xs">
+                <Text fw={600}>
+                    Preview your Scheduled Delivery and Customize
+                </Text>
+                <Tooltip
+                    multiline
+                    withinPortal
+                    maw={350}
+                    label="You can preview your Scheduled Delivery below. You are also
+                able to customize the size of the Scheduled Delivery to ensure it is sent as expected. The filters you have applied to this scheduled delivery will be applied to the preview."
+                >
+                    <MantineIcon icon={IconInfoCircle} />
+                </Tooltip>
+            </Group>
+            <PreviewAndCustomizeScreenshot
+                exportMutation={exportDashboardMutation}
+                previews={previews}
+                setPreviews={setPreviews}
+                previewChoice={previewChoice}
+                setPreviewChoice={setPreviewChoice}
+                onPreviewClick={handlePreviewClick}
+            />
+        </Stack>
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { Group, Stack, Text, Tooltip } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
 import { PreviewAndCustomizeScreenshot } from '../../preview';
@@ -69,14 +69,6 @@ export const SchedulerPreview: FC<Props> = ({
         getSchedulerFilterOverridesQueryString,
     ]);
 
-    useEffect(() => {
-        onChange(
-            previewChoice === CUSTOM_WIDTH_OPTIONS[1].value
-                ? undefined
-                : previewChoice,
-        );
-    }, [onChange, previewChoice]);
-
     return (
         <Stack p="md">
             <Group spacing="xs">
@@ -98,7 +90,16 @@ export const SchedulerPreview: FC<Props> = ({
                 previews={previews}
                 setPreviews={setPreviews}
                 previewChoice={previewChoice}
-                setPreviewChoice={setPreviewChoice}
+                setPreviewChoice={(pc: string | undefined) => {
+                    setPreviewChoice(() => {
+                        onChange(
+                            pc === CUSTOM_WIDTH_OPTIONS[1].value
+                                ? undefined
+                                : pc,
+                        );
+                        return pc;
+                    });
+                }}
                 onPreviewClick={handlePreviewClick}
             />
         </Stack>

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -1,0 +1,209 @@
+import {
+    applyDimensionOverrides,
+    Dashboard,
+    SchedulerFilterRule,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Card,
+    Flex,
+    Group,
+    Image,
+    LoadingOverlay,
+    Modal,
+    Radio,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconCheck, IconEye, IconEyeClosed } from '@tabler/icons-react';
+import { FC, useCallback, useState } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
+
+const CUSTOM_WIDTH_OPTIONS = [
+    {
+        label: 'Small (1000px)',
+        value: '1000',
+    },
+    {
+        label: 'Medium (1400px)',
+        value: '1400',
+    },
+    {
+        label: 'Large (1500px)',
+        value: '1500',
+    },
+];
+
+type Props = {
+    dashboard: Dashboard;
+    schedulerFilters: SchedulerFilterRule[] | undefined;
+    onChange: (
+        previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'],
+    ) => void;
+};
+
+export const SchedulerPreview: FC<Props> = ({
+    dashboard,
+    schedulerFilters,
+    onChange,
+}) => {
+    const [previews, setPreviews] = useState<Record<string, string>>({});
+    const [previewChoice, setPreviewChoice] = useState<
+        typeof CUSTOM_WIDTH_OPTIONS[number]['value']
+    >(CUSTOM_WIDTH_OPTIONS[0].value);
+    const exportDashboardMutation = useExportDashboard();
+
+    const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+
+    const getSchedulerFilterOverridesQueryString = useCallback(() => {
+        if (schedulerFilters) {
+            const overriddenDimensions = applyDimensionOverrides(
+                dashboard.filters,
+                schedulerFilters,
+            );
+
+            const filtersParam = encodeURIComponent(
+                JSON.stringify({
+                    dimensions: overriddenDimensions,
+                    metrics: [],
+                    tableCalculations: [],
+                }),
+            );
+            return `?filters=${filtersParam}`;
+        }
+        return '';
+    }, [dashboard.filters, schedulerFilters]);
+
+    const handlePreviewClick = useCallback(async () => {
+        const url = await exportDashboardMutation.mutateAsync({
+            dashboard,
+            gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
+            queryFilters: getSchedulerFilterOverridesQueryString(),
+            isPreview: true,
+        });
+
+        setPreviews((prev) => ({
+            ...prev,
+            ...(previewChoice ? { [previewChoice]: url } : {}),
+        }));
+    }, [
+        dashboard,
+        exportDashboardMutation,
+        previewChoice,
+        getSchedulerFilterOverridesQueryString,
+    ]);
+
+    return (
+        <Box>
+            <LoadingOverlay visible={exportDashboardMutation.isLoading} />
+
+            <Stack spacing="md" px="md" py="md">
+                <Flex align="flex-start" justify="space-between">
+                    <Radio.Group
+                        name="customWidth"
+                        label="Custom width configuration"
+                        defaultValue=""
+                        onChange={(value) => {
+                            setPreviewChoice(value);
+                        }}
+                        value={previewChoice}
+                    >
+                        <Flex direction="column" gap="sm" pt="sm">
+                            {CUSTOM_WIDTH_OPTIONS.map((option) => (
+                                <Radio
+                                    key={option.value}
+                                    value={option.value}
+                                    label={option.label}
+                                    checked={previewChoice === option.value}
+                                />
+                            ))}
+                        </Flex>
+                    </Radio.Group>
+
+                    <Stack>
+                        <Card withBorder p={0}>
+                            <Image
+                                src={previewChoice && previews[previewChoice]}
+                                onClick={() => {
+                                    if (
+                                        previewChoice &&
+                                        previews[previewChoice]
+                                    )
+                                        setIsImageModalOpen(true);
+                                }}
+                                width={400}
+                                height={400}
+                                style={{
+                                    objectPosition: 'top',
+                                    cursor:
+                                        previewChoice && previews[previewChoice]
+                                            ? 'pointer'
+                                            : 'default',
+                                }}
+                                withPlaceholder
+                                placeholder={
+                                    <Flex
+                                        gap="md"
+                                        align="center"
+                                        direction="column"
+                                    >
+                                        <MantineIcon
+                                            icon={IconEyeClosed}
+                                            size={30}
+                                        />
+
+                                        <Text>No preview yet</Text>
+                                    </Flex>
+                                }
+                            />
+                        </Card>
+                        <Group>
+                            <Button
+                                mx="auto"
+                                display="block"
+                                size="xs"
+                                variant="default"
+                                leftIcon={<MantineIcon icon={IconEye} />}
+                                disabled={!previewChoice}
+                                onClick={handlePreviewClick}
+                            >
+                                Generate preview
+                            </Button>
+                            <Button
+                                mx="auto"
+                                display="block"
+                                size="xs"
+                                variant="default"
+                                leftIcon={<MantineIcon icon={IconCheck} />}
+                                disabled={!previewChoice}
+                                onClick={() => onChange(previewChoice)}
+                            >
+                                Set this size
+                            </Button>
+                        </Group>
+                    </Stack>
+                </Flex>
+            </Stack>
+
+            <Modal
+                fullScreen
+                onClose={() => setIsImageModalOpen(false)}
+                opened={isImageModalOpen}
+            >
+                <Image
+                    src={exportDashboardMutation.data}
+                    onClick={() => {
+                        setIsImageModalOpen(false);
+                    }}
+                    width="100%"
+                    height="100%"
+                    style={{
+                        cursor: 'pointer',
+                    }}
+                />
+            </Modal>
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -1,47 +1,32 @@
 import {
     applyDimensionOverrides,
     Dashboard,
+    DashboardScheduler,
     SchedulerFilterRule,
 } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Card,
-    Flex,
-    Group,
-    Image,
-    LoadingOverlay,
-    Modal,
-    Radio,
-    Stack,
-    Text,
-} from '@mantine/core';
-import { IconCheck, IconEye, IconEyeClosed } from '@tabler/icons-react';
-import { FC, useCallback, useState } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
+import { PreviewAndCustomizeScreenshot } from '../../preview';
 import { CUSTOM_WIDTH_OPTIONS } from '../constants';
 
 type Props = {
     dashboard: Dashboard;
     schedulerFilters: SchedulerFilterRule[] | undefined;
-    onChange: (
-        previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'],
-    ) => void;
+    customViewportWidth: DashboardScheduler['customViewportWidth'];
+    onChange: (previewChoice: string | undefined) => void;
 };
 
 export const SchedulerPreview: FC<Props> = ({
     dashboard,
     schedulerFilters,
+    customViewportWidth,
     onChange,
 }) => {
     const [previews, setPreviews] = useState<Record<string, string>>({});
     const [previewChoice, setPreviewChoice] = useState<
-        typeof CUSTOM_WIDTH_OPTIONS[number]['value']
-    >(CUSTOM_WIDTH_OPTIONS[1].value);
+        typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined
+    >(customViewportWidth?.toString() ?? CUSTOM_WIDTH_OPTIONS[1].value);
     const exportDashboardMutation = useExportDashboard();
-
-    const [isImageModalOpen, setIsImageModalOpen] = useState(false);
 
     const getSchedulerFilterOverridesQueryString = useCallback(() => {
         if (schedulerFilters) {
@@ -81,115 +66,22 @@ export const SchedulerPreview: FC<Props> = ({
         getSchedulerFilterOverridesQueryString,
     ]);
 
+    useEffect(() => {
+        onChange(
+            previewChoice === CUSTOM_WIDTH_OPTIONS[1].value
+                ? undefined
+                : previewChoice,
+        );
+    }, [onChange, previewChoice]);
+
     return (
-        <Box>
-            <LoadingOverlay visible={exportDashboardMutation.isLoading} />
-
-            <Stack spacing="md" px="md" py="md">
-                <Flex align="flex-start" justify="space-between">
-                    <Radio.Group
-                        name="customWidth"
-                        label="Custom width configuration"
-                        defaultValue=""
-                        onChange={(value) => {
-                            setPreviewChoice(value);
-                        }}
-                        value={previewChoice}
-                    >
-                        <Flex direction="column" gap="sm" pt="sm">
-                            {CUSTOM_WIDTH_OPTIONS.map((option) => (
-                                <Radio
-                                    key={option.value}
-                                    value={option.value}
-                                    label={option.label}
-                                    checked={previewChoice === option.value}
-                                />
-                            ))}
-                        </Flex>
-                    </Radio.Group>
-
-                    <Stack>
-                        <Card withBorder p={0}>
-                            <Image
-                                src={previewChoice && previews[previewChoice]}
-                                onClick={() => {
-                                    if (
-                                        previewChoice &&
-                                        previews[previewChoice]
-                                    )
-                                        setIsImageModalOpen(true);
-                                }}
-                                width={400}
-                                height={400}
-                                style={{
-                                    objectPosition: 'top',
-                                    cursor:
-                                        previewChoice && previews[previewChoice]
-                                            ? 'pointer'
-                                            : 'default',
-                                }}
-                                withPlaceholder
-                                placeholder={
-                                    <Flex
-                                        gap="md"
-                                        align="center"
-                                        direction="column"
-                                    >
-                                        <MantineIcon
-                                            icon={IconEyeClosed}
-                                            size={30}
-                                        />
-
-                                        <Text>No preview yet</Text>
-                                    </Flex>
-                                }
-                            />
-                        </Card>
-                        <Group>
-                            <Button
-                                mx="auto"
-                                display="block"
-                                size="xs"
-                                variant="default"
-                                leftIcon={<MantineIcon icon={IconEye} />}
-                                disabled={!previewChoice}
-                                onClick={handlePreviewClick}
-                            >
-                                Generate preview
-                            </Button>
-                            <Button
-                                mx="auto"
-                                display="block"
-                                size="xs"
-                                variant="default"
-                                leftIcon={<MantineIcon icon={IconCheck} />}
-                                disabled={!previewChoice}
-                                onClick={() => onChange(previewChoice)}
-                            >
-                                Set this size
-                            </Button>
-                        </Group>
-                    </Stack>
-                </Flex>
-            </Stack>
-
-            <Modal
-                fullScreen
-                onClose={() => setIsImageModalOpen(false)}
-                opened={isImageModalOpen}
-            >
-                <Image
-                    src={exportDashboardMutation.data}
-                    onClick={() => {
-                        setIsImageModalOpen(false);
-                    }}
-                    width="100%"
-                    height="100%"
-                    style={{
-                        cursor: 'pointer',
-                    }}
-                />
-            </Modal>
-        </Box>
+        <PreviewAndCustomizeScreenshot
+            exportMutation={exportDashboardMutation}
+            previews={previews}
+            setPreviews={setPreviews}
+            previewChoice={previewChoice}
+            setPreviewChoice={setPreviewChoice}
+            onPreviewClick={handlePreviewClick}
+        />
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -20,21 +20,7 @@ import { IconCheck, IconEye, IconEyeClosed } from '@tabler/icons-react';
 import { FC, useCallback, useState } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useExportDashboard } from '../../../hooks/dashboard/useDashboard';
-
-const CUSTOM_WIDTH_OPTIONS = [
-    {
-        label: 'Small (1000px)',
-        value: '1000',
-    },
-    {
-        label: 'Medium (1400px)',
-        value: '1400',
-    },
-    {
-        label: 'Large (1500px)',
-        value: '1500',
-    },
-];
+import { CUSTOM_WIDTH_OPTIONS } from '../constants';
 
 type Props = {
     dashboard: Dashboard;
@@ -52,7 +38,7 @@ export const SchedulerPreview: FC<Props> = ({
     const [previews, setPreviews] = useState<Record<string, string>>({});
     const [previewChoice, setPreviewChoice] = useState<
         typeof CUSTOM_WIDTH_OPTIONS[number]['value']
-    >(CUSTOM_WIDTH_OPTIONS[0].value);
+    >(CUSTOM_WIDTH_OPTIONS[1].value);
     const exportDashboardMutation = useExportDashboard();
 
     const [isImageModalOpen, setIsImageModalOpen] = useState(false);

--- a/packages/frontend/src/features/scheduler/constants/index.ts
+++ b/packages/frontend/src/features/scheduler/constants/index.ts
@@ -1,0 +1,14 @@
+export const CUSTOM_WIDTH_OPTIONS = [
+    {
+        label: 'Small (1000px)',
+        value: '1000',
+    },
+    {
+        label: 'Medium (1400px)',
+        value: '1400',
+    },
+    {
+        label: 'Large (1500px)',
+        value: '1500',
+    },
+];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8276

### Description:

Add `<SchedulerPreview />` component
Add new column to `scheduler` DB table: `custom_viewport_width`
Allow users to preview their scheduled deliveries for dashboard in image format in 3 sizes
Allow users to set their selection (if `Medium`, then that's the default value) -> Subsequent deliveries will respect the width selection
Create shared component `PreviewAndCustomizeScreenshot` that is shared by the Dashboard Export feature and the Scheduler Preview feature

> [!NOTE]
> This doesn't work yet with `Send Now` feature. 

Demo: 

https://github.com/lightdash/lightdash/assets/7611706/e0aa440b-14aa-4462-b762-e473964d4848

Scheduled delivery with Large setting: 
![image](https://github.com/lightdash/lightdash/assets/7611706/17938193-27e4-43e2-89c4-b863b2baa06f)

Scheduled delivery with Small setting (see the 2nd markdown tile from above ^ being moved randomly to another row further down)
![image](https://github.com/lightdash/lightdash/assets/7611706/71424421-5bfb-4cab-a5b0-cb0ad5913a1d)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
