### PR TITLE
feat: parameterize the output path of `generate-exposures`

### DIFF
--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -11,6 +11,7 @@ import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 type GenerateExposuresHandlerOptions = {
     projectDir: string;
     verbose: boolean;
+    output?: string;
 };
 
 export const generateExposuresHandler = async (
@@ -53,10 +54,9 @@ export const generateExposuresHandler = async (
             styles.info(`Found ${Object.keys(exposures).length} exposures`),
         );
 
-        const outputFilePath = path.join(
-            absoluteProjectPath,
-            `/models/lightdash_exposures.yml`,
-        );
+        const outputFilePath =
+            options.output ||
+            path.join(absoluteProjectPath, 'models', 'lightdash_exposures.yml');
         const updatedYml = {
             version: 2 as const,
             exposures: Object.values(exposures).map(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -599,6 +599,11 @@ ${styles.bold('Examples:')}
         defaultProjectDir,
     )
     .option('--verbose', undefined, false)
+    .option(
+        '--output <path>',
+        'The path where the output exposures YAML file will be written',
+        undefined,
+    )
     .action(generateExposuresHandler);
 
 const errorHandler = (err: Error) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: NA

If I should open an issue for the pull request ahead, please let me know.

### Description:
It would be useful to provide an option to determine the output path of the exposures YAML file.

We assume if we deploy multiple Lightdash projects from a dbt project by switching dbt selectors. We might want to separate the exposures YAML files corresponding to Lightdash projects respectively. 

I don't completely understand the behavior of the CLI command. But, here is what I'm thinking. 
```
# Deploy project1
lightdash deploy --selector project1
# Generate exposures for project1
LIGHTDASH_PROJECT="xxxx-for-project1" lightdash generate-exposures --output ./models/exposures/project1.yml 

# Deploy project2
lightdash deploy --selector project2
# Genrate exposures for project2
LIGHTDASH_PROJECT="xxxx-for-project2" lightdash generate-exposures --output ./models/exposures/project2.yml
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
