### PR TITLE
feat: add disabled edit tile content option

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -173,24 +173,35 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                             )}
                                             {isEditMode && (
                                                 <>
-                                                    {!belongsToDashboard && (
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconEdit
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                setIsEditingTileContent(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Edit tile content
-                                                        </Menu.Item>
-                                                    )}
+                                                    <Tooltip
+                                                        disabled={
+                                                            !belongsToDashboard
+                                                        }
+                                                        label="Tile content in charts from dashboards is not editable"
+                                                    >
+                                                        <Box>
+                                                            <Menu.Item
+                                                                icon={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconEdit
+                                                                        }
+                                                                    />
+                                                                }
+                                                                onClick={() =>
+                                                                    setIsEditingTileContent(
+                                                                        true,
+                                                                    )
+                                                                }
+                                                                disabled={
+                                                                    belongsToDashboard
+                                                                }
+                                                            >
+                                                                Edit tile
+                                                                content
+                                                            </Menu.Item>
+                                                        </Box>
+                                                    </Tooltip>
                                                     {belongsToDashboard ? (
                                                         <Menu.Item
                                                             color="red"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to PR #8407 

### Description:
Refer to comments in above mentioned PR.

For Charts created within dashboard, added an `edit tile content` button disabled with a tooltip explaining that `charts from dashboards aren't editable`

Example Output: Chart created within dashboard

![image](https://github.com/lightdash/lightdash/assets/85165953/6fa2aac6-a06c-43b3-ac4a-d256531026d1)

On Hover:

![image](https://github.com/lightdash/lightdash/assets/85165953/cbcc0ea6-8d81-4bb5-bcf5-ed6b1c3d6c4f)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
