### PR TITLE
feat: organization groups with members api

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -26,6 +26,7 @@ import {
     Path,
     Post,
     Put,
+    Query,
     Request,
     Response,
     Route,
@@ -322,15 +323,18 @@ export class OrganizationController extends Controller {
     /**
      * Gets all the groups in the current user's organization
      * @param req
+     * @param includeMembers number of members to include
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Get('/groups')
     @OperationId('ListGroupsInOrganization')
     async listGroupsInOrganization(
         @Request() req: express.Request,
+        @Query() includeMembers?: number,
     ): Promise<ApiGroupListResponse> {
         const groups = await organizationService.listGroupsInOrganization(
             req.user!,
+            includeMembers,
         );
         this.setStatus(200);
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1010,8 +1010,20 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'GroupWithMembers' },
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'Group' },
+                        },
+                        {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'GroupWithMembers',
+                            },
+                        },
+                    ],
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -983,6 +983,27 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Pick_Group.name_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GroupWithMembers: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Group' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        members: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'GroupMember' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGroupListResponse: {
         dataType: 'refAlias',
         type: {
@@ -990,7 +1011,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: {
                     dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'Group' },
+                    array: { dataType: 'refAlias', ref: 'GroupWithMembers' },
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -5990,6 +6011,11 @@ export function RegisterRoutes(app: express.Router) {
                     name: 'req',
                     required: true,
                     dataType: 'object',
+                },
+                includeMembers: {
+                    in: 'query',
+                    name: 'includeMembers',
+                    dataType: 'double',
                 },
             };
 

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -100,7 +100,7 @@ export class GroupsModel {
                     .where('group_memberships.group_uuid', groupUuid)
                     .andWhere('emails.is_primary', true);
 
-                if (includeMembers) {
+                if (includeMembers !== undefined) {
                     memberQuery = memberQuery.limit(includeMembers);
                 }
 

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -86,10 +86,10 @@ export class GroupsModel {
         };
     }
 
-    async getGroupWithMembers(groupUuid: string): Promise<GroupWithMembers> {
+    async getGroupWithMembers(groupUuid: string, includeMembers?: number) {
         const rows = await this.database('groups')
             .with('members', (query) => {
-                query
+                let memberQuery = query
                     .from('group_memberships')
                     .innerJoin(
                         'users',
@@ -98,14 +98,19 @@ export class GroupsModel {
                     )
                     .innerJoin('emails', 'users.user_id', 'emails.user_id')
                     .where('group_memberships.group_uuid', groupUuid)
-                    .andWhere('emails.is_primary', true)
-                    .select(
-                        'group_memberships.group_uuid',
-                        'users.user_uuid',
-                        'users.first_name',
-                        'users.last_name',
-                        'emails.email',
-                    );
+                    .andWhere('emails.is_primary', true);
+
+                if (includeMembers) {
+                    memberQuery = memberQuery.limit(includeMembers);
+                }
+
+                return memberQuery.select(
+                    'group_memberships.group_uuid',
+                    'users.user_uuid',
+                    'users.first_name',
+                    'users.last_name',
+                    'emails.email',
+                );
             })
             .innerJoin(
                 'organizations',
@@ -115,6 +120,7 @@ export class GroupsModel {
             .leftJoin('members', 'groups.group_uuid', 'members.group_uuid')
             .where('groups.group_uuid', groupUuid)
             .select();
+
         if (rows.length === 0) {
             throw new NotFoundError(`No group found`);
         }

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -5,6 +5,7 @@ import {
     CreateOrganization,
     ForbiddenError,
     Group,
+    GroupWithMembers,
     isUserWithOrg,
     LightdashMode,
     NotExistsError,
@@ -461,7 +462,10 @@ export class OrganizationService {
         return group;
     }
 
-    async listGroupsInOrganization(actor: SessionUser): Promise<Group[]> {
+    async listGroupsInOrganization(
+        actor: SessionUser,
+        includeMembers?: number,
+    ): Promise<GroupWithMembers[]> {
         if (actor.organizationUuid === undefined) {
             throw new ForbiddenError();
         }
@@ -471,6 +475,16 @@ export class OrganizationService {
         const allowedGroups = groups.filter((group) =>
             actor.ability.can('view', subject('Group', group)),
         );
-        return allowedGroups;
+
+        const groupWithMembers = await Promise.all(
+            allowedGroups.map((group) =>
+                this.groupsModel.getGroupWithMembers(
+                    group.uuid,
+                    includeMembers,
+                ),
+            ),
+        );
+
+        return groupWithMembers;
     }
 }

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -465,7 +465,7 @@ export class OrganizationService {
     async listGroupsInOrganization(
         actor: SessionUser,
         includeMembers?: number,
-    ): Promise<GroupWithMembers[]> {
+    ): Promise<Group[] | GroupWithMembers[]> {
         if (actor.organizationUuid === undefined) {
             throw new ForbiddenError();
         }
@@ -476,7 +476,11 @@ export class OrganizationService {
             actor.ability.can('view', subject('Group', group)),
         );
 
-        const groupWithMembers = await Promise.all(
+        if (includeMembers === undefined) {
+            return allowedGroups;
+        }
+
+        const groupsWithMembers = await Promise.all(
             allowedGroups.map((group) =>
                 this.groupsModel.getGroupWithMembers(
                     group.uuid,
@@ -485,6 +489,6 @@ export class OrganizationService {
             ),
         );
 
-        return groupWithMembers;
+        return groupsWithMembers;
     }
 }

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -71,5 +71,5 @@ export type ApiGroupResponse = {
 
 export type ApiGroupListResponse = {
     status: 'ok';
-    results: GroupWithMembers[];
+    results: Group[] | GroupWithMembers[];
 };

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -71,5 +71,5 @@ export type ApiGroupResponse = {
 
 export type ApiGroupListResponse = {
     status: 'ok';
-    results: Group[];
+    results: GroupWithMembers[];
 };


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

for UI purposes to display user avatars https://mantine.dev/core/avatar/#avatargroup
this does not include pagination as it does not make sense with multiple groups. 

![CleanShot 2023-12-29 at 12 03 31@2x](https://github.com/lightdash/lightdash/assets/962095/b21d622a-f597-4117-98de-98c9d2493c18)

![CleanShot 2023-12-29 at 12 02 50@2x](https://github.com/lightdash/lightdash/assets/962095/f639a467-a55a-486d-b82f-64dfcfb0a433)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
