### PR TITLE
fix: empty line chart axis range

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/AxesOptions.tsx
@@ -1,12 +1,9 @@
 import {
-    DimensionType,
     getAxisName,
     getDateGroupLabel,
     getItemLabelWithoutTableName,
-    isField,
     isNumericItem,
     ItemsMap,
-    MetricType,
 } from '@lightdash/common';
 import {
     Checkbox,
@@ -133,17 +130,6 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
         },
         [false, false],
     );
-    const isXFieldDateOrNumber = () => {
-        const dateEnums: string[] = [
-            DimensionType.DATE,
-            DimensionType.TIMESTAMP,
-            MetricType.DATE,
-            MetricType.TIMESTAMP,
-        ];
-        const isDate =
-            isField(xAxisField) && dateEnums.includes(xAxisField?.type);
-        return isNumericItem(xAxisField) || isDate;
-    };
 
     return (
         <Stack spacing="xs" mb="xl">
@@ -158,7 +144,7 @@ const AxesOptions: FC<Props> = ({ itemsMap }) => {
                 }
                 onBlur={(e) => setXAxisName(e.currentTarget.value)}
             />
-            {isXFieldDateOrNumber() && (
+            {isNumericItem(xAxisField) && (
                 <AxisMinMax
                     label={`Auto ${
                         dirtyLayout?.flipAxes ? 'y' : 'x'

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1430,14 +1430,23 @@ const useEchartsCartesianConfig = (
             if (xFieldId === undefined) return results;
             const { min, max } = axes.xAxis[0];
 
-            const hasCustomRange = min !== undefined && max !== undefined;
+            const hasCustomRange =
+                (min !== undefined || max !== undefined) &&
+                (typeof min === 'string' || typeof max === 'string');
+
             const resultsInRange = hasCustomRange
                 ? results.filter((result) => {
                       const value = result[xFieldId];
                       if (!value) return true;
 
-                      const isGreaterThan = min === undefined || value > min;
-                      const isLessThan = max === undefined || value < max;
+                      const isGreaterThan =
+                          min === undefined ||
+                          typeof min !== 'string' ||
+                          value > min;
+                      const isLessThan =
+                          max === undefined ||
+                          typeof max !== 'string' ||
+                          value < max;
 
                       return isGreaterThan && isLessThan;
                   })


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/8748

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

The issue: 

Line / scatter charts have a `min` function, (not a string) , so the filtering was wrong. 

![Screenshot from 2024-01-29 08-53-14](https://github.com/lightdash/lightdash/assets/1983672/c4c5eab1-579c-4fcb-9154-be49063878c3)


<!-- Even better add a screenshot / gif / loom -->
Before:
![Screenshot from 2024-01-29 08-57-28](https://github.com/lightdash/lightdash/assets/1983672/55cc1973-9503-4bce-ae49-827369d1d225)


After:
![Screenshot from 2024-01-29 09-00-05](https://github.com/lightdash/lightdash/assets/1983672/3f473994-d1ba-4a84-b04c-efa420e6b3ee)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
