### PR TITLE
fix: week num chart float

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -27,6 +27,7 @@ import {
     Series,
     TableCalculation,
     timeFrameConfigs,
+    TimeFrames,
 } from '@lightdash/common';
 import {
     DefaultLabelFormatterCallbackParams,
@@ -885,6 +886,35 @@ const getEchartAxes = ({
                     },
                 },
             };
+        } else if (
+            axisItem &&
+            isDimension(axisItem) &&
+            axisItem.timeInterval &&
+            isTimeInterval(axisItem.timeInterval)
+        ) {
+            // Some int numbers are converted to float by default on echarts
+            // This is to ensure the value is correctly formatted on some types
+            switch (axisItem.timeInterval) {
+                case TimeFrames.WEEK_NUM:
+                    axisConfig.axisLabel = {
+                        formatter: (value: any) => {
+                            return formatItemValue(axisItem, value, false);
+                        },
+                    };
+                    axisConfig.axisPointer = {
+                        label: {
+                            formatter: (value: any) => {
+                                return formatItemValue(
+                                    axisItem,
+                                    value.value,
+                                    false,
+                                );
+                            },
+                        },
+                    };
+                    break;
+                default:
+            }
         }
         if (axisMinInterval) {
             axisConfig.minInterval = axisMinInterval;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8674

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

I'm not sure if there is a better fix for it, I spent an hour on this and I couldn't find a better solution. getAxisLabelFormatter on timeframes will not work here, we could add a new function, but that seems a bit too much for this edge case. 

I think the underlying issue is that echarts by default formats some numbers into floats (perhaps this depends on the `axis type` (time/value/category) ) 

If this is true, I guess it is affecting more types , but this PR is only fixing week_num to avoid introducing some new bugs. I am going to also look a some date bugs in tooltips, so I might reuse some of this code. 


Before:
![Screenshot from 2024-01-23 10-15-11](https://github.com/lightdash/lightdash/assets/1983672/26679372-3089-4a52-a9a6-d43514f5d9e0)


After:

![Screenshot from 2024-01-23 10-15-02](https://github.com/lightdash/lightdash/assets/1983672/47025ee9-4091-4104-ae29-2a2bc6277839)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
