### PR TITLE
fix: Remedy for disappearing Organisation input issue 8450

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/index.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/index.tsx
@@ -103,7 +103,7 @@ const UserCompletionModal: FC = () => {
                 <Stack>
                     <form name="complete_user" onSubmit={handleSubmit}>
                         <Stack>
-                            {user?.data?.organizationName === '' && (
+                            {user.data?.organizationName === '' && (
                                 <TextInput
                                     label="Organization name"
                                     placeholder="Enter company name"
@@ -123,7 +123,7 @@ const UserCompletionModal: FC = () => {
                             />
 
                             <Stack spacing="xs">
-                                {user?.data?.organizationName === '' &&
+                                {user.data?.organizationName === '' &&
                                     isValidOrganizationDomain && (
                                         <Checkbox
                                             label={`Allow users with @${getEmailDomain(

--- a/packages/frontend/src/components/UserCompletionModal/index.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/index.tsx
@@ -103,7 +103,7 @@ const UserCompletionModal: FC = () => {
                 <Stack>
                     <form name="complete_user" onSubmit={handleSubmit}>
                         <Stack>
-                            {user.data?.organizationName === '' && (
+                            {user?.data?.organizationName === '' && (
                                 <TextInput
                                     label="Organization name"
                                     placeholder="Enter company name"
@@ -123,7 +123,7 @@ const UserCompletionModal: FC = () => {
                             />
 
                             <Stack spacing="xs">
-                                {user.data?.organizationName === '' &&
+                                {user?.data?.organizationName === '' &&
                                     isValidOrganizationDomain && (
                                         <Checkbox
                                             label={`Allow users with @${getEmailDomain(

--- a/packages/frontend/src/components/UserCompletionModal/index.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/index.tsx
@@ -103,7 +103,7 @@ const UserCompletionModal: FC = () => {
                 <Stack>
                     <form name="complete_user" onSubmit={handleSubmit}>
                         <Stack>
-                            {form.values.organizationName === '' && (
+                            {user.data?.organizationName === '' && (
                                 <TextInput
                                     label="Organization name"
                                     placeholder="Enter company name"
@@ -123,7 +123,7 @@ const UserCompletionModal: FC = () => {
                             />
 
                             <Stack spacing="xs">
-                                {form.values.organizationName === '' &&
+                                {user.data?.organizationName === '' &&
                                     isValidOrganizationDomain && (
                                         <Checkbox
                                             label={`Allow users with @${getEmailDomain(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [On the first onboarding screen, the 'Organization Name' input disappears when I try to fill it out](https://github.com/lightdash/lightdash/issues/8450)

### Description:
Fixed the issue where the Organisation input disappears. It also fixes an unreported issue where the checkbox to allow users with a valid domain disappears in the same circumstances.

_BEFORE:_
![image](https://github.com/lightdash/lightdash/assets/11949472/cb6daa59-e004-4b46-8ea5-160f87eccf14)

_AFTER:_
![image](https://github.com/lightdash/lightdash/assets/11949472/af7d50a4-306f-4955-96a9-549010ed77a4)

_NOTES:_
I believe the intention was to check the existence of an existing organisation name and use it to show/hide these form elements. But the check was accidentally made against the form state.  Updated to check against the value loaded from the context instead.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
