### PR TITLE
fix: add extra scopes env var for okta groups

### DIFF
--- a/docs/docs/references/groups.mdx
+++ b/docs/docs/references/groups.mdx
@@ -32,7 +32,13 @@ You can assign user attributes to groups as well as individual users. To learn m
 
 ## Using OKTA to manage groups in Lightdash
 
-If your Lightdash instance is configured to [use OKTA as an authentication provider](../self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx#okta), then users will automatically be assigned to the same groups in Lightdash as they are in OKTA. Note that users will only be assigned to groups that exist in Lightdash (groups won't be created automatically) and exactly match the name of the group in OKTA.
+If your Lightdash instance is configured to [use OKTA as an authentication provider](../self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx#okta), then users will automatically be assigned to the same groups in Lightdash as they are in OKTA. See the guide to [setting up OKTA](../self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx#okta) for more information on setting the correct environment variables as well as Okta configuration: with/without custom authorization server. 
+
+:::info
+
+Note that users will only be assigned to groups that exist in Lightdash (groups won't be created automatically) and exactly match the name of the group in OKTA.
+
+:::
 
 To manage groups in Lightdash using OKTA, you'll need to:
 1. [Setup groups in your directory in OKTA](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-bulk-assign-group-people.htm)

--- a/docs/docs/self-host/customize-deployment/environment-variables.mdx
+++ b/docs/docs/self-host/customize-deployment/environment-variables.mdx
@@ -49,22 +49,23 @@ This is a reference to all the SMTP environment variables that can be used to co
 
 These variables enable you to control Single Sign On (SSO) functionality.
 
-| Variable                               | Description                                              | Required? | Default |
-|----------------------------------------|----------------------------------------------------------|-----------|---------|
-| `AUTH_DISABLE_PASSWORD_AUTHENTICATION` | If `"true"` disables signing in with plain passwords     |           | false   |
-| `AUTH_GOOGLE_OAUTH2_CLIENT_ID`         | Required for Google SSO                                  |           |         |
-| `AUTH_GOOGLE_OAUTH2_CLIENT_SECRET`     | Required for Google SSO                                  |           |         |
-| `AUTH_OKTA_OAUTH_CLIENT_ID`            | Required for Okta SSO                                    |           |         |
-| `AUTH_OKTA_OAUTH_CLIENT_SECRET`        | Required for Okta SSO                                    |           |         |
-| `AUTH_OKTA_OAUTH_ISSUER`               | Required for Okta SSO                                    |           |         |
-| `AUTH_OKTA_DOMAIN`                     | Required for Okta SSO                                    |           |         |
-| `AUTH_OKTA_AUTHORIZATION_SERVER_ID`    | Optional for Okta SSO with a custom authorization server |           |         |
-| `AUTH_ONE_LOGIN_OAUTH_CLIENT_ID`       | Required for One Login SSO                               |           |         |
-| `AUTH_ONE_LOGIN_OAUTH_CLIENT_SECRET`   | Required for One Login SSO                               |           |         |
-| `AUTH_ONE_LOGIN_OAUTH_ISSUER`          | Required for One Login SSO                               |           |         |
-| `AUTH_AZURE_AD_OAUTH_CLIENT_ID`        | Required for Azure AD                                    |           |         |
-| `AUTH_AZURE_AD_OAUTH_CLIENT_SECRET`    | Required for Azure AD                                    |           |         |
-| `AUTH_AZURE_AD_OAUTH_TENANT_ID`        | Required for Azure AD                                    |           |         |
+| Variable                               | Description                                                                      | Required? | Default |
+|----------------------------------------|----------------------------------------------------------------------------------|-----------|---------|
+| `AUTH_DISABLE_PASSWORD_AUTHENTICATION` | If `"true"` disables signing in with plain passwords                             |           | false   |
+| `AUTH_GOOGLE_OAUTH2_CLIENT_ID`         | Required for Google SSO                                                          |           |         |
+| `AUTH_GOOGLE_OAUTH2_CLIENT_SECRET`     | Required for Google SSO                                                          |           |         |
+| `AUTH_OKTA_OAUTH_CLIENT_ID`            | Required for Okta SSO                                                            |           |         |
+| `AUTH_OKTA_OAUTH_CLIENT_SECRET`        | Required for Okta SSO                                                            |           |         |
+| `AUTH_OKTA_OAUTH_ISSUER`               | Required for Okta SSO                                                            |           |         |
+| `AUTH_OKTA_DOMAIN`                     | Required for Okta SSO                                                            |           |         |
+| `AUTH_OKTA_AUTHORIZATION_SERVER_ID`    | Optional for Okta SSO with a custom authorization server                         |           |         |
+| `AUTH_OKTA_EXTRA_SCOPES`               | Optional for Okta SSO scopes (e.g. groups) without a custom authorization server |           |         |
+| `AUTH_ONE_LOGIN_OAUTH_CLIENT_ID`       | Required for One Login SSO                                                       |           |         |
+| `AUTH_ONE_LOGIN_OAUTH_CLIENT_SECRET`   | Required for One Login SSO                                                       |           |         |
+| `AUTH_ONE_LOGIN_OAUTH_ISSUER`          | Required for One Login SSO                                                       |           |         |
+| `AUTH_AZURE_AD_OAUTH_CLIENT_ID`        | Required for Azure AD                                                            |           |         |
+| `AUTH_AZURE_AD_OAUTH_CLIENT_SECRET`    | Required for Azure AD                                                            |           |         |
+| `AUTH_AZURE_AD_OAUTH_TENANT_ID`        | Required for Azure AD                                                            |           |         |
 
 # Logging environment variables
 

--- a/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -76,7 +76,7 @@ You'll need to set the following environment variables in your Lightdash deploym
 
 #### Groups & Okta
 
-If you want to use groups to control access to Lightdash, you'll need to set the `AUTH_OKTA_EXTRA_SCOPES` environment, and add the `groups` scope (e.g. `AUTH_OKTA_EXTRA_SCOPES=groups`).
+If you want to use groups to control access to Lightdash, you'll need to configure Okta and Lightdash to support this.
 
 If you're **not** using a custom authorization server ID:
 - on `OpenID Connect ID Token` section in the Okta application settings, add `groups` to the `Groups claim` field, by setting a Groups claims type to `Filter` and a Filter to match expression to `.*`

--- a/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -61,6 +61,17 @@ for a custom authorization server navigate to **API** > **Authorization Servers*
 server and note the **Issuer URI** and **Name** of the authorization server. For example the `default` authorization
 server has an issuer URI of `https://dev-123456.okta.com/oauth2/default`.
 
+#### Groups & Okta
+
+If you want to use groups to control access to Lightdash, you'll need to configure Okta and Lightdash to support this.
+
+If you're **not** using a custom authorization server ID:
+- on `OpenID Connect ID Token` section in the Okta application settings, add `groups` to the `Groups claim` field, by setting a Groups claims type to `Filter` and a Filter to match expression to `.*`
+
+If you're using a custom authorization server ID:
+- you don't need to set the `AUTH_OKTA_EXTRA_SCOPES` environment variable
+- on the Authorization Server settings, add claim `groups`, value type `Groups`, matches regex `.*`
+
 ### Configuring Lightdash for Okta
 
 You'll need to set the following environment variables in your Lightdash deployment:
@@ -74,16 +85,7 @@ You'll need to set the following environment variables in your Lightdash deploym
 | `AUTH_OKTA_AUTHORIZATION_SERVER_ID` | Optional. The **Name** of a custom authorization server if not using the org authorization server. |            |
 | `AUTH_OKTA_EXTRA_SCOPES`            | Optional. The extra **scopes** (e.g. "groups") when not using a custom authorization server        |            |
 
-#### Groups & Okta
 
-If you want to use groups to control access to Lightdash, you'll need to configure Okta and Lightdash to support this.
-
-If you're **not** using a custom authorization server ID:
-- on `OpenID Connect ID Token` section in the Okta application settings, add `groups` to the `Groups claim` field, by setting a Groups claims type to `Filter` and a Filter to match expression to `.*`
-
-If you're using a custom authorization server ID:
-- you don't need to set the `AUTH_OKTA_EXTRA_SCOPES` environment variable
-- on the Authorization Server settings, add claim `groups`, value type `Groups`, matches regex `.*`
 
 ## Google
 

--- a/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -73,7 +73,17 @@ You'll need to set the following environment variables in your Lightdash deploym
 | `AUTH_OKTA_OAUTH_ISSUER`            | The **Issuer URI** copied from the authorization server. Should include `https://`                 | ✅         |
 | `AUTH_OKTA_AUTHORIZATION_SERVER_ID` | Optional. The **Name** of a custom authorization server if not using the org authorization server. |            |
 | `AUTH_OKTA_EXTRA_SCOPES`            | Optional. The extra **scopes** (e.g. "groups") when not using a custom authorization server        |            |
-| `AUTH_OKTA_EXTRA_SCOPES`            | Optional for Okta SSO scopes (e.g. groups) without a custom authorization server                   |            |
+
+#### Groups & Okta
+
+If you want to use groups to control access to Lightdash, you'll need to set the `AUTH_OKTA_EXTRA_SCOPES` environment, and add the `groups` scope (e.g. `AUTH_OKTA_EXTRA_SCOPES=groups`).
+
+If you're **not** using a custom authorization server ID:
+- on `OpenID Connect ID Token` section in the Okta application settings, add `groups` to the `Groups claim` field, by setting a Groups claims type to `Filter` and a Filter to match expression to `.*`
+
+If you're using a custom authorization server ID:
+- you don't need to set the `AUTH_OKTA_EXTRA_SCOPES` environment variable
+- on the Authorization Server settings, add claim `groups`, value type `Groups`, matches regex `.*`
 
 ## Google
 

--- a/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -65,13 +65,15 @@ server has an issuer URI of `https://dev-123456.okta.com/oauth2/default`.
 
 You'll need to set the following environment variables in your Lightdash deployment:
 
-| Variable                            | Description                                                                                        | Required? |
-|-------------------------------------|----------------------------------------------------------------------------------------------------|-----------|
+| Variable                            | Description                                                                                        | Required?  |
+|-------------------------------------|----------------------------------------------------------------------------------------------------|------------|
 | `AUTH_OKTA_DOMAIN`                  | The `{{ okta_domain }}`. Should not include `https://`                                             | ✅         |
 | `AUTH_OKTA_OAUTH_CLIENT_ID`         | The **Client ID** copied from the application settings in okta                                     | ✅         |
 | `AUTH_OKTA_OAUTH_CLIENT_SECRET`     | The **Client secret** copied from the application settings in okta                                 | ✅         |
 | `AUTH_OKTA_OAUTH_ISSUER`            | The **Issuer URI** copied from the authorization server. Should include `https://`                 | ✅         |
-| `AUTH_OKTA_AUTHORIZATION_SERVER_ID` | Optional. The **Name** of a custom authorization server if not using the org authorization server. |           |
+| `AUTH_OKTA_AUTHORIZATION_SERVER_ID` | Optional. The **Name** of a custom authorization server if not using the org authorization server. |            |
+| `AUTH_OKTA_EXTRA_SCOPES`            | Optional. The extra **scopes** (e.g. "groups") when not using a custom authorization server        |            |
+| `AUTH_OKTA_EXTRA_SCOPES`            | Optional for Okta SSO scopes (e.g. groups) without a custom authorization server                   |            |
 
 ## Google
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -192,6 +192,7 @@ type AuthOktaConfig = {
     oauth2ClientId: string | undefined;
     oauth2ClientSecret: string | undefined;
     authorizationServerId: string | undefined;
+    extraScopes: string | undefined;
     oktaDomain: string | undefined;
     callbackPath: string;
     loginPath: string;
@@ -330,6 +331,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
                 oauth2ClientSecret: process.env.AUTH_OKTA_OAUTH_CLIENT_SECRET,
                 authorizationServerId:
                     process.env.AUTH_OKTA_AUTHORIZATION_SERVER_ID,
+                extraScopes: process.env.AUTH_OKTA_EXTRA_SCOPES,
                 oktaDomain: process.env.AUTH_OKTA_DOMAIN,
                 callbackPath: '/oauth/redirect/okta',
                 loginPath: '/login/okta',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -192,7 +192,7 @@ type AuthOktaConfig = {
     oauth2ClientId: string | undefined;
     oauth2ClientSecret: string | undefined;
     authorizationServerId: string | undefined;
-    extraScopes: string | undefined;
+    extraScopes: string[] | undefined;
     oktaDomain: string | undefined;
     callbackPath: string;
     loginPath: string;
@@ -331,7 +331,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
                 oauth2ClientSecret: process.env.AUTH_OKTA_OAUTH_CLIENT_SECRET,
                 authorizationServerId:
                     process.env.AUTH_OKTA_AUTHORIZATION_SERVER_ID,
-                extraScopes: process.env.AUTH_OKTA_EXTRA_SCOPES,
+                extraScopes: process.env.AUTH_OKTA_EXTRA_SCOPES?.split(' '),
                 oktaDomain: process.env.AUTH_OKTA_DOMAIN,
                 callbackPath: '/oauth/redirect/okta',
                 loginPath: '/login/okta',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -192,7 +192,7 @@ type AuthOktaConfig = {
     oauth2ClientId: string | undefined;
     oauth2ClientSecret: string | undefined;
     authorizationServerId: string | undefined;
-    extraScopes: string[] | undefined;
+    extraScopes: string | undefined;
     oktaDomain: string | undefined;
     callbackPath: string;
     loginPath: string;
@@ -331,7 +331,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
                 oauth2ClientSecret: process.env.AUTH_OKTA_OAUTH_CLIENT_SECRET,
                 authorizationServerId:
                     process.env.AUTH_OKTA_AUTHORIZATION_SERVER_ID,
-                extraScopes: process.env.AUTH_OKTA_EXTRA_SCOPES?.split(' '),
+                extraScopes: process.env.AUTH_OKTA_EXTRA_SCOPES,
                 oktaDomain: process.env.AUTH_OKTA_DOMAIN,
                 callbackPath: '/oauth/redirect/okta',
                 loginPath: '/login/okta',

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -250,10 +250,14 @@ export const initiateOktaOpenIdLogin: RequestHandler = async (
         const codeVerifier = generators.codeVerifier();
         const codeChallenge = generators.codeChallenge(codeVerifier);
 
+        const extraScopes = lightdashConfig.auth.okta.extraScopes
+            ? ` ${lightdashConfig.auth.okta.extraScopes.join(' ')}`
+            : '';
+
         const authorizationUrl = client.authorizationUrl({
             redirect_uri: redirectUri,
             response_type: 'code',
-            scope: 'openid profile email',
+            scope: 'openid profile email'.concat(extraScopes),
             code_challenge: codeChallenge,
             code_challenge_method: 'S256',
             state,

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -28,7 +28,6 @@ import {
     VerifyFunctionWithRequest,
 } from 'passport-openidconnect';
 import { Strategy } from 'passport-strategy';
-import path from 'path';
 import { URL } from 'url';
 import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
@@ -231,7 +230,6 @@ export class OpenIDClientOktaStrategy extends Strategy {
         } catch (err) {
             return this.error(err);
         }
-        return this.fail(401);
     }
 }
 

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -250,14 +250,14 @@ export const initiateOktaOpenIdLogin: RequestHandler = async (
         const codeVerifier = generators.codeVerifier();
         const codeChallenge = generators.codeChallenge(codeVerifier);
 
-        const extraScopes = lightdashConfig.auth.okta.extraScopes
-            ? ` ${lightdashConfig.auth.okta.extraScopes.join(' ')}`
-            : '';
-
         const authorizationUrl = client.authorizationUrl({
             redirect_uri: redirectUri,
             response_type: 'code',
-            scope: 'openid profile email'.concat(extraScopes),
+            scope: 'openid profile email'.concat(
+                lightdashConfig.auth.okta.extraScopes
+                    ? ` ${lightdashConfig.auth.okta.extraScopes}`
+                    : '',
+            ),
             code_challenge: codeChallenge,
             code_challenge_method: 'S256',
             state,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -55,7 +55,7 @@ export const lightdashConfigMock: LightdashConfig = {
             oauth2ClientId: undefined,
             oauth2Issuer: undefined,
             authorizationServerId: undefined,
-            extraScopes: '',
+            extraScopes: undefined,
             oktaDomain: undefined,
         },
         oneLogin: {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -55,6 +55,7 @@ export const lightdashConfigMock: LightdashConfig = {
             oauth2ClientId: undefined,
             oauth2Issuer: undefined,
             authorizationServerId: undefined,
+            extraScopes: '',
             oktaDomain: undefined,
         },
         oneLogin: {

--- a/packages/backend/src/models/SavedChartModel.mock.ts
+++ b/packages/backend/src/models/SavedChartModel.mock.ts
@@ -53,6 +53,7 @@ export const lightdashConfigMock: LightdashConfig = {
             oauth2ClientId: undefined,
             oauth2Issuer: undefined,
             authorizationServerId: undefined,
+            extraScopes: '',
             oktaDomain: undefined,
         },
         oneLogin: {

--- a/packages/backend/src/models/SavedChartModel.mock.ts
+++ b/packages/backend/src/models/SavedChartModel.mock.ts
@@ -53,7 +53,7 @@ export const lightdashConfigMock: LightdashConfig = {
             oauth2ClientId: undefined,
             oauth2Issuer: undefined,
             authorizationServerId: undefined,
-            extraScopes: '',
+            extraScopes: undefined,
             oktaDomain: undefined,
         },
         oneLogin: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8610

### Description:

Recap:
1. if `AUTH_OKTA_AUTHORIZATION_SERVER_ID` is set:
we use that and the `AUTH_OKTA_DOMAIN`  + `AUTH_OKTA_AUTHORIZATION_SERVER_ID` to construct the issuer URI

Okta-side config:
we expect the user to turn on the `claims` to get groups on the Okta Admin panel for the Authorization Server

2. if `AUTH_OKTA_AUTHORIZATION_SERVER_ID` is  not set:
we just use the AUTH_OKTA_DOMAIN to construct the issuer URI
⚠️ introduced on this PR: we pass the `groups` scope by adding this scope as `AUTH_OKTA_EXTRA_SCOPES`.

Okta-side config:
we expect the user to turn on the `claim` `groups` on the `sign on` section of the Okta App configuration

With the new env var `AUTH_OKTA_EXTRA_SCOPES`, this should be set as a space-delimited string of scopes, e.g. "groups scope1 scope2"


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
