### PR TITLE
feat: format comparison differently in big value charts

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -39,6 +39,8 @@ const BigNumberConfigTabs = memo(() => {
         setBigNumberLabel,
         bigNumberStyle,
         setBigNumberStyle,
+        bigNumberComparisonStyle,
+        setBigNumberComparisonStyle,
         showStyle,
         selectedField: selectedFieldId,
         setSelectedField,
@@ -106,8 +108,12 @@ const BigNumberConfigTabs = memo(() => {
                             onChange={(newValue) => {
                                 if (!newValue) {
                                     setBigNumberStyle(undefined);
+                                    setBigNumberComparisonStyle(undefined);
                                 } else {
                                     setBigNumberStyle(
+                                        newValue as CompactOrAlias,
+                                    );
+                                    setBigNumberComparisonStyle(
                                         newValue as CompactOrAlias,
                                     );
                                 }
@@ -168,6 +174,27 @@ const BigNumberConfigTabs = memo(() => {
                                     setComparisonLabel(e.currentTarget.value)
                                 }
                             />
+
+                            {showStyle &&
+                                comparisonFormat ===
+                                    ComparisonFormatTypes.RAW && (
+                                    <Select
+                                        label="Format"
+                                        data={StyleOptions}
+                                        value={bigNumberComparisonStyle ?? ''}
+                                        onChange={(newValue) => {
+                                            if (!newValue) {
+                                                setBigNumberComparisonStyle(
+                                                    undefined,
+                                                );
+                                            } else {
+                                                setBigNumberComparisonStyle(
+                                                    newValue as CompactOrAlias,
+                                                );
+                                            }
+                                        }}
+                                    />
+                                )}
                         </>
                     ) : null}
                 </Stack>

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -42,7 +42,7 @@ const formatComparisonValue = (
     comparisonDiff: ComparisonDiffTypes | undefined,
     item: ItemsMap[string] | undefined,
     value: number | string,
-    bigNumberStyle: CompactOrAlias | undefined,
+    bigNumberComparisonStyle: CompactOrAlias | undefined,
 ) => {
     const prefix =
         comparisonDiff === ComparisonDiffTypes.POSITIVE ||
@@ -64,12 +64,12 @@ const formatComparisonValue = (
             }
             return `${prefix}${formatValue(value, {
                 format: isField(item) ? item.format : undefined,
-                round: bigNumberStyle
+                round: bigNumberComparisonStyle
                     ? 2
                     : isField(item)
                     ? item.round
                     : undefined,
-                compact: bigNumberStyle,
+                compact: bigNumberComparisonStyle,
             })}`;
         default:
             if (item !== undefined && isTableCalculation(item)) {
@@ -77,12 +77,12 @@ const formatComparisonValue = (
             }
             return formatValue(value, {
                 format: isField(item) ? item.format : undefined,
-                round: bigNumberStyle
+                round: bigNumberComparisonStyle
                     ? 2
                     : isField(item)
                     ? item.round
                     : undefined,
-                compact: bigNumberStyle,
+                compact: bigNumberComparisonStyle,
             });
     }
 };
@@ -166,6 +166,9 @@ const useBigNumberConfig = (
     const [bigNumberStyle, setBigNumberStyle] = useState<
         BigNumber['style'] | undefined
     >(bigNumberConfigData?.style);
+    const [bigNumberComparisonStyle, setBigNumberComparisonStyle] = useState<
+        BigNumber['style'] | undefined
+    >(bigNumberConfigData?.style);
 
     const [showComparison, setShowComparison] = useState<
         BigNumber['showComparison'] | undefined
@@ -188,6 +191,7 @@ const useBigNumberConfig = (
         setShowBigNumberLabel(bigNumberConfigData?.showBigNumberLabel ?? true);
 
         setBigNumberStyle(bigNumberConfigData?.style);
+        setBigNumberComparisonStyle(bigNumberConfigData?.style);
 
         setShowComparison(bigNumberConfigData?.showComparison ?? false);
         setComparisonFormat(
@@ -266,14 +270,14 @@ const useBigNumberConfig = (
                   comparisonDiff,
                   item,
                   unformattedValue,
-                  bigNumberStyle,
+                  bigNumberComparisonStyle,
               );
     }, [
         comparisonFormat,
         comparisonDiff,
         item,
         unformattedValue,
-        bigNumberStyle,
+        bigNumberComparisonStyle,
     ]);
 
     const comparisonTooltip = useMemo(() => {
@@ -326,6 +330,8 @@ const useBigNumberConfig = (
         validConfig,
         bigNumberStyle,
         setBigNumberStyle,
+        bigNumberComparisonStyle,
+        setBigNumberComparisonStyle,
         showStyle,
         selectedField,
         setSelectedField,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8065 

### Description:

Added separate style for comparisons in big value charts.

- [x]  There is a format option in the comparison tab as well as the layout tab
- [x]  When we set the format in the layout tab, it automatically sets the same format in the comparison tab
- [x]  We can override the format in the comparison tab

Output -

Layout Tab -

![image](https://github.com/lightdash/lightdash/assets/85165953/e249106e-49e7-4e6d-ab65-1e7fdec2d117)

Comparison Tab -

![image](https://github.com/lightdash/lightdash/assets/85165953/c4464a1f-60ed-46de-87d4-873ef1999e81)

Example with different formats for big number and comparison -

![image](https://github.com/lightdash/lightdash/assets/85165953/028c74f3-6da2-40b6-a60d-38acaad8bcab)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
