### PR TITLE
feat(cli): command to generate exposures

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
@@ -160,3 +160,19 @@ exposures:
       - ref('orders')
       - ref('payments')
       - ref('customers')
+  - name: ld_dashboard_a2a53dfe_2743_4bb6_b636_2b94a470a3da
+    type: dashboard
+    owner:
+      name: David Attenborough
+      email: ""
+    label: Jaffle dashboard
+    description: n/a
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/a2a53dfe-2743-4bb6-b636-2b94a470a3da/view
+    tags:
+      - lightdash
+      - dashboard
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')

--- a/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
@@ -1,0 +1,162 @@
+version: 2
+exposures:
+  - name: ld_project_3675b69e_8324_4110_bdca_059031aa8da3
+    type: application
+    owner:
+      name: David Attenborough
+      email: demo@lightdash.com
+    label: Lightdash - Jaffle shop
+    description: Lightdash project
+    url: http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/home
+    tags:
+      - lightdash
+      - project
+    depends_on:
+      - ref('plan')
+      - ref('customers')
+      - ref('membership')
+      - ref('orders')
+      - ref('payments')
+  - name: ld_chart_01962af0_d72a_4428_913b_2673298d752d
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How many users were created each month ?
+    description: A pivot table sample
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/01962af0-d72a-4428-913b-2673298d752d/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('plan')
+      - ref('customers')
+      - ref('membership')
+  - name: ld_chart_c53c4c5b_10d3_4b79_a616_0f7797c8fc21
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: What's our total revenue to date?
+    description: A single number showing the sum of all historical revenue
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/c53c4c5b-10d3-4b79-a616-0f7797c8fc21/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_be15e7e2_2ad4_49c7_b1fe_40d334e17373
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How many orders did we get on February?
+    description: A single value of the total number of orders received in February
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/be15e7e2-2ad4-49c7-b1fe-40d334e17373/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('customers')
+  - name: ld_chart_d801d67d_2852_4a94_a6cc_ac32e5a089bf
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How much revenue do we have per payment method each month?
+    description: A pivot table sample
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/d801d67d-2852-4a94-a6cc-ac32e5a089bf/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_3dc53928_60a1_450f_a351_9f443b87d988
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How much revenue do we have per payment method?
+    description: >-
+      Total revenue received via coupons, gift cards, bank transfers, and credit
+      cards
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/3dc53928-60a1-450f-a351-9f443b87d988/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_66d48c9a_4b09_45b2_a38b_09750abc569b
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How many orders we have over time ?
+    description: Time series of orders received per day and total orders over time
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/66d48c9a-4b09-45b2-a38b-09750abc569b/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('customers')
+  - name: ld_chart_28287c81_c608_42c3_9fa5_af4dec1e574b
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: What's the average spend per customer?
+    description: Average order size for each customer id
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/28287c81-c608-42c3-9fa5-af4dec1e574b/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('customers')
+  - name: ld_chart_2eac20e1_e391_46a9_901e_73ee5e453e78
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How do payment methods vary across different amount ranges?"
+    description: Payment range by amount
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/2eac20e1-e391-46a9-901e-73ee5e453e78/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_3cc86d58_4031_4587_bfdd_bc59a11c24b5
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: Which customers have not recently ordered an item?
+    description: A table of the 20 customers that least recently placed an order with us
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/3cc86d58-4031-4587-bfdd-bc59a11c24b5/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -11,6 +11,7 @@ import {
     ApiSuccessEmpty,
     CalculateTotalFromQuery,
     CreateProjectMember,
+    DbtExposure,
     UpdateProjectMember,
 } from '@lightdash/common';
 import {
@@ -18,6 +19,7 @@ import {
     Controller,
     Delete,
     Get,
+    Hidden,
     Middlewares,
     OperationId,
     Patch,
@@ -315,6 +317,26 @@ export class ProjectController extends Controller {
         return {
             status: 'ok',
             results: totalResult,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/dbt-exposures')
+    @OperationId('GetDbtExposures')
+    @Hidden()
+    async GetDbtExposures(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<{ status: 'ok'; results: Record<string, DbtExposure> }> {
+        this.setStatus(200);
+        const exposures = await projectService.getDbtExposures(
+            req.user!,
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results: exposures,
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2489,6 +2489,15 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.DbtExposure_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CacheMetadata: {
         dataType: 'refAlias',
         type: {
@@ -7045,6 +7054,52 @@ export function RegisterRoutes(app: express.Router) {
                 const controller = new ProjectController();
 
                 const promise = controller.CalculateTotalFromQuery.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/dbt-exposures',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.GetDbtExposures,
+        ),
+
+        function ProjectController_GetDbtExposures(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new ProjectController();
+
+                const promise = controller.GetDbtExposures.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2831,6 +2831,11 @@
                 "required": ["explore", "metricQuery"],
                 "type": "object"
             },
+            "Record_string.DbtExposure_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
             "CacheMetadata": {
                 "properties": {
                     "cacheHit": {
@@ -5690,7 +5695,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.930.0",
+        "version": "0.937.0",
         "description": "Open API documentation for all public Lightdash API endpoints",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -805,9 +805,7 @@ export class DashboardModel {
         }));
     }
 
-    async findInfoForDbtExposures(
-        projectUuid: string,
-    ): Promise<
+    async findInfoForDbtExposures(projectUuid: string): Promise<
         Array<
             Pick<Dashboard, 'uuid' | 'name' | 'description'> &
                 Pick<LightdashUser, 'firstName' | 'lastName'> & {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -10,6 +10,7 @@ import { s3CacheClient } from '../../clients/clients';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import {
     analyticsModel,
+    dashboardModel,
     jobModel,
     onboardingModel,
     projectModel,
@@ -93,6 +94,7 @@ jest.mock('../../models/models', () => ({
         getAttributeValuesForOrgMember: jest.fn(async () => ({})),
     },
     analyticsModel: {},
+    dashboardModel: {},
 }));
 
 describe('ProjectService', () => {
@@ -110,6 +112,7 @@ describe('ProjectService', () => {
         userAttributesModel,
         s3CacheClient,
         analyticsModel,
+        dashboardModel,
     });
     afterEach(() => {
         jest.clearAllMocks();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3150,7 +3150,7 @@ export class ProjectService {
                     email: '', // omit for now to avoid heavier query
                 },
                 label: chart.name,
-                description: chart.description,
+                description: chart.description ?? '',
                 url: `${lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${chart.uuid}/view`,
                 dependsOn: Object.keys(
                     explores.find(({ name }) => name === chart.tableName)
@@ -3175,7 +3175,7 @@ export class ProjectService {
                         email: '', // omit for now to avoid heavier query
                     },
                     label: dashboard.name,
-                    description: dashboard.description,
+                    description: dashboard.description ?? '',
                     url: `${lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboard.uuid}/view`,
                     dependsOn: uniq(
                         dashboard.chartUuids

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -88,6 +88,7 @@ export const projectService = new ProjectService({
     userAttributesModel,
     s3CacheClient,
     analyticsModel,
+    dashboardModel,
 });
 
 export const shareService = new ShareService({

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -40,6 +40,18 @@ type BaseTrack = Omit<AnalyticsTrack, 'context'>;
 - install.started
 - install.completed
 */
+type CliGenerateExposuresStarted = BaseTrack & {
+    event: 'generate_exposures.started';
+};
+type CliGenerateExposuresCompleted = BaseTrack & {
+    event: 'generate_exposures.completed';
+    properties: {
+        countExposures: number;
+    };
+};
+type CliGenerateExposuresError = BaseTrack & {
+    event: 'generate_exposures.error';
+};
 
 type CliGenerateStarted = BaseTrack & {
     event: 'generate.started';
@@ -216,6 +228,9 @@ type Track =
     | CliCreateError
     | CliStartStopPreview
     | CliStopPreviewMissing
+    | CliGenerateExposuresStarted
+    | CliGenerateExposuresCompleted
+    | CliGenerateExposuresError
     | CliLogin;
 
 export class LightdashAnalytics {

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -1,0 +1,89 @@
+import { AuthorizationError, DbtExposure } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import * as path from 'path';
+import { LightdashAnalytics } from '../analytics/analytics';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+
+type GenerateExposuresHandlerOptions = {
+    projectDir: string;
+    verbose: boolean;
+};
+
+export const generateExposuresHandler = async (
+    options: GenerateExposuresHandlerOptions,
+) => {
+    GlobalState.setVerbose(options.verbose);
+    await checkLightdashVersion();
+    const config = await getConfig();
+    if (!(config.context?.project && config.context.serverUrl)) {
+        throw new AuthorizationError(
+            `No active Lightdash project. Run 'lightdash login --help'`,
+        );
+    }
+
+    await LightdashAnalytics.track({
+        event: 'generate_exposures.started',
+    });
+
+    console.info(
+        styles.warning(
+            `This is an experimental feature and may change in future versions`,
+        ),
+    );
+
+    const spinner = GlobalState.startSpinner(
+        `  Generating .yml for Lightdash exposures`,
+    );
+    try {
+        const absoluteProjectPath = path.resolve(options.projectDir);
+
+        const exposures = await lightdashApi<Record<string, DbtExposure>>({
+            method: 'GET',
+            url: `/api/v1/projects/${config.context.project}/dbt-exposures`,
+            body: undefined,
+        });
+
+        console.info(
+            styles.info(`Found ${Object.keys(exposures).length} exposures`),
+        );
+
+        const outputFilePath = path.join(
+            absoluteProjectPath,
+            `/models/lightdash_exposures.yml`,
+        );
+        const updatedYml = {
+            version: 2 as const,
+            exposures: Object.values(exposures).map(
+                ({ dependsOn, ...rest }) => ({
+                    ...rest,
+                    depends_on: dependsOn,
+                }),
+            ),
+        };
+        const ymlString = yaml.dump(updatedYml, {
+            quotingType: '"',
+        });
+        await fs.writeFile(outputFilePath, ymlString);
+        spinner.succeed(`  Generated exposures file in '${outputFilePath}'`);
+        await LightdashAnalytics.track({
+            event: 'generate_exposures.completed',
+            properties: {
+                countExposures: Object.keys(exposures).length,
+            },
+        });
+    } catch (e: any) {
+        await LightdashAnalytics.track({
+            event: 'generate_exposures.error',
+            properties: {
+                trigger: 'generate',
+                error: `${e.message}`,
+            },
+        });
+        spinner.fail(`  Failed to generate exposures file'`);
+        throw e;
+    }
+};

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -36,7 +36,9 @@ export const generateExposuresHandler = async (
     );
 
     const spinner = GlobalState.startSpinner(
-        `  Generating .yml for Lightdash exposures`,
+        `  Generating Lightdash exposures .yml for project ${styles.bold(
+            config.context.projectName || config.context.project,
+        )}`,
     );
     try {
         const absoluteProjectPath = path.resolve(options.projectDir);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { refreshHandler } from './handlers/dbt/refresh';
 import { dbtRunHandler } from './handlers/dbt/run';
 import { deployHandler } from './handlers/deploy';
 import { generateHandler } from './handlers/generate';
+import { generateExposuresHandler } from './handlers/generateExposures';
 import { login } from './handlers/login';
 import {
     previewHandler,
@@ -575,6 +576,30 @@ ${styles.bold('Examples:')}
     .option('--verbose', undefined, false)
 
     .action(generateHandler);
+
+program
+    .command('generate-exposures')
+    .description(
+        '[Experimental command] Generates a .yml file for Lightdash exposures',
+    )
+    .addHelpText(
+        'after',
+        `
+${styles.bold('Examples:')}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+            'generate-exposures',
+        )} ${styles.secondary(
+            '-- generates .yml file for all lightdash exposures',
+        )}
+`,
+    )
+    .option(
+        '--project-dir <path>',
+        'The directory of the dbt project',
+        defaultProjectDir,
+    )
+    .option('--verbose', undefined, false)
+    .action(generateExposuresHandler);
 
 const errorHandler = (err: Error) => {
     console.error(styles.error(err.message || 'Error had no message'));

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -56,6 +56,7 @@ import { SlackSettings } from './types/slackSettings';
 
 import { Email } from './types/api/email';
 import { ApiSuccessEmpty } from './types/api/success';
+import { DbtExposure } from './types/dbt';
 import { EmailStatusExpiring } from './types/email';
 import { FieldValueSearchResult } from './types/fieldMatch';
 import { DashboardFilters } from './types/filter';
@@ -558,6 +559,7 @@ type ApiResults =
     | ApiSshKeyPairResponse['results']
     | MostPopularAndRecentlyUpdated
     | ApiCalculateTotalResponse['results']
+    | Record<string, DbtExposure>
     | ApiSuccessEmpty;
 
 export type ApiResponse = {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -431,3 +431,25 @@ export enum DbtManifestVersion {
     V10 = 'v10',
     V11 = 'v11',
 }
+
+export enum DbtExposureType {
+    DASHBOARD = 'dashboard',
+    NOTEBOOK = 'notebook',
+    ANALYSIS = 'analysis',
+    ML = 'ml',
+    APPLICATION = 'application',
+}
+
+export type DbtExposure = {
+    name: string; // a unique exposure name written in snake case
+    owner: {
+        name: string;
+        email: string;
+    };
+    type: DbtExposureType;
+    dependsOn: string[]; // list of refs to models. eg: ref('fct_orders')
+    label?: string;
+    description?: string;
+    url?: string;
+    tags?: string[];
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4062 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add experimental command to generate exposures.

**Note 1:** At the moment, it generates a yml file in `models/lightdash_exposures.yml` and replaces the existing file.
**Note 2:** only the active project and its dashboard and charts are generated.
**Note 3:** the owner is the last user whom updated the chart.
**Note 4:** charts depend on all possible joined tables

Command:
```lightdash generate-exposures```
<img width="1079" alt="Screenshot 2024-01-12 at 17 27 38" src="https://github.com/lightdash/lightdash/assets/9117144/280d053b-d07b-47e5-9dee-2397c055c496">

Dbt docs
<img width="1315" alt="Screenshot 2024-01-12 at 17 38 42" src="https://github.com/lightdash/lightdash/assets/9117144/7d0a2b57-3b33-401b-b59b-4561599c65b1">

Lineage
<img width="1260" alt="Screenshot 2024-01-12 at 17 40 09" src="https://github.com/lightdash/lightdash/assets/9117144/54dbf715-e348-45a1-bce6-9b4f669bb1ea">




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
