### PR TITLE
fix: date zoom timestamp

### DIFF
--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -105,7 +105,12 @@ export const isDateItem = (
         return false;
     }
     if (isField(item) || isAdditionalMetric(item)) {
-        const dateTypes: string[] = [DimensionType.DATE, MetricType.DATE];
+        const dateTypes: string[] = [
+            DimensionType.DATE,
+            MetricType.DATE,
+            DimensionType.TIMESTAMP,
+            MetricType.TIMESTAMP,
+        ];
         return dateTypes.includes(item.type);
     }
     return true;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #8269

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Fix date zoom on timestamps 

Tips PR does not add new zoom types

[Screencast from 16-01-24 11:16:18.webm](https://github.com/lightdash/lightdash/assets/1983672/533e9254-81f1-4c3f-b358-3a2d01f9af63)

This common date function was also used on reference lines, which I tested

This common method was used to return `hasADateDimension` on metadata, so the frontend knows which charts need to reload on date zoom changes 


![Screenshot from 2024-01-16 11-17-31](https://github.com/lightdash/lightdash/assets/1983672/562664e3-79f0-4f25-adb5-5a4f67797e3f)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
