### PR TITLE
fix: only append authorizationServerId if exists

### DIFF
--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -149,13 +149,16 @@ const createOpenIdUserFromProfile = (
 };
 
 const setupClient = async () => {
-    const issuer = lightdashConfig.auth.okta.oauth2Issuer;
-    const authorizationServerPath = lightdashConfig.auth.okta
-        .authorizationServerId
-        ? `/oauth2/${lightdashConfig.auth.okta.authorizationServerId}`
-        : '';
-    const issuerUrl = new URL(authorizationServerPath, issuer);
-    const oktaIssuer = await Issuer.discover(issuerUrl.href);
+    const { okta } = lightdashConfig.auth;
+
+    const oktaIssuerUri = new URL(
+        okta.authorizationServerId
+            ? `/oauth2/${okta.authorizationServerId}`
+            : '',
+        `https://${okta.oktaDomain}`,
+    ).href;
+
+    const oktaIssuer = await Issuer.discover(oktaIssuerUri);
 
     const redirectUri = new URL(
         `/api/v1${lightdashConfig.auth.okta.callbackPath}`,
@@ -163,8 +166,8 @@ const setupClient = async () => {
     ).href;
 
     const client = new oktaIssuer.Client({
-        client_id: lightdashConfig.auth.okta.oauth2ClientId ?? '',
-        client_secret: lightdashConfig.auth.okta.oauth2ClientSecret,
+        client_id: okta.oauth2ClientId ?? '',
+        client_secret: okta.oauth2ClientSecret,
         redirect_uris: [redirectUri],
         response_types: ['code'],
     });

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -150,9 +150,9 @@ const createOpenIdUserFromProfile = (
 
 const setupClient = async () => {
     const oktaIssuer = await Issuer.discover(
-        `https://${lightdashConfig.auth.okta.oktaDomain}/oauth2${
+        `${lightdashConfig.auth.okta.oauth2Issuer}${
             lightdashConfig.auth.okta.authorizationServerId
-                ? `/${lightdashConfig.auth.okta.authorizationServerId}`
+                ? `/oauth2/${lightdashConfig.auth.okta.authorizationServerId}`
                 : ''
         }`,
     );

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -150,7 +150,11 @@ const createOpenIdUserFromProfile = (
 
 const setupClient = async () => {
     const oktaIssuer = await Issuer.discover(
-        `https://${lightdashConfig.auth.okta.oktaDomain}/oauth2/default`,
+        `https://${lightdashConfig.auth.okta.oktaDomain}/oauth2${
+            lightdashConfig.auth.okta.authorizationServerId
+                ? `/${lightdashConfig.auth.okta.authorizationServerId}`
+                : ''
+        }`,
     );
 
     const redirectUri = new URL(
@@ -264,19 +268,6 @@ export const initiateOktaOpenIdLogin: RequestHandler = async (
     } catch (e) {
         return next(e);
     }
-};
-
-export const generateOktaUrl = (apiUrlPath: string): string => {
-    const fullPath = path.posix.join(
-        path.posix.sep,
-        'oauth2',
-        lightdashConfig.auth.okta.authorizationServerId || '', // empty string will be skipped
-        'v1',
-        apiUrlPath,
-    );
-
-    return new URL(fullPath, `https://${lightdashConfig.auth.okta.oktaDomain}`)
-        .href;
 };
 
 export const localPassportStrategy = new LocalStrategy(

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -149,13 +149,13 @@ const createOpenIdUserFromProfile = (
 };
 
 const setupClient = async () => {
-    const oktaIssuer = await Issuer.discover(
-        `${lightdashConfig.auth.okta.oauth2Issuer}${
-            lightdashConfig.auth.okta.authorizationServerId
-                ? `/oauth2/${lightdashConfig.auth.okta.authorizationServerId}`
-                : ''
-        }`,
-    );
+    const issuer = lightdashConfig.auth.okta.oauth2Issuer;
+    const authorizationServerPath = lightdashConfig.auth.okta
+        .authorizationServerId
+        ? `/oauth2/${lightdashConfig.auth.okta.authorizationServerId}`
+        : '';
+    const issuerUrl = new URL(authorizationServerPath, issuer);
+    const oktaIssuer = await Issuer.discover(issuerUrl.href);
 
     const redirectUri = new URL(
         `/api/v1${lightdashConfig.auth.okta.callbackPath}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

Related to: #8498 

### Description:

users were getting: 
```
{"status":"error","error":{"statusCode":500,"name":"UnexpectedServerError","message":"OPError: expected 200 OK, got: 401 Unauthorized","data":{}}}
```

when signing in with okta because it the `authorizationUrl` had `/default` by default. Some Okta apps might not have that Authorization Id (even though it's added by default and can be later disabled - ref: https://developer.okta.com/docs/concepts/auth-servers/#default-custom-authorization-server).

This ensures we append that only when it's available from the configuration. 

Also, remove unused `generateOktaUrl` function - not needed anymore because the package generates the other URLs for us.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
