### PR TITLE
feat: Render not equals SQL for boolean filter

### DIFF
--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -40,10 +40,11 @@ To learn more about using filters, check out our docs on limiting data using fil
 ### Boolean filters
 
 | Filter      | logic                                                                    |
-| ----------- | ------------------------------------------------------------------------ |
+|-------------|--------------------------------------------------------------------------|
 | is null     | Only pulls in rows where the values are null for the field selected.     |
 | is not null | Only pulls in rows where the values are not null for the field selected. |
 | is          | Only pulls in rows where the values are equal to the values listed.      |
+| is not      | Only pulls in rows where the values are not equal to the values listed.  |
 
 ### Date filters
 

--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -44,7 +44,6 @@ To learn more about using filters, check out our docs on limiting data using fil
 | is null     | Only pulls in rows where the values are null for the field selected.     |
 | is not null | Only pulls in rows where the values are not null for the field selected. |
 | is          | Only pulls in rows where the values are equal to the values listed.      |
-| is not      | Only pulls in rows where the values are not equal to the values listed.  |
 
 ### Date filters
 

--- a/docs/docs/references/filters.md
+++ b/docs/docs/references/filters.md
@@ -40,7 +40,7 @@ To learn more about using filters, check out our docs on limiting data using fil
 ### Boolean filters
 
 | Filter      | logic                                                                    |
-|-------------|--------------------------------------------------------------------------|
+| ----------- | ------------------------------------------------------------------------ |
 | is null     | Only pulls in rows where the values are null for the field selected.     |
 | is not null | Only pulls in rows where the values are not null for the field selected. |
 | is          | Only pulls in rows where the values are equal to the values listed.      |

--- a/docs/docs/references/metrics.mdx
+++ b/docs/docs/references/metrics.mdx
@@ -602,20 +602,22 @@ columns:
 
 ### Available filter types
 
-| Type                        | Example (in English)                           | Example (as code)     |
-|-----------------------------|------------------------------------------------|-----------------------|
+| Type                        | Example (in English)                           | Example (as code)       |
+|-----------------------------|------------------------------------------------|-------------------------|
 | is                          | User name is equal to katie                    | `user_name: "katie"`    |
 | is not                      | User name is not equal to katie                | `user_name: "!katie"`   |
 | contains                    | User name contains katie                       | `user_name: "%katie%"`  |
 | does not contain            | User name does not contain katie               | `user_name: "!%katie%"` |
 | starts with                 | User name starts with katie                    | `user_name: "katie%"`   |
 | ends with                   | User name ends with katie                      | `user_name: "%katie"`   |
-| is greater than             | Number of orders is greater than 4             | `num_orders: "> 4"`   |
-| is greater than or equal to | Number of orders is greater than or equal to 4 | `num_orders: ">= 4"`  |
-| is less than                | Number of orders is less than 4                | `num_orders: "< 4"`   |
-| is less than or equal to    | Number of orders is less than or equal to 4    | `num_orders: "<= 4"`  |
-| is null                     | Status is `NULL`                               | `status: "null"`         |
-| is not null                 | Status is not `NULL`                           | `status: "!null"`     |
+| is greater than             | Number of orders is greater than 4             | `num_orders: "> 4"`     |
+| is greater than or equal to | Number of orders is greater than or equal to 4 | `num_orders: ">= 4"`    |
+| is less than                | Number of orders is less than 4                | `num_orders: "< 4"`     |
+| is less than or equal to    | Number of orders is less than or equal to 4    | `num_orders: "<= 4"`    |
+| is null                     | Status is `NULL`                               | `status: "null"`        |
+| is not null                 | Status is not `NULL`                           | `status: "!null"`       |
+| is [boolean]                | Is complete is true                            | `is_complete: "true"`   |
+| is not [boolean]            | Is complete is false or null                   | `is_complete: "!true"`  |
 
 :::info
 

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -291,6 +291,8 @@ const renderBooleanFilterSql = (
     switch (filter.operator) {
         case 'equals':
             return `(${dimensionSql}) = ${!!filter.values?.[0]}`;
+        case 'notEquals':
+            return `((${dimensionSql}) != ${!!filter.values?.[0]} OR (${dimensionSql}) IS NULL)`;
         case 'isNull':
             return `(${dimensionSql}) IS NULL`;
         case 'notNull':

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -292,7 +292,8 @@ const renderBooleanFilterSql = (
         case 'equals':
             return `(${dimensionSql}) = ${!!filter.values?.[0]}`;
         case 'notEquals':
-            return `((${dimensionSql}) != ${!!filter.values?.[0]} OR (${dimensionSql}) IS NULL)`;
+            return `((${dimensionSql}) != ${!!filter
+                .values?.[0]} OR (${dimensionSql}) IS NULL)`;
         case 'isNull':
             return `(${dimensionSql}) IS NULL`;
         case 'notNull':


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8728

### Description:
This may be intentionally designed as such, so apologies if so!!
But we were attempting to filter by "!true" and came across this, in a column that was brought in from a join onto our base table in such a way that true, false, null were all available, and we explicitly want [false, null].
Filtering as a list of values also fails as it casts them to string if that's preferable to fix?

<img width="865" alt="Screenshot 2024-01-25 at 17 30 52" src="https://github.com/lightdash/lightdash/assets/13685708/fe004545-fe5e-4417-93b6-e1850d4b4662">

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
