### PR TITLE
feat: add single selection filter input type and operator

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -25,6 +25,7 @@ export const ExpectedNumberFilterSQL: Record<FilterOperator, string | null> = {
     [FilterOperator.NULL]: '(customers.age) IS NULL',
     [FilterOperator.NOT_NULL]: '(customers.age) IS NOT NULL',
     [FilterOperator.EQUALS]: '(customers.age) IN (1)',
+    [FilterOperator.EQUALS_ONLY]: '(customers.age) IN (1)',
     [FilterOperator.NOT_EQUALS]:
         '((customers.age) NOT IN (1) OR (customers.age) IS NULL)',
     [FilterOperator.STARTS_WITH]: null,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -43,6 +43,7 @@ export const renderStringFilterSql = (
 
     switch (filter.operator) {
         case FilterOperator.EQUALS:
+        case FilterOperator.EQUALS_ONLY:
             return !escapedFilterValues || escapedFilterValues.length === 0
                 ? 'true'
                 : `(${dimensionSql}) IN (${escapedFilterValues
@@ -101,6 +102,7 @@ export const renderNumberFilterSql = (
     const filterType = filter.operator;
     switch (filter.operator) {
         case FilterOperator.EQUALS:
+        case FilterOperator.EQUALS_ONLY:
             return !filter.values || filter.values.length === 0
                 ? 'true'
                 : `(${dimensionSql}) IN (${filter.values.join(',')})`;

--- a/packages/common/src/types/conditionalRule.ts
+++ b/packages/common/src/types/conditionalRule.ts
@@ -3,6 +3,7 @@ export enum ConditionalOperator {
     NOT_NULL = 'notNull',
     EQUALS = 'equals',
     NOT_EQUALS = 'notEquals',
+    EQUALS_ONLY = 'equalsOnly',
     STARTS_WITH = 'startsWith',
     ENDS_WITH = 'endsWith',
     INCLUDE = 'include',

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -97,6 +97,7 @@ export const hasMatchingConditionalRules = (
                 case ConditionalOperator.NOT_NULL:
                     return convertedValue !== null;
                 case ConditionalOperator.EQUALS:
+                case ConditionalOperator.EQUALS_ONLY:
                     return rule.values.some((v) => convertedValue === v);
                 case ConditionalOperator.NOT_EQUALS:
                     return rule.values.some((v) => convertedValue !== v);

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -26,6 +26,7 @@ export const isFilterEnabled = (
         case FilterOperator.NOT_NULL:
             return true;
         case FilterOperator.EQUALS:
+        case FilterOperator.EQUALS_ONLY:
         case FilterOperator.NOT_EQUALS:
         case FilterOperator.LESS_THAN:
         case FilterOperator.GREATER_THAN:

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -13,6 +13,7 @@ import { useFiltersContext } from '../FiltersProvider';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
 import FilterMultiStringInput from './FilterMultiStringInput';
 import FilterNumberInput from './FilterNumberInput';
+import FilterSingleStringAutoComplete from './FilterSingleStringAutoComplete';
 import FilterStringAutoComplete from './FilterStringAutoComplete';
 
 const DefaultFilterInputs = <T extends ConditionalRule>({
@@ -133,6 +134,55 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                     }}
                 />
             );
+        case FilterOperator.EQUALS_ONLY: {
+            switch (filterType) {
+                case FilterType.STRING:
+                    return (
+                        <FilterSingleStringAutoComplete
+                            filterId={
+                                isTableCalculationField(field) ? '' : rule.id
+                            }
+                            disabled={disabled}
+                            field={field}
+                            placeholder={placeholder}
+                            suggestions={
+                                isTableCalculationField(field)
+                                    ? []
+                                    : suggestions || []
+                            }
+                            withinPortal={popoverProps?.withinPortal}
+                            onDropdownOpen={popoverProps?.onOpen}
+                            onDropdownClose={popoverProps?.onClose}
+                            value={
+                                (rule.values || []).filter(isString)[0] || ''
+                            } // Take the first value or empty string if none
+                            onChange={(value) =>
+                                onChange({
+                                    ...rule,
+                                    values: value !== '' ? [value] : [], // Wrap the single value in an array
+                                })
+                            }
+                            tableCalculationField={isTableCalculationField(
+                                field,
+                            )}
+                        />
+                    );
+                default:
+                    return (
+                        <FilterNumberInput
+                            disabled={disabled}
+                            placeholder={placeholder}
+                            value={rule.values?.[0]}
+                            onChange={(newValue) => {
+                                onChange({
+                                    ...rule,
+                                    values: newValue ? [newValue] : [],
+                                });
+                            }}
+                        />
+                    );
+            }
+        }
         default:
             return assertUnreachable(
                 rule.operator,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
@@ -1,5 +1,5 @@
 import { TextInput, TextInputProps } from '@mantine/core';
-import { ChangeEvent, FC, useEffect, useState } from 'react';
+import { ChangeEvent, FC, useEffect, useRef, useState } from 'react';
 
 interface Props extends Omit<TextInputProps, 'type' | 'value' | 'onChange'> {
     value: unknown;
@@ -15,8 +15,21 @@ const FilterNumberInput: FC<Props> = ({
     ...rest
 }) => {
     const [internalValue, setInternalValue] = useState('');
+    const initialized = useRef(false);
 
     useEffect(() => {
+        // To update value when option changes from Multi-Value to Single-Value
+        if (!initialized.current) {
+            onChange(
+                typeof value === 'string'
+                    ? parseFloat(value)
+                    : typeof value === 'number'
+                    ? value
+                    : null,
+            );
+            initialized.current = true;
+        }
+
         if (typeof value === 'string') {
             setInternalValue(value);
         } else if (typeof value === 'number') {
@@ -28,7 +41,7 @@ const FilterNumberInput: FC<Props> = ({
                 `FilterNumberInput: Invalid value type: ${typeof value}`,
             );
         }
-    }, [value]);
+    }, [value, onChange]);
 
     const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterSingleStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterSingleStringAutoComplete.tsx
@@ -1,0 +1,198 @@
+import { FilterableItem } from '@lightdash/common';
+import {
+    Group,
+    Loader,
+    ScrollArea,
+    Select,
+    SelectProps,
+    Text,
+} from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+import uniq from 'lodash/uniq';
+import {
+    FC,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import {
+    MAX_AUTOCOMPLETE_RESULTS,
+    useFieldValues,
+} from '../../../../hooks/useFieldValues';
+import MantineIcon from '../../MantineIcon';
+import { useFiltersContext } from '../FiltersProvider';
+
+type Props = Omit<SelectProps, 'data' | 'onChange'> & {
+    filterId: string;
+    field: FilterableItem;
+    value: string;
+    suggestions: string[];
+    tableCalculationField: boolean;
+    onChange: (value: string) => void;
+};
+
+const FilterSingleStringAutoComplete: FC<Props> = ({
+    filterId,
+    value,
+    field,
+    suggestions: initialSuggestionData,
+    disabled,
+    onChange,
+    placeholder,
+    onDropdownOpen,
+    onDropdownClose,
+    tableCalculationField,
+    ...rest
+}) => {
+    const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
+    if (!projectUuid) {
+        throw new Error('projectUuid is required in FiltersProvider');
+    }
+
+    const [search, setSearch] = useState('');
+
+    const initialized = useRef(false);
+
+    // To update value when option changes from Multi-Select to Single-Select
+    useEffect(() => {
+        if (!initialized.current) {
+            onChange(value);
+            initialized.current = true;
+        }
+    }, [value, onChange]);
+
+    const autocompleteFilterGroup = useMemo(
+        () => getAutocompleteFilterGroup(filterId, field),
+        [field, filterId, getAutocompleteFilterGroup],
+    );
+
+    const { isLoading, results: resultsSet } = useFieldValues(
+        search,
+        initialSuggestionData,
+        projectUuid,
+        field,
+        autocompleteFilterGroup,
+        true,
+        { refetchOnMount: 'always' },
+    );
+
+    const results = useMemo(() => [...resultsSet], [resultsSet]);
+
+    const handleChange = useCallback(
+        (updatedValue: string) => {
+            onChange(updatedValue);
+        },
+        [onChange],
+    );
+
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+                handleChange(search);
+            }
+        },
+        [handleChange, search],
+    );
+
+    const data = useMemo(() => {
+        const filteredResults = results.filter((val) => val);
+        const validValue = value ? [value] : [];
+        return uniq([...filteredResults, ...validValue]).map((val) => ({
+            value: val,
+            label: val,
+        }));
+    }, [results, value]);
+
+    const searchedMaxResults = resultsSet.size >= MAX_AUTOCOMPLETE_RESULTS;
+
+    const DropdownComponentOverride = useCallback(
+        ({ children, ...props }: { children: ReactNode }) => (
+            <ScrollArea {...props}>
+                {searchedMaxResults ? (
+                    <Text
+                        color="dimmed"
+                        size="xs"
+                        px="sm"
+                        pt="xs"
+                        pb="xxs"
+                        bg="white"
+                    >
+                        Showing first {MAX_AUTOCOMPLETE_RESULTS} results.{' '}
+                        {search ? 'Continue' : 'Start'} typing...
+                    </Text>
+                ) : null}
+
+                {children}
+            </ScrollArea>
+        ),
+        [searchedMaxResults, search],
+    );
+
+    return (
+        <Select
+            size="xs"
+            w="100%"
+            placeholder={value || disabled ? undefined : placeholder}
+            disabled={disabled}
+            creatable
+            getCreateLabel={(query) => (
+                <Group spacing="xxs">
+                    <MantineIcon icon={IconPlus} color="blue" size="sm" />
+                    <Text color="blue">Select "{query}"</Text>
+                </Group>
+            )}
+            styles={{
+                item: {
+                    '&:last-child:not([value])': {
+                        position: 'sticky',
+                        bottom: 4,
+                        boxShadow: '0 4px 0 0 white',
+                    },
+                    '&:last-child:not([value]):not(:hover)': {
+                        background: 'white',
+                    },
+                },
+            }}
+            searchable
+            searchValue={search}
+            {...rest}
+            onSearchChange={setSearch}
+            limit={MAX_AUTOCOMPLETE_RESULTS}
+            nothingFound={
+                tableCalculationField
+                    ? 'Please type to add the filter value'
+                    : isLoading
+                    ? 'Loading...'
+                    : 'No results found'
+            }
+            rightSection={
+                tableCalculationField ? null : isLoading ? (
+                    <Loader size="xs" color="gray" />
+                ) : null
+            }
+            dropdownComponent={DropdownComponentOverride}
+            itemComponent={({ label, ...others }) =>
+                others.disabled ? (
+                    <Text color="dimmed" {...others}>
+                        {label}
+                    </Text>
+                ) : (
+                    <Text {...others}>{label}</Text>
+                )
+            }
+            data={data}
+            value={value}
+            onDropdownOpen={onDropdownOpen}
+            onDropdownClose={() => {
+                onDropdownClose?.();
+            }}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+        />
+    );
+};
+
+export default FilterSingleStringAutoComplete;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -33,6 +33,7 @@ const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.NOT_NULL]: 'is not null',
     [FilterOperator.EQUALS]: 'is',
     [FilterOperator.NOT_EQUALS]: 'is not',
+    [FilterOperator.EQUALS_ONLY]: 'is only',
     [FilterOperator.STARTS_WITH]: 'starts with',
     [FilterOperator.ENDS_WITH]: 'ends with',
     [FilterOperator.NOT_INCLUDE]: 'does not include',
@@ -96,6 +97,7 @@ export const getFilterOperatorOptions = (
                 FilterOperator.NOT_NULL,
                 FilterOperator.EQUALS,
                 FilterOperator.NOT_EQUALS,
+                FilterOperator.EQUALS_ONLY,
                 FilterOperator.STARTS_WITH,
                 FilterOperator.ENDS_WITH,
                 FilterOperator.INCLUDE,
@@ -107,6 +109,7 @@ export const getFilterOperatorOptions = (
                 FilterOperator.NOT_NULL,
                 FilterOperator.EQUALS,
                 FilterOperator.NOT_EQUALS,
+                FilterOperator.EQUALS_ONLY,
                 FilterOperator.LESS_THAN,
                 FilterOperator.GREATER_THAN,
             ]);
@@ -180,6 +183,7 @@ const getValueAsString = (
                 case FilterOperator.NOT_NULL:
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
+                case FilterOperator.EQUALS_ONLY:
                 case FilterOperator.STARTS_WITH:
                 case FilterOperator.ENDS_WITH:
                 case FilterOperator.INCLUDE:

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -21,6 +21,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
                     return 'Enter value(s)';
+                case FilterOperator.EQUALS_ONLY:
                 case FilterOperator.LESS_THAN:
                 case FilterOperator.GREATER_THAN:
                     return 'Enter value';
@@ -47,6 +48,8 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
                     return 'Start typing to filter results';
+                case FilterOperator.EQUALS_ONLY:
+                    return 'Select one value';
                 case FilterOperator.STARTS_WITH:
                 case FilterOperator.ENDS_WITH:
                 case FilterOperator.INCLUDE:
@@ -89,6 +92,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';
+                case FilterOperator.EQUALS_ONLY:
                 case FilterOperator.STARTS_WITH:
                 case FilterOperator.ENDS_WITH:
                 case FilterOperator.INCLUDE:
@@ -105,6 +109,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                 case FilterOperator.NOT_NULL:
                     return '';
                 case FilterOperator.NOT_EQUALS:
+                case FilterOperator.EQUALS_ONLY:
                 case FilterOperator.LESS_THAN:
                 case FilterOperator.GREATER_THAN:
                 case FilterOperator.LESS_THAN_OR_EQUAL:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8138 

### Description:
Added an `EQUALS_ONLY` FilterOperator

There are basically 2 main types for which we would need this – `STRING` and `NUMBER`.
For these, I have kept the backend same ie. using the IN clause in sql, just that now we would have a single element array when EQUALS_ONLY is selected.

For the frontend,
the numbers can directly use our `FilterNumberInput` which accepts a simple `NumberInput`.

In strings, for cases (like EQUALS, NOT_EQUALS etc), we use the components `FilterStringAutoComplete` and `FilterMultiStringInput` depending on whether it `isTableCalculationField`.
Modifying both of these components was also an alternative here (but that might have made the logic more complex)

So, I have added a new component `FilterSingleStringAutoComplete` as this felt a lot cleaner to me.
This handles both cases - Normal as well as TableCalculationFields using a flag. 
Here we would have a Select rather than a Multi-Select

I have also added some logic in useEffect to handles option changes from multiple to single inputs.
This is useful when a user has selected lets say 3 inputs (in `is` option) and then switches to `is_only` option. Then we update the value with the first element of the input. I do think there will be an optimised way to do this. Would love to discuss this.

Here are some screenshots of the output,

Strings -
![image](https://github.com/lightdash/lightdash/assets/85165953/d20d804e-cb0e-43df-aea7-07306f6b6bdc)

![image](https://github.com/lightdash/lightdash/assets/85165953/fec2fd0c-d47f-41b4-8ec7-0ef0c28891fb)

Numbers -
![image](https://github.com/lightdash/lightdash/assets/85165953/8d7be201-303e-4222-a868-cd90526fd2a3)

![image](https://github.com/lightdash/lightdash/assets/85165953/27ab4a16-dee6-460d-9c8a-ccb61b266671)

Combination - 
![image](https://github.com/lightdash/lightdash/assets/85165953/fb827341-bf46-4178-8e9b-5c070dc82f6f)

![image](https://github.com/lightdash/lightdash/assets/85165953/a6f0651f-429a-4c52-b240-e1b905d3bc5a)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
