### PR TITLE
fix: update groups validation error

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5567,7 +5567,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.922.0",
+        "version": "0.927.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -21,7 +21,7 @@ export type CreateGroup = Pick<Group, 'name'> & {
     members?: Pick<GroupMember, 'userUuid'>[];
 };
 
-export type UpdateGroup = Pick<Group, 'name' | 'uuid'>;
+export type UpdateGroup = Pick<Group, 'name'>;
 
 /**
  * A summary for a Lightdash user within a group
@@ -61,7 +61,7 @@ export type GroupWithMembers = Group & {
     members: GroupMember[];
 };
 
-export type UpdateGroupWithMembers = Pick<GroupWithMembers, 'uuid'> & {
+export type UpdateGroupWithMembers = {
     name?: string;
     members?: Pick<GroupMember, 'userUuid'>[];
 };

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
@@ -55,7 +55,9 @@ const CreateGroupModal: FC<
         onClose();
     };
 
-    const handleSubmitUpdate = async (data: UpdateGroupWithMembers) => {
+    const handleSubmitUpdate = async (
+        data: UpdateGroupWithMembers & { uuid: string },
+    ) => {
         mutateAsyncUpdateGroup({
             name: form.isDirty('name') ? data.name : undefined,
             members: form.isDirty('members') ? data.members : undefined,

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -69,7 +69,9 @@ export const useGroupCreateMutation = () => {
     );
 };
 
-const updateGroupQuery = async (data: UpdateGroupWithMembers) =>
+const updateGroupQuery = async (
+    data: UpdateGroupWithMembers & { uuid: string },
+) =>
     lightdashApi<GroupWithMembers>({
         url: `/groups/${data.uuid}`,
         method: 'PATCH',
@@ -82,25 +84,26 @@ const updateGroupQuery = async (data: UpdateGroupWithMembers) =>
 export const useGroupUpdateMutation = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
-    return useMutation<Group, ApiError, UpdateGroupWithMembers>(
-        (data) => updateGroupQuery(data),
-        {
-            mutationKey: ['update_group'],
-            onSuccess: async (_, updateGroup) => {
-                await queryClient.invalidateQueries(['organization_groups']);
+    return useMutation<
+        Group,
+        ApiError,
+        UpdateGroupWithMembers & { uuid: string }
+    >((data) => updateGroupQuery(data), {
+        mutationKey: ['update_group'],
+        onSuccess: async (_, updateGroup) => {
+            await queryClient.invalidateQueries(['organization_groups']);
 
-                showToastSuccess({
-                    title: `Success! Group, ${updateGroup.name} was updated.`,
-                });
-            },
-            onError: (error) => {
-                showToastError({
-                    title: `Failed to update group`,
-                    subtitle: error.error.message,
-                });
-            },
+            showToastSuccess({
+                title: `Success! Group, ${updateGroup.name} was updated.`,
+            });
         },
-    );
+        onError: (error) => {
+            showToastError({
+                title: `Failed to update group`,
+                subtitle: error.error.message,
+            });
+        },
+    });
 };
 
 const deleteGroupQuery = async (data: Group) =>


### PR DESCRIPTION
### Description:

Fix a validation error when updating groups. The types got out of sync with the generated API. This removes the uuid from the update payload and regenerates the endpoints. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
