### PR TITLE
feat: chart x-axis label rotation

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -226,6 +226,7 @@ type Axis = {
     min?: string | undefined;
     max?: string | undefined;
     inverse?: boolean;
+    rotate?: number;
 };
 
 export type CompleteCartesianChartLayout = {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
@@ -177,7 +177,7 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
                             dirtyEchartsConfig?.xAxis?.[0].rotate || 0
                         }
                         min={0}
-                        max={180}
+                        max={90}
                         step={15}
                         size="xs"
                         w={80}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
@@ -8,6 +8,7 @@ import {
 import {
     Checkbox,
     Group,
+    NumberInput,
     SegmentedControl,
     Stack,
     Switch,
@@ -97,6 +98,7 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
         setShowGridX,
         setShowGridY,
         setInverseX,
+        setXAxisLabelRotation,
     } = visualizationConfig.chartConfig;
 
     const xAxisField =
@@ -128,7 +130,7 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
     );
 
     return (
-        <Stack spacing="xs">
+        <Stack spacing="xs" mb="xl">
             <TextInput
                 label={`${dirtyLayout?.flipAxes ? 'Y' : 'X'}-axis label`}
                 placeholder="Enter axis label"
@@ -165,6 +167,26 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
                     }}
                 />
             </Group>
+            {!dirtyLayout?.flipAxes && (
+                <Group noWrap spacing="xs" align="baseline">
+                    <Text fw={600} mt="sm">
+                        Rotation
+                    </Text>
+                    <NumberInput
+                        defaultValue={
+                            dirtyEchartsConfig?.xAxis?.[0].rotate || 0
+                        }
+                        min={0}
+                        max={180}
+                        step={15}
+                        size="xs"
+                        w={80}
+                        onChange={(value) => {
+                            setXAxisLabelRotation(Number(value));
+                        }}
+                    />
+                </Group>
+            )}
             <TextInput
                 label={`${dirtyLayout?.flipAxes ? 'X' : 'Y'}-axis label (${
                     dirtyLayout?.flipAxes ? 'bottom' : 'left'

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -247,6 +247,15 @@ const useCartesianChartConfig = ({
             return x;
         });
     }, []);
+    const setXAxisLabelRotation = useCallback((rotation: number) => {
+        setDirtyEchartsConfig((prevState) => {
+            const [firstAxis, ...axes] = prevState?.xAxis || [];
+            return {
+                ...prevState,
+                xAxis: [{ ...firstAxis, rotate: rotation }, ...axes],
+            };
+        });
+    }, []);
     const addSingleSeries = useCallback((yField: string) => {
         setDirtyLayout((prev) => ({
             ...prev,
@@ -702,6 +711,7 @@ const useCartesianChartConfig = ({
         setShowGridX,
         setShowGridY,
         setInverseX,
+        setXAxisLabelRotation,
         updateSeries,
         referenceLines,
         setReferenceLines,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -887,9 +887,8 @@ const getEchartAxes = ({
                 (longestLabelWidth || 0) * Math.sin(rotateRadians);
             axisConfig.axisLabel = axisConfig.axisLabel || {};
             axisConfig.axisLabel.rotate = rotate;
-            axisConfig.nameGap = oppositeSide + 10;
+            axisConfig.nameGap = oppositeSide + 15;
         }
-        axisConfig.hideOverlap = false;
         return axisConfig;
     };
 
@@ -1048,9 +1047,8 @@ const getEchartAxes = ({
                 ...getAxisFormatter({
                     axisItem: topAxisXField,
                     longestLabelWidth: calculateWidthText(longestValueXAxisTop),
+                    defaultNameGap: 30,
                 }),
-                nameGap: 30,
-
                 nameTextStyle: {
                     fontWeight: 'bold',
                 },
@@ -1096,7 +1094,6 @@ const getEchartAxes = ({
                     axisItem: leftAxisYField,
                     defaultNameGap: leftYaxisGap + 20,
                 }),
-                nameGap: leftYaxisGap + 20,
                 splitLine: {
                     show: validCartesianConfig.layout.flipAxes
                         ? showGridX


### PR DESCRIPTION
Closes: #6327 

### Description:

Enables label rotation for the x-axis (non-flipped). We can add this for the other axes if necessary. I did some of the setup, but wanted to see if we found this the right approach. And if we add it fro the other labels we probably should think about the UI differently; here it is just a single number input. 

A couple notes:
- This moves the axis name in a way that *usually* looks good, but can end up pushing the name offscreen if the fields are long. We could either add field truncation (I played with this and have some ideas) or allow them to place the name. 
- When there are *a lot* of labels, some still get hidden. Theres an echarts bug about this. 

The code in the config file is a little tangled -- I think I made reasonable tradeoffs 😅, but I'm happy to make changes. I added a couple comments in this review to try to clarify.  

Example:
<img width="1231" alt="Screenshot 2024-01-18 at 19 24 38" src="https://github.com/lightdash/lightdash/assets/1864179/6467242c-f0cd-4cf1-9965-1fde37219bdc">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
