### PR TITLE
fix: keep menu open while exporting google sheets

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -148,7 +148,7 @@ const ExportGoogleSheet: FC<{ savedChart: SavedChart; disabled?: boolean }> = ({
     return (
         <ExportToGoogleSheet
             getGsheetLink={getGsheetLink}
-            asMenuItem={true}
+            asMenuItem
             disabled={disabled}
         />
     );

--- a/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
+++ b/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
@@ -55,6 +55,7 @@ export const ExportToGoogleSheet: FC<ExportToGoogleSheetProps> = memo(
                     }
                     disabled={isExporting || disabled}
                     onClick={() => setIsGoogleAuthQueryEnabled(true)}
+                    closeMenuOnClick={false}
                 >
                     Export Google Sheets
                 </Menu.Item>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8576

### Description:

`closeMenuOnClick` set to `false` so the request doesn't get canceled 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
