### PR TITLE
fix: get screenshot from element instead

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -493,10 +493,8 @@ export class UnfurlService {
                         });
                     }
 
-                    const imageBuffer = await page.screenshot({
+                    const imageBuffer = await element.screenshot({
                         path,
-                        fullPage: true,
-                        captureBeyondViewport: true,
                     });
 
                     return imageBuffer;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Some dashboard screenshots are being cropped because we were targeting the page.screenshot when we should continue targetting the `element`. 

PR that introduced this change was: https://github.com/lightdash/lightdash/pull/8389/files#diff-9b86624a0467c9253f755c66928390e96818008cdd1df400c3509984ce4d1071L473-L475

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
