### PR TITLE
fix: refetch pinned items on space mutation

### DIFF
--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -152,6 +152,7 @@ export const useUpdateMutation = (projectUuid: string, spaceUuid: string) => {
                     projectUuid,
                     'spaces',
                 ]);
+                await queryClient.invalidateQueries(['pinned_items']);
                 await queryClient.refetchQueries(['spaces', projectUuid]);
                 queryClient.setQueryData(
                     ['space', projectUuid, spaceUuid],


### PR DESCRIPTION
### Description:

Refetch pinned items on space mutation. Changing names wasn't causing an update. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
