### PR TITLE
fix: user management permission issue

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -450,7 +450,12 @@ const Settings: FC = () => {
                     </Route>
                 )}
 
-                {user.ability.can('view', 'OrganizationMemberProfile') && (
+                {user.ability.can(
+                    'manage',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ) && (
                     <Route path="/generalSettings/userManagement">
                         <UsersAndGroupsPanel />
                     </Route>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Only admins should be able to view `/userManagement` in settings. 

Currently, non-admins (or < admin role) can view the page. They shouldn't be able to. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
