### PR TITLE
feat: add user details to delete dialog

### DIFF
--- a/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
@@ -49,7 +49,7 @@ describe('Settings - Invites', () => {
             .contains('tr', 'demo+marygreen@lightdash.com')
             .find('.tabler-icon-trash')
             .click({ force: true });
-        cy.findByText('Are you sure you want to delete this user ?')
+        cy.findByText('Are you sure you want to delete this user?')
             .parents('.mantine-Modal-root')
             .findByText('Delete')
             .click();


### PR DESCRIPTION
### Description:

Updates the user-delete dialog to show information about the user being deleted. Before it felt a bit like a prayer 😅. There is also a bit of a refactor of the user list here that is going to be necessary to add some of the group interactions. 

Before (who are you deleting?!)
<img width="479" alt="Screenshot 2024-01-04 at 17 46 48" src="https://github.com/lightdash/lightdash/assets/1864179/b1d0f620-6e1c-41a0-a7a3-e77df04938d2">

With this update
<img width="495" alt="Screenshot 2024-01-04 at 17 46 26" src="https://github.com/lightdash/lightdash/assets/1864179/05e681f0-1723-4af2-a564-dc2bab77d787">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
