### PR TITLE
chore: groups can be created with users

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
@@ -95,7 +95,6 @@ const CreateGroupModal: FC<ModalProps> = ({ opened, onClose }) => {
                             form?.values.members?.map((v) => v.userUuid) ?? []
                         }
                         onChange={(userIds) => {
-                            console.log('add users', userIds);
                             form?.setValues({
                                 members: userIds.map((userUuid) => ({
                                     userUuid,

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
@@ -1,5 +1,6 @@
-import { Group as UserGroup } from '@lightdash/common';
+import { GroupWithMembers } from '@lightdash/common';
 import {
+    Badge,
     Button,
     Group,
     Modal,
@@ -24,19 +25,53 @@ import CreateGroupModal from './CreateGroupModal';
 
 const GroupListItem: FC<{
     disabled?: boolean;
-    group: UserGroup;
-    onDelete: (group: UserGroup) => void;
+    group: GroupWithMembers;
+    onDelete: (group: GroupWithMembers) => void;
 }> = ({ disabled, group, onDelete }) => {
     return (
         <tr>
-            <td width={500}>
-                <Text fz="xs" fw={400} color="gray.8">
-                    {group.name}
-                </Text>
+            <td width={260}>
+                <Stack spacing="xxs">
+                    <Title order={6}>{group.name}</Title>
+                    {group.members.length > 0 && (
+                        <Text color="gray">{`${group.members.length} members`}</Text>
+                    )}
+                </Stack>
             </td>
 
             <td>
-                <Text>No users</Text>
+                {group.members.length > 0 ? (
+                    <Group
+                        spacing="xxs"
+                        maw={400}
+                        mah={55}
+                        sx={(theme) => ({
+                            overflow: 'auto',
+                            border: `1px solid ${theme.colors.gray[2]}`,
+                            borderRadius: theme.radius.xs,
+                            padding: theme.spacing.xxs,
+                        })}
+                    >
+                        {group.members.map((member) => (
+                            <Badge
+                                key={member.userUuid}
+                                variant="filled"
+                                color="gray.2"
+                                radius="xs"
+                                sx={{ textTransform: 'none' }}
+                                px="xxs"
+                            >
+                                <Text fz="xs" fw={400} color="gray.8">
+                                    {member.email}
+                                </Text>
+                            </Badge>
+                        ))}
+                    </Group>
+                ) : (
+                    <Text color="gray" fs="italic">
+                        No members
+                    </Text>
+                )}
             </td>
             <td>
                 <Group position="right">
@@ -57,7 +92,7 @@ const GroupListItem: FC<{
 
 const DeleteGroupModal: FC<
     ModalProps & {
-        group?: UserGroup;
+        group?: GroupWithMembers;
         disableControls?: boolean;
         onAcceptDelete: () => void;
     }
@@ -102,14 +137,14 @@ const GroupsView: FC = () => {
     const [showCreateGroupModal, setShowCreateGroupModal] = useState(false);
 
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-    const [groupToDelete, setGroupToDelete] = useState<UserGroup | undefined>(
-        undefined,
-    );
+    const [groupToDelete, setGroupToDelete] = useState<
+        GroupWithMembers | undefined
+    >(undefined);
 
     const { mutate, isLoading: isDeleting } = useGroupDeleteMutation();
 
     const { data: groups, isLoading: isLoadingGroups } =
-        useOrganizationGroups();
+        useOrganizationGroups(100); // TODO: pagination
 
     const handleDelete = useCallback(() => {
         if (groupToDelete) {
@@ -139,7 +174,7 @@ const GroupsView: FC = () => {
                     <thead>
                         <tr>
                             <th>Group</th>
-                            <th>Users</th>
+                            <th>Members</th>
                             <th />
                         </tr>
                     </thead>

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -1,21 +1,28 @@
-import { ApiError, CreateGroup, Group } from '@lightdash/common';
+import {
+    ApiError,
+    CreateGroup,
+    Group,
+    GroupWithMembers,
+} from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
-const getOrganizationGroupsQuery = async () =>
-    lightdashApi<Group[]>({
-        url: `/org/groups`,
+const getOrganizationGroupsQuery = async (includeMembers?: number) =>
+    lightdashApi<GroupWithMembers[]>({
+        url: `/org/groups${
+            includeMembers ? `?includeMembers=${includeMembers}` : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
 
-export const useOrganizationGroups = () => {
+export const useOrganizationGroups = (includeMembers?: number) => {
     const setErrorResponse = useQueryError();
-    return useQuery<Group[], ApiError>({
+    return useQuery<GroupWithMembers[], ApiError>({
         queryKey: ['organization_groups'],
-        queryFn: getOrganizationGroupsQuery,
+        queryFn: () => getOrganizationGroupsQuery(includeMembers),
         onError: (result) => setErrorResponse(result),
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8442 

### Description:

Adds a user select when creating a group so users can be added in the UI. Also shows the group members in the group list. This enables the functionality, but there more style work to be done. For now the users are listed in a scrolling box, but we probably want to change that. 

Create group with users:
<img width="680" alt="Screenshot 2023-12-29 at 17 08 53" src="https://github.com/lightdash/lightdash/assets/1864179/ed18e151-8097-4e48-a500-3dcc010d3db7">

Group list including users:
<img width="876" alt="Screenshot 2023-12-29 at 17 09 04" src="https://github.com/lightdash/lightdash/assets/1864179/e1b4cdd8-f1ac-4a71-80cf-1b75ee0be2eb">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
