### PR TITLE
feat: update groups when users sign up and in (okta)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -87,6 +87,7 @@
         "node-fetch": "^2.6.1",
         "nodemailer": "^6.9.5",
         "nodemailer-express-handlebars": "^6.1.0",
+        "openid-client": "^5.6.4",
         "passport": "^0.6.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-google-oidc": "^0.1.0",

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -5,6 +5,8 @@ declare module 'express-session' {
         oauth: {
             inviteCode?: string | undefined;
             returnTo?: string | undefined;
+            codeVerifier?: string | undefined;
+            state?: string | undefined;
         };
     }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -26,9 +26,10 @@ import {
     apiKeyPassportStrategy,
     googlePassportStrategy,
     localPassportStrategy,
-    oktaPassportStrategy,
+    isOktaPassportStrategyAvailableToUse,
     azureAdPassportStrategy,
     oneLoginPassportStrategy,
+    OpenIDClientOktaStrategy,
 } from './controllers/authentication';
 import database from './database/database';
 import { errorHandler } from './errors';
@@ -260,8 +261,8 @@ if (googlePassportStrategy) {
     passport.use(googlePassportStrategy);
     refresh.use(googlePassportStrategy);
 }
-if (oktaPassportStrategy) {
-    passport.use('okta', oktaPassportStrategy);
+if (isOktaPassportStrategyAvailableToUse) {
+    passport.use('okta', new OpenIDClientOktaStrategy());
 }
 if (oneLoginPassportStrategy) {
     passport.use('oneLogin', oneLoginPassportStrategy);

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -3,6 +3,7 @@ import passport from 'passport';
 import { lightdashConfig } from '../config/lightdashConfig';
 import {
     getSuccessURLWithReturnTo,
+    initiateOktaOpenIdLogin,
     redirectOIDC,
     storeOIDCRedirect,
 } from '../controllers/authentication';
@@ -63,9 +64,7 @@ apiV1Router.post('/login', passport.authenticate('local'), (req, res, next) => {
 apiV1Router.get(
     lightdashConfig.auth.okta.loginPath,
     storeOIDCRedirect,
-    passport.authenticate('okta', {
-        scope: ['openid', 'profile', 'email'],
-    }),
+    initiateOktaOpenIdLogin,
 );
 
 apiV1Router.get(lightdashConfig.auth.okta.callbackPath, (req, res, next) =>

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -39,6 +39,7 @@ import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
+import { GroupsModel } from '../models/GroupsModel';
 import { InviteLinkModel } from '../models/InviteLinkModel';
 import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
@@ -51,6 +52,7 @@ import { UserModel } from '../models/UserModel';
 type UserServiceDependencies = {
     inviteLinkModel: InviteLinkModel;
     userModel: UserModel;
+    groupsModel: GroupsModel;
     sessionModel: SessionModel;
     emailModel: EmailModel;
     openIdIdentityModel: OpenIdIdentityModel;
@@ -66,6 +68,8 @@ export class UserService {
     private readonly inviteLinkModel: InviteLinkModel;
 
     private readonly userModel: UserModel;
+
+    private readonly groupsModel: GroupsModel;
 
     private readonly sessionModel: SessionModel;
 
@@ -92,6 +96,7 @@ export class UserService {
     constructor({
         inviteLinkModel,
         userModel,
+        groupsModel,
         sessionModel,
         emailModel,
         openIdIdentityModel,
@@ -104,6 +109,7 @@ export class UserService {
     }: UserServiceDependencies) {
         this.inviteLinkModel = inviteLinkModel;
         this.userModel = userModel;
+        this.groupsModel = groupsModel;
         this.sessionModel = sessionModel;
         this.emailModel = emailModel;
         this.openIdIdentityModel = openIdIdentityModel;
@@ -335,6 +341,18 @@ export class UserService {
                     loginProvider: 'google',
                 },
             });
+
+            if (
+                Array.isArray(openIdUser.openId.groups) &&
+                openIdUser.openId.groups.length &&
+                loginUser.organizationUuid
+            )
+                await this.groupsModel.addUserToGroupsIfExist({
+                    userUuid: loginUser.userUuid,
+                    groups: openIdUser.openId.groups,
+                    organizationUuid: loginUser.organizationUuid,
+                });
+
             return loginUser;
         }
 
@@ -356,6 +374,18 @@ export class UserService {
                     loginProvider: 'google',
                 },
             });
+
+            if (
+                Array.isArray(openIdUser.openId.groups) &&
+                openIdUser.openId.groups.length &&
+                sessionUser.organizationUuid
+            )
+                await this.groupsModel.addUserToGroupsIfExist({
+                    userUuid: sessionUser.userUuid,
+                    groups: openIdUser.openId.groups,
+                    organizationUuid: sessionUser.organizationUuid,
+                });
+
             return sessionUser;
         }
 
@@ -365,6 +395,18 @@ export class UserService {
             inviteCode,
         );
         await this.tryVerifyUserEmail(createdUser, openIdUser.openId.email);
+
+        if (
+            Array.isArray(openIdUser.openId.groups) &&
+            openIdUser.openId.groups.length &&
+            createdUser.organizationUuid
+        )
+            await this.groupsModel.addUserToGroupsIfExist({
+                userUuid: createdUser.userUuid,
+                groups: openIdUser.openId.groups,
+                organizationUuid: createdUser.organizationUuid,
+            });
+
         return createdUser;
     }
 

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -55,6 +55,7 @@ const encryptionService = new EncryptionService({ lightdashConfig });
 export const userService = new UserService({
     inviteLinkModel,
     userModel,
+    groupsModel,
     sessionModel,
     emailModel,
     openIdIdentityModel,

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -57,6 +57,7 @@ export interface OpenIdUser {
         email: string;
         firstName: string | undefined;
         lastName: string | undefined;
+        groups?: string[] | undefined;
     };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10904,6 +10904,11 @@ follow-redirects@^1.15.4:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
+follow-redirects@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
@@ -13372,6 +13377,11 @@ join-component@^1.1.0:
   resolved "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz"
   integrity sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=
 
+jose@^4.15.4:
+  version "4.15.4"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
+  integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz"
@@ -15290,6 +15300,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.10.3, object-inspect@^1.9.0:
   version "1.10.3"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz"
@@ -15415,6 +15430,11 @@ obuf@~1.1.2:
   resolved "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
+oidc-token-hash@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz#9a229f0a1ce9d4fc89bcaee5478c97a889e7b7b6"
+  integrity sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==
+
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
@@ -15462,6 +15482,16 @@ open@^7.3.1, open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+openid-client@^5.6.4:
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.6.4.tgz#b2c25e6d5338ba3ce00e04341bb286798a196177"
+  integrity sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==
+  dependencies:
+    jose "^4.15.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.3"
 
 opentracing@^0.14.4:
   version "0.14.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8498

### Description:

Change Okta Sign up/in flow by using `node-openid-client`: https://github.com/panva/node-openid-client, so that we can get `groups` when requesting `user info`. 
With the previous implementation (using `passport-openidconnect`), the package wouldn't send back `groups` even if they were available: https://github.com/jaredhanson/passport-openidconnect/blob/master/lib/profile.js and relevant issue here: https://github.com/jaredhanson/passport-openidconnect/issues/100

Now, we get the `groups`, create the openId user, and then we add the user to the groups where the Okta group `name` === the `name` of the group in Lightdash. 

Most code on the `OpenIDClientOktaStrategy.authenticate` (which is only used for Okta atm), comes from the readme here: https://github.com/panva/node-openid-client?tab=readme-ov-file#quick-start
^ this includes changes to the current passport strategy, where we utilise a custom strategy. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
