### PR TITLE
feat: override chart filters with dashboard filters

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -8,6 +8,7 @@ import {
     DownloadCsvPayload,
     DownloadFileType,
     DownloadMetricCsv,
+    FeatureFlags,
     ForbiddenError,
     formatItemValue,
     friendlyName,
@@ -52,6 +53,7 @@ import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { UserModel } from '../../models/UserModel';
+import { isFeatureFlagEnabled } from '../../postHog';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { runWorkerThread } from '../../utils';
 import { ProjectService } from '../ProjectService/ProjectService';
@@ -407,10 +409,19 @@ export class CsvService {
                   )
                 : undefined;
 
+        const isDashboardFilterOverrideEnabled: boolean =
+            await isFeatureFlagEnabled(
+                FeatureFlags.DashboardFilterOverridesChartFilters,
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid,
+                },
+            );
         const metricQueryWithDashboardFilters = dashboardFiltersForTile
             ? addDashboardFiltersToMetricQuery(
                   metricQuery,
                   dashboardFiltersForTile,
+                  isDashboardFilterOverrideEnabled,
               )
             : metricQuery;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1372,10 +1372,19 @@ export class ProjectService {
                 dashboardFilters.tableCalculations,
             ),
         };
+        const isDashboardFilterOverrideEnabled: boolean =
+            await isFeatureFlagEnabled(
+                FeatureFlags.DashboardFilterOverridesChartFilters,
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid,
+                },
+            );
         const metricQueryWithDashboardOverrides: MetricQuery = {
             ...addDashboardFiltersToMetricQuery(
                 savedChart.metricQuery,
                 appliedDashboardFilters,
+                isDashboardFilterOverrideEnabled,
             ),
             sorts:
                 dashboardSorts && dashboardSorts.length > 0
@@ -3617,10 +3626,21 @@ export class ProjectService {
                   ),
               }
             : undefined;
