### PR TITLE
fix: datetime timezone issue

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -769,12 +769,16 @@ const getLongestLabel = ({
     );
 };
 
-const formatValuesAndTimestamps = (field: Field, value: unknown): string => {
-    const isTimestamp = DimensionType.TIMESTAMP === field.type;
-    if (isTimestamp && typeof value === 'number' && isField(field)) {
+const formatValuesAndDates = (field: Field, value: unknown): string => {
+    const isDate =
+        DimensionType.TIMESTAMP === field.type ||
+        DimensionType.DATE === field.type;
+
+    if (isDate && typeof value === 'number') {
         // This is for formatting timestamp values from echarts to the right value in UTC
         const dateInUtc = moment(value).utc();
         const dateWithoutTimezone = dateInUtc.format('YYYY-MM-DD HH:mm:ss');
+
         return formatItemValue(field, dateWithoutTimezone, true);
     }
     return formatItemValue(field, value, false);
@@ -867,7 +871,7 @@ const getEchartAxes = ({
             axisConfig.axisPointer = {
                 label: {
                     formatter: (value: any) => {
-                        return formatValuesAndTimestamps(axisItem, value.value);
+                        return formatValuesAndDates(axisItem, value.value);
                     },
                 },
             };
@@ -878,7 +882,7 @@ const getEchartAxes = ({
             axisConfig.axisPointer = {
                 label: {
                     formatter: (value: any) => {
-                        return formatValuesAndTimestamps(axisItem, value.value);
+                        return formatValuesAndDates(axisItem, value.value);
                     },
                 },
             };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/8505

### How to test

 Change your own timezone, refresh the browser, and make sure the tooltip matches the data. It is easier to test if you limit the results to just 1 row

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
axispointer fix:  For timestamps, convert first the "echart" number value to UTC, remove timezone and format. 
Tooltip fix: Unless timestamp raw, simply the chart label (default). For timestamp raw, apply the fix above. 

Before:

![Screenshot from 2024-01-25 06-16-08](https://github.com/lightdash/lightdash/assets/1983672/ae966992-d3b0-44a5-be41-41c26149051f)




After:


![Screenshot from 2024-01-25 06-41-12](https://github.com/lightdash/lightdash/assets/1983672/18657ee5-4f5a-4007-aa7d-9f702454d3a0)
![Screenshot from 2024-01-25 06-42-24](https://github.com/lightdash/lightdash/assets/1983672/1013aaaa-dad8-47bb-8c7c-63a5a365c6dd)
![Screenshot from 2024-01-25 06-42-34](https://github.com/lightdash/lightdash/assets/1983672/c97342cf-d416-4433-8985-a9dcb45bad15)


### Raw timestamp tooltip bug

before: 

![Screenshot from 2024-01-25 06-44-04](https://github.com/lightdash/lightdash/assets/1983672/cd661477-75aa-40ae-a0f2-d2c8c7de3447)

after: 

![Screenshot from 2024-01-25 06-43-38](https://github.com/lightdash/lightdash/assets/1983672/31a1c0ed-d6d7-4673-bf44-18e0777085fb)




<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
