### PR TITLE
fix: incorrect pluralization in attributes list

### DIFF
--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -66,12 +66,14 @@ const UserListItem: FC<{
                     <Group spacing="sm">
                         <Text fz="xs" color="gray.6">
                             {orgUserAttribute.users.length} user
-                            {orgUserAttribute.users.length > 1 ? 's' : ''}
+                            {orgUserAttribute.users.length !== 1 ? 's' : ''}
                         </Text>
                         {isGroupsFeatureFlagEnabled && (
                             <Text fz="xs" color="gray.6">
                                 {orgUserAttribute.groups.length} group
-                                {orgUserAttribute.groups.length > 1 ? 's' : ''}
+                                {orgUserAttribute.groups.length !== 1
+                                    ? 's'
+                                    : ''}
                             </Text>
                         )}
                     </Group>


### PR DESCRIPTION
### Description:

A small thing I noticed: users and groups count pluralization was wrong for the 0 case in the attributes list. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
