### PR TITLE
feat: add option to query members and their groups

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -168,13 +168,14 @@ export class OrganizationController extends Controller {
     @OperationId('ListOrganizationMembers')
     async getOrganizationMembers(
         @Request() req: express.Request,
+        @Query() includeGroups?: number,
     ): Promise<ApiOrganizationMemberProfiles> {
         this.setStatus(200);
         return {
             status: 'ok',
             results: await organizationService.getUsers(
                 req.user!,
-                !!req.query.includeGroups,
+                includeGroups,
             ),
         };
     }

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -172,7 +172,10 @@ export class OrganizationController extends Controller {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.getUsers(req.user!),
+            results: await organizationService.getUsers(
+                req.user!,
+                !!req.query.includeGroups,
+            ),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3631,6 +3631,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        customViewportWidth: { dataType: 'double' },
                         filters: {
                             dataType: 'array',
                             array: {
@@ -5743,6 +5744,11 @@ export function RegisterRoutes(app: express.Router) {
                     name: 'req',
                     required: true,
                     dataType: 'object',
+                },
+                includeGroups: {
+                    in: 'query',
+                    name: 'includeGroups',
+                    dataType: 'double',
                 },
             };
 

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -625,32 +625,6 @@
                 "required": ["organizationUuid", "createdAt", "name", "uuid"],
                 "type": "object"
             },
-            "ApiGroupResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Group"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiSuccessEmpty": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
             "GroupMember": {
                 "properties": {
                     "lastName": {
@@ -674,6 +648,60 @@
                 "required": ["lastName", "firstName", "email", "userUuid"],
                 "type": "object",
                 "description": "A summary for a Lightdash user within a group"
+            },
+            "GroupWithMembers": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Group"
+                    },
+                    {
+                        "properties": {
+                            "members": {
+                                "items": {
+                                    "$ref": "#/components/schemas/GroupMember"
+                                },
+                                "type": "array",
+                                "description": "A list of the group's members."
+                            }
+                        },
+                        "required": ["members"],
+                        "type": "object"
+                    }
+                ],
+                "description": "Details for a group including a list of the group's members."
+            },
+            "ApiGroupResponse": {
+                "properties": {
+                    "results": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Group"
+                            },
+                            {
+                                "$ref": "#/components/schemas/GroupWithMembers"
+                            }
+                        ]
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSuccessEmpty": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
             },
             "ApiGroupMembersResponse": {
                 "properties": {
@@ -1078,16 +1106,53 @@
             "UpdateAllowedEmailDomains": {
                 "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
             },
+            "Pick_GroupMember.userUuid_": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string",
+                        "description": "Unique id for the user",
+                        "format": "uuid"
+                    }
+                },
+                "required": ["userUuid"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
             "CreateGroup": {
-                "$ref": "#/components/schemas/Pick_Group.name_"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_Group.name_"
+                    },
+                    {
+                        "properties": {
+                            "members": {
+                                "items": {
+                                    "$ref": "#/components/schemas/Pick_GroupMember.userUuid_"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "ApiGroupListResponse": {
                 "properties": {
                     "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/Group"
-                        },
-                        "type": "array"
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/Group"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/GroupWithMembers"
+                                },
+                                "type": "array"
+                            }
+                        ]
                     },
                     "status": {
                         "type": "string",
@@ -5487,7 +5552,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.917.5",
+        "version": "0.920.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -5767,6 +5832,26 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "number of members to include",
+                        "in": "query",
+                        "name": "includeMembers",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "description": "offset of members to include",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]
@@ -6552,7 +6637,18 @@
                 "description": "Gets all the groups in the current user's organization",
                 "tags": ["Organizations"],
                 "security": [],
-                "parameters": []
+                "parameters": [
+                    {
+                        "description": "number of members to include",
+                        "in": "query",
+                        "name": "includeMembers",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/pinned-lists/{pinnedListUuid}/items": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4118,6 +4118,10 @@
                     },
                     {
                         "properties": {
+                            "customViewportWidth": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "filters": {
                                 "items": {
                                     "$ref": "#/components/schemas/SchedulerFilterRule"
@@ -5552,7 +5556,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.920.0",
+        "version": "0.921.2",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"
@@ -6360,7 +6364,17 @@
                 "description": "Gets all the members of the current user's organization",
                 "tags": ["Organizations"],
                 "security": [],
-                "parameters": []
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "includeGroups",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/org/users/{userUuid}": {

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -121,12 +121,9 @@ export class OrganizationMemberProfileModel {
 
     async getOrganizationMembersAndGroups(
         organizationUuid: string,
+        includeGroups?: number,
     ): Promise<OrganizationMemberProfileWithGroups[]> {
-        const queryResult: (DbOrganizationMemberProfile & {
-            group_uuids: string[];
-            group_names: string[];
-            groups: { name: string; uuid: string }[];
-        })[] = await this.database(UserTableName)
+        let orgMembersAndGroupsQuery = this.database(UserTableName)
             .leftJoin(
                 OrganizationMembershipsTableName,
                 `${UserTableName}.user_id`,
@@ -190,7 +187,18 @@ export class OrganizationMemberProfileModel {
                 ),
             );
 
-        const updatedMembers = queryResult.map((row) => ({
+        if (includeGroups !== undefined) {
+            orgMembersAndGroupsQuery =
+                orgMembersAndGroupsQuery.limit(includeGroups);
+        }
+
+        const result: (DbOrganizationMemberProfile & {
+            group_uuids: string[];
+            group_names: string[];
+            groups: { name: string; uuid: string }[];
+        })[] = await orgMembersAndGroupsQuery;
+
+        const updatedMembers = result.map((row) => ({
             ...row,
             groups:
                 !row.group_uuids && !row.group_names

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -2,10 +2,13 @@ import {
     NotFoundError,
     OrganizationMemberProfile,
     OrganizationMemberProfileUpdate,
+    OrganizationMemberProfileWithGroups,
     OrganizationMemberRole,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { EmailTableName } from '../database/entities/emails';
+import { GroupTableName } from '../database/entities/groups';
+import { GroupMembershipTableName } from '../database/entities/group_memberships';
 import { InviteLinkTableName } from '../database/entities/inviteLinks';
 import {
     DbOrganizationMembership,
@@ -31,6 +34,7 @@ type DbOrganizationMemberProfile = {
 
 const SelectColumns = [
     `${UserTableName}.user_uuid`,
+    `${UserTableName}.user_id`,
     `${UserTableName}.first_name`,
     `${UserTableName}.last_name`,
     `${UserTableName}.is_active`,
@@ -113,6 +117,96 @@ export class OrganizationMemberProfileModel {
             )
             .select<DbOrganizationMemberProfile[]>(SelectColumns);
         return members.map(OrganizationMemberProfileModel.parseRow);
+    }
+
+    async getOrganizationMembersAndGroups(
+        organizationUuid: string,
+    ): Promise<OrganizationMemberProfileWithGroups[]> {
+        const queryResult: (DbOrganizationMemberProfile & {
+            group_uuids: string[];
+            group_names: string[];
+            groups: { name: string; uuid: string }[];
+        })[] = await this.database(UserTableName)
+            .leftJoin(
+                OrganizationMembershipsTableName,
+                `${UserTableName}.user_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
+            )
+            .leftJoin(
+                OrganizationTableName,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .leftJoin(
+                GroupMembershipTableName,
+                `${UserTableName}.user_id`,
+                `${GroupMembershipTableName}.user_id`,
+            )
+            .leftJoin(
+                GroupTableName,
+                `${GroupMembershipTableName}.group_uuid`,
+                `${GroupTableName}.group_uuid`,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .joinRaw(
+                `INNER JOIN ${EmailTableName} ON ${UserTableName}.user_id = ${EmailTableName}.user_id AND ${EmailTableName}.is_primary`,
+            )
+            .leftJoin(
+                InviteLinkTableName,
+                `${UserTableName}.user_uuid`,
+                `${InviteLinkTableName}.user_uuid`,
+            )
+            .groupBy(
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.user_id`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${UserTableName}.is_active`,
+                `${EmailTableName}.email`,
+                `${OrganizationTableName}.organization_uuid`,
+                `${OrganizationMembershipsTableName}.role`,
+                `${InviteLinkTableName}.expires_at`,
+            )
+            .select(
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.user_id`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${UserTableName}.is_active`,
+                `${EmailTableName}.email`,
+                `${OrganizationTableName}.organization_uuid`,
+                `${OrganizationMembershipsTableName}.role`,
+                `${InviteLinkTableName}.expires_at`,
+            )
+            .select(
+                this.database.raw(
+                    `ARRAY_AGG(DISTINCT ${GroupTableName}.group_uuid) FILTER (WHERE ${GroupTableName}.group_uuid IS NOT NULL) as group_uuids`,
+                ),
+                this.database.raw(
+                    `ARRAY_AGG(DISTINCT ${GroupTableName}.name) FILTER (WHERE ${GroupTableName}.name IS NOT NULL) as group_names`,
+                ),
+            );
+
+        console.log({ queryResult });
+
+        const updatedMembers = queryResult.map((row) => ({
+            ...row,
+            groups:
+                !row.group_uuids && !row.group_names
+                    ? []
+                    : row.group_uuids.map((groupUuid, index) => ({
+                          uuid: groupUuid,
+                          name: row.group_names[index],
+                      })),
+        }));
+
+        return updatedMembers.map((m) => ({
+            ...OrganizationMemberProfileModel.parseRow(m),
+            groups: m.groups,
+        }));
     }
 
     async getOrganizationAdmins(

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -190,8 +190,6 @@ export class OrganizationMemberProfileModel {
                 ),
             );
 
-        console.log({ queryResult });
-
         const updatedMembers = queryResult.map((row) => ({
             ...row,
             groups:

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -206,7 +206,6 @@ export class OrganizationService {
             throw new ForbiddenError();
         }
 
-        // TODO: Get groups that user is a member of
         return members.filter((member) =>
             user.ability.can(
                 'view',

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -185,7 +185,7 @@ export class OrganizationService {
 
     async getUsers(
         user: SessionUser,
-        includeGroups?: boolean,
+        includeGroups?: number,
     ): Promise<OrganizationMemberProfile[]> {
         const { organizationUuid } = user;
         if (user.ability.cannot('view', 'OrganizationMemberProfile')) {
@@ -197,6 +197,7 @@ export class OrganizationService {
         const members = includeGroups
             ? await this.organizationMemberProfileModel.getOrganizationMembersAndGroups(
                   organizationUuid,
+                  includeGroups,
               )
             : await this.organizationMemberProfileModel.getOrganizationMembers(
                   organizationUuid,

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -202,10 +202,6 @@ export class OrganizationService {
                   organizationUuid,
               );
 
-        if (user.organizationUuid === undefined) {
-            throw new ForbiddenError();
-        }
-
         return members.filter((member) =>
             user.ability.can(
                 'view',

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -1,3 +1,5 @@
+import { Group } from './groups';
+
 export enum OrganizationMemberRole {
     MEMBER = 'member',
     VIEWER = 'viewer',
@@ -35,6 +37,10 @@ export type OrganizationMemberProfile = {
      * Whether the user's invite to the organization has expired
      */
     isInviteExpired?: boolean;
+};
+
+export type OrganizationMemberProfileWithGroups = OrganizationMemberProfile & {
+    groups: Pick<Group, 'name' | 'uuid'>[];
 };
 
 export type OrganizationMemberProfileUpdate = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Allows `includeGroups` in query for `/org/users`;

Gets users and the groups they belong to;

> [!NOTE]
> Should we do extra checks on permissions?

Example
<img width="581" alt="Screenshot 2023-12-29 at 16 50 19" src="https://github.com/lightdash/lightdash/assets/7611706/ba259f05-9ad5-46a8-91ab-5108ba17d636">
<img width="880" alt="Screenshot 2023-12-29 at 16 50 33" src="https://github.com/lightdash/lightdash/assets/7611706/122ea922-5eca-4705-9bb4-3441257e36c0">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
