### PR TITLE
chore: change seeded filter timerange

### DIFF
--- a/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
+++ b/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
@@ -203,7 +203,7 @@ export async function seed(knex: Knex): Promise<void> {
                             fieldId: 'orders_order_date_year',
                             tableName: 'orders',
                         },
-                        values: [5],
+                        values: [10],
                         operator: FilterOperator.IN_THE_PAST,
                         settings: { completed: true, unitOfTime: 'years' },
                         label: undefined,


### PR DESCRIPTION
### Description:

Tests are failing because there is a dashboard filter that filters out data before 2019. This changes the filter to look back 10 years instead of 5. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-frontend
test-cli
test-backend