### PR TITLE
feat: filter rows and columns based on group attributes

### DIFF
--- a/packages/backend/src/models/UserAttributesModel.mock.ts
+++ b/packages/backend/src/models/UserAttributesModel.mock.ts
@@ -3,10 +3,27 @@ export const MOCK_GET_ATTR_VALUES_FOR_ORG_MEMBER_FILTERS = {
     userUuid: 'fake_user_uuid',
 };
 export const MOCK_USER_ATTRIBUTES_NAME_DEFAULT_VALUE = [
-    { name: 'fruit', attribute_default: 'default_fruit' },
-    { name: 'vegetable', attribute_default: 'default_vegetable' },
-    { name: 'section', attribute_default: null },
-    { name: 'category', attribute_default: null },
+    {
+        user_attribute_uuid: 'fruit',
+        name: 'fruit',
+        attribute_default: 'default_fruit',
+    },
+    {
+        user_attribute_uuid: 'vegetable',
+        name: 'vegetable',
+        attribute_default: 'default_vegetable',
+    },
+    {
+        user_attribute_uuid: 'section',
+        name: 'section',
+        attribute_default: null,
+    },
+    {
+        user_attribute_uuid: 'category',
+        name: 'category',
+        attribute_default: null,
+    },
+    { user_attribute_uuid: 'area', name: 'area', attribute_default: null },
 ];
 
 export const MOCK_ORG_MEMBER_ATTRIBUTES_VALUE = [
@@ -14,9 +31,15 @@ export const MOCK_ORG_MEMBER_ATTRIBUTES_VALUE = [
     { name: 'section', value: 'user_section' },
 ];
 
+export const MOCK_GROUP_USER_ATTRIBUTES_VALUE = [
+    { name: 'fruit', value: 'group_fruit' },
+    { name: 'area', value: 'group_area' },
+];
+
 export const EXPECTED_ORG_MEMBER_ATTRIBUTE_VALUES = {
-    fruit: 'user_fruit',
-    vegetable: 'default_vegetable',
-    section: 'user_section',
-    category: null,
+    fruit: ['user_fruit', 'group_fruit'], // expect both user and group values
+    vegetable: ['default_vegetable'], // expect default value
+    section: ['user_section'], // expect user value
+    category: [], // expect no value
+    area: ['group_area'], // expect group value
 };

--- a/packages/backend/src/models/UserAttributesModel.test.ts
+++ b/packages/backend/src/models/UserAttributesModel.test.ts
@@ -1,6 +1,7 @@
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import {
+    GroupUserAttributesTable,
     OrganizationMemberUserAttributesTable,
     UserAttributesTable,
 } from '../database/entities/userAttributes';
@@ -8,6 +9,7 @@ import { UserAttributesModel } from './UserAttributesModel';
 import {
     EXPECTED_ORG_MEMBER_ATTRIBUTE_VALUES,
     MOCK_GET_ATTR_VALUES_FOR_ORG_MEMBER_FILTERS,
+    MOCK_GROUP_USER_ATTRIBUTES_VALUE,
     MOCK_ORG_MEMBER_ATTRIBUTES_VALUE,
     MOCK_USER_ATTRIBUTES_NAME_DEFAULT_VALUE,
 } from './UserAttributesModel.mock';
@@ -25,19 +27,22 @@ describe('UserAttributesModel', () => {
         tracker.reset();
     });
 
-    test('should combine attributes default values and org member values', async () => {
+    test('should combine user, group and default attribute values', async () => {
         tracker.on
             .select(UserAttributesTable)
             .responseOnce(MOCK_USER_ATTRIBUTES_NAME_DEFAULT_VALUE);
         tracker.on
             .select(OrganizationMemberUserAttributesTable)
             .responseOnce(MOCK_ORG_MEMBER_ATTRIBUTES_VALUE);
+        tracker.on
+            .select(GroupUserAttributesTable)
+            .responseOnce(MOCK_GROUP_USER_ATTRIBUTES_VALUE);
 
         const dashboard = await model.getAttributeValuesForOrgMember(
             MOCK_GET_ATTR_VALUES_FOR_ORG_MEMBER_FILTERS,
         );
 
         expect(dashboard).toEqual(EXPECTED_ORG_MEMBER_ATTRIBUTE_VALUES);
-        expect(tracker.history.select).toHaveLength(2);
+        expect(tracker.history.select).toHaveLength(3);
     });
 });

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -255,7 +255,7 @@ describe('Query builder', () => {
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
                 userAttributes: {
-                    country: 'EU',
+                    country: ['EU'],
                 },
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_SQL_FILTER);
@@ -286,7 +286,7 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should replace sqlFilter with user attribute', async () => {
-        const userAttributes = { test: '1' };
+        const userAttributes = { test: ['1'] };
         const expected = "'1' > 1";
         expect(
             replaceUserAttributes(
@@ -301,7 +301,7 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should replace sqlFilter with multiple user attributes', async () => {
-        const userAttributes = { test: '1', another: '2' };
+        const userAttributes = { test: ['1'], another: ['2'] };
         const sqlFilter =
             '${dimension} IS NOT NULL OR (${lightdash.attribute.test} > 1 AND ${lightdash.attribute.another} = 2)';
         const expected = "${dimension} IS NOT NULL OR ('1' > 1 AND '2' = 2)";
@@ -311,7 +311,7 @@ describe('replaceUserAttributes', () => {
     });
 
     it('method should replace sqlFilter using short aliases', async () => {
-        const userAttributes = { test: '1', another: '2' };
+        const userAttributes = { test: ['1'], another: ['2'] };
         const expected = "'1' > 1";
         expect(
             replaceUserAttributes('${ld.attribute.test} > 1', userAttributes),
@@ -371,7 +371,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
                         is_admin: 'true',
                     },
                 },
-                { is_admin: 'false' },
+                { is_admin: ['false'] },
                 '',
             ),
         ).toThrowError(ForbiddenError);
@@ -385,7 +385,7 @@ describe('assertValidDimensionRequiredAttribute', () => {
                     is_admin: 'true',
                 },
             },
-            { is_admin: 'true' },
+            { is_admin: ['true'] },
             '',
         );
 

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -108,7 +108,8 @@ export const replaceUserAttributes = (
 
     return sqlAttributes.reduce<string>((acc, sqlAttribute) => {
         const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
-        const userValue: string | null | undefined = userAttributes[attribute];
+        const userValue: string | null | undefined =
+            userAttributes[attribute]?.[0]; // Pick first value, where user value takes precedence over group values
 
         if (userValue === undefined) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -2,53 +2,55 @@ import { hasUserAttribute, hasUserAttributes } from './UserAttributeUtils';
 
 describe('hasUserAttribute', () => {
     test('should be false if attribute is not present', () => {
-        expect(hasUserAttribute({ test: '1' }, 'another', '1')).toStrictEqual(
+        expect(hasUserAttribute({ test: ['1'] }, 'another', '1')).toStrictEqual(
             false,
         );
     });
     test('should be false if attribute value does not match', () => {
-        expect(hasUserAttribute({ test: '1' }, 'test', '2')).toStrictEqual(
+        expect(hasUserAttribute({ test: ['1'] }, 'test', '2')).toStrictEqual(
             false,
         );
     });
     test('should be true if attribute value match user', () => {
-        expect(hasUserAttribute({ test: '1' }, 'test', '1')).toStrictEqual(
+        expect(hasUserAttribute({ test: ['1'] }, 'test', '1')).toStrictEqual(
             true,
         );
     });
 
     test('should be false if attribute value match a different user', () => {
-        expect(hasUserAttribute({ test: null }, 'test', '1')).toStrictEqual(
+        expect(hasUserAttribute({ test: [] }, 'test', '1')).toStrictEqual(
             false,
         );
     });
 });
 describe('hasUserAttributes', () => {
     test('should be true if there are no required attributes', () => {
-        expect(hasUserAttributes(undefined, { test: '1' })).toStrictEqual(true);
-        expect(hasUserAttributes({}, { test: '1' })).toStrictEqual(true);
+        expect(hasUserAttributes(undefined, { test: ['1'] })).toStrictEqual(
+            true,
+        );
+        expect(hasUserAttributes({}, { test: ['1'] })).toStrictEqual(true);
     });
     test('should be false if required attributes are not present', () => {
         expect(
-            hasUserAttributes({ another: '1' }, { test: '1' }),
+            hasUserAttributes({ another: '1' }, { test: ['1'] }),
         ).toStrictEqual(false);
     });
     test('should be false if required attribute values does not match', () => {
-        expect(hasUserAttributes({ test: '2' }, { test: '1' })).toStrictEqual(
+        expect(hasUserAttributes({ test: '2' }, { test: ['1'] })).toStrictEqual(
             false,
         );
-        expect(hasUserAttributes({ test: '1' }, { test: null })).toStrictEqual(
+        expect(hasUserAttributes({ test: '1' }, { test: [] })).toStrictEqual(
             false,
         );
         expect(
             hasUserAttributes(
                 { test: '2', another: '1' },
-                { test: '1', another: '1' },
+                { test: ['1'], another: ['1'] },
             ),
         ).toStrictEqual(false);
     });
     test('should be true if required attribute value match', () => {
-        expect(hasUserAttributes({ test: '1' }, { test: '1' })).toStrictEqual(
+        expect(hasUserAttributes({ test: '1' }, { test: ['1'] })).toStrictEqual(
             true,
         );
     });

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -4,7 +4,9 @@ export const hasUserAttribute = (
     userAttributes: UserAttributeValueMap,
     attributeName: string,
     value: string,
-) => userAttributes[attributeName] === value;
+): boolean =>
+    !!userAttributes[attributeName] &&
+    userAttributes[attributeName].includes(value);
 
 export const hasUserAttributes = (
     requiredAttributes: Record<string, string | string[]> | undefined,

--- a/packages/common/src/types/userAttributes.ts
+++ b/packages/common/src/types/userAttributes.ts
@@ -20,7 +20,7 @@ export type GroupAttributeValue = {
     value: string;
 };
 
-export type UserAttributeValueMap = Record<string, string | null>;
+export type UserAttributeValueMap = Record<string, string[]>;
 
 export type CreateUserAttributeValue = Omit<UserAttributeValue, 'email'>;
 export type CreateGroupAttributeValue = GroupAttributeValue;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8500 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

- [x] Column security - valid if the attribute matches a user or any group attribute
- [x] Row security - validated against one value. Value at user level takes precedence over values at group level and if neither is defined, uses the default value. In the case of multiple groups with values for the same attribute, only one will be used. There is no specific group order.

This PR does not improve query performance for user attributes. To be done in separate PR.

### Tested

Needs to be tested locally since we can't edit group attributes in the UI( needs to be changed directly in DB ).

Row filtering eg
```
models:
  - name: events
    meta:
      sql_filter: ${TABLE}.event = ${lightdash.attributes.event}
```

Column filtering eg

```
      - name: event
        meta:
          dimension:
            required_attributes:
              is_admin: "true"
```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
