### PR TITLE
feat: group api with member uuids

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -592,6 +592,11 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        memberUuids: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
                         members: {
                             dataType: 'array',
                             array: { dataType: 'refAlias', ref: 'GroupMember' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -656,6 +656,12 @@
                     },
                     {
                         "properties": {
+                            "memberUuids": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
                             "members": {
                                 "items": {
                                     "$ref": "#/components/schemas/GroupMember"
@@ -664,7 +670,7 @@
                                 "description": "A list of the group's members."
                             }
                         },
-                        "required": ["members"],
+                        "required": ["memberUuids", "members"],
                         "type": "object"
                     }
                 ],
@@ -5695,7 +5701,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.937.0",
+        "version": "0.942.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -12,7 +12,7 @@ import {
 import { Knex } from 'knex';
 import differenceBy from 'lodash/differenceBy';
 import { EmailTableName } from '../database/entities/emails';
-import { GroupMembershipTableName } from '../database/entities/group_memberships';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
 import {
     DBProjectGroupAccess,

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -59,6 +59,7 @@ export type GroupWithMembers = Group & {
      * A list of the group's members.
      */
     members: GroupMember[];
+    memberUuids: string[];
 };
 
 export type UpdateGroupWithMembers = {


### PR DESCRIPTION
related to: https://github.com/lightdash/lightdash/issues/8545

### Description:

this is for two reasons:
- for UI to count total users in a group
- show inherited user role from groups in the UI

> why do we have `includeMembers=5`?

to display avatar groups like this: https://mantine.dev/core/avatar/#avatargroup
![CleanShot 2024-01-12 at 12 01 42@2x](https://github.com/lightdash/lightdash/assets/962095/d9712c0d-e82a-42e2-88eb-17b9f42b32fe)


![CleanShot 2024-01-12 at 11 56 03@2x](https://github.com/lightdash/lightdash/assets/962095/9032e891-e110-4de1-8072-9844533f4f50)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
