### PR TITLE
fix: pass dbt vars to getCompiledModels

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -302,6 +302,7 @@ export const getCompiledModels = async (
         profilesDir: string;
         target: string | undefined;
         profile: string | undefined;
+        vars: string | undefined;
     },
 ): Promise<CompiledModel[]> => {
     let allModelIds = models.map((model) => model.unique_id);
@@ -319,6 +320,7 @@ export const getCompiledModels = async (
                 ...(args.profile ? ['--profile', args.profile] : []),
                 ...(args.select ? ['--select', args.select.join(' ')] : []),
                 ...(args.exclude ? ['--exclude', args.exclude.join(' ')] : []),
+                ...(args.vars ? ['--vars', args.vars] : []),
                 '--resource-type=model',
                 '--output=json',
             ]);

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -96,6 +96,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
         target: options.target,
         select: options.select || options.models,
         exclude: options.exclude,
+        vars: options.vars || undefined,
     });
 
     GlobalState.debug(`> Compiled models: ${compiledModels.length}`);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: NA

### Description:
When I tried to use `lightdash generate` at `0.946.0`, I got the subsequent error. It seems that it doesn't pass the dbt vars to `getCompiledModels`. So, I want to enable passing it to the function.

```
$ lightdash generate --profiles-dir . --vars "$(cat ./vars.yml)" --verbose

> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/health
> HTTP request returned status: 200
> HTTP request returned status: ok
> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/user
> HTTP request returned status: 200
> HTTP request returned status: ok
> Loading dbt_project.yml file from: /Users/[username]/local/src/xxx/dwh-dbt
> dbt target directory: target
> Loading profiles from directory: /Users/[username]/local/src/xxx/dwh-dbt
> Loaded target from profiles: bigquery
> Loading dbt manifest from /Users/[username]/local/src/xxx/dwh-dbt/target/manifest.json
⠏ Filtering modelsFailed to filter models: Error: Command failed with exit code 2: dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json
00:42:03  Running with dbt=1.7.4
00:42:03  Registered adapter: bigquery=1.7.2
00:42:08  Encountered an error:
Parsing Error
  at path ['database']: Undefined is not valid under any of the given schemas
Command failed with exit code 2: dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json
00:42:03  Running with dbt=1.7.4
00:42:03  Registered adapter: bigquery=1.7.2
00:42:08  Encountered an error:
Parsing Error
  at path ['database']: Undefined is not valid under any of the given schemas
Error: Command failed with exit code 2: dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json
00:42:03  Running with dbt=1.7.4
00:42:03  Registered adapter: bigquery=1.7.2
00:42:08  Encountered an error:
Parsing Error
  at path ['database']: Undefined is not valid under any of the given schemas
    at makeError (/Users/[username]/.anyenv/envs/nodenv/versions/20.10.0/lib/node_modules/@lightdash/cli/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/Users/[username]/.anyenv/envs/nodenv/versions/20.10.0/lib/node_modules/@lightdash/cli/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  shortMessage: 'Command failed with exit code 2: dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json',
  command: 'dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json',
  escapedCommand: 'dbt ls --profiles-dir "/Users/[username]/local/src/xxx/dwh-dbt" --project-dir "/Users/[username]/local/src/xxx/dwh-dbt" --target local --profile docs --select "models/xxx_jp_data_engineering/elementary_v0/" "--resource-type=model" "--output=json"',
  exitCode: 2,
  signal: undefined,
  signalDescription: undefined,
  stdout: '\x1B[0m00:42:03  Running with dbt=1.7.4\n' +
    '\x1B[0m00:42:03  Registered adapter: bigquery=1.7.2\n' +
    '\x1B[0m00:42:08  Encountered an error:\n' +
    'Parsing Error\n' +
    "  at path ['database']: Undefined is not valid under any of the given schemas",
  stderr: '',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
Error: Command failed with exit code 2: dbt ls --profiles-dir /Users/[username]/local/src/xxx/dwh-dbt --project-dir /Users/[username]/local/src/xxx/dwh-dbt --target local --profile docs --select models/xxx_jp_data_engineering/elementary_v0/ --resource-type=model --output=json
00:42:03  Running with dbt=1.7.4
00:42:03  Registered adapter: bigquery=1.7.2
00:42:08  Encountered an error:
Parsing Error
  at path ['database']: Undefined is not valid under any of the given schemas
    at makeError (/Users/[username]/.anyenv/envs/nodenv/versions/20.10.0/lib/node_modules/@lightdash/cli/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/Users/[username]/.anyenv/envs/nodenv/versions/20.10.0/lib/node_modules/@lightdash/cli/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
