### PR TITLE
feat: allow chart edit when loading in dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -880,16 +880,27 @@ export const GenericDashboardChartTile: FC<
     error,
     ...rest
 }) => {
-    if (isLoading)
+    const { projectUuid } = useParams<{
+        projectUuid: string;
+        dashboardUuid: string;
+    }>();
+
+    if (isLoading) {
         return (
             <TileBase
                 isEditMode={isEditMode}
+                chartName={tile.properties.chartName ?? ''}
+                titleHref={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/`}
+                description={''}
+                belongsToDashboard={tile.properties.belongsToDashboard}
                 tile={tile}
-                isLoading={true}
-                title={''}
+                isLoading
+                title={tile.properties.title || tile.properties.chartName || ''}
                 {...rest}
             />
         );
+    }
+
     if (error !== null || !data)
         return (
             <TileBase

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -896,6 +896,11 @@ export const GenericDashboardChartTile: FC<
                 tile={tile}
                 isLoading
                 title={tile.properties.title || tile.properties.chartName || ''}
+                extraMenuItems={
+                    tile.properties.savedChartUuid && (
+                        <EditChartMenuItem tile={tile} />
+                    )
+                }
                 {...rest}
             />
         );

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -899,6 +899,7 @@ export const GenericDashboardChartTile: FC<
                 isLoading
                 title={tile.properties.title || tile.properties.chartName || ''}
                 extraMenuItems={
+                    !minimal &&
                     userCanManageChart &&
                     tile.properties.savedChartUuid && (
                         <EditChartMenuItem tile={tile} />

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -884,6 +884,8 @@ export const GenericDashboardChartTile: FC<
         projectUuid: string;
         dashboardUuid: string;
     }>();
+    const { user } = useApp();
+    const userCanManageChart = user.data?.ability?.can('manage', 'SavedChart');
 
     if (isLoading) {
         return (
@@ -897,6 +899,7 @@ export const GenericDashboardChartTile: FC<
                 isLoading
                 title={tile.properties.title || tile.properties.chartName || ''}
                 extraMenuItems={
+                    userCanManageChart &&
                     tile.properties.savedChartUuid && (
                         <EditChartMenuItem tile={tile} />
                     )

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -28,19 +28,11 @@ const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
     }>();
 
     const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
-    const userCanManageSavedChart = user.data?.ability?.can(
-        'manage',
-        'SavedChart',
-    );
 
-    const cannotEditChart =
-        !tile.properties.savedChartUuid ||
-        !userCanManageExplore ||
-        !userCanManageSavedChart;
+    if (!tile.properties.savedChartUuid || !userCanManageExplore) return null;
 
     return (
         <LinkMenuItem
-            disabled={cannotEditChart}
             icon={<MantineIcon icon={IconFilePencil} />}
             onClick={() => {
                 if (tile.properties.belongsToDashboard) {

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -28,11 +28,19 @@ const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
     }>();
 
     const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
+    const userCanManageSavedChart = user.data?.ability?.can(
+        'manage',
+        'SavedChart',
+    );
 
-    if (!tile.properties.savedChartUuid || !userCanManageExplore) return null;
+    const cannotEditChart =
+        !tile.properties.savedChartUuid ||
+        !userCanManageExplore ||
+        !userCanManageSavedChart;
 
     return (
         <LinkMenuItem
+            disabled={cannotEditChart}
             icon={<MantineIcon icon={IconFilePencil} />}
             onClick={() => {
                 if (tile.properties.belongsToDashboard) {

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -99,247 +99,207 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         >
             <LoadingOverlay visible={isLoading ?? false} />
 
-            {isLoading && (
-                <Box
-                    style={{
-                        zIndex: getDefaultZIndex('overlay') + 1,
-                    }}
+            <HeaderContainer
+                $isEditMode={isEditMode}
+                $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
+                style={
+                    isLoading
+                        ? {
+                              zIndex: getDefaultZIndex('overlay') + 1,
+                          }
+                        : {}
+                }
+            >
+                <Tooltip
+                    disabled={!description || !!titleLeftIcon}
+                    label={description}
+                    multiline
+                    position="top-start"
+                    withinPortal
+                    maw={400}
                 >
-                    <HeaderContainer
-                        $isEditMode={isEditMode}
-                        $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
-                    >
-                        <TitleWrapper>
-                            <TileTitleLink
-                                ref={titleRef}
-                                href={titleHref}
-                                $hovered={titleHovered}
-                                target="_blank"
-                                className="non-draggable"
+                    <TitleWrapper $hovered={titleHovered}>
+                        <Group spacing="xs">
+                            {titleLeftIcon}
+
+                            <Tooltip
+                                disabled={!description || !titleLeftIcon}
+                                label={description}
+                                multiline
+                                position="top-start"
+                                withinPortal
+                                maw={400}
                             >
-                                {title}
-                            </TileTitleLink>
-                        </TitleWrapper>
-                    </HeaderContainer>
-                </Box>
-            )}
+                                {!hideTitle ? (
+                                    belongsToDashboard ? (
+                                        <Text fw={600} size="md">
+                                            {title}
+                                        </Text>
+                                    ) : (
+                                        <TileTitleLink
+                                            ref={titleRef}
+                                            href={titleHref}
+                                            $hovered={titleHovered}
+                                            target="_blank"
+                                            className="non-draggable"
+                                        >
+                                            {title}
+                                        </TileTitleLink>
+                                    )
+                                ) : (
+                                    <Box />
+                                )}
+                            </Tooltip>
+                        </Group>
+                    </TitleWrapper>
+                </Tooltip>
 
-            {!isLoading && (
-                <>
-                    <HeaderContainer
-                        $isEditMode={isEditMode}
-                        $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
-                    >
-                        <Tooltip
-                            disabled={!description || !!titleLeftIcon}
-                            label={description}
-                            multiline
-                            position="top-start"
-                            withinPortal
-                            maw={400}
-                        >
-                            <TitleWrapper $hovered={titleHovered}>
-                                <Group spacing="xs">
-                                    {titleLeftIcon}
-
-                                    <Tooltip
-                                        disabled={
-                                            !description || !titleLeftIcon
-                                        }
-                                        label={description}
-                                        multiline
-                                        position="top-start"
-                                        withinPortal
-                                        maw={400}
-                                    >
-                                        {!hideTitle ? (
-                                            belongsToDashboard ? (
-                                                <Text fw={600} size="md">
-                                                    {title}
-                                                </Text>
-                                            ) : (
-                                                <TileTitleLink
-                                                    ref={titleRef}
-                                                    href={titleHref}
-                                                    $hovered={titleHovered}
-                                                    target="_blank"
-                                                    className="non-draggable"
-                                                >
-                                                    {title}
-                                                </TileTitleLink>
-                                            )
-                                        ) : (
-                                            <Box />
-                                        )}
-                                    </Tooltip>
-                                </Group>
-                            </TitleWrapper>
-                        </Tooltip>
-
-                        {(containerHovered && !titleHovered) || isMenuOpen ? (
-                            <ButtonsWrapper className="non-draggable">
-                                {extraHeaderElement}
-                                {(isEditMode ||
-                                    (!isEditMode && extraMenuItems)) && (
-                                    <Menu
-                                        withArrow
-                                        withinPortal
-                                        shadow="md"
-                                        position="bottom-end"
-                                        offset={4}
-                                        arrowOffset={10}
-                                        opened={isMenuOpen}
-                                        onOpen={() => toggleMenu(true)}
-                                        onClose={() => toggleMenu(false)}
-                                    >
-                                        <Menu.Dropdown>
-                                            {extraMenuItems}
-                                            {isEditMode && extraMenuItems && (
-                                                <Menu.Divider />
-                                            )}
-                                            {isEditMode && (
-                                                <>
-                                                    <Tooltip
-                                                        disabled={
-                                                            !belongsToDashboard
+                {(containerHovered && !titleHovered) || isMenuOpen ? (
+                    <ButtonsWrapper className="non-draggable">
+                        {extraHeaderElement}
+                        {(isEditMode || (!isEditMode && extraMenuItems)) && (
+                            <Menu
+                                withArrow
+                                withinPortal
+                                shadow="md"
+                                position="bottom-end"
+                                offset={4}
+                                arrowOffset={10}
+                                opened={isMenuOpen}
+                                onOpen={() => toggleMenu(true)}
+                                onClose={() => toggleMenu(false)}
+                            >
+                                <Menu.Dropdown>
+                                    {extraMenuItems}
+                                    {isEditMode && extraMenuItems && (
+                                        <Menu.Divider />
+                                    )}
+                                    {isEditMode && (
+                                        <>
+                                            <Tooltip
+                                                disabled={!belongsToDashboard}
+                                                label="Tile content in charts from dashboards is not editable"
+                                            >
+                                                <Box>
+                                                    <Menu.Item
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconEdit}
+                                                            />
                                                         }
-                                                        label="Tile content in charts from dashboards is not editable"
+                                                        onClick={() =>
+                                                            setIsEditingTileContent(
+                                                                true,
+                                                            )
+                                                        }
+                                                        disabled={
+                                                            belongsToDashboard
+                                                        }
                                                     >
-                                                        <Box>
-                                                            <Menu.Item
-                                                                icon={
-                                                                    <MantineIcon
-                                                                        icon={
-                                                                            IconEdit
-                                                                        }
-                                                                    />
-                                                                }
-                                                                onClick={() =>
-                                                                    setIsEditingTileContent(
-                                                                        true,
-                                                                    )
-                                                                }
-                                                                disabled={
-                                                                    belongsToDashboard
-                                                                }
-                                                            >
-                                                                Edit tile
-                                                                content
-                                                            </Menu.Item>
-                                                        </Box>
-                                                    </Tooltip>
-                                                    {belongsToDashboard ? (
-                                                        <Menu.Item
-                                                            color="red"
-                                                            onClick={() =>
-                                                                setIsDeletingChartThatBelongsToDashboard(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Delete chart
-                                                        </Menu.Item>
-                                                    ) : (
-                                                        <>
-                                                            <Menu.Divider />
-                                                            <Menu.Item
-                                                                color="red"
-                                                                icon={
-                                                                    <MantineIcon
-                                                                        icon={
-                                                                            IconTrash
-                                                                        }
-                                                                    />
-                                                                }
-                                                                onClick={() =>
-                                                                    onDelete(
-                                                                        tile,
-                                                                    )
-                                                                }
-                                                            >
-                                                                Remove tile
-                                                            </Menu.Item>
-                                                        </>
-                                                    )}
+                                                        Edit tile content
+                                                    </Menu.Item>
+                                                </Box>
+                                            </Tooltip>
+                                            {belongsToDashboard ? (
+                                                <Menu.Item
+                                                    color="red"
+                                                    onClick={() =>
+                                                        setIsDeletingChartThatBelongsToDashboard(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Delete chart
+                                                </Menu.Item>
+                                            ) : (
+                                                <>
+                                                    <Menu.Divider />
+                                                    <Menu.Item
+                                                        color="red"
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            onDelete(tile)
+                                                        }
+                                                    >
+                                                        Remove tile
+                                                    </Menu.Item>
                                                 </>
                                             )}
-                                        </Menu.Dropdown>
+                                        </>
+                                    )}
+                                </Menu.Dropdown>
 
-                                        <Menu.Target>
-                                            <ActionIcon
-                                                size="sm"
-                                                style={{
-                                                    position: 'relative',
-                                                    zIndex: 1,
-                                                }}
-                                            >
-                                                <MantineIcon
-                                                    data-testid="tile-icon-more"
-                                                    icon={IconDots}
-                                                />
-                                            </ActionIcon>
-                                        </Menu.Target>
-                                    </Menu>
-                                )}
-                            </ButtonsWrapper>
-                        ) : null}
-                    </HeaderContainer>
+                                <Menu.Target>
+                                    <ActionIcon
+                                        size="sm"
+                                        style={{
+                                            position: 'relative',
+                                            zIndex: 1,
+                                        }}
+                                    >
+                                        <MantineIcon
+                                            data-testid="tile-icon-more"
+                                            icon={IconDots}
+                                        />
+                                    </ActionIcon>
+                                </Menu.Target>
+                            </Menu>
+                        )}
+                    </ButtonsWrapper>
+                ) : null}
+            </HeaderContainer>
 
-                    <ChartContainer className="non-draggable sentry-block ph-no-capture">
-                        {children}
-                    </ChartContainer>
+            <ChartContainer className="non-draggable sentry-block ph-no-capture">
+                {children}
+            </ChartContainer>
 
-                    {isEditingTileContent &&
-                        (tile.type === DashboardTileTypes.SAVED_CHART ? (
-                            <ChartUpdateModal
-                                opened={isEditingTileContent}
-                                tile={tile}
-                                onClose={() => setIsEditingTileContent(false)}
-                                onConfirm={(
-                                    newTitle,
-                                    newUuid,
-                                    shouldHideTitle,
-                                ) => {
-                                    onEdit({
-                                        ...tile,
-                                        properties: {
-                                            ...tile.properties,
-                                            title: newTitle,
-                                            savedChartUuid: newUuid,
-                                            hideTitle: shouldHideTitle,
-                                        },
-                                    });
-                                    setIsEditingTileContent(false);
-                                }}
-                                hideTitle={!!hideTitle}
-                            />
-                        ) : (
-                            <TileUpdateModal
-                                className="non-draggable"
-                                opened={isEditingTileContent}
-                                tile={tile}
-                                onClose={() => setIsEditingTileContent(false)}
-                                onConfirm={(newTile) => {
-                                    onEdit(newTile);
-                                    setIsEditingTileContent(false);
-                                }}
-                            />
-                        ))}
-
-                    <DeleteChartTileThatBelongsToDashboardModal
-                        className={'non-draggable'}
-                        name={chartName ?? ''}
-                        opened={isDeletingChartThatBelongsToDashboard}
-                        onClose={() =>
-                            setIsDeletingChartThatBelongsToDashboard(false)
-                        }
-                        onConfirm={() => {
-                            onDelete(tile);
-                            setIsDeletingChartThatBelongsToDashboard(false);
+            {isEditingTileContent &&
+                (tile.type === DashboardTileTypes.SAVED_CHART ? (
+                    <ChartUpdateModal
+                        opened={isEditingTileContent}
+                        tile={tile}
+                        onClose={() => setIsEditingTileContent(false)}
+                        onConfirm={(newTitle, newUuid, shouldHideTitle) => {
+                            onEdit({
+                                ...tile,
+                                properties: {
+                                    ...tile.properties,
+                                    title: newTitle,
+                                    savedChartUuid: newUuid,
+                                    hideTitle: shouldHideTitle,
+                                },
+                            });
+                            setIsEditingTileContent(false);
+                        }}
+                        hideTitle={!!hideTitle}
+                    />
+                ) : (
+                    <TileUpdateModal
+                        className="non-draggable"
+                        opened={isEditingTileContent}
+                        tile={tile}
+                        onClose={() => setIsEditingTileContent(false)}
+                        onConfirm={(newTile) => {
+                            onEdit(newTile);
+                            setIsEditingTileContent(false);
                         }}
                     />
-                </>
-            )}
+                ))}
+
+            <DeleteChartTileThatBelongsToDashboardModal
+                className={'non-draggable'}
+                name={chartName ?? ''}
+                opened={isDeletingChartThatBelongsToDashboard}
+                onClose={() => setIsDeletingChartThatBelongsToDashboard(false)}
+                onConfirm={() => {
+                    onDelete(tile);
+                    setIsDeletingChartThatBelongsToDashboard(false);
+                }}
+            />
         </Card>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -4,6 +4,7 @@ import {
     Box,
     Card,
     Flex,
+    getDefaultZIndex,
     Group,
     LoadingOverlay,
     Menu,
@@ -97,6 +98,31 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             })}
         >
             <LoadingOverlay visible={isLoading ?? false} />
+
+            {isLoading && (
+                <Box
+                    style={{
+                        zIndex: getDefaultZIndex('overlay') + 1,
+                    }}
+                >
+                    <HeaderContainer
+                        $isEditMode={isEditMode}
+                        $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
+                    >
+                        <TitleWrapper>
+                            <TileTitleLink
+                                ref={titleRef}
+                                href={titleHref}
+                                $hovered={titleHovered}
+                                target="_blank"
+                                className="non-draggable"
+                            >
+                                {title}
+                            </TileTitleLink>
+                        </TitleWrapper>
+                    </HeaderContainer>
+                </Box>
+            )}
 
             {!isLoading && (
                 <>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8518

### Description:

While the chart is loading, we show:
* title (if exists) -user can click on title to view chart
* 3-dot menu `Edit chart` option to edit the chart without having to wait for the `/chart-and-results` endpoint to settle

More info on the ticket ^

Admin experience

https://github.com/lightdash/lightdash/assets/7611706/8ff1321f-c5d3-4d92-8b73-d4d7414fe531

Member experience

https://github.com/lightdash/lightdash/assets/7611706/e2dd1027-834f-4bc9-842b-081082bf8d48


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
