### PR TITLE
fix: spaces in date part names

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -189,7 +189,7 @@ const postgresConfig: WarehouseConfig = {
                 `Cannot recognise format expression for ${timeFrame}`,
             );
         }
-        return `TO_CHAR(${originalSql}, '${formatExpression}')`;
+        return `TO_CHAR(${originalSql}, 'FM${formatExpression}')`;
     },
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8447 

### Description:
The extra spacing was just due to how TO_CHAR works in postgres.
We can use the FM option to suppress these.

Documentation link - https://www.postgresql.org/docs/9.2/functions-formatting.html#FUNCTIONS-FORMATTING-NUMERICMOD-TABLE

After updating the code, query becomes - 

![image](https://github.com/lightdash/lightdash/assets/85165953/95e049ef-10cc-430e-be4b-d56ab19afe1a)

Output -

![image](https://github.com/lightdash/lightdash/assets/85165953/c27a815d-b9dc-41cf-82b8-92a9c55d62fa)

Run e2e tests:
test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
