### PR TITLE
fix: incorrect query key in useOrganizationUsers

### DIFF
--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -56,7 +56,7 @@ export const useDeleteOrganizationUserMutation = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
     return useMutation<undefined, ApiError, string>(deleteUserQuery, {
-        mutationKey: ['saved_query_create'],
+        mutationKey: ['organization_users_delete'],
         onSuccess: async () => {
             await queryClient.invalidateQueries('organization_users');
             showToastSuccess({


### PR DESCRIPTION
### Description:

Small thing I noticed while doing group work. This query key wasn't right. I dont think it's causing any noticeable problems, but we might as well add this. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
