### PR TITLE
fix: remove a custom metric with filter

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -214,11 +214,13 @@ export const removeMetricFromFilterGroupItem = (
     }
 };
 
-export const removeMetricFromFilters = (
+export const removeMetricFromFiltersUtil = (
     filterGroup: FilterGroup | undefined,
     metricName: string,
 ): void => {
-    if (!filterGroup) return;
+    if (!filterGroup) {
+        return;
+    }
 
     const processGroupItems = (items: FilterGroupItem[]): FilterGroupItem[] =>
         items
@@ -229,28 +231,53 @@ export const removeMetricFromFilters = (
             });
 
     const isNotEmptyGroup = (item: FilterGroupItem): boolean => {
-        if (isOrFilterGroup(item)) return item.or.length !== 0;
-        if (isAndFilterGroup(item)) return item.and.length !== 0;
+        if (!item) {
+            return false;
+        }
+        if (isOrFilterGroup(item)) {
+            return item.or.length !== 0;
+        }
+        if (isAndFilterGroup(item)) {
+            return item.and.length !== 0;
+        }
         return true;
     };
 
     /* eslint-disable no-param-reassign */
     if (isOrFilterGroup(filterGroup)) {
         filterGroup.or = processGroupItems(filterGroup.or);
-        if (filterGroup.or.length === 0) filterGroup = undefined;
-        else
+        if (filterGroup.or.length !== 0) {
             filterGroup.or = filterGroup.or.filter((item) =>
                 isNotEmptyGroup(item),
             );
+        }
     } else if (isAndFilterGroup(filterGroup)) {
         filterGroup.and = processGroupItems(filterGroup.and);
-        if (filterGroup.and.length === 0) filterGroup = undefined;
-        else
+        if (filterGroup.and.length !== 0) {
             filterGroup.and = filterGroup.and.filter((item) =>
                 isNotEmptyGroup(item),
             );
+        }
     }
     /* eslint-enable no-param-reassign */
+};
+
+export const removeMetricFromFilters = (
+    filterGroup: FilterGroup | undefined,
+    metricName: string,
+): FilterGroup | undefined => {
+    removeMetricFromFiltersUtil(filterGroup, metricName);
+
+    if (filterGroup) {
+        if (
+            (isOrFilterGroup(filterGroup) && filterGroup.or.length === 0) ||
+            (isAndFilterGroup(filterGroup) && filterGroup.and.length === 0)
+        ) {
+            return undefined;
+        }
+    }
+
+    return filterGroup;
 };
 
 export const applyDimensionOverrides = (

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -20,6 +20,7 @@ import {
     MetricType,
     PieChartConfig,
     removeEmptyProperties,
+    removeMetricFromFilters,
     SavedChart,
     SortField,
     TableCalculation,
@@ -974,6 +975,22 @@ function reducer(
                         sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
                             (sort) => sort.fieldId !== action.payload,
                         ),
+                        filters: Object.entries(
+                            state.unsavedChartVersion.metricQuery.filters,
+                        ).reduce((acc, [key, value]) => {
+                            let valueDeepCopy = cloneDeep(value);
+                            if (key === 'metrics') {
+                                removeMetricFromFilters(
+                                    valueDeepCopy,
+                                    action.payload,
+                                );
+                            }
+
+                            return {
+                                ...acc,
+                                [key]: valueDeepCopy,
+                            };
+                        }, {}),
                     },
                     tableConfig: {
                         ...state.unsavedChartVersion.tableConfig,

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -980,10 +980,15 @@ function reducer(
                         ).reduce((acc, [key, value]) => {
                             let valueDeepCopy = cloneDeep(value);
                             if (key === 'metrics') {
-                                removeMetricFromFilters(
-                                    valueDeepCopy,
-                                    action.payload,
-                                );
+                                const updatedFiltersOnRemoval =
+                                    removeMetricFromFilters(
+                                        valueDeepCopy,
+                                        action.payload,
+                                    );
+                                return {
+                                    ...acc,
+                                    [key]: updatedFiltersOnRemoval,
+                                };
                             }
 
                             return {

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -20,7 +20,7 @@ import {
     MetricType,
     PieChartConfig,
     removeEmptyProperties,
-    removeMetricFromFilters,
+    removeFieldFromFilterGroup,
     SavedChart,
     SortField,
     TableCalculation,
@@ -980,14 +980,12 @@ function reducer(
                         ).reduce((acc, [key, value]) => {
                             let valueDeepCopy = cloneDeep(value);
                             if (key === 'metrics') {
-                                const updatedFiltersOnRemoval =
-                                    removeMetricFromFilters(
-                                        valueDeepCopy,
-                                        action.payload,
-                                    );
                                 return {
                                     ...acc,
-                                    [key]: updatedFiltersOnRemoval,
+                                    [key]: removeFieldFromFilterGroup(
+                                        valueDeepCopy,
+                                        action.payload,
+                                    ),
                                 };
                             }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8629 

### Description:
Added logic for updating filters when custom metrics are removed.

Example -

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/1986a7a7-9a21-4391-bbed-7bc4d8563618)
![image](https://github.com/lightdash/lightdash/assets/85165953/cf8cbc56-fab8-4b30-8ac4-46582d0cdfac)

On removing:

![image](https://github.com/lightdash/lightdash/assets/85165953/6e9b9cd9-62f3-475d-9923-bef8353a3634)
![image](https://github.com/lightdash/lightdash/assets/85165953/6ae47ef2-7a92-4b46-9b60-3ad5f7aaa72f)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
