### PR TITLE
feat: expand description box in charts and dashboards

### DIFF
--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -10,6 +10,7 @@ import {
     Modal,
     Select,
     Stack,
+    Textarea,
     TextInput,
     Title,
 } from '@mantine/core';
@@ -247,10 +248,13 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                 required
                                 {...form.getInputProps('dashboardName')}
                             />
-                            <TextInput
+                            <Textarea
                                 id="dashboard-description"
                                 label="Dashboard description"
                                 placeholder="A few words to give your team some context"
+                                autosize
+                                maxRows={3}
+                                style={{ overflowY: 'auto' }}
                                 {...form.getInputProps('dashboardDescription')}
                             />
                             {!isLoadingSpaces && !showNewSpaceInput ? (

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -158,7 +158,7 @@ const DashboardHeader = ({
                             </ActionIcon>
                         </Popover.Target>
 
-                        <Popover.Dropdown>
+                        <Popover.Dropdown maw={500}>
                             <Stack spacing="xs">
                                 {dashboardDescription && (
                                     <Text fz="xs" color="gray.7" fw={500}>

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -217,7 +217,6 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                         placeholder="A few words to give your team some context"
                         autosize
                         maxRows={3}
-                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
                     {fromDashboard && fromDashboard.length > 0 && (

--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -13,6 +13,7 @@ import {
     Select,
     Stack,
     Text,
+    Textarea,
     TextInput,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -211,9 +212,12 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                         {...form.getInputProps('name')}
                         data-testid="ChartCreateModal/NameInput"
                     />
-                    <TextInput
+                    <Textarea
                         label="Chart description"
                         placeholder="A few words to give your team some context"
+                        autosize
+                        maxRows={3}
+                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
                     {fromDashboard && fromDashboard.length > 0 && (

--- a/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
@@ -80,7 +80,6 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
                         disabled={isUpdating}
                         autosize
                         maxRows={3}
-                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
 

--- a/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
@@ -5,6 +5,7 @@ import {
     Modal,
     ModalProps,
     Stack,
+    Textarea,
     TextInput,
     Title,
 } from '@mantine/core';
@@ -73,10 +74,13 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
                         {...form.getInputProps('name')}
                     />
 
-                    <TextInput
+                    <Textarea
                         label="Chart description"
                         placeholder="A few words to give your team some context"
                         disabled={isUpdating}
+                        autosize
+                        maxRows={3}
+                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
 

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Stack,
     Text,
+    Textarea,
     TextInput,
     Title,
 } from '@mantine/core';
@@ -148,10 +149,13 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                             required
                             {...form.getInputProps('dashboardName')}
                         />
-                        <TextInput
+                        <Textarea
                             label="Dashboard description"
                             placeholder="A few words to give your team some context"
                             disabled={isCreatingDashboard}
+                            autosize
+                            maxRows={3}
+                            style={{ overflowY: 'auto' }}
                             {...form.getInputProps('dashboardDescription')}
                         />
                         {!isLoadingSpaces && spaces ? (

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -155,7 +155,6 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                             disabled={isCreatingDashboard}
                             autosize
                             maxRows={3}
-                            style={{ overflowY: 'auto' }}
                             {...form.getInputProps('dashboardDescription')}
                         />
                         {!isLoadingSpaces && spaces ? (

--- a/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
@@ -5,6 +5,7 @@ import {
     Modal,
     ModalProps,
     Stack,
+    Textarea,
     TextInput,
     Title,
 } from '@mantine/core';
@@ -75,10 +76,13 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
                         {...form.getInputProps('name')}
                     />
 
-                    <TextInput
+                    <Textarea
                         label="Description"
                         placeholder="A few words to give your team some context"
                         disabled={isUpdating}
+                        autosize
+                        maxRows={3}
+                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
 

--- a/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardUpdateModal.tsx
@@ -82,7 +82,6 @@ const DashboardUpdateModal: FC<DashboardUpdateModalProps> = ({
                         disabled={isUpdating}
                         autosize
                         maxRows={3}
-                        style={{ overflowY: 'auto' }}
                         {...form.getInputProps('description')}
                     />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7819 

### Description:
Changed TextInput to Textarea to support multiple rows and scroll in our chart and dashboard descriptions.
I have added maxRows of 3 so the box will expand until 3 rows and will scroll from there on.

Example - Update Dashboard
![image](https://github.com/lightdash/lightdash/assets/85165953/35310556-8378-4d73-94c8-99db2aeb244c)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
