### PR TITLE
docs: moves embedding info about cloud + beta to info pill

### DIFF
--- a/docs/docs/references/embedding.mdx
+++ b/docs/docs/references/embedding.mdx
@@ -6,7 +6,13 @@ import CreateUserAttribute from '../guides/assets/create-user-attribute.png';
 
 # Embedding
 
-You can embed Lightdash content in your website or application securely using Lightdash embedding. Embedding is only available with a commercial Lightdash license, [get in touch](https://calendly.com/lightdash-cloud/lightdash-embedding) to have this enabled in your account.
+You can embed Lightdash content in your website or application securely using Lightdash embedding. 
+
+:::info
+
+Embedding is currently in Beta for Lightdash Cloud customers - [reach out to the team for access](https://calendly.com/lightdash-cloud/lightdash-embedding)
+
+:::
 
 ## Embed secret
 


### PR DESCRIPTION
Moves embedding info to a pill to make it more obvious