### PR TITLE
fix: omitting field in joins in tables with alias

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -1030,6 +1030,70 @@ export const compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields: Ex
         },
     };
 
+export const joinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields: UncompiledExplore =
+    {
+        ...exploreReferenceInJoin,
+        joinedTables: [
+            {
+                table: 'b',
+                alias: 'custom_alias', // includes alias
+                sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+                fields: ['dim2', 'dim3'], // doesn't include "dim1" that is required for join SQL
+            },
+        ],
+    };
+
+export const compiledJoinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields: Explore =
+    {
+        ...exploreReferenceInJoinCompiled,
+        joinedTables: [
+            {
+                table: 'custom_alias',
+                sqlOn: '${a.dim1} = ${custom_alias.dim1}',
+                compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
+                type: undefined,
+                hidden: undefined,
+            },
+        ],
+        tables: {
+            a: exploreReferenceInJoinCompiled.tables.a,
+            custom_alias: {
+                ...exploreReferenceInJoinCompiled.tables.b,
+                name: 'custom_alias',
+                label: 'Custom alias',
+                dimensions: {
+                    ...exploreReferenceInJoinCompiled.tables.b.dimensions,
+                    dim1: {
+                        ...exploreReferenceInJoinCompiled.tables.b.dimensions
+                            .dim1,
+                        table: 'custom_alias',
+                        tableLabel: 'Custom alias',
+                        compiledSql: '"custom_alias".dim1',
+                        tablesReferences: ['custom_alias'],
+
+                        hidden: true,
+                    },
+                    dim2: {
+                        ...exploreReferenceInJoinCompiled.tables.b.dimensions
+                            .dim2,
+                        table: 'custom_alias',
+                        tableLabel: 'Custom alias',
+                        compiledSql: '("a".dim1)',
+                        tablesReferences: ['custom_alias', 'a'],
+                    },
+                    dim3: {
+                        ...exploreReferenceInJoinCompiled.tables.b.dimensions
+                            .dim3,
+                        table: 'custom_alias',
+                        tableLabel: 'Custom alias',
+                        compiledSql: '"custom_alias".dim3',
+                        tablesReferences: ['custom_alias'],
+                    },
+                },
+            },
+        },
+    };
+
 export const exploreWithMetricNumber: UncompiledExplore = {
     ...exploreBase,
     tables: {

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -6,6 +6,7 @@ import {
     compiledJoinedExploreOverridingAliasAndLabel,
     compiledJoinedExploreOverridingJoinAlias,
     compiledJoinedExploreOverridingJoinLabel,
+    compiledJoinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields,
     compiledJoinedExploreWithSubsetOfFields,
     compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     compiledSimpleJoinedExplore,
@@ -33,6 +34,7 @@ import {
     joinedExploreOverridingAliasAndLabel,
     joinedExploreOverridingJoinAlias,
     joinedExploreOverridingJoinLabel,
+    joinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields,
     joinedExploreWithSubsetOfFields,
     joinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     simpleJoinedExplore,
@@ -149,6 +151,15 @@ describe('Explores with a base table and joined table', () => {
             ),
         ).toStrictEqual(
             compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
+        );
+    });
+    test('should compile joins with a join alias and a subset of fields selected on join which dont include the fields in the join SQL', () => {
+        expect(
+            compiler.compileExplore(
+                joinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields,
+            ),
+        ).toStrictEqual(
+            compiledJoinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeSqlFields,
         );
     });
     test('should compile with a hidden join', () => {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -123,7 +123,7 @@ export class ExploreCompiler {
                     join.sqlOn,
                     join.table,
                 ).reduce<string[]>((acc, reference) => {
-                    if (reference.refTable === join.table) {
+                    if (reference.refTable === joinTableName) {
                         acc.push(reference.refName);
                     }
                     return acc;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8305 

### Description:

The table alias was not considered when `requiredDimensionsForJoin` were calculated.
Changed `join.table` to  `joinTableName`.
Added tests for the same.

Example Schema:
```
name: customers
    meta:
      joins:
        - join: membership
          alias: membership_alias
          sql_on: ${customers.customer_id } = ${membership_alias.customer_id}
          fields: [plan_id]
```

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/c501e1a3-f83f-47da-9ad6-c2d227bb3799)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/42ee0435-81d8-44d6-bf28-13dfa126197a)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