+
+        const isDashboardFilterOverrideEnabled: boolean =
+            await isFeatureFlagEnabled(
+                FeatureFlags.DashboardFilterOverridesChartFilters,
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid,
+                },
+            );
+
         const metricQuery: MetricQuery = appliedDashboardFilters
             ? addDashboardFiltersToMetricQuery(
                   savedChart.metricQuery,
                   appliedDashboardFilters,
+                  isDashboardFilterOverrideEnabled,
               )
             : savedChart.metricQuery;
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -30,4 +30,7 @@ export enum FeatureFlags {
 
     /* Shows the two-stage login flow */
     newLoginEnabled = 'new-login-enabled',
+
+    /* Dashboard filters will override chart filters */
+    DashboardFilterOverridesChartFilters = 'dashboard-filter-overrides-chart-filters',
 }

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -142,7 +142,9 @@ export const isAndFilterGroup = (
 export const isFilterGroup = (value: FilterGroupItem): value is FilterGroup =>
     isOrFilterGroup(value) || isAndFilterGroup(value);
 
-export const isFilterRule = (value: ConditionalRule): value is FilterRule =>
+export const isFilterRule = (
+    value: ConditionalRule | FilterGroupItem,
+): value is FilterRule =>
     'id' in value && 'target' in value && 'operator' in value;
 
 export const getFilterRules = (filters: Filters): FilterRule[] => {

--- a/packages/common/src/utils/filters.mock.ts
+++ b/packages/common/src/utils/filters.mock.ts
@@ -1,5 +1,12 @@
 import { ConditionalOperator } from '../types/conditionalRule';
-import { AndFilterGroup, FilterRule, OrFilterGroup } from '../types/filter';
+import {
+    FilterOperator,
+    type AndFilterGroup,
+    type DashboardFilters,
+    type FilterRule,
+    type OrFilterGroup,
+} from '../types/filter';
+import type { MetricQuery } from '../types/metricQuery';
 
 export const chartAndFilterGroup: AndFilterGroup = {
     id: 'fillter-group-1',
@@ -60,3 +67,130 @@ export const dashboardFilterWithSameTargetButDifferentOperator: FilterRule[] = [
         operator: ConditionalOperator.NOT_EQUALS,
     },
 ];
+
+export const metricQueryWithFilters: MetricQuery = {
+    exploreName: 'test',
+    limit: 501,
+    dimensions: ['a_dim1'],
+    metrics: [],
+    sorts: [],
+    tableCalculations: [],
+    filters: {
+        dimensions: {
+            id: 'root',
+            and: [
+                {
+                    id: '1',
+                    target: {
+                        fieldId: 'a_dim1',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: [0],
+                },
+            ],
+        },
+    },
+};
+
+export const dashboardFilters: DashboardFilters = {
+    dimensions: [
+        {
+            id: '4',
+            label: undefined,
+            target: {
+                fieldId: 'a_dim1',
+                tableName: 'test',
+            },
+            operator: ConditionalOperator.EQUALS,
+            values: ['1', '2', '3'],
+        },
+    ],
+    metrics: [],
+    tableCalculations: [],
+};
+
+export const expectedChartWithMergedDashboardFilters: MetricQuery = {
+    exploreName: 'test',
+    dimensions: ['a_dim1'],
+    limit: 501,
+    metrics: [],
+    sorts: [],
+    tableCalculations: [],
+    filters: {
+        dimensions: {
+            and: [
+                {
+                    id: 'root',
+                    and: [
+                        {
+                            id: '1',
+                            target: {
+                                fieldId: 'a_dim1',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [0],
+                        },
+                    ],
+                },
+                {
+                    id: '4',
+                    target: { fieldId: 'a_dim1' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['1', '2', '3'],
+                },
+            ],
+            id: 'uuid',
+        },
+        metrics: {
+            and: [],
+            id: 'uuid',
+        },
+        tableCalculations: {
+            and: [],
+            id: 'uuid',
+        },
+    },
+};
+
+export const expectedChartWithOverrideDashboardFilters: MetricQuery = {
+    exploreName: 'test',
+    dimensions: ['a_dim1'],
+    limit: 501,
+    metrics: [],
+    sorts: [],
+    tableCalculations: [],
+    filters: {
+        dimensions: {
+            and: [
+                {
+                    id: 'root',
+                    and: [
+                        {
+                            id: '1',
+                            target: {
+                                fieldId: 'a_dim1',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['1', '2', '3'],
+                        },
+                    ],
+                },
+                {
+                    id: '4',
+                    target: { fieldId: 'a_dim1' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['1', '2', '3'],
+                },
+            ],
+            id: 'uuid',
+        },
+        metrics: {
+            and: [],
+            id: 'uuid',
+        },
+        tableCalculations: {
+            and: [],
+            id: 'uuid',
+        },
+    },
+};

--- a/packages/common/src/utils/filters.mock.ts
+++ b/packages/common/src/utils/filters.mock.ts
@@ -1,0 +1,62 @@
+import { ConditionalOperator } from '../types/conditionalRule';
+import { AndFilterGroup, FilterRule, OrFilterGroup } from '../types/filter';
+
+export const chartAndFilterGroup: AndFilterGroup = {
+    id: 'fillter-group-1',
+    and: [
+        {
+            id: '1',
+            target: { fieldId: 'field-1' },
+            values: ['1'],
+            disabled: false,
+            operator: ConditionalOperator.EQUALS,
+        },
+        {
+            id: '2',
+            target: { fieldId: 'field-2' },
+            values: ['2'],
+            disabled: false,
+            operator: ConditionalOperator.EQUALS,
+        },
+    ],
+};
+
+export const chartOrFilterGroup: OrFilterGroup = {
+    id: 'fillter-group-1',
+    or: [
+        {
+            id: '3',
+            target: { fieldId: 'field-1' },
+            values: ['1'],
+            disabled: false,
+            operator: ConditionalOperator.EQUALS,
+        },
+        {
+            id: '4',
+            target: { fieldId: 'field-2' },
+            values: ['2'],
+            disabled: false,
+            operator: ConditionalOperator.EQUALS,
+        },
+    ],
+};
+
+export const dashboardFilterWithSameTargetAndOperator: FilterRule[] = [
+    {
+        id: '5',
+        target: { fieldId: 'field-1' },
+        values: ['1', '2', '3'],
+        disabled: false,
+        operator: ConditionalOperator.EQUALS,
+    },
+];
+
+export const dashboardFilterWithSameTargetButDifferentOperator: FilterRule[] = [
+    {
+        id: '5',
+        target: { fieldId: 'field-1' },
+        values: ['1', '2', '3'],
+        disabled: false,
+        operator: ConditionalOperator.NOT_EQUALS,
+    },
+];

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,0 +1,88 @@
+import { ConditionalOperator } from '../types/conditionalRule';
+import { overrideChartFilter } from './filters';
+import {
+    chartAndFilterGroup,
+    chartOrFilterGroup,
+    dashboardFilterWithSameTargetAndOperator,
+    dashboardFilterWithSameTargetButDifferentOperator,
+} from './filters.mock';
+
+describe('overrideChartFilter', () => {
+    test('should override the chart and group filter', async () => {
+        const result = overrideChartFilter(
+            chartAndFilterGroup,
+            dashboardFilterWithSameTargetAndOperator,
+        );
+        expect(result).toEqual({
+            id: 'fillter-group-1',
+            and: [
+                {
+                    id: '1',
+                    target: { fieldId: 'field-1' },
+                    values: ['1', '2', '3'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+                {
+                    id: '2',
+                    target: { fieldId: 'field-2' },
+                    values: ['2'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+            ],
+        });
+    });
+
+    test('should override the chart or group filter', async () => {
+        const result = overrideChartFilter(
+            chartOrFilterGroup,
+            dashboardFilterWithSameTargetAndOperator,
+        );
+        expect(result).toEqual({
+            id: 'fillter-group-1',
+            or: [
+                {
+                    id: '3',
+                    target: { fieldId: 'field-1' },
+                    values: ['1', '2', '3'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+                {
+                    id: '4',
+                    target: { fieldId: 'field-2' },
+                    values: ['2'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+            ],
+        });
+    });
+
+    test('should not override the chart group filter when operator is different', async () => {
+        const result = overrideChartFilter(
+            chartAndFilterGroup,
+            dashboardFilterWithSameTargetButDifferentOperator,
+        );
+        expect(result).toEqual({
+            id: 'fillter-group-1',
+            and: [
+                {
+                    id: '1',
+                    target: { fieldId: 'field-1' },
+                    values: ['1'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+                {
+                    id: '2',
+                    target: { fieldId: 'field-2' },
+                    values: ['2'],
+                    disabled: false,
+                    operator: ConditionalOperator.EQUALS,
+                },
+            ],
+        });
+    });
+});

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,12 +1,41 @@
 import { ConditionalOperator } from '../types/conditionalRule';
-import { overrideChartFilter } from './filters';
+import {
+    addDashboardFiltersToMetricQuery,
+    overrideChartFilter,
+} from './filters';
 import {
     chartAndFilterGroup,
     chartOrFilterGroup,
+    dashboardFilters,
     dashboardFilterWithSameTargetAndOperator,
     dashboardFilterWithSameTargetButDifferentOperator,
+    expectedChartWithMergedDashboardFilters,
+    expectedChartWithOverrideDashboardFilters,
+    metricQueryWithFilters,
 } from './filters.mock';
 
+jest.mock('uuid', () => ({
+    v4: jest.fn(() => 'uuid'),
+}));
+
+describe('addDashboardFiltersToMetricQuery', () => {
+    test('should merge the chart filters with dashboard filters', async () => {
+        const result = addDashboardFiltersToMetricQuery(
+            metricQueryWithFilters,
+            dashboardFilters,
+            false,
+        );
+        expect(result).toEqual(expectedChartWithMergedDashboardFilters);
+    });
+    test('should override the chart filters with dashboard filters', async () => {
+        const result = addDashboardFiltersToMetricQuery(
+            metricQueryWithFilters,
+            dashboardFilters,
+            true,
+        );
+        expect(result).toEqual(expectedChartWithOverrideDashboardFilters);
+    });
+});
 describe('overrideChartFilter', () => {
     test('should override the chart and group filter', async () => {
         const result = overrideChartFilter(

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -598,7 +598,7 @@ const convertDashboardFilterRuleToFilterRule = (
 export const addDashboardFiltersToMetricQuery = (
     metricQuery: MetricQuery,
     dashboardFilters: DashboardFilters,
-    shouldOverride: boolean = false,
+    shouldOverride: boolean,
 ): MetricQuery => {
     const mergeStrategy = shouldOverride
         ? overrideFilterGroupWithFilterRules

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -20,6 +20,8 @@ import {
     FilterType,
     isAndFilterGroup,
     isFilterGroup,
+    isFilterRule,
+    OrFilterGroup,
     UnitOfTime,
     type DashboardFieldTarget,
     type DashboardFilterRule,
@@ -30,6 +32,7 @@ import {
     type FilterGroupItem,
     type FilterRule,
     type Filters,
+    type AndFilterGroup,
 } from '../types/filter';
 import { type MetricQuery } from '../types/metricQuery';
 import { TimeFrames } from '../types/timeFrames';
@@ -519,12 +522,52 @@ export const addFiltersToMetricQuery = (
     },
 });
 
+const findAndOverrideChartFilter = (
+    item: FilterGroupItem,
+    filterRulesList: FilterRule[],
+): FilterGroupItem => {
+    const identicalDashboardFilter = isFilterRule(item)
+        ? filterRulesList.find(
+              (x) =>
+                  x.target.fieldId === item.target.fieldId &&
+                  x.operator === item.operator,
+          )
+        : undefined;
+    return identicalDashboardFilter
+        ? {
+              ...item,
+              values: identicalDashboardFilter.values,
+          }
+        : item;
+};
+
+export const overrideChartFilter = (
+    filterGroup: AndFilterGroup | OrFilterGroup,
+    filterRules: FilterRule[],
+): FilterGroup =>
+    isAndFilterGroup(filterGroup)
+        ? {
+              id: filterGroup.id,
+              and: filterGroup.and.map((item) =>
+                  findAndOverrideChartFilter(item, filterRules),
+              ),
+          }
+        : {
+              id: filterGroup.id,
+              or: filterGroup.or.map((item) =>
+                  findAndOverrideChartFilter(item, filterRules),
+              ),
+          };
+
 const combineFilterGroupWithFilterRules = (
     filterGroup: FilterGroup | undefined,
     filterRules: FilterRule[],
 ): FilterGroup => ({
     id: uuidv4(),
-    and: [...(filterGroup ? [filterGroup] : []), ...filterRules],
+    and: [
+        ...(filterGroup ? [overrideChartFilter(filterGroup, filterRules)] : []),
+        ...filterRules,
+    ],
 });
 
 const convertDashboardFilterRuleToFilterRule = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Relates to: #7268

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Introduces a feature flag to let dashboard filters override the chart filter if they have the same target field. 


https://github.com/lightdash/lightdash/assets/9117144/0a89e223-4ba0-4536-9621-ecb15d3fd779



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
