### PR TITLE
feat: add accordion to format custom metrics

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -5,6 +5,7 @@ import {
     isDimension,
     MetricType,
 } from '@lightdash/common';
+import { isNumericItem } from '@lightdash/common/src/utils/item';
 import {
     Accordion,
     Button,
@@ -16,6 +17,7 @@ import {
     Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -37,6 +39,10 @@ export const CustomMetricModal = () => {
         item,
         type: customMetricType,
     } = useExplorerContext((context) => context.state.modals.additionalMetric);
+
+    const isCustomMetricFormattingEnabled = useFeatureFlagEnabled(
+        'custom-metrics-formatting',
+    );
 
     const toggleModal = useExplorerContext(
         (context) => context.actions.toggleAdditionalMetricModal,
@@ -230,6 +236,16 @@ export const CustomMetricModal = () => {
                         />
                     )}
                     <Accordion chevronPosition="left" chevronSize="xs">
+                        {isCustomMetricFormattingEnabled &&
+                            isNumericItem(item) && (
+                                <Accordion.Item value="format">
+                                    <Accordion.Control>
+                                        <Text fw={500} fz="sm">
+                                            Format
+                                        </Text>
+                                    </Accordion.Control>
+                                </Accordion.Item>
+                            )}
                         <Accordion.Item value="filters">
                             <Accordion.Control>
                                 <Text fw={500} fz="sm">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8688

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- Add `custom-metrics-format` feature flag checking
- Show format modal when creating a numeric custom metric
<!-- Even better add a screenshot / gif / loom -->
![Screenshot 2024-01-23 at 14 55 28](https://github.com/lightdash/lightdash/assets/22939015/805a0a16-42ee-4d4e-a80c-330e051f6389)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
