### PR TITLE
fix: show invalid dashboard filters

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -1,7 +1,9 @@
 import { Group, Skeleton } from '@mantine/core';
 import { FC } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
+import { FieldWithSuggestions } from '../../common/Filters/FiltersProvider';
 import Filter from '../Filter';
+import InvalidFilter from '../InvalidFilter';
 
 interface ActiveFiltersProps {
     isEditMode: boolean;
@@ -52,13 +54,15 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
 
     return (
         <>
-            {dashboardFilters.dimensions
-                .filter((item) => !!fieldsWithSuggestions[item.target.fieldId])
-                .map((item, index) => (
+            {dashboardFilters.dimensions.map((item, index) => {
+                const field = fieldsWithSuggestions[item.target.fieldId] as
+                    | FieldWithSuggestions
+                    | undefined;
+                return field ? (
                     <Filter
                         key={item.id}
                         isEditMode={isEditMode}
-                        field={fieldsWithSuggestions[item.target.fieldId]}
+                        field={field}
                         filterRule={item}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
@@ -75,16 +79,28 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                             )
                         }
                     />
-                ))}
+                ) : (
+                    <InvalidFilter
+                        key={item.id}
+                        isEditMode={isEditMode}
+                        filterRule={item}
+                        onRemove={() =>
+                            removeDimensionDashboardFilter(index, false)
+                        }
+                    />
+                );
+            })}
 
-            {dashboardTemporaryFilters.dimensions
-                .filter((item) => !!fieldsWithSuggestions[item.target.fieldId])
-                .map((item, index) => (
+            {dashboardTemporaryFilters.dimensions.map((item, index) => {
+                const field = fieldsWithSuggestions[item.target.fieldId] as
+                    | FieldWithSuggestions
+                    | undefined;
+                return field ? (
                     <Filter
                         key={item.id}
                         isTemporary
                         isEditMode={isEditMode}
-                        field={fieldsWithSuggestions[item.target.fieldId]}
+                        field={field}
                         filterRule={item}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
@@ -101,7 +117,17 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                             )
                         }
                     />
-                ))}
+                ) : (
+                    <InvalidFilter
+                        key={item.id}
+                        isEditMode={isEditMode}
+                        filterRule={item}
+                        onRemove={() =>
+                            removeDimensionDashboardFilter(index, false)
+                        }
+                    />
+                );
+            })}
         </>
     );
 };

