### PR TITLE
feat: granular date part options for date dimensions

### DIFF
--- a/docs/docs/references/dimensions.mdx
+++ b/docs/docs/references/dimensions.mdx
@@ -221,6 +221,8 @@ You can see all of the interval options for date and timestamp fields below.
 | MONTH_NUM         | Month number                 | Number | 7               |                                                                               |
 | QUARTER_NUM       | Quarter number               | Number | 3               |                                                                               |
 | YEAR_NUM          | Year number                  | Number | 2019            |                                                                               |
+| MINUTE_OF_HOUR_NUM| Minute number                | Number | 50              |                                                                               |
+| HOUR_OF_DAY_NUM   | Hour number                  | Number | 22              |                                                                               |
 
 ### String options
 

--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -27,6 +27,8 @@ models:
               - QUARTER_NAME
               - YEAR
               - YEAR_NUM
+              - HOUR_OF_DAY_NUM
+              - MINUTE_OF_HOUR_NUM
       - name: timestamp_ntz
         description: ""
         meta:

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -272,7 +272,9 @@
                                                                     "DAY_OF_MONTH_NUM",
                                                                     "DAY_OF_YEAR_NUM",
                                                                     "QUARTER_NUM",
-                                                                    "YEAR_NUM"
+                                                                    "YEAR_NUM",
+                                                                    "HOUR_OF_DAY_NUM",
+                                                                    "MINUTE_OF_HOUR_NUM"
                                                                 ]
                                                             }
                                                         },

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -21,6 +21,8 @@ export enum TimeFrames {
     DAY_OF_WEEK_NAME = 'DAY_OF_WEEK_NAME',
     MONTH_NAME = 'MONTH_NAME',
     QUARTER_NAME = 'QUARTER_NAME',
+    HOUR_OF_DAY_NUM = 'HOUR_OF_DAY_NUM',
+    MINUTE_OF_HOUR_NUM = 'MINUTE_OF_HOUR_NUM',
 }
 
 export enum DateGranularity {

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -38,6 +38,8 @@ const nullTimeFrameMap: Record<TimeFrames, null> = {
     WEEK: null,
     YEAR: null,
     YEAR_NUM: null,
+    HOUR_OF_DAY_NUM: null,
+    MINUTE_OF_HOUR_NUM: null,
 };
 
 const timeFrameToDatePartMap: Record<TimeFrames, string | null> = {
@@ -48,6 +50,8 @@ const timeFrameToDatePartMap: Record<TimeFrames, string | null> = {
     [TimeFrames.MONTH_NUM]: 'MONTH',
     [TimeFrames.QUARTER_NUM]: 'QUARTER',
     [TimeFrames.YEAR_NUM]: 'YEAR',
+    [TimeFrames.HOUR_OF_DAY_NUM]: 'HOUR',
+    [TimeFrames.MINUTE_OF_HOUR_NUM]: 'MINUTE',
 };
 
 type WarehouseConfig = {
@@ -456,6 +460,20 @@ export const timeFrameConfigs: Record<TimeFrames, TimeFrameConfig> = {
         getAxisMinInterval: () => null,
         getAxisLabelFormatter: () => null,
     },
+    HOUR_OF_DAY_NUM: {
+        getLabel: () => 'Hour of day (number)',
+        getDimensionType: () => DimensionType.NUMBER,
+        getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
+        getAxisLabelFormatter: () => null,
+    },
+    MINUTE_OF_HOUR_NUM: {
+        getLabel: () => 'Minute of hour (number)',
+        getDimensionType: () => DimensionType.NUMBER,
+        getSql: getSqlForDatePart,
+        getAxisMinInterval: () => null,
+        getAxisLabelFormatter: () => null,
+    },
 };
 
 export const getDefaultTimeFrames = (type: DimensionType) =>
@@ -500,6 +518,8 @@ const timeFrameOrder = [
     TimeFrames.QUARTER_NAME,
     TimeFrames.YEAR,
     TimeFrames.YEAR_NUM,
+    TimeFrames.HOUR_OF_DAY_NUM,
+    TimeFrames.MINUTE_OF_HOUR_NUM,
 ];
 
 export const sortTimeFrames = (a: TimeFrames, b: TimeFrames) =>

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -295,6 +295,8 @@ const testTimeIntervalsResults = (
                 'events_timestamp_tz_quarter_name',
                 'events_timestamp_tz_year',
                 'events_timestamp_tz_year_num',
+                'events_timestamp_tz_hour_of_day_num',
+                'events_timestamp_tz_minute_of_hour_num',
             ],
             metrics: [],
             filters: {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8139 

### Description:
Added granular date options - `hour_of_day` and `minute_of_hour` date options to existing time frames.

Example - 

Table field view -

![image](https://github.com/lightdash/lightdash/assets/85165953/377121da-1eba-4ded-ba45-22b66cee8c36)

Output -

1) Results -

![image](https://github.com/lightdash/lightdash/assets/85165953/f6616912-4b7d-41c1-ace6-5d83f7b964a4)

2) SQL -

![image](https://github.com/lightdash/lightdash/assets/85165953/d081cefc-974c-4b08-b09e-175d17fd941f)

Another Example output with Filters - 

![image](https://github.com/lightdash/lightdash/assets/85165953/507648df-c521-4071-9877-dd32abbbf941)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
