### PR TITLE
feat: Include multiple values in metric filter

### DIFF
--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -617,6 +617,27 @@ columns:
 | is null                     | Status is `NULL`                               | `status: "null"`         |
 | is not null                 | Status is not `NULL`                           | `status: "!null"`     |
 
+:::info
+
+To filter a field by a set of given values you can supply them as an array for that field. For example,
+if you wanted to filter for orders with order status `paid` or `shipped` you should write the metric like:
+
+
+```yaml
+columns:
+  - name: order_id
+    meta:
+      metrics:
+        total_completed_orders:
+          type: count_distinct
+          filters:
+            - order_status:
+                - paid
+                - shipped
+```
+
+:::
+
 ### If you have many filters in your list, they will be joined using `AND`.
 
 For example:

--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -620,7 +620,7 @@ columns:
 :::info
 
 To filter a field by a set of given values you can supply them as an array for that field. For example,
-if you wanted to filter for orders with order status `paid` or `shipped` you should write the metric like:
+if you wanted to filter for orders with order status `completed` or `shipped` you should write the metric like:
 
 
 ```yaml
@@ -628,11 +628,11 @@ columns:
   - name: order_id
     meta:
       metrics:
-        total_completed_orders:
+        completed_or_shipped_order_count:
           type: count_distinct
           filters:
             - order_status:
-                - paid
+                - completed
                 - shipped
 ```
 

--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -89,6 +89,13 @@ models:
           metrics:
             unique_order_count:
               type: count_distinct
+            completed_or_shipped_order_count:
+              label: Completed or Shipped Order Count
+              type: count_distinct
+              filters:
+                - status:
+                    - completed
+                    - shipped
       - name: is_completed
         description: Boolean indicating if status is completed
         meta:

--- a/packages/common/src/types/filterGrammar.test.ts
+++ b/packages/common/src/types/filterGrammar.test.ts
@@ -289,7 +289,7 @@ describe('Parse metric filters', () => {
         expect(removeIds(parseFilters(filters))).toStrictEqual([
             {
                 id: undefined,
-                operator: FilterOperator.INCLUDE,
+                operator: FilterOperator.EQUALS,
                 target: {
                     fieldRef: 'name',
                 },

--- a/packages/common/src/types/filterGrammar.test.ts
+++ b/packages/common/src/types/filterGrammar.test.ts
@@ -257,7 +257,7 @@ describe('Parse metric filters', () => {
         ]);
     });
 
-    it('Should parse NULL using gtrammar', () => {
+    it('Should parse NULL using grammar', () => {
         const filters = [{ name: null }];
         expect(removeIds(parseFilters(filters))).toStrictEqual([
             {
@@ -270,7 +270,7 @@ describe('Parse metric filters', () => {
             },
         ]);
     });
-    it('Should parse NOT_NULL using gtrammar', () => {
+    it('Should parse NOT_NULL using grammar', () => {
         const filters = [{ name: '!null' }];
         expect(removeIds(parseFilters(filters))).toStrictEqual([
             {
@@ -280,6 +280,20 @@ describe('Parse metric filters', () => {
                     fieldRef: 'name',
                 },
                 values: [1],
+            },
+        ]);
+    });
+
+    it('Should parse multiple filter values using grammar', () => {
+        const filters = [{ name: ['cat', 'dog'] }];
+        expect(removeIds(parseFilters(filters))).toStrictEqual([
+            {
+                id: undefined,
+                operator: FilterOperator.INCLUDE,
+                target: {
+                    fieldRef: 'name',
+                },
+                values: ['cat', 'dog'],
             },
         ]);
     });

--- a/packages/common/src/types/filterGrammar.ts
+++ b/packages/common/src/types/filterGrammar.ts
@@ -245,7 +245,7 @@ export const parseFilters = (
                 {
                     id: uuidv4(),
                     target: { fieldRef: key },
-                    operator: FilterOperator.INCLUDE,
+                    operator: FilterOperator.EQUALS,
                     values: value,
                 },
             ];

--- a/packages/common/src/types/filterGrammar.ts
+++ b/packages/common/src/types/filterGrammar.ts
@@ -239,6 +239,17 @@ export const parseFilters = (
                 },
             ];
         }
+        if (typeof value === 'object') {
+            return [
+                ...acc,
+                {
+                    id: uuidv4(),
+                    target: { fieldRef: key },
+                    operator: FilterOperator.INCLUDE,
+                    values: value,
+                },
+            ];
+        }
         return [
             ...acc,
             {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5048
Closes: #5485

### Description:
Allows metric filters to specify an array of values to include (should it also take the inverse?? 🤔 I feel like I've way underestimated how complex this might get 😅  )

<img width="984" alt="Screenshot 2024-01-22 at 21 14 28" src="https://github.com/lightdash/lightdash/assets/13685708/3bed2c16-7df4-4532-81b7-eae539755320">

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