--- a/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
@@ -1,0 +1,66 @@
+import { DashboardFilterRule } from '@lightdash/common';
+import {
+    Button,
+    CloseButton,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine/core';
+import { IconAlertTriangleFilled } from '@tabler/icons-react';
+import { FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+
+type Props = {
+    isEditMode: boolean;
+    filterRule: DashboardFilterRule;
+    onRemove?: () => void;
+};
+
+const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
+    const theme = useMantineTheme();
+    return (
+        <Tooltip
+            position="top-start"
+            withinPortal
+            offset={0}
+            arrowOffset={16}
+            label={
+                <Text span>
+                    <Text span color="gray.6">
+                        Tried to reference field with unknown id:
+                    </Text>
+                    <Text span> {filterRule.target.fieldId}</Text>
+                </Text>
+            }
+        >
+            <Button
+                size="xs"
+                variant="default"
+                data-disabled
+                leftIcon={
+                    <MantineIcon
+                        icon={IconAlertTriangleFilled}
+                        color="red.6"
+                        style={{ color: theme.colors.red[6] }}
+                    />
+                }
+                sx={{
+                    '&[data-disabled="true"]': {
+                        pointerEvents: 'all',
+                    },
+                }}
+                rightIcon={
+                    isEditMode && <CloseButton size="sm" onClick={onRemove} />
+                }
+            >
+                <Text fz="xs">
+                    <Text fw={600} span>
+                        Invalid filter
+                    </Text>
+                </Text>
+            </Button>
+        </Tooltip>
+    );
+};
+
+export default InvalidFilter;

--- a/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
@@ -6,7 +6,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { IconAlertTriangleFilled } from '@tabler/icons-react';
+import { IconAlertTriangle } from '@tabler/icons-react';
 import { FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 
@@ -39,7 +39,7 @@ const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
                 data-disabled
                 leftIcon={
                     <MantineIcon
-                        icon={IconAlertTriangleFilled}
+                        icon={IconAlertTriangle}
                         color="red.6"
                         style={{ color: theme.colors.red[6] }}
                     />

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -19,7 +19,7 @@ import {
     useMantineTheme,
 } from '@mantine/core';
 import {
-    IconAlertTriangleFilled,
+    IconAlertTriangle,
     IconPencil,
     IconRotate2,
 } from '@tabler/icons-react';
@@ -117,7 +117,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                 <Stack key={dashboardFilter.id} spacing="xs" w="100%">
                     <Group spacing="xs">
                         <MantineIcon
-                            icon={IconAlertTriangleFilled}
+                            icon={IconAlertTriangle}
                             color="red.6"
                             style={{ color: theme.colors.red[6] }}
                         />

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -16,8 +16,13 @@ import {
     Stack,
     Text,
     Tooltip,
+    useMantineTheme,
 } from '@mantine/core';
-import { IconPencil, IconRotate2 } from '@tabler/icons-react';
+import {
+    IconAlertTriangleFilled,
+    IconPencil,
+    IconRotate2,
+} from '@tabler/icons-react';
 import { FC, useCallback, useMemo, useState } from 'react';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
@@ -27,6 +32,7 @@ import {
     getFilterOperatorOptions,
 } from '../../../components/common/Filters/FilterInputs';
 import {
+    FieldWithSuggestions,
     FiltersProvider,
     useFiltersContext,
 } from '../../../components/common/Filters/FiltersProvider';
@@ -80,18 +86,16 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
     onRevert,
     hasChanged,
 }) => {
+    const theme = useMantineTheme();
     const { fieldsMap } = useFiltersContext();
-    const field = fieldsMap[dashboardFilter.target.fieldId];
+    const field = fieldsMap[dashboardFilter.target.fieldId] as
+        | FieldWithSuggestions
+        | undefined;
     const [isEditing, setIsEditing] = useState(false);
 
     const filterType = useMemo(() => {
         return field ? getFilterTypeFromItem(field) : FilterType.STRING;
     }, [field]);
-
-    const filterSummary = getConditionalRuleLabel(
-        schedulerFilter ?? dashboardFilter,
-        field,
-    );
 
     const isDisabled = useMemo(
         () => Boolean((schedulerFilter ?? dashboardFilter).disabled),
@@ -101,6 +105,36 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
     const filterOperatorOptions = useMemo(() => {
         return getFilterOperatorOptions(filterType);
     }, [filterType]);
+
+    if (!field) {
+        // show invalid dashboard filter
+        return (
+            <Group spacing="xs" align="flex-start" noWrap>
+                <ActionIcon size="xs" disabled>
+                    <MantineIcon icon={IconRotate2} />
+                </ActionIcon>
+
+                <Stack key={dashboardFilter.id} spacing="xs" w="100%">
+                    <Group spacing="xs">
+                        <MantineIcon
+                            icon={IconAlertTriangleFilled}
+                            color="red.6"
+                            style={{ color: theme.colors.red[6] }}
+                        />
+                        <Text span fw={500}>
+                            Invalid filter
+                        </Text>
+                        <Text fw={400} span>
+                            <Text span color="gray.6">
+                                Tried to reference field with unknown id:
+                            </Text>
+                            <Text span> {dashboardFilter.target.fieldId}</Text>
+                        </Text>
+                    </Group>
+                </Stack>
+            </Group>
+        );
+    }
 
     return (
         <Group spacing="xs" align="flex-start" noWrap>
@@ -137,7 +171,10 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                     <>
                         {isEditing || hasChanged ? null : (
                             <FilterSummaryLabel
-                                filterSummary={filterSummary}
+                                filterSummary={getConditionalRuleLabel(
+                                    schedulerFilter ?? dashboardFilter,
+                                    field,
+                                )}
                                 isDisabled={isDisabled}
                             />
                         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8488 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fixes 2 issues when there are invalid dashboard filters:
- updating & removing valid filters would affect a different filter
- creating & updating scheduled deliveries would crash page


View mode
<img width="1374" alt="Screenshot 2024-01-05 at 14 28 04" src="https://github.com/lightdash/lightdash/assets/9117144/7ee706a2-88da-4838-9c8b-d340faee3102">

View mode + tooltip
<img width="1373" alt="Screenshot 2024-01-05 at 14 28 15" src="https://github.com/lightdash/lightdash/assets/9117144/c3616690-a2b0-4d56-9ed1-392f6fedf49a">

Edit mode
<img width="1373" alt="Screenshot 2024-01-05 at 14 28 25" src="https://github.com/lightdash/lightdash/assets/9117144/363eb6fe-593d-4813-8e75-135d9c69c09a">

Schedule delivery filter
<img width="667" alt="Screenshot 2024-01-05 at 10 56 20" src="https://github.com/lightdash/lightdash/assets/9117144/2462168f-e54e-41b5-b7d6-5cff9773d3b5">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
