### PR TITLE
feat: sequential ordering of month and day names

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -540,3 +540,28 @@ export const getDateDimension = (dimensionId: string) => {
 
     return {};
 };
+
+export const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+];
+
+export const dayOfWeekNames = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
+];

--- a/packages/frontend/src/utils/sortUtils.ts
+++ b/packages/frontend/src/utils/sortUtils.ts
@@ -73,6 +73,12 @@ export const getSortLabel = (
                     ? NumericSortLabels.ASC
                     : NumericSortLabels.DESC;
             case DimensionType.STRING:
+                if (item.timeInterval) {
+                    return direction === SortDirection.ASC
+                        ? DateSortLabels.ASC
+                        : DateSortLabels.DESC;
+                }
+
                 return direction === SortDirection.ASC
                     ? StringSortLabels.ASC
                     : StringSortLabels.DESC;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4095 

### Description:

- Added `CASE.....WHEN` statement to allow sequential ordering of month and day of week names in dimensions
- Updated ordering option for `month_name` and `day_of_week_name` to date-like (Old-New / New-Old)
- Had to move the orderBy code after the metric and table calc. filter logic as we had to modify the field names if CTE was used.

Resultant Query:

```
SELECT
  TO_CHAR("events".timestamp_tz, 'FMMonth') AS "events_timestamp_tz_month_name",
  TO_CHAR("events".timestamp_tz, 'FMDay') AS "events_timestamp_tz_day_of_week_name",
  COUNT("events".event) AS "events_count"
FROM "postgres"."jaffle"."events" AS "events"

GROUP BY 1,2
ORDER BY (
  CASE TO_CHAR("events".timestamp_tz, 'FMMonth')
    WHEN 'January' THEN 1
    WHEN 'February' THEN 2
    WHEN 'March' THEN 3
    WHEN 'April' THEN 4
    WHEN 'May' THEN 5
    WHEN 'June' THEN 6
    WHEN 'July' THEN 7
    WHEN 'August' THEN 8
    WHEN 'September' THEN 9
    WHEN 'October' THEN 10
    WHEN 'November' THEN 11
    WHEN 'December' THEN 12
  END
)
LIMIT 500
```

As mentioned in the issue comments,
We can also use the `MONTH_NUM` and `DAY_OF_WEEK_INDEX` directly to sort sequentially.
I had tried that as well. We can reuse the `getSqlForDatePart` function to get the sql. This is definitely shorter.

But in this case, we would also have to update our GROUP BY statement to include the order by sql as it isn't included in the select fields. 

Example - 
```
SELECT
  TO_CHAR("events".timestamp_tz, 'FMMonth') AS "events_timestamp_tz_month_name",
  TO_CHAR("events".timestamp_tz, 'FMDay') AS "events_timestamp_tz_day_of_week_name"
FROM "postgres"."jaffle"."events" AS "events"


GROUP BY 1,2,DATE_PART('MONTH', "events".timestamp_tz)
ORDER BY DATE_PART('MONTH', "events".timestamp_tz)
LIMIT 500
```

Here, `"events.timestamp_tz"` must appear in the GROUP BY clause or be used in an aggregate function
Considering we don't want to select the field, we would have to add it to the Group by statement.
This sort of changes our Group by standard logic of using the select columns in group by with their index numbers.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
