### PR TITLE
Revert "feat: strict same site cookies"

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -129,7 +129,7 @@ app.use(
             maxAge: (lightdashConfig.cookiesMaxAgeHours || 24) * 60 * 60 * 1000, // in ms
             secure: lightdashConfig.secureCookies,
             httpOnly: true,
-            sameSite: 'strict',
+            sameSite: 'lax',
         },
         resave: false,
         saveUninitialized: false,


### PR DESCRIPTION
Reverts lightdash/lightdash#8374

Because azure login fails with this configuration.

More details in this bug:
https://github.com/lightdash/lightdash/issues/8476