### PR TITLE
fix: timezone raw results

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -855,7 +855,7 @@ const getEchartAxes = ({
             axisConfig.axisPointer = {
                 label: {
                     formatter: (value: any) => {
-                        return formatItemValue(axisItem, value.value, false);
+                        return formatItemValue(axisItem, value.value, true);
                     },
                 },
             };
@@ -866,7 +866,7 @@ const getEchartAxes = ({
             axisConfig.axisPointer = {
                 label: {
                     formatter: (value: any) => {
-                        return formatItemValue(axisItem, value.value, false);
+                        return formatItemValue(axisItem, value.value, true);
                     },
                 },
             };
@@ -1569,22 +1569,6 @@ const useEchartsCartesianConfig = (
                         );
 
                         return `${tooltipHeader}<br/><table>${tooltipRows}</table>`;
-                    }
-                    if (
-                        isDimension(field) &&
-                        (field.type === DimensionType.DATE ||
-                            field.type === DimensionType.TIMESTAMP)
-                    ) {
-                        const date = (params[0].data as Record<string, any>)[
-                            dimensionId
-                        ]; // get full timestamp from data
-                        const dateFormatted = getFormattedValue(
-                            date,
-                            dimensionId,
-                            itemsMap,
-                            false,
-                        );
-                        return `${dateFormatted}<br/><table>${tooltipRows}</table>`;
                     }
 
                     const hasFormat = isField(field)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/8505


### How to test

Change your own timezone, refresh the browser, and make sure the tooltip matches the data. It is easier to test if you limit the results to just 1 row
### Description:

This should fix the timezone tooltip issue by making sure everything is on UTC, including the results we return from the backend (in raw) 


![Screenshot from 2024-01-26 01-09-08](https://github.com/lightdash/lightdash/assets/1983672/ec54d8d8-b7dd-4729-8014-e15422262079)
![Screenshot from 2024-01-26 01-09-17](https://github.com/lightdash/lightdash/assets/1983672/d9ad9b6d-14c1-423c-8c5a-24b241407b16)
![Screenshot from 2024-01-26 01-12-37](https://github.com/lightdash/lightdash/assets/1983672/d342a025-b841-4889-bb97-96ebefa37687)


## Raw timestamp

![Screenshot from 2024-01-26 01-12-37](https://github.com/lightdash/lightdash/assets/1983672/09984dc5-5dd1-4878-9287-742a67db7c5f)


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
