### PR TITLE
chore(cli): add execution ID to command events

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -42,20 +42,28 @@ type BaseTrack = Omit<AnalyticsTrack, 'context'>;
 */
 type CliGenerateExposuresStarted = BaseTrack & {
     event: 'generate_exposures.started';
+    properties: {
+        executionId: string;
+    };
 };
 type CliGenerateExposuresCompleted = BaseTrack & {
     event: 'generate_exposures.completed';
     properties: {
+        executionId: string;
         countExposures: number;
     };
 };
 type CliGenerateExposuresError = BaseTrack & {
     event: 'generate_exposures.error';
+    properties: {
+        executionId: string;
+    };
 };
 
 type CliGenerateStarted = BaseTrack & {
     event: 'generate.started';
     properties: {
+        executionId: string;
         numModelsSelected: number | undefined;
         trigger: string; // generate or dbt
     };
@@ -63,6 +71,7 @@ type CliGenerateStarted = BaseTrack & {
 type CliGenerateCompleted = BaseTrack & {
     event: 'generate.completed';
     properties: {
+        executionId: string;
         numModelsSelected: number | undefined;
         trigger: string; // generate or dbt
     };
@@ -70,6 +79,7 @@ type CliGenerateCompleted = BaseTrack & {
 type CliGenerateError = BaseTrack & {
     event: 'generate.error';
     properties: {
+        executionId: string;
         trigger: string;
         error: string;
     };
@@ -92,18 +102,28 @@ type CliDbtError = BaseTrack & {
 type CliPreviewStarted = BaseTrack & {
     event: 'preview.started';
     properties: {
+        executionId: string;
         projectId: string;
     };
 };
 type CliPreviewCompleted = BaseTrack & {
     event: 'preview.completed';
     properties: {
+        executionId: string;
+        projectId: string;
+    };
+};
+type CliPreviewStopped = BaseTrack & {
+    event: 'preview.stopped';
+    properties: {
+        executionId: string;
         projectId: string;
     };
 };
 type CliPreviewError = BaseTrack & {
     event: 'preview.error';
     properties: {
+        executionId: string;
         projectId: string;
         error: string;
     };
@@ -112,18 +132,21 @@ type CliPreviewError = BaseTrack & {
 type CliRefreshStarted = BaseTrack & {
     event: 'refresh.started';
     properties: {
+        executionId: string;
         projectId: string;
     };
 };
 type CliRefreshCompleted = BaseTrack & {
     event: 'refresh.completed';
     properties: {
+        executionId: string;
         projectId: string;
     };
 };
 type CliRefreshError = BaseTrack & {
     event: 'refresh.error';
     properties: {
+        executionId: string;
         projectId: string;
         error: string;
     };
@@ -132,6 +155,7 @@ type CliRefreshError = BaseTrack & {
 type CliCompileStarted = BaseTrack & {
     event: 'compile.started';
     properties: {
+        executionId: string;
         dbtVersion: string;
         skipDbtCompile: boolean;
         skipWarehouseCatalog: boolean;
@@ -141,6 +165,7 @@ type CliCompileStarted = BaseTrack & {
 type CliCompileCompleted = BaseTrack & {
     event: 'compile.completed';
     properties: {
+        executionId: string;
         explores: number;
         errors: number;
         dbtMetrics: number;
@@ -150,6 +175,7 @@ type CliCompileCompleted = BaseTrack & {
 type CliCompileError = BaseTrack & {
     event: 'compile.error';
     properties: {
+        executionId: string;
         dbtVersion: string;
         error: string;
     };
@@ -165,6 +191,7 @@ type CliDeployTriggered = BaseTrack & {
 type CliCreateStarted = BaseTrack & {
     event: 'create.started';
     properties: {
+        executionId: string;
         projectName: string;
         isDefaultName: boolean;
     };
@@ -172,6 +199,7 @@ type CliCreateStarted = BaseTrack & {
 type CliCreateCompleted = BaseTrack & {
     event: 'create.completed';
     properties: {
+        executionId: string;
         projectId: string;
         projectName: string;
     };
@@ -179,6 +207,7 @@ type CliCreateCompleted = BaseTrack & {
 type CliCreateError = BaseTrack & {
     event: 'create.error';
     properties: {
+        executionId: string;
         error: string;
     };
 };
@@ -190,6 +219,7 @@ type CliStartStopPreview = BaseTrack & {
         | 'stop_preview.delete'
         | 'stop_preview.missing';
     properties: {
+        executionId: string;
         projectId: string;
         name: string;
     };
@@ -218,6 +248,7 @@ type Track =
     | CliDbtError
     | CliPreviewStarted
     | CliPreviewCompleted
+    | CliPreviewStopped
     | CliPreviewError
     | CliRefreshStarted
     | CliRefreshCompleted

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -12,6 +12,7 @@ import {
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import inquirer from 'inquirer';
 import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getDbtContext } from '../dbt/context';
 import { getDbtManifest, loadManifest } from '../dbt/manifest';
@@ -40,9 +41,11 @@ export const compile = async (options: CompileHandlerOptions) => {
     const dbtVersion = await getDbtVersion();
     const manifestVersion = await getDbtManifest();
     GlobalState.debug(`> dbt version ${dbtVersion}`);
+    const executionId = uuidv4();
     await LightdashAnalytics.track({
         event: 'compile.started',
         properties: {
+            executionId,
             dbtVersion,
             useDbtList: !!options.useDbtList,
             skipWarehouseCatalog: !!options.skipWarehouseCatalog,
@@ -154,6 +157,7 @@ ${errors.join('')}`),
         await LightdashAnalytics.track({
             event: 'compile.error',
             properties: {
+                executionId,
                 dbtVersion,
                 error: `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
             },
@@ -201,6 +205,7 @@ ${errors.join('')}`),
     await LightdashAnalytics.track({
         event: 'compile.completed',
         properties: {
+            executionId,
             explores: explores.length,
             errors,
             dbtMetrics: Object.values(manifest.metrics).length,

--- a/packages/cli/src/handlers/dbt/refresh.ts
+++ b/packages/cli/src/handlers/dbt/refresh.ts
@@ -9,6 +9,7 @@ import {
     ParameterError,
     Project,
 } from '@lightdash/common';
+import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/analytics';
 import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
@@ -91,7 +92,7 @@ type RefreshHandlerOptions = {
 export const refreshHandler = async (options: RefreshHandlerOptions) => {
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
-
+    const executionId = uuidv4();
     const config = await getConfig();
     if (!(config.context?.project && config.context.serverUrl)) {
         throw new AuthorizationError(
@@ -112,6 +113,7 @@ export const refreshHandler = async (options: RefreshHandlerOptions) => {
         await LightdashAnalytics.track({
             event: 'refresh.started',
             properties: {
+                executionId,
                 projectId: projectUuid,
             },
         });
@@ -122,6 +124,7 @@ export const refreshHandler = async (options: RefreshHandlerOptions) => {
         await LightdashAnalytics.track({
             event: 'refresh.completed',
             properties: {
+                executionId,
                 projectId: projectUuid,
             },
         });
@@ -130,6 +133,7 @@ export const refreshHandler = async (options: RefreshHandlerOptions) => {
         await LightdashAnalytics.track({
             event: 'refresh.error',
             properties: {
+                executionId,
                 projectId: projectUuid,
                 error: `Error refreshing project: ${e}`,
             },

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'fs';
 import inquirer from 'inquirer';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getDbtContext } from '../dbt/context';
 import { loadManifest } from '../dbt/manifest';
@@ -34,7 +35,7 @@ type GenerateHandlerOptions = CompileHandlerOptions & {
 export const generateHandler = async (options: GenerateHandlerOptions) => {
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
-
+    const executionId = uuidv4();
     if (
         options.select === undefined &&
         options.exclude === undefined &&
@@ -57,6 +58,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     await LightdashAnalytics.track({
         event: 'generate.started',
         properties: {
+            executionId,
             trigger: 'generate',
             numModelsSelected,
         },
@@ -144,6 +146,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
             await LightdashAnalytics.track({
                 event: 'generate.error',
                 properties: {
+                    executionId,
                     trigger: 'generate',
                     error: `${e.message}`,
                 },
@@ -156,6 +159,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     await LightdashAnalytics.track({
         event: 'generate.completed',
         properties: {
+            executionId,
             trigger: 'generate',
             numModelsSelected,
         },

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -2,6 +2,7 @@ import { AuthorizationError, DbtExposure } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig } from '../config';
 import GlobalState from '../globalState';
@@ -19,6 +20,7 @@ export const generateExposuresHandler = async (
 ) => {
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
+    const executionId = uuidv4();
     const config = await getConfig();
     if (!(config.context?.project && config.context.serverUrl)) {
         throw new AuthorizationError(
@@ -28,6 +30,9 @@ export const generateExposuresHandler = async (
 
     await LightdashAnalytics.track({
         event: 'generate_exposures.started',
+        properties: {
+            executionId,
+        },
     });
 
     console.info(
@@ -74,6 +79,7 @@ export const generateExposuresHandler = async (
         await LightdashAnalytics.track({
             event: 'generate_exposures.completed',
             properties: {
+                executionId,
                 countExposures: Object.keys(exposures).length,
             },
         });
@@ -81,6 +87,7 @@ export const generateExposuresHandler = async (
         await LightdashAnalytics.track({
             event: 'generate_exposures.error',
             properties: {
+                executionId,
                 trigger: 'generate',
                 error: `${e.message}`,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add a `executionId` to most CLI events so they can be related. 
This will help us find how long a command execution took. eg: 'compile.started' -> 'compile.completed' or 'compile.error'


Changes:
- add `executionId` to most events
- generate uuid at the beginning of command handlers and pass down to other functions if needed
- refactor `preview.completed` to be recorded when the preview is ready instead when the preview is stopped/deleted
- add `preview.stopped` event to know when a preview is stopped/deleted

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
