### PR TITLE
fix: Can't filter between two times in the same day #8511

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -31,19 +31,17 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 withSeconds
                 disabled={disabled}
                 placeholder="Start date"
-                maxDate={
-                    date2 ? dayjs(date2).subtract(1, 'day').toDate() : undefined
-                }
+                maxDate={date2 ? dayjs(date2).toDate() : undefined}
                 firstDayOfWeek={firstDayOfWeek}
                 {...rest}
                 value={date1}
                 onChange={(newDate) => {
                     setDate1(newDate);
-
                     if (newDate && date2) {
                         onChange([newDate, date2]);
                     }
                 }}
+                error={date1 && date2 && date1 > date2}
             />
 
             <Text color="dimmed" sx={{ whiteSpace: 'nowrap' }} size="xs">
@@ -55,9 +53,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 withSeconds
                 disabled={disabled}
                 placeholder="End date"
-                minDate={
-                    date1 ? dayjs(date1).add(1, 'day').toDate() : undefined
-                }
+                minDate={date1 ? dayjs(date1).toDate() : undefined}
                 firstDayOfWeek={firstDayOfWeek}
                 {...rest}
                 value={date2}
@@ -68,6 +64,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                         onChange([date1, newDate]);
                     }
                 }}
+                error={date1 && date2 && date1 > date2}
             />
         </Flex>
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -59,7 +59,6 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 value={date2}
                 onChange={(newDate) => {
                     setDate2(newDate);
-
                     if (newDate && date1) {
                         onChange([date1, newDate]);
                     }


### PR DESCRIPTION
Closes: [Can't filter between two times in the same day #8511](https://github.com/lightdash/lightdash/issues/8511)

### Description:
Fixes inability to choose a time range within a day and shows error state if the times overlap.

![image](https://github.com/lightdash/lightdash/assets/11949472/ef2626b5-8ac7-42c4-af57-0e52573a4d2d)

![image](https://github.com/lightdash/lightdash/assets/11949472/19715dc0-867f-4fc8-84fc-aacf30be287e)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
