### PR TITLE
fix: get correct regex for chart-and-results endpoint

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -413,7 +413,11 @@ export class UnfurlService {
 
                     await page.on('response', (response) => {
                         const responseUrl = response.url();
-                        if (responseUrl.match(/\/saved\/[a-f0-9-]+\/results/)) {
+                        const regexUrlToMatch =
+                            lightdashPage === LightdashPage.EXPLORE
+                                ? /\/saved\/[a-f0-9-]+\/results/
+                                : /\/saved\/[a-f0-9-]+\/chart-and-results/; // NOTE: Chart endpoint in Dashboards is different
+                        if (responseUrl.match(regexUrlToMatch)) {
                             chartRequests += 1;
                             response.buffer().then(
                                 (buffer) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Related to Dashboard Screenshots / Scheduled deliveries logging. 

When we introduced the `/chart-and-results`, we didn't update the regex that is used to match and then log warnings/errors to grafana. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
