### PR TITLE
fix: validate email inputs to not allow whitespaces

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -171,15 +171,24 @@ export * from './utils/time';
 export * from './utils/timeFrames';
 
 export const validateEmail = (email: string): boolean => {
+    if (/\s/.test(email)) {
+        return false;
+    }
+
     const re =
         /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(String(email).toLowerCase());
 };
 
 export const getEmailSchema = () =>
-    z.string().refine((email) => validateEmail(email), {
-        message: 'must be a valid email',
-    });
+    z
+        .string()
+        .refine((email) => validateEmail(email), {
+            message: 'Email address is not valid',
+        })
+        .refine((email) => !/\s/.test(email), {
+            message: 'Email address must not contain whitespaces',
+        });
 
 export const getPasswordSchema = () =>
     z

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -1,4 +1,8 @@
 export const getEmailDomain = (email: string): string => {
+    if (/\s/.test(email)) {
+        throw new Error(`Invalid email, contains whitespace: ${email}`);
+    }
+
     const domain = email.split('@')[1];
     if (!domain) {
         throw new Error(`Invalid email: ${email}`);

--- a/packages/e2e/cypress/e2e/app/login.cy.ts
+++ b/packages/e2e/cypress/e2e/app/login.cy.ts
@@ -27,10 +27,16 @@ describe('Login', () => {
         cy.findByPlaceholderText('Your email address').type('test-email');
         cy.findByPlaceholderText('Your password').type('test-password');
         cy.get('[data-cy="signin-button"]').click();
-        cy.findByText('Your email address is not valid').should('be.visible');
+        cy.findByText('Email address is not valid').should('be.visible');
         cy.findByPlaceholderText('Your email address').type('test@emaill.com');
         cy.findByPlaceholderText('Your password').type('test-password');
         cy.get('[data-cy="signin-button"]').click();
         cy.findByText('Email and password not recognized').should('be.visible');
+        cy.findByPlaceholderText('Your email address').type('test@email.com ');
+        cy.findByPlaceholderText('Your password').type('test-password');
+        cy.get('[data-cy="signin-button"]').click();
+        cy.findByText('Email address must not contain whitespaces').should(
+            'be.visible',
+        );
     });
 });

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InvitesModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InvitesModal.tsx
@@ -1,12 +1,13 @@
 import {
     CreateInviteLink,
+    getEmailSchema,
     OrganizationMemberRole,
-    validateEmail,
 } from '@lightdash/common';
 import { Button, Group, Modal, Select, TextInput, Title } from '@mantine/core';
-import { useForm } from '@mantine/form';
+import { useForm, zodResolver } from '@mantine/form';
 import { IconUser } from '@tabler/icons-react';
 import React, { FC } from 'react';
+import { z } from 'zod';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useApp } from '../../../providers/AppProvider';
 import { TrackPage, useTracking } from '../../../providers/TrackingProvider';
@@ -30,10 +31,11 @@ const InvitesModal: FC<{
             email: '',
             role: OrganizationMemberRole.EDITOR,
         },
-        validate: {
-            email: (value: string) =>
-                validateEmail(value) ? null : 'Your email address is not valid',
-        },
+        validate: zodResolver(
+            z.object({
+                email: getEmailSchema(),
+            }),
+        ),
     });
     const { track } = useTracking();
     const { health, user } = useApp();

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -1,11 +1,11 @@
 import {
     ApiError,
+    getEmailSchema,
     LightdashMode,
     LightdashUser,
     OpenIdIdentityIssuerType,
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
-    validateEmail,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -19,11 +19,12 @@ import {
     TextInput,
     Title,
 } from '@mantine/core';
-import { useForm } from '@mantine/form';
+import { useForm, zodResolver } from '@mantine/form';
 import { FC, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { Redirect, useLocation } from 'react-router-dom';
 
+import { z } from 'zod';
 import { lightdashApi } from '../api';
 import Page from '../components/common/Page/Page';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
@@ -67,10 +68,11 @@ const LoginContent: FC = () => {
             email: '',
             password: '',
         },
-        validate: {
-            email: (value) =>
-                validateEmail(value) ? null : 'Your email address is not valid',
-        },
+        validate: zodResolver(
+            z.object({
+                email: getEmailSchema(),
+            }),
+        ),
     });
 
     const { identify } = useTracking();

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -1,4 +1,4 @@
-import { validateEmail } from '@lightdash/common';
+import { getEmailSchema } from '@lightdash/common';
 import {
     Anchor,
     Button,
@@ -9,9 +9,10 @@ import {
     TextInput,
     Title,
 } from '@mantine/core';
-import { useForm } from '@mantine/form';
+import { useForm, zodResolver } from '@mantine/form';
 import { FC } from 'react';
 import { Link } from 'react-router-dom';
+import { z } from 'zod';
 import { usePasswordResetLinkMutation } from '../hooks/usePasswordReset';
 import { useApp } from '../providers/AppProvider';
 
@@ -23,10 +24,11 @@ export const PasswordRecoveryForm: FC = () => {
         initialValues: {
             email: '',
         },
-        validate: {
-            email: (value: string) =>
-                validateEmail(value) ? null : 'Your email address is not valid',
-        },
+        validate: zodResolver(
+            z.object({
+                email: getEmailSchema(),
+            }),
+        ),
     });
 
     const { isLoading, isSuccess, mutate, reset } =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8198 

### Description:

- Updated `getEmailSchema` and `validateEmail` to check for whitespaces in emails.
- Utilised zodResolver to validate emails.
- Updated login e2e tests to check for whitespaces
- Project Access contain a Select for user email so it shouldn't be an issue here.
- The Profile section handles this automatically by built-in validation. If needed, we can add the logic for text in showToastError.

![image](https://github.com/lightdash/lightdash/assets/85165953/dd417bc1-3e25-4a02-8376-43d35706d595)

Some Examples:

Login:

![image](https://github.com/lightdash/lightdash/assets/85165953/c7a76249-18e0-4b10-bcdf-d09a372ef980)

Signup:

![image](https://github.com/lightdash/lightdash/assets/85165953/1b4d5d54-8d4b-4fdd-ac55-6f1f45aec6b7)

Invite User:

![image](https://github.com/lightdash/lightdash/assets/85165953/3f3c821d-a592-4f28-803e-2addb85ac76e)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
