### PR TITLE
feat: extra large option to export and scheduler

### DIFF
--- a/packages/frontend/src/features/scheduler/constants/index.ts
+++ b/packages/frontend/src/features/scheduler/constants/index.ts
@@ -11,4 +11,8 @@ export const CUSTOM_WIDTH_OPTIONS = [
         label: 'Large (1500px)',
         value: '1500',
     },
+    {
+        label: 'Extra Large (1600px)',
+        value: '1600',
+    },
 ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8276

### Description:

Adds another option for Dashboard exports and Dashboard Scheduled delivery `Preview and customization`

From render:

<img width="665" alt="Screenshot 2024-01-04 at 14 06 33" src="https://github.com/lightdash/lightdash/assets/7611706/70493a23-b5cc-4d1a-8e35-2e2b153c6684">
<img width="814" alt="Screenshot 2024-01-04 at 14 06 20" src="https://github.com/lightdash/lightdash/assets/7611706/04007f3d-ad58-4747-bd19-18001199c315">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
