### PR TITLE
feat: show group info in users list

### DIFF
--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -43,6 +43,10 @@ export type OrganizationMemberProfileWithGroups = OrganizationMemberProfile & {
     groups: Pick<Group, 'name' | 'uuid'>[];
 };
 
+export const isOrganizationMemberProfileWithGroups = (
+    obj: OrganizationMemberProfile | OrganizationMemberProfileWithGroups,
+): obj is OrganizationMemberProfileWithGroups => 'groups' in obj;
+
 export type OrganizationMemberProfileUpdate = {
     role: OrganizationMemberRole;
 };

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -329,8 +329,9 @@ const UsersView: FC = () => {
 
     const [search, setSearch] = useState('');
 
+    // TODO: fix the hardcoded groups number. This should be paginated.
     const { data: organizationUsers, isLoading: isLoadingUsers } =
-        useOrganizationUsers({ searchInput: search, includeGroups: 1000 });
+        useOrganizationUsers({ searchInput: search, includeGroups: 10000 });
 
     if (isLoadingUsers) {
         return <LoadingState title="Loading users" />;

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -42,7 +42,7 @@ export const useOrganizationUsers = (params?: {
 }) => {
     const setErrorResponse = useQueryError();
     return useQuery<OrganizationMemberProfile[], ApiError>({
-        queryKey: ['organization_users'],
+        queryKey: ['organization_users', params?.includeGroups],
         queryFn: () => getOrganizationUsersQuery(params?.includeGroups),
         onError: (result) => setErrorResponse(result),
         select: (data) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8535 

### Description:

Shows basic group info in the users list. The number of groups is in the list and the groups are shown on hover.

<img width="874" alt="Screenshot 2024-01-10 at 19 08 25" src="https://github.com/lightdash/lightdash/assets/1864179/4aa6dc4d-1cae-442c-9139-6c3a845480e9">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
