### PR TITLE
test: fix invite test when there are many users

### DIFF
--- a/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
@@ -47,6 +47,7 @@ describe('Settings - Invites', () => {
         cy.contains('User management').click();
         cy.get('table')
             .contains('tr', 'demo+marygreen@lightdash.com')
+            .scrollIntoView()
             .find('.tabler-icon-trash')
             .click({ force: true });
         cy.findByText('Are you sure you want to delete this user?')

--- a/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
@@ -9,7 +9,7 @@ describe('Settings - Invites', () => {
         cy.findByRole('menuitem', { name: 'Organization settings' }).click();
 
         cy.contains('User management').click();
-        cy.contains('button', 'Add user').click();
+        cy.contains('button', 'Add user').scrollIntoView().click();
         cy.findByLabelText('Enter user email address *').type(
             'demo+marygreen@lightdash.com',
         );


### PR DESCRIPTION
### Description:

The invites tests fail when re-run because too many users get added to the list and the one being searched is out of view. This scrolls it into view, which should help. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
