### PR TITLE
test: fix cypress errors in dashboard and projects

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -237,7 +237,7 @@ describe('Dashboard', () => {
         cy.findAllByText('Add tile').click();
         cy.findByText('Markdown').click();
         cy.findByLabelText('Title').type('Title');
-        cy.get('textarea').type('Content');
+        cy.get('.mantine-Modal-body').find('textarea').type('Content');
         cy.findByText('Add').click();
 
         cy.findByText('Save').click();

--- a/packages/frontend/src/providers/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJobProvider.tsx
@@ -44,6 +44,12 @@ export const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({
             if (!job || isJobsDrawerOpen) return;
 
             const toastTitle = jobStatusLabel(job?.jobStatus);
+
+            // TODO: this hides the current notification and things
+            // seem to look ok, but it would be better to update it.
+            // That will require a refactor of the useToaster hook.
+            notifications.hide(TOAST_KEY_FOR_REFRESH_JOB);
+
             switch (job.jobStatus) {
                 case 'DONE':
                     if (job.jobType === JobType.CREATE_PROJECT) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixes a couple persistent cypress errors after react/cypress upgrade. I don't have satisfying explanations about why these broke, but these fixes unblock some of the tests. 

1. Find a specific textarea in the markdown dialog. The test was failing because this was returning multiple elements. I don't know why. 
2. Hide the job-in-progress toast between steps. It seems we were rendering each step in a new dtoast instead of updating the old one. There is more to be done here to make this 'correct' -- we should refactor the showToast hook to use `notifications` and update toasts. But this should work for now. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
