### PR TITLE
fix: formatting of tooltip on dashboard filter

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -180,7 +180,9 @@ const Filter: FC<Props> = ({
                             <Tooltip
                                 withinPortal
                                 position="top-start"
-                                disabled={isPopoverOpen}
+                                disabled={
+                                    isPopoverOpen || !filterRuleTables?.length
+                                }
                                 offset={8}
                                 label={
                                     <Text fz="xs">

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -184,23 +184,12 @@ const Filter: FC<Props> = ({
                                 offset={8}
                                 label={
                                     <Text fz="xs">
-                                        {filterRuleTables?.length === 0 ? (
-                                            <>
-                                                Table:
-                                                <Text span fw={600}>
-                                                    {filterRuleTables[0]}
-                                                </Text>
-                                            </>
-                                        ) : (
-                                            <>
-                                                Tables:{' '}
-                                                <Text span fw={600}>
-                                                    {filterRuleTables?.join(
-                                                        ', ',
-                                                    )}
-                                                </Text>
-                                            </>
-                                        )}
+                                        {filterRuleTables?.length === 1
+                                            ? 'Table: '
+                                            : 'Tables: '}
+                                        <Text span fw={600}>
+                                            {filterRuleTables?.join(', ')}
+                                        </Text>
                                     </Text>
                                 }
                             >


### PR DESCRIPTION
Closes: [Dashboard filter tooltip shows plural tables for a single table](https://github.com/lightdash/lightdash/issues/8448)

### Description:
Fixes the issue where a dashboard filter for a single table shows the plural `Tables` in the tooltip. Also fixes the possibility of a tooltip showing if `filterRuleTables` is undefined or empty.

_Before:_
![image](https://github.com/lightdash/lightdash/assets/11949472/f7e39f15-b84f-4ca0-a310-f0d79f84f158)

_After:_
![image](https://github.com/lightdash/lightdash/assets/11949472/9988aef2-a59e-4e95-be15-803171fb9b9a)

_Notes:_
I have simplified the ternary for readability, since `filterRuleTables?.join(', ')` produces the same result as `filterRuleTables[0]` for an array of strings with a single item.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
