### PR TITLE
fix: filter between two times in the same day

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -32,16 +32,20 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 disabled={disabled}
                 placeholder="Start date"
                 maxDate={
-                    date2 ? dayjs(date2).subtract(1, 'day').toDate() : undefined
+                    date2
+                        ? dayjs(date2).subtract(1, 'second').toDate()
+                        : undefined
                 }
                 firstDayOfWeek={firstDayOfWeek}
                 {...rest}
                 value={date1}
                 onChange={(newDate) => {
-                    setDate1(newDate);
+                    if (!date2 || dayjs(newDate).isBefore(dayjs(date2))) {
+                        setDate1(newDate);
 
-                    if (newDate && date2) {
-                        onChange([newDate, date2]);
+                        if (newDate && date2) {
+                            onChange([newDate, date2]);
+                        }
                     }
                 }}
             />
@@ -56,16 +60,17 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 disabled={disabled}
                 placeholder="End date"
                 minDate={
-                    date1 ? dayjs(date1).add(1, 'day').toDate() : undefined
+                    date1 ? dayjs(date1).add(1, 'second').toDate() : undefined
                 }
                 firstDayOfWeek={firstDayOfWeek}
                 {...rest}
                 value={date2}
                 onChange={(newDate) => {
-                    setDate2(newDate);
-
-                    if (newDate && date1) {
-                        onChange([date1, newDate]);
+                    if (!date1 || dayjs(newDate).isAfter(dayjs(date1))) {
+                        setDate2(newDate);
+                        if (newDate && date1) {
+                            onChange([date1, newDate]);
+                        }
                     }
                 }}
             />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8511 

### Description:
Changed **day** to **second** in `maxDate` and `minDate` in `FilterDateTimeRangePicker` to allow same day range filter.
I have also added the logic to prevent the user from selecting an invalid date.

_There is an alternative to handling this. We can also allow the user to select any date and as per the selection, can modify the other date._

_For example - If a user selects a Start Date that is after the End Date, we can change the End Date to (Start Date + 1 hour) and vice versa._

Here is the output:

![image](https://github.com/lightdash/lightdash/assets/85165953/36d4a67a-a9db-4ab0-a9da-2bc8078bd386)

We can also add a red error state on the input if the time range is invalid.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
