### PR TITLE
fix: show SSO authentication error once

### DIFF
--- a/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
@@ -6,9 +6,11 @@ import {
 } from '@lightdash/common';
 import { ActionIcon, Card, Group, Stack, Text } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { Entries } from 'type-fest';
 import useHealth from '../../../hooks/health/useHealth';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import {
     useDeleteOpenIdentityMutation,
     useOpenIdentities,
@@ -40,8 +42,18 @@ const isIssuerTypeAvailable = (
 const SocialLoginsPanel: FC = () => {
     const { data: health } = useHealth();
     const { data: userSocialLogins } = useOpenIdentities();
-
     const deleteMutation = useDeleteOpenIdentityMutation();
+    const { showToastError } = useToaster();
+    const flashMessages = useFlashMessages();
+
+    useEffect(() => {
+        if (flashMessages.data?.error) {
+            showToastError({
+                title: 'Failed to authenticate',
+                subtitle: flashMessages.data.error.join('\n'),
+            });
+        }
+    }, [flashMessages.data, showToastError]);
 
     if (!health) return null;
 

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -4,8 +4,6 @@ import {
 } from '@lightdash/common';
 import { Button, ButtonProps, Image } from '@mantine/core';
 import { FC } from 'react';
-import useToaster from '../../../hooks/toaster/useToaster';
-import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import { useApp } from '../../../providers/AppProvider';
 
 type ThirdPartySignInButtonProps = {
@@ -33,16 +31,6 @@ const ThirdPartySignInButtonBase: FC<
     redirect,
     ...props
 }) => {
-    const { showToastError } = useToaster();
-    const flashMessages = useFlashMessages();
-
-    if (flashMessages.data?.error) {
-        showToastError({
-            title: 'Failed to authenticate',
-            subtitle: flashMessages.data.error.join('\n'),
-        });
-    }
-
     return (
         <Button
             variant="default"

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -26,6 +26,7 @@ import PageSpinner from '../components/PageSpinner';
 import CreateUserForm from '../components/RegisterForms/CreateUserForm';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
+import { useFlashMessages } from '../hooks/useFlashMessages';
 import { useInviteLink } from '../hooks/useInviteLink';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
@@ -102,6 +103,16 @@ const Invite: FC = () => {
     const { inviteCode } = useParams<{ inviteCode: string }>();
     const { health } = useApp();
     const { showToastError } = useToaster();
+    const flashMessages = useFlashMessages();
+
+    useEffect(() => {
+        if (flashMessages.data?.error) {
+            showToastError({
+                title: 'Failed to authenticate',
+                subtitle: flashMessages.data.error.join('\n'),
+            });
+        }
+    }, [flashMessages.data, showToastError]);
     const { search } = useLocation();
     const { identify } = useTracking();
     const redirectUrl = '/';

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -29,6 +29,7 @@ import Page from '../components/common/Page/Page';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
 import PageSpinner from '../components/PageSpinner';
 import useToaster from '../hooks/toaster/useToaster';
+import { useFlashMessages } from '../hooks/useFlashMessages';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
@@ -46,6 +47,17 @@ const LoginContent: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
     const { health } = useApp();
     const { showToastError } = useToaster();
+    const flashMessages = useFlashMessages();
+
+    useEffect(() => {
+        if (flashMessages.data?.error) {
+            showToastError({
+                title: 'Failed to authenticate',
+                subtitle: flashMessages.data.error.join('\n'),
+            });
+        }
+    }, [flashMessages.data, showToastError]);
+
     const redirectUrl = location.state?.from
         ? `${location.state.from.pathname}${location.state.from.search}`
         : '/';

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -13,7 +13,7 @@ import {
     Text,
     Title,
 } from '@mantine/core';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useLocation } from 'react-router-dom';
 import { lightdashApi } from '../api';
@@ -22,6 +22,7 @@ import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInBut
 import PageSpinner from '../components/PageSpinner';
 import CreateUserForm from '../components/RegisterForms/CreateUserForm';
 import useToaster from '../hooks/toaster/useToaster';
+import { useFlashMessages } from '../hooks/useFlashMessages';
 import { useApp } from '../providers/AppProvider';
 import { useTracking } from '../providers/TrackingProvider';
 import LightdashLogo from '../svgs/lightdash-black.svg';
@@ -37,6 +38,16 @@ const Register: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
     const { health } = useApp();
     const { showToastError } = useToaster();
+    const flashMessages = useFlashMessages();
+
+    useEffect(() => {
+        if (flashMessages.data?.error) {
+            showToastError({
+                title: 'Failed to authenticate',
+                subtitle: flashMessages.data.error.join('\n'),
+            });
+        }
+    }, [flashMessages.data, showToastError]);
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
     const { identify } = useTracking();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Quick fix with duplication. We need to extract the authentication form to a separate component since is duplicated across all these pages.

Before: we show a toast each time the sso button rerenders

<img width="1634" alt="Screenshot 2024-01-04 at 18 17 09" src="https://github.com/lightdash/lightdash/assets/9117144/9f149db5-5c8c-4940-b730-d3ab9e72f55c">


After: renders once
<img width="1579" alt="Screenshot 2024-01-04 at 18 46 30" src="https://github.com/lightdash/lightdash/assets/9117144/f087cf31-addb-47d7-9dee-ad8609a5bec5">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
