### PR TITLE
feat: multiple values in required attributes

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -137,7 +137,21 @@ export const assertValidDimensionRequiredAttribute = (
     if (dimension.requiredAttributes)
         Object.entries(dimension.requiredAttributes).map((attribute) => {
             const [attributeName, value] = attribute;
-            if (!hasUserAttribute(userAttributes, attributeName, value)) {
+            let hasUserAttributeVal = false;
+
+            if (typeof value === 'string') {
+                hasUserAttributeVal = hasUserAttribute(
+                    userAttributes,
+                    attributeName,
+                    value,
+                );
+            } else {
+                hasUserAttributeVal = value.some((v) =>
+                    hasUserAttribute(userAttributes, attributeName, v),
+                );
+            }
+
+            if (!hasUserAttributeVal) {
                 throw new ForbiddenError(
                     `Invalid or missing user attribute "${attribute}" on ${field}`,
                 );

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -7,7 +7,7 @@ export const hasUserAttribute = (
 ) => userAttributes[attributeName] === value;
 
 export const hasUserAttributes = (
-    requiredAttributes: Record<string, string> | undefined,
+    requiredAttributes: Record<string, string | string[]> | undefined,
     userAttributes: UserAttributeValueMap,
 ): boolean => {
     if (requiredAttributes === undefined) return true; // No required attributes
@@ -15,7 +15,13 @@ export const hasUserAttributes = (
     // Check all required attributes conditions for dimension
     return Object.entries(requiredAttributes).every((attribute) => {
         const [attributeName, value] = attribute;
-        return hasUserAttribute(userAttributes, attributeName, value);
+
+        if (typeof value === 'string')
+            return hasUserAttribute(userAttributes, attributeName, value);
+
+        return value.some((v) =>
+            hasUserAttribute(userAttributes, attributeName, v),
+        );
     });
 };
 

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -93,7 +93,7 @@ type DbtColumnLightdashDimension = {
     format?: Format;
     group_label?: string;
     urls?: FieldUrl[];
-    required_attributes?: Record<string, string>;
+    required_attributes?: Record<string, string | string[]>;
 };
 
 type DbtColumnLightdashAdditionalDimension = Omit<

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -236,7 +236,7 @@ export interface Dimension extends Field {
     fieldType: FieldType.DIMENSION;
     type: DimensionType;
     group?: string;
-    requiredAttributes?: Record<string, string>;
+    requiredAttributes?: Record<string, string | string[]>;
     timeInterval?: TimeFrames;
     isAdditionalDimension?: boolean;
 }

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -55,7 +55,7 @@ export type FieldSearchResult = Pick<
     | 'table'
     | 'tableLabel'
 > & {
-    requiredAttributes?: Record<string, string>;
+    requiredAttributes?: Record<string, string | string[]>;
     explore: string;
     exploreLabel: string;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8464 
### Description:

Updated `required_attributes` types to `Record<string, string | string[]>` to support string arrays and corresponding code that searches for the required_attributes.

Example:
```
name: first_name
description: Customer's first name
meta:
  dimension:
    ...
    required_attributes:
      group: ["a","b"]
```

Group attribute settings - 
![image](https://github.com/lightdash/lightdash/assets/85165953/ec6018c0-4fb5-4c5f-bdeb-a148596e29c1)

User 1 with group a -
![image](https://github.com/lightdash/lightdash/assets/85165953/79e0618a-c6aa-48d8-9a01-e13c1624f248)

User 2 with group b -
![image](https://github.com/lightdash/lightdash/assets/85165953/6a682110-62a1-4814-a856-5788668bf1cf)

User 3 with group c -
![image](https://github.com/lightdash/lightdash/assets/85165953/c2994227-796e-4c28-a979-1570acaa288d)

User 4 without group attribute -
![image](https://github.com/lightdash/lightdash/assets/85165953/7f221a84-a4e4-4453-96c9-1083d475795d)

I had tested the existing string only required_attributes after the change and it worked fine as well.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
