### PR TITLE
chore: add table for group attribute mappings

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -152,8 +152,10 @@ import {
     SshKeyPairTableName,
 } from '../database/entities/ssh_key_pairs';
 import {
+    DbGroupUserAttribute,
     DbOrganizationMemberUserAttribute,
     DbUserAttribute,
+    GroupUserAttributesTable,
     OrganizationMemberUserAttributesTable,
     UserAttributesTable,
 } from '../database/entities/userAttributes';
@@ -221,6 +223,7 @@ declare module 'knex/types/tables' {
         [SshKeyPairTableName]: SshKeyPairTable;
         [UserAttributesTable]: DbUserAttribute;
         [OrganizationMemberUserAttributesTable]: DbOrganizationMemberUserAttribute;
+        [GroupUserAttributesTable]: DbGroupUserAttribute;
         [SavedChartCustomDimensionsTableName]: SavedChartCustomDimensionsTable;
     }
 }

--- a/packages/backend/src/database/entities/userAttributes.ts
+++ b/packages/backend/src/database/entities/userAttributes.ts
@@ -16,6 +16,15 @@ export type DbOrganizationMemberUserAttribute = {
     value: string;
 };
 
+export type DbGroupUserAttribute = {
+    group_id: number;
+    organization_id: number;
+    user_attribute_uuid: string;
+    value: string;
+};
+
 export const UserAttributesTable = 'user_attributes';
 export const OrganizationMemberUserAttributesTable =
     'organization_member_user_attributes';
+
+export const GroupUserAttributesTable = 'group_user_attributes';

--- a/packages/backend/src/database/entities/userAttributes.ts
+++ b/packages/backend/src/database/entities/userAttributes.ts
@@ -18,7 +18,7 @@ export type DbOrganizationMemberUserAttribute = {
 
 export type DbGroupUserAttribute = {
     group_id: number;
-    organization_id: number;
+    group_uuid: string;
     user_attribute_uuid: string;
     value: string;
 };

--- a/packages/backend/src/database/entities/userAttributes.ts
+++ b/packages/backend/src/database/entities/userAttributes.ts
@@ -17,7 +17,6 @@ export type DbOrganizationMemberUserAttribute = {
 };
 
 export type DbGroupUserAttribute = {
-    group_id: number;
     group_uuid: string;
     user_attribute_uuid: string;
     value: string;

--- a/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
+++ b/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const userAttributesTableName = 'user_attributes';
+const groupUserAttributes = 'group_user_attributes';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(groupUserAttributes))) {
+        await knex.schema.createTable(groupUserAttributes, (table) => {
+            table.uuid('group_uuid').notNullable();
+            table.integer('organization_id').notNullable();
+
+            table
+                .foreign(['group_uuid', 'organization_id'])
+                .references(['group_uuid', 'organization_id'])
+                .inTable('groups')
+                .onDelete('CASCADE');
+            table.uuid('user_attribute_uuid').notNullable();
+            table
+                .foreign(['user_attribute_uuid', 'organization_id'])
+                .references(['user_attribute_uuid', 'organization_id'])
+                .inTable(userAttributesTableName)
+                .onDelete('CASCADE');
+            table.string('value').notNullable();
+            table.primary(['group_uuid', 'user_attribute_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(groupUserAttributes);
+}

--- a/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
+++ b/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
@@ -8,16 +8,15 @@ export async function up(knex: Knex): Promise<void> {
         await knex.schema.createTable(groupUserAttributes, (table) => {
             table.uuid('group_uuid').notNullable();
             table.integer('organization_id').notNullable();
-
             table
-                .foreign(['group_uuid', 'organization_id'])
-                .references(['group_uuid', 'organization_id'])
+                .foreign('group_uuid')
+                .references('group_uuid')
                 .inTable('groups')
                 .onDelete('CASCADE');
             table.uuid('user_attribute_uuid').notNullable();
             table
-                .foreign(['user_attribute_uuid', 'organization_id'])
-                .references(['user_attribute_uuid', 'organization_id'])
+                .foreign('user_attribute_uuid')
+                .references('user_attribute_uuid')
                 .inTable(userAttributesTableName)
                 .onDelete('CASCADE');
             table.string('value').notNullable();

--- a/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
+++ b/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
@@ -6,15 +6,15 @@ const groupUserAttributes = 'group_user_attributes';
 export async function up(knex: Knex): Promise<void> {
     if (!(await knex.schema.hasTable(groupUserAttributes))) {
         await knex.schema.createTable(groupUserAttributes, (table) => {
-            table.uuid('group_uuid').notNullable();
             table
-                .foreign('group_uuid')
+                .uuid('group_uuid')
+                .notNullable()
                 .references('group_uuid')
                 .inTable('groups')
                 .onDelete('CASCADE');
-            table.uuid('user_attribute_uuid').notNullable();
             table
-                .foreign('user_attribute_uuid')
+                .uuid('user_attribute_uuid')
+                .notNullable()
                 .references('user_attribute_uuid')
                 .inTable(userAttributesTableName)
                 .onDelete('CASCADE');

--- a/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
+++ b/packages/backend/src/database/migrations/20240108152115_group_attributes.ts
@@ -7,7 +7,6 @@ export async function up(knex: Knex): Promise<void> {
     if (!(await knex.schema.hasTable(groupUserAttributes))) {
         await knex.schema.createTable(groupUserAttributes, (table) => {
             table.uuid('group_uuid').notNullable();
-            table.integer('organization_id').notNullable();
             table
                 .foreign('group_uuid')
                 .references('group_uuid')


### PR DESCRIPTION
### Description:

Add table mapping groups to user attributes. 

Note that the groups table references the same user attributes table, `user_attributes` as the user attributes.

We could potentially clean up some of the names here.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
