### PR TITLE
feat: add placeholder UI to add user attributes to groups

### DIFF
--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -40,7 +40,7 @@ describe('User attributes sql_filter', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attributes').click();
+        cy.findByText('Add new attribute').click();
 
         cy.get('input[name="name"]').type('customer_id');
         cy.findByText('Add user').click();
@@ -65,7 +65,7 @@ describe('User attributes sql_filter', () => {
     it('Edit user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
 
-        cy.contains('customer_id').parents('tr').contains('Edit').click();
+        cy.contains('customer_id').parents('tr').find('button').first().click();
         cy.get('input[name="users.0.value"]').clear().type('30');
         cy.findByText('Update').click();
         cy.contains('Success');
@@ -130,7 +130,7 @@ describe('User attributes dimension required_attribute', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attributes').click();
+        cy.findByText('Add new attribute').click();
 
         cy.get('input[name="name"]').type('is_admin');
         cy.findByText('Add user').click();
@@ -155,7 +155,7 @@ describe('User attributes dimension required_attribute', () => {
     it('Edit user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
 
-        cy.contains('is_admin').parents('tr').contains('Edit').click();
+        cy.contains('is_admin').parents('tr').find('button').first().click();
         cy.get('input[name="users.0.value"]').clear().type('false');
         cy.findByText('Update').click();
         cy.contains('Success');

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -13,7 +13,7 @@ import {
     Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { IconTrash, IconUserPlus } from '@tabler/icons-react';
 import { FC, useEffect, useState } from 'react';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import {
@@ -116,7 +116,7 @@ const UserAttributeModal: FC<{
                     handleSubmit(values),
                 )}
             >
-                <Stack spacing="md">
+                <Stack spacing="xs">
                     <TextInput
                         name="name"
                         label="Attribute name"
@@ -153,6 +153,7 @@ const UserAttributeModal: FC<{
                             />
                             {checked && (
                                 <TextInput
+                                    size="xs"
                                     name={`attributeDefault`}
                                     placeholder="E.g. US"
                                     required
@@ -168,6 +169,7 @@ const UserAttributeModal: FC<{
                             return (
                                 <Group key={index}>
                                     <Select
+                                        size="xs"
                                         sx={{ flexGrow: 1 }}
                                         label={
                                             index === 0
@@ -190,6 +192,7 @@ const UserAttributeModal: FC<{
                                     />
 
                                     <TextInput
+                                        size="xs"
                                         sx={{ flexGrow: 1 }}
                                         label={
                                             index === 0 ? 'Value' : undefined
@@ -220,8 +223,10 @@ const UserAttributeModal: FC<{
                             );
                         })}
                         <Button
-                            w={200}
-                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            size="xs"
+                            variant="default"
+                            sx={{ alignSelf: 'flex-start' }}
+                            leftIcon={<MantineIcon icon={IconUserPlus} />}
                             onClick={() => {
                                 form.setFieldValue('users', [
                                     ...(form.values.users || []),

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -13,8 +13,10 @@ import {
     Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconTrash, IconUserPlus } from '@tabler/icons-react';
+import { IconTrash, IconUserPlus, IconUsersPlus } from '@tabler/icons-react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { FC, useEffect, useState } from 'react';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import {
     useCreateUserAtributesMutation,
@@ -28,11 +30,14 @@ const UserAttributeModal: FC<{
     allUserAttributes: UserAttribute[];
     onClose: () => void;
 }> = ({ opened, userAttribute, allUserAttributes, onClose }) => {
+    const isGroupsFeatureFlagEnabled =
+        useFeatureFlagEnabled('group-management');
     const form = useForm<CreateUserAttribute>({
         initialValues: {
             name: userAttribute?.name || '',
             description: userAttribute?.description,
             users: userAttribute?.users || [],
+            // TODO: add groups
             attributeDefault: userAttribute?.attributeDefault || null,
         },
     });
@@ -99,6 +104,10 @@ const UserAttributeModal: FC<{
     };
 
     const { data: orgUsers } = useOrganizationUsers();
+    const { data: groups } = useOrganizationGroups({
+        enabled: !!isGroupsFeatureFlagEnabled,
+    });
+
     return (
         <Modal
             opened={opened}
@@ -162,80 +171,172 @@ const UserAttributeModal: FC<{
                             )}
                         </Group>
                     </Stack>
-                    <Stack spacing="xs">
-                        <Text fw={500}>Assign to users</Text>
+                    <Stack>
+                        <Stack spacing="xs">
+                            <Text fw={500}>Assign to users</Text>
 
-                        {form.values.users?.map((user, index) => {
-                            return (
-                                <Group key={index}>
-                                    <Select
-                                        size="xs"
-                                        sx={{ flexGrow: 1 }}
-                                        label={
-                                            index === 0
-                                                ? 'User email'
-                                                : undefined
-                                        }
-                                        name={`users.${index}.userUuid`}
-                                        placeholder="E.g. test@lightdash.com"
-                                        required
-                                        searchable
-                                        {...form.getInputProps(
-                                            `users.${index}.userUuid`,
-                                        )}
-                                        data={
-                                            orgUsers?.map((orgUser) => ({
-                                                value: orgUser.userUuid,
-                                                label: orgUser.email,
-                                            })) || []
-                                        }
-                                    />
+                            {form.values.users?.map((user, index) => {
+                                return (
+                                    <Group key={index}>
+                                        <Select
+                                            size="xs"
+                                            sx={{ flexGrow: 1 }}
+                                            label={
+                                                index === 0
+                                                    ? 'User email'
+                                                    : undefined
+                                            }
+                                            name={`users.${index}.userUuid`}
+                                            placeholder="E.g. test@lightdash.com"
+                                            required
+                                            searchable
+                                            {...form.getInputProps(
+                                                `users.${index}.userUuid`,
+                                            )}
+                                            data={
+                                                orgUsers?.map((orgUser) => ({
+                                                    value: orgUser.userUuid,
+                                                    label: orgUser.email,
+                                                })) || []
+                                            }
+                                        />
 
-                                    <TextInput
-                                        size="xs"
-                                        sx={{ flexGrow: 1 }}
-                                        label={
-                                            index === 0 ? 'Value' : undefined
-                                        }
-                                        name={`users.${index}.value`}
-                                        placeholder="E.g. US"
-                                        required
-                                        {...form.getInputProps(
-                                            `users.${index}.value`,
-                                        )}
-                                    />
-                                    <ActionIcon
-                                        mt={index === 0 ? 20 : undefined}
-                                        color="red"
-                                        variant="outline"
-                                        onClick={() => {
-                                            form.setFieldValue(
-                                                'users',
-                                                form.values.users.filter(
-                                                    (_, i) => i !== index,
-                                                ),
-                                            );
-                                        }}
-                                    >
-                                        <MantineIcon icon={IconTrash} />
-                                    </ActionIcon>
-                                </Group>
-                            );
-                        })}
-                        <Button
-                            size="xs"
-                            variant="default"
-                            sx={{ alignSelf: 'flex-start' }}
-                            leftIcon={<MantineIcon icon={IconUserPlus} />}
-                            onClick={() => {
-                                form.setFieldValue('users', [
-                                    ...(form.values.users || []),
-                                    { userUuid: '', value: '' },
-                                ]);
-                            }}
-                        >
-                            Add user
-                        </Button>
+                                        <TextInput
+                                            size="xs"
+                                            sx={{ flexGrow: 1 }}
+                                            label={
+                                                index === 0
+                                                    ? 'Value'
+                                                    : undefined
+                                            }
+                                            name={`users.${index}.value`}
+                                            placeholder="E.g. US"
+                                            required
+                                            {...form.getInputProps(
+                                                `users.${index}.value`,
+                                            )}
+                                        />
+                                        <ActionIcon
+                                            mt={index === 0 ? 20 : undefined}
+                                            color="red"
+                                            variant="outline"
+                                            onClick={() => {
+                                                form.setFieldValue(
+                                                    'users',
+                                                    form.values.users.filter(
+                                                        (_, i) => i !== index,
+                                                    ),
+                                                );
+                                            }}
+                                        >
+                                            <MantineIcon icon={IconTrash} />
+                                        </ActionIcon>
+                                    </Group>
+                                );
+                            })}
+                            <Button
+                                size="xs"
+                                variant="default"
+                                sx={{ alignSelf: 'flex-start' }}
+                                leftIcon={<MantineIcon icon={IconUserPlus} />}
+                                onClick={() => {
+                                    form.setFieldValue('users', [
+                                        ...(form.values.users || []),
+                                        { userUuid: '', value: '' },
+                                    ]);
+                                }}
+                            >
+                                Add user
+                            </Button>
+                        </Stack>
+
+                        {isGroupsFeatureFlagEnabled && (
+                            <Stack spacing="xs">
+                                <Text fw={500}>Assign to groups</Text>
+
+                                {/* TODO: Get from form.values.groups */}
+                                {[].map((user, index) => {
+                                    return (
+                                        <Group key={index}>
+                                            <Select
+                                                size="xs"
+                                                sx={{ flexGrow: 1 }}
+                                                label={
+                                                    index === 0
+                                                        ? 'Group name'
+                                                        : undefined
+                                                }
+                                                name={`groups.${index}.groupUuid`}
+                                                placeholder="E.g. Marketing, Product"
+                                                required
+                                                searchable
+                                                {...form.getInputProps(
+                                                    `groups.${index}.userUuid`,
+                                                )}
+                                                data={
+                                                    groups?.map((orgUser) => ({
+                                                        value: orgUser.uuid,
+                                                        label: orgUser.name,
+                                                    })) || []
+                                                }
+                                            />
+
+                                            <TextInput
+                                                size="xs"
+                                                sx={{ flexGrow: 1 }}
+                                                label={
+                                                    index === 0
+                                                        ? 'Value'
+                                                        : undefined
+                                                }
+                                                name={`groups.${index}.value`}
+                                                placeholder="E.g. US"
+                                                required
+                                                {...form.getInputProps(
+                                                    `groups.${index}.value`,
+                                                )}
+                                            />
+                                            <ActionIcon
+                                                mt={
+                                                    index === 0 ? 20 : undefined
+                                                }
+                                                color="red"
+                                                variant="outline"
+                                                onClick={() => {
+                                                    form.setFieldValue(
+                                                        'groups',
+                                                        // TODO: Get from form.values.groups
+                                                        [].filter(
+                                                            (_, i) =>
+                                                                i !== index,
+                                                        ),
+                                                    );
+                                                }}
+                                            >
+                                                <MantineIcon icon={IconTrash} />
+                                            </ActionIcon>
+                                        </Group>
+                                    );
+                                })}
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    sx={{ alignSelf: 'flex-start' }}
+                                    leftIcon={
+                                        <MantineIcon icon={IconUsersPlus} />
+                                    }
+                                    onClick={() => {
+                                        form.setFieldValue('groups', [
+                                            // TODO: Get from form.values.groups
+                                            ...[],
+                                            { uuid: '', name: '' },
+                                        ]);
+                                    }}
+                                >
+                                    Add group
+                                </Button>
+                            </Stack>
+                        )}
                     </Stack>
 
                     <Group spacing="xs" position="right">

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -104,7 +104,7 @@ const UserAttributeModal: FC<{
     };
 
     const { data: orgUsers } = useOrganizationUsers();
-    const { data: groups } = useOrganizationGroups({
+    const { data: groups } = useOrganizationGroups(undefined, {
         enabled: !!isGroupsFeatureFlagEnabled,
     });
 

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -162,7 +162,7 @@ const UserAttributeModal: FC<{
                             )}
                         </Group>
                     </Stack>
-                    <Stack>
+                    <Stack spacing="xs">
                         <Text fw={500}>Assign to users</Text>
 
                         {form.values.users?.map((user, index) => {

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -1,6 +1,8 @@
 import { subject } from '@casl/ability';
 import { UserAttribute } from '@lightdash/common';
 import {
+    ActionIcon,
+    Box,
     Button,
     Group,
     Modal,
@@ -17,6 +19,7 @@ import {
     IconInfoCircle,
     IconTrash,
 } from '@tabler/icons-react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { FC, useState } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
@@ -126,6 +129,8 @@ const UserListItem: FC<{
 };
 
 const UserAttributesPanel: FC = () => {
+    const isGroupsFeatureFlagEnabled =
+        useFeatureFlagEnabled('group-management');
     const { classes } = useTableStyles();
     const { user } = useApp();
     const [showAddAttributeModal, addAttributeModal] = useDisclosure(false);
@@ -152,34 +157,33 @@ const UserAttributesPanel: FC = () => {
         <Stack>
             <Group position="apart">
                 <Group spacing="two">
-                    <Title order={5}>User attributes</Title>
+                    <Title order={5}>
+                        {isGroupsFeatureFlagEnabled
+                            ? 'User and Group attributes'
+                            : 'User attributes'}
+                    </Title>
                     <Tooltip
                         multiline
                         w={400}
                         withArrow
                         label={
-                            <div>
+                            <Box>
                                 User attributes are metadata defined by your
                                 organization. They can used to control and
                                 cutomize the user experience through data access
-                                and personzalization. Learn more about using
-                                user attributes in the
-                                <a
-                                    href="https://docs.lightdash.com"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    {' '}
-                                    docs
-                                </a>
-                                .
-                            </div>
+                                and personalization. Learn more about using user
+                                attributes by clicking on the icon.
+                            </Box>
                         }
                     >
-                        {/* TODO add link to docs */}
-                        {/* TODO keep tooltip open on hover */}
-
-                        <MantineIcon icon={IconInfoCircle} color="gray.6" />
+                        <ActionIcon
+                            component="a"
+                            href="https://docs.lightdash.com/references/user-attributes"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            <MantineIcon icon={IconInfoCircle} />
+                        </ActionIcon>
                     </Tooltip>
                 </Group>
                 <>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -69,23 +69,22 @@ const UserListItem: FC<{
             </td>
             <td width="1%">
                 <Group noWrap spacing="xs">
-                    <Button
-                        onClick={onEdit}
-                        variant="outline"
+                    <ActionIcon
                         color="blue.4"
-                        leftIcon={<MantineIcon icon={IconEdit} />}
+                        variant="outline"
+                        onClick={onEdit}
                     >
-                        Edit
-                    </Button>
+                        <MantineIcon icon={IconEdit} />
+                    </ActionIcon>
 
-                    <Button
-                        leftIcon={<MantineIcon icon={IconTrash} />}
+                    <ActionIcon
                         variant="outline"
                         onClick={deleteDialog.open}
                         color="red"
                     >
-                        Delete
-                    </Button>
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
+
                     <Modal
                         opened={isDeleteDialogOpen}
                         onClose={deleteDialog.close}

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -169,10 +169,10 @@ const UserAttributesPanel: FC = () => {
                         label={
                             <Box>
                                 User attributes are metadata defined by your
-                                organization. They can used to control and
+                                organization. They can be used to control and
                                 cutomize the user experience through data access
                                 and personalization. Learn more about using user
-                                attributes by clicking on the icon.
+                                attributes by clicking on this icon.
                             </Box>
                         }
                     >

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -17,6 +17,7 @@ import {
     IconAlertCircle,
     IconEdit,
     IconInfoCircle,
+    IconPlus,
     IconTrash,
 } from '@tabler/icons-react';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
@@ -186,8 +187,12 @@ const UserAttributesPanel: FC = () => {
                     </Tooltip>
                 </Group>
                 <>
-                    <Button onClick={addAttributeModal.open}>
-                        Add new attributes
+                    <Button
+                        size="xs"
+                        leftIcon={<MantineIcon icon={IconPlus} />}
+                        onClick={addAttributeModal.open}
+                    >
+                        Add new attribute
                     </Button>
                     <UserAttributeModal
                         opened={showAddAttributeModal}

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -4,7 +4,12 @@ import {
     Group,
     GroupWithMembers,
 } from '@lightdash/common';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    UseQueryOptions,
+} from 'react-query';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
@@ -18,12 +23,16 @@ const getOrganizationGroupsQuery = async (includeMembers?: number) =>
         body: undefined,
     });
 
-export const useOrganizationGroups = (includeMembers?: number) => {
+export const useOrganizationGroups = (
+    includeMembers?: number,
+    queryOptions?: UseQueryOptions<GroupWithMembers[], ApiError>,
+) => {
     const setErrorResponse = useQueryError();
     return useQuery<GroupWithMembers[], ApiError>({
         queryKey: ['organization_groups'],
         queryFn: () => getOrganizationGroupsQuery(includeMembers),
         onError: (result) => setErrorResponse(result),
+        ...queryOptions,
     });
 };
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -189,7 +189,7 @@ const Settings: FC = () => {
                                     <RouterNavLink
                                         label={
                                             groupManagementEnabled
-                                                ? 'Users and groups'
+                                                ? 'Users & groups'
                                                 : 'User management'
                                         }
                                         to="/generalSettings/userManagement"
@@ -207,7 +207,11 @@ const Settings: FC = () => {
                                     }),
                                 ) && (
                                     <RouterNavLink
-                                        label="User attributes"
+                                        label={
+                                            groupManagementEnabled
+                                                ? 'User & Group Attributes'
+                                                : 'User attributes'
+                                        }
                                         to="/generalSettings/userAttributes"
                                         exact
                                         icon={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #5444 

### Description:

Add placeholder UI to then assign user attributes to Groups

Update copy for Settings tab label
Fix copy for user attributes: missing link, typos, etc
Change buttons to `edit` and `delete` user attributes by replacing them with `ActionIcon`s. 
Small style changes

Demo (will be complete once BE work is done)

https://github.com/lightdash/lightdash/assets/7611706/665bc1eb-9ca6-4e14-a8f2-a1e75cd1d445

Demo with the feature flag turned off

https://github.com/lightdash/lightdash/assets/7611706/c53c8926-bb30-4ac3-8bbc-db171e8f252e


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
