### PR TITLE
feat: organization group creation with members

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1003,9 +1003,38 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_GroupMember.userUuid_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateGroup: {
         dataType: 'refAlias',
-        type: { ref: 'Pick_Group.name_', validators: {} },
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_Group.name_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        members: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'Pick_GroupMember.userUuid_',
+                            },
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGroupListResponse: {

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -17,7 +17,9 @@ export type Group = {
     organizationUuid: string;
 };
 
-export type CreateGroup = Pick<Group, 'name'>;
+export type CreateGroup = Pick<Group, 'name'> & {
+    members?: Pick<GroupMember, 'userUuid'>[];
+};
 
 export type UpdateGroup = Pick<Group, 'name'>;
 


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

use from the frontend:

```ts
const { mutateAsync, isLoading } = useGroupCreateMutation();

const handleSubmit = async (data: CreateGroup) => {
    await mutateAsync({
        ...data,
        // optional members property
        members: [
            { userUuid: 'b264d83a-9000-426a-85ec-3f9c20f368ce' },
            { userUuid: '57cd4548-cbe3-42b3-aa13-97821713e307' },
            { userUuid: '4d242922-a402-427b-bd6d-74f9bddf90cd' },
        ],
    });
}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
