### PR TITLE
fix: error when using groups with members

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
@@ -40,7 +40,7 @@ const GroupListItem: FC<{
             </td>
 
             <td>
-                {group.members.length > 0 ? (
+                {group?.members.length > 0 ? (
                     <Group
                         spacing="xxs"
                         maw={400}

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -29,7 +29,7 @@ export const useOrganizationGroups = (
 ) => {
     const setErrorResponse = useQueryError();
     return useQuery<GroupWithMembers[], ApiError>({
-        queryKey: ['organization_groups', includeMembers, queryOptions],
+        queryKey: ['organization_groups', includeMembers],
         queryFn: () => getOrganizationGroupsQuery(includeMembers),
         onError: (result) => setErrorResponse(result),
         ...queryOptions,

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -29,7 +29,7 @@ export const useOrganizationGroups = (
 ) => {
     const setErrorResponse = useQueryError();
     return useQuery<GroupWithMembers[], ApiError>({
-        queryKey: ['organization_groups'],
+        queryKey: ['organization_groups', includeMembers, queryOptions],
         queryFn: () => getOrganizationGroupsQuery(includeMembers),
         onError: (result) => setErrorResponse(result),
         ...queryOptions,


### PR DESCRIPTION
### Description:

Some group fetches include members, and some don't. We weren't using the member count as part of the query key, so it wasn't being refetched. That caused an error. This fixes that by including member count in the query key. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
