### PR TITLE
fix: inconsistent spacing in scheduler form

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -372,6 +372,11 @@ const SchedulerForm: FC<Props> = ({
                             placeholder="Name your delivery"
                             required
                             {...form.getInputProps('name')}
+                            styles={{
+                                label: {
+                                    marginBottom: '0.25rem',
+                                },
+                            }}
                         />
                         <Input.Wrapper label="Delivery frequency">
                             <Box mt="xxs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8736 

### Description:

To add spacing b/w label and field in TextInput, we cannot use mt or mb as these props are typically used for setting margin on the component as a whole, not for internal elements like labels.

So I have added a marginBottom of 0.25rem to the label. Considering other inputs have a margin of xxs which is equal to rem(4) in our mantine styles. Hence in rem it is, 4/16 = 0.25rem.

Reference - https://mantine.dev/styles/rem/

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/f5189319-3b35-4d12-8acc-da38c9d1bd90)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/9f54bc04-67d9-4479-9714-cd6ee3da6f16)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
