### PR TITLE
feat: use lightdash generate for dbt deps packages

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -137,6 +137,7 @@ type FindAndUpdateModelYamlArgs = {
     docs: Record<string, DbtDoc>;
     includeMeta: boolean;
     projectDir: string;
+    projectName: string;
 };
 export const findAndUpdateModelYaml = async ({
     model,
@@ -144,6 +145,7 @@ export const findAndUpdateModelYaml = async ({
     docs,
     includeMeta,
     projectDir,
+    projectName,
 }: FindAndUpdateModelYamlArgs): Promise<{
     updatedYml: YamlSchema;
     outputFilePath: string;
@@ -156,8 +158,17 @@ export const findAndUpdateModelYaml = async ({
     const filenames = [];
     const { patchPath } = model;
     if (patchPath) {
-        const { path: expectedYamlSubPath } = patchPathParts(patchPath);
-        const expectedYamlPath = path.join(projectDir, expectedYamlSubPath);
+        const { project: expectedYamlProject, path: expectedYamlSubPath } =
+            patchPathParts(patchPath);
+        const projectSubpath =
+            expectedYamlProject !== projectName
+                ? path.join('dbt_packages', expectedYamlProject)
+                : '.';
+        const expectedYamlPath = path.join(
+            projectDir,
+            projectSubpath,
+            expectedYamlSubPath,
+        );
         filenames.push(expectedYamlPath);
     }
     const defaultYmlPath = path.join(

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -117,6 +117,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     docs: manifest.docs,
                     includeMeta: !options.excludeMeta,
                     projectDir: absoluteProjectPath,
+                    projectName: context.projectName,
                 },
             );
             try {


### PR DESCRIPTION
User requested to generate the metrics in a package they important into their dbt project (i.e. they live in `packages.yml` and `dbt_packages`). 

`lightdash generate` could find the model but was outputting them into the main project instead of `dbt_packages` 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
