### PR TITLE
chore: add otel events to explore filtering

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/generated_a.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/generated_a.yml
@@ -70,6 +70,8 @@ models:
         meta:
           dimension:
             type: string
+            required_attributes:
+              is_admin: "true"
       - name: phone
         description: ""
         meta:

--- a/examples/full-jaffle-shop-demo/dbt/models/generated_a.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/generated_a.yml
@@ -70,8 +70,6 @@ models:
         meta:
           dimension:
             type: string
-            required_attributes:
-              is_admin: "true"
       - name: phone
         description: ""
         meta:

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2202,7 +2202,13 @@ export class ProjectService {
                         );
                     }
 
-                    if (!exploreHasFilteredAttribute(explore)) {
+                    const shouldFilterExplore = await wrapOtelSpan(
+                        'ProjectService.getExplore.shouldFilterExplore',
+                        {},
+                        async () => exploreHasFilteredAttribute(explore),
+                    );
+
+                    if (!shouldFilterExplore) {
                         return explore;
                     }
                     const userAttributes =
@@ -2213,7 +2219,15 @@ export class ProjectService {
                             },
                         );
 
-                    return filterDimensionsFromExplore(explore, userAttributes);
+                    return wrapOtelSpan(
+                        'ProjectService.getExplore.filterDimensionsFromExplore',
+                        {},
+                        async () =>
+                            filterDimensionsFromExplore(
+                                explore,
+                                userAttributes,
+                            ),
+                    );
                 },
             );
         } finally {


### PR DESCRIPTION
Adding OTEL events so we can track how slow it is to filter explore dimensions.

I haven't seen a big impact when filtering dimensions.

Tests requesting an explore with 20 joins and 1000 dimensions (from top to bottom):

- explore with column filter and user attribute
- explore with column filter and no user attribute
- explore without column filter


<img width="1091" alt="Screenshot 2024-01-11 at 10 21 02" src="https://github.com/lightdash/lightdash/assets/9117144/47b047a2-24d8-42b1-a4eb-3429508c4356">

Traces when filtering
<img width="1462" alt="Screenshot 2024-01-11 at 10 16 28" src="https://github.com/lightdash/lightdash/assets/9117144/013f1b3f-57c0-4c64-a10e-57a7aded2179">



