### PR TITLE
fix(cli): generate exposures for dashboards

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -809,7 +809,7 @@ export class DashboardModel {
         Array<
             Pick<Dashboard, 'uuid' | 'name' | 'description'> &
                 Pick<LightdashUser, 'firstName' | 'lastName'> & {
-                    chartUuids: string[];
+                    chartUuids: string[] | null;
                 }
         >
     > {
@@ -852,7 +852,7 @@ export class DashboardModel {
                 firstName: `${UserTableName}.first_name`,
                 lastName: `${UserTableName}.last_name`,
                 chartUuids: this.database.raw(
-                    "COALESCE(json_agg(saved_queries.saved_query_uuid), '[]')",
+                    'ARRAY_AGG(DISTINCT saved_queries.saved_query_uuid) FILTER (WHERE saved_queries.saved_query_uuid IS NOT NULL)',
                 ),
             })
             .orderBy([

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -873,6 +873,7 @@ export class DashboardModel {
                 `${DashboardVersionsTableName}.dashboard_id`,
                 `${DashboardVersionsTableName}.created_at`,
             )
+            .distinctOn(`${DashboardVersionsTableName}.dashboard_id`)
             .where(`${ProjectTableName}.project_uuid`, projectUuid);
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3177,21 +3177,24 @@ export class ProjectService {
                     label: dashboard.name,
                     description: dashboard.description ?? '',
                     url: `${lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboard.uuid}/view`,
-                    dependsOn: uniq(
-                        dashboard.chartUuids
-                            .map((chartUuid) => {
-                                const chartExposureId = `ld_chart_${snakeCaseName(
-                                    chartUuid,
-                                )}`;
-                                const chartExposure = chartExposures.find(
-                                    ({ name }) => name === chartExposureId,
-                                );
-                                return chartExposure
-                                    ? chartExposure.dependsOn
-                                    : [];
-                            })
-                            .flat(),
-                    ),
+                    dependsOn: dashboard.chartUuids
+                        ? uniq(
+                              dashboard.chartUuids
+                                  .map((chartUuid) => {
+                                      const chartExposureId = `ld_chart_${snakeCaseName(
+                                          chartUuid,
+                                      )}`;
+                                      const chartExposure = chartExposures.find(
+                                          ({ name }) =>
+                                              name === chartExposureId,
+                                      );
+                                      return chartExposure
+                                          ? chartExposure.dependsOn
+                                          : [];
+                                  })
+                                  .flat(),
+                          )
+                        : [],
                     tags: ['lightdash', 'dashboard'],
                 });
                 return acc;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8604 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Changes:
- Amend SQL to ignore any possible null values and handle when dashboard doesn't have any charts
- Amend SQL to only return one row per dashboard instead of 1 row per dashboard version

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
