### PR TITLE
fix: rename a custom metric with filter

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -167,6 +167,38 @@ export const getFilterRules = (filters: Filters): FilterRule[] => {
     return rules;
 };
 
+export const updateFieldIdInFilterGroupItem = (
+    filterGroupItem: FilterGroupItem,
+    previousName: string,
+    newName: string,
+): void => {
+    if (isFilterGroup(filterGroupItem)) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        updateFieldIdInFilters(filterGroupItem, previousName, newName);
+    } else if (filterGroupItem.target.fieldId === previousName) {
+        // eslint-disable-next-line no-param-reassign
+        filterGroupItem.target.fieldId = newName;
+    }
+};
+
+export const updateFieldIdInFilters = (
+    filterGroup: FilterGroup | undefined,
+    previousName: string,
+    newName: string,
+): void => {
+    if (filterGroup) {
+        if (isOrFilterGroup(filterGroup)) {
+            filterGroup.or.forEach((item) =>
+                updateFieldIdInFilterGroupItem(item, previousName, newName),
+            );
+        } else if (isAndFilterGroup(filterGroup)) {
+            filterGroup.and.forEach((item) =>
+                updateFieldIdInFilterGroupItem(item, previousName, newName),
+            );
+        }
+    }
+};
+
 export const applyDimensionOverrides = (
     dashboardFilters: DashboardFilters,
     overrides: DashboardFilters | SchedulerFilterRule[],

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -22,6 +22,7 @@ import {
     TableCalculation,
     TableChartConfig,
     toggleArrayValue,
+    updateFieldIdInFilters,
 } from '@lightdash/common';
 import produce from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
@@ -886,6 +887,22 @@ function reducer(
                                       }
                                     : sortField,
                         ),
+                        filters: Object.entries(
+                            state.unsavedChartVersion.metricQuery.filters,
+                        ).reduce((acc, [key, value]) => {
+                            let valueDeepCopy = cloneDeep(value);
+                            if (key === 'metrics') {
+                                updateFieldIdInFilters(
+                                    valueDeepCopy,
+                                    action.payload.previousAdditionalMetricName,
+                                    additionalMetricFieldId,
+                                );
+                            }
+                            return {
+                                ...acc,
+                                [key]: valueDeepCopy,
+                            };
+                        }, {}),
                     },
                     tableConfig: {
                         ...state.unsavedChartVersion.tableConfig,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8061 

### Description:

Added the logic for updating filters when custom metrics are edited.
As our filter structure can be nested as well, so I have updated the custom metric names recursively.

Initial filters:

![image](https://github.com/lightdash/lightdash/assets/85165953/730c8117-adaf-4ef2-bfe3-b1dd3fca882c)

On renaming:

![image](https://github.com/lightdash/lightdash/assets/85165953/1107862d-ee7b-4243-ab2f-b30117edd4fc)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
