### PR TITLE
fix: show success toast on refresh dbt complete

### DIFF
--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -98,6 +98,10 @@ const useToaster = () => {
 
             const method = openedKeys.current.has(key) ? 'update' : 'show';
 
+            if (method === 'show') {
+                openedKeys.current.add(key);
+            }
+
             notifications[method]({
                 id: key,
                 ...commonProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8658 

### Description:
As our openedKeys did not keep track of the toast keys shown, our update/show notification logic was not working which caused the issue.

Updated code to add key on notification method `show`.

Toast shown on job done -

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/7edcf35e-9bb0-43a2-afc6-7fa2d8af2549)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/6763f85f-4ed0-4fed-a763-c8fddc9e8369)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
