### PR TITLE
fix: update libcurl3-gnutls on bullseye-backports dependency

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -21,11 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install security updates
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list \
     && apt-get update && apt-get -t bullseye-backports install -y \
-    libcurl3-gnutls=7.88.1-10+deb12u3~bpo11+1
-
-RUN echo "deb http://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y  \
-    zlib1g=1:1.2.13.dfsg-1
+    libcurl3-gnutls=7.88.* 
 
 # Installing multiple versions of dbt
 # dbt 1.4 is the default


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
