### PR TITLE
docs: switch embedding interest link to calendly

### DIFF
--- a/docs/docs/references/embedding.mdx
+++ b/docs/docs/references/embedding.mdx
@@ -6,7 +6,7 @@ import CreateUserAttribute from '../guides/assets/create-user-attribute.png';
 
 # Embedding
 
-You can embed Lightdash content in your website or application securely using Lightdash embedding. Embedding is only available with a commercial Lightdash license, [get in touch](https://lightdash.typeform.com/to/BujU5wg5) to have this enabled in your account.
+You can embed Lightdash content in your website or application securely using Lightdash embedding. Embedding is only available with a commercial Lightdash license, [get in touch](https://calendly.com/lightdash-cloud/lightdash-embedding) to have this enabled in your account.
 
 ## Embed secret
 


### PR DESCRIPTION
switch embedding link from typeform+zapier to direct calendly booking.