### PR TITLE
fix: project group access list does not exclude already assigned groups

### DIFF
--- a/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
@@ -1,30 +1,34 @@
-import { CreateProjectGroupAccess, ProjectMemberRole } from '@lightdash/common';
-import { Button, Group, Modal, ModalProps, Select, Title } from '@mantine/core';
+import {
+    CreateProjectGroupAccess,
+    GroupWithMembers,
+    ProjectMemberRole,
+} from '@lightdash/common';
+import { Box, Button, Group, Modal, Select, Text, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconUsersGroup } from '@tabler/icons-react';
 import { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import useToaster from '../../../hooks/toaster/useToaster';
-import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { TrackPage } from '../../../providers/TrackingProvider';
 import { CategoryName, PageName, PageType } from '../../../types/Events';
-import { useAddProjectGroupAccessMutation } from '../hooks/useProjectGroupAccess';
 
-interface AddProjectGroupAccessModalProps extends ModalProps {
+interface AddProjectGroupAccessModalProps {
     projectUuid: string;
+    isSubmitting: boolean;
+    totalNumberOfGroups: number;
+    availableGroups: GroupWithMembers[];
+    onSubmit: (formData: CreateProjectGroupAccess) => void;
+    onClose: () => void;
 }
 
 const AddProjectGroupAccessModal: FC<AddProjectGroupAccessModalProps> = ({
-    opened,
-    onClose,
     projectUuid,
+    isSubmitting,
+    totalNumberOfGroups,
+    availableGroups,
+    onSubmit,
+    onClose,
 }) => {
-    const { showToastSuccess } = useToaster();
-    const { data: organizationGroups, isLoading } = useOrganizationGroups();
-
-    const { mutateAsync: addProjectGroupAccess, isLoading: isSubmitting } =
-        useAddProjectGroupAccessMutation();
-
     const form = useForm<CreateProjectGroupAccess>({
         initialValues: {
             projectUuid,
@@ -34,14 +38,12 @@ const AddProjectGroupAccessModal: FC<AddProjectGroupAccessModalProps> = ({
     });
 
     const handleSubmit = async (formData: CreateProjectGroupAccess) => {
-        await addProjectGroupAccess(formData);
-        showToastSuccess({ title: 'Group access added' });
-        onClose();
+        onSubmit(formData);
     };
 
     return (
         <Modal
-            opened={opened}
+            opened
             onClose={onClose}
             keepMounted={false}
             title={
@@ -57,52 +59,71 @@ const AddProjectGroupAccessModal: FC<AddProjectGroupAccessModalProps> = ({
                 type={PageType.MODAL}
                 category={CategoryName.SETTINGS}
             >
-                <form
-                    name="add_project_group_access"
-                    onSubmit={form.onSubmit(handleSubmit)}
-                >
-                    <Group align="flex-end" spacing="xs">
-                        <Select
-                            name="groupUuid"
-                            withinPortal
-                            label="Select group"
-                            placeholder="Click here to select group"
-                            nothingFound="No groups found"
-                            searchable
-                            required
-                            disabled={isLoading}
-                            data={
-                                organizationGroups?.map((group) => ({
-                                    value: group.uuid,
-                                    label: group.name,
-                                })) ?? []
+                {availableGroups.length === 0 ? (
+                    <Box mb="lg">
+                        <SuboptimalState
+                            icon={IconUsersGroup}
+                            title="No groups available"
+                            description={
+                                totalNumberOfGroups ? (
+                                    "You've already given access to all groups"
+                                ) : (
+                                    <Text w="70%">
+                                        Your organization doesn't have any
+                                        groups yet. Go to{' '}
+                                        <Text span fw={500}>
+                                            "Organization settings" &gt; "Users
+                                            & Groups"{' '}
+                                        </Text>{' '}
+                                        to create a group
+                                    </Text>
+                                )
                             }
-                            {...form.getInputProps('groupUuid')}
-                            sx={{ flexGrow: 1 }}
                         />
-                        <Select
-                            data={Object.values(ProjectMemberRole).map(
-                                (orgMemberRole) => ({
-                                    value: orgMemberRole,
-                                    label: orgMemberRole.replace('_', ' '),
-                                }),
-                            )}
-                            disabled={isLoading}
-                            required
-                            placeholder="Select role"
-                            dropdownPosition="bottom"
-                            withinPortal
-                            {...form.getInputProps('role')}
-                        />
+                    </Box>
+                ) : (
+                    <form
+                        name="add_project_group_access"
+                        onSubmit={form.onSubmit(handleSubmit)}
+                    >
+                        <Group align="flex-end" spacing="xs">
+                            <Select
+                                name="groupUuid"
+                                withinPortal
+                                label="Select group"
+                                placeholder="Click here to select group"
+                                nothingFound="No groups found"
+                                searchable
+                                required
+                                data={
+                                    availableGroups.map((group) => ({
+                                        value: group.uuid,
+                                        label: group.name,
+                                    })) ?? []
+                                }
+                                {...form.getInputProps('groupUuid')}
+                                sx={{ flexGrow: 1 }}
+                            />
+                            <Select
+                                data={Object.values(ProjectMemberRole).map(
+                                    (orgMemberRole) => ({
+                                        value: orgMemberRole,
+                                        label: orgMemberRole.replace('_', ' '),
+                                    }),
+                                )}
+                                required
+                                placeholder="Select role"
+                                dropdownPosition="bottom"
+                                withinPortal
+                                {...form.getInputProps('role')}
+                            />
 
-                        <Button
-                            disabled={isLoading || isSubmitting}
-                            type="submit"
-                        >
-                            Give access
-                        </Button>
-                    </Group>
-                </form>
+                            <Button disabled={isSubmitting} type="submit">
+                                Give access
+                            </Button>
+                        </Group>
+                    </form>
+                )}
             </TrackPage>
         </Modal>
     );

--- a/packages/frontend/src/features/projectGroupAccess/components/EditProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/EditProjectGroupAccessModal.tsx
@@ -36,9 +36,8 @@ const EditProjectGroupAccessModal: FC<EditProjectGroupAccessModalProps> = ({
         },
     });
 
-    const handleSubmit = async (formData: UpdateProjectGroupAccess) => {
+    const handleSubmit = (formData: UpdateProjectGroupAccess) => {
         onUpdate(formData);
-        onClose();
     };
 
     return (

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccessItem.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccessItem.tsx
@@ -16,13 +16,11 @@ import EditProjectGroupAccessModal from './EditProjectGroupAccessModal';
 import RevokeProjectGroupAccessModal from './RevokeProjectGroupAccessModal';
 
 type ProjectGroupAccessItemProps = {
-    projectUuid: string;
     group: GroupWithMembers;
     access: ProjectGroupAccess;
 };
 
 const ProjectGroupAccessItem: FC<ProjectGroupAccessItemProps> = ({
-    projectUuid,
     group,
     access,
 }) => {
@@ -42,11 +40,16 @@ const ProjectGroupAccessItem: FC<ProjectGroupAccessItemProps> = ({
     ) => {
         await updateProjectGroupAccess(updatedAccess);
         showToastSuccess({ title: 'Group access updated' });
+        setIsEditDialogOpen(false);
     };
 
-    const handleRemoveProjectGroupAccess = async (groupUuid: string) => {
-        await removeProjectGroupAccess({ projectUuid, groupUuid });
+    const handleRemoveProjectGroupAccess = async () => {
+        await removeProjectGroupAccess({
+            projectUuid: access.projectUuid,
+            groupUuid: access.groupUuid,
+        });
         showToastSuccess({ title: 'Group access removed' });
+        setIsDeleteDialogOpen(false);
     };
 
     return (
@@ -91,9 +94,7 @@ const ProjectGroupAccessItem: FC<ProjectGroupAccessItemProps> = ({
             {isDeleteDialogOpen && (
                 <RevokeProjectGroupAccessModal
                     group={group}
-                    onDelete={() =>
-                        handleRemoveProjectGroupAccess(access.groupUuid)
-                    }
+                    onDelete={() => handleRemoveProjectGroupAccess()}
                     onClose={() => setIsDeleteDialogOpen(false)}
                 />
             )}


### PR DESCRIPTION
### Description:

![CleanShot 2024-01-11 at 15 13 03@2x](https://github.com/lightdash/lightdash/assets/962095/4bcd7240-6600-4d16-92d4-5ed03220eed5)

![CleanShot 2024-01-11 at 15 13 10@2x](https://github.com/lightdash/lightdash/assets/962095/a898284e-d1a1-49af-8ee2-627ba14c95fb)

![CleanShot 2024-01-11 at 15 12 39@2x](https://github.com/lightdash/lightdash/assets/962095/6e4017f9-f318-4f79-80b8-6821f80f8f1d)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
