### PR TITLE
feat: access all attribute values when filtering rows

### DIFF
--- a/docs/docs/references/user-attributes.mdx
+++ b/docs/docs/references/user-attributes.mdx
@@ -63,14 +63,17 @@ When referencing user attributes in SQL you can use the following [SQL variables
 
 You can use user attributes to filter the rows returned by a query. This is useful if you want to restrict the data 
 based on the user's attributes. To reference a user attribute in your sql, use the special lightdash reference 
-`${lightdash.attributes.<attribute_name> }`. For example, if you have a user attribute called `sales_region` you can
+`${lightdash.attributes.<attribute_name> }`.
+We recommend using the `IN` operator because the attribute might have multiple values.
+
+For example, if you have a user attribute called `sales_region` you can
 use it in your sql like this:
 
 ```yaml
 models:
   - name: my_model
     meta:
-      sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}
+      sql_filter: ${TABLE}.sales_region IN(${lightdash.attributes.sales_region})
 ```
 
 ### Column filtering with `required_attributes`
@@ -205,7 +208,7 @@ In this example, the `tropical_fruits_column` will be visible to them because `c
 
 ### Row filtering
 
-If the user has group and user attribute values assigned, the user attribute values take precedence over group attribute values. If there are multiple group attribute values, there is no prioritization over which value will be used. 
+The template reference will be replaced by an array of the user's group or user attribute values.
 
 Let's walk through an example:
 
@@ -213,19 +216,8 @@ Let's walk through an example:
 models:
   - name: my_model
     meta:
-      sql_filter: ${TABLE}.fruit = ${lightdash.attributes.fruit}
+      sql_filter: ${TABLE}.fruit IN (${lightdash.attributes.fruit})
 ```
 
-**Scenario 1**:
-- The default attribute value is `banana`.
-- The user's been assigned the value `coconut`
-- They also have group values assigned of `kiwi` and `orange` 
-
-The `${lightdash.attributes.fruit}` reference will equal `coconut`. User attribute values take precedence over group attribute values.
-
-**Scenario 2**:
-- The default attribute value is `banana`.
-- The user's been assigned no value.
-- They also have group values assigned of `kiwi` and `orange` 
-
-The `${lightdash.attributes.fruit}` reference will equal either `kiwi` or `orange. The order of multiple group attribute values is not defined. 
+In this example, the `${lightdash.attributes.fruit}` will be replaced with `'kiwi','orange','coconut'`.
+The final SQL will be `my_model.fruit IN ('kiwi','orange','coconut)`

--- a/docs/docs/references/user-attributes.mdx
+++ b/docs/docs/references/user-attributes.mdx
@@ -64,7 +64,7 @@ When referencing user attributes in SQL you can use the following [SQL variables
 You can use user attributes to filter the rows returned by a query. This is useful if you want to restrict the data 
 based on the user's attributes. To reference a user attribute in your sql, use the special lightdash reference 
 `${lightdash.attributes.<attribute_name> }`.
-We recommend using the `IN` operator because the attribute might have multiple values.
+You should use the `IN` operator since the attribute might have multiple values.
 
 For example, if you have a user attribute called `sales_region` you can
 use it in your sql like this:
@@ -73,7 +73,7 @@ use it in your sql like this:
 models:
   - name: my_model
     meta:
-      sql_filter: ${TABLE}.sales_region IN(${lightdash.attributes.sales_region})
+      sql_filter: ${TABLE}.sales_region IN (${lightdash.attributes.sales_region})
 ```
 
 ### Column filtering with `required_attributes`

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -297,6 +297,14 @@ describe('replaceUserAttributes', () => {
         ).toThrowError(ForbiddenError);
     });
 
+    it('method with no user attribute value should throw error', async () => {
+        expect(() =>
+            replaceUserAttributes('${lightdash.attribute.test} > 1', {
+                test: [],
+            }),
+        ).toThrowError(ForbiddenError);
+    });
+
     it('method should replace sqlFilter with user attribute', async () => {
         const userAttributes = { test: ['1'] };
         const expected = "'1' > 1";
@@ -310,6 +318,14 @@ describe('replaceUserAttributes', () => {
         expect(
             replaceUserAttributes('${ld.attr.test} > 1', userAttributes),
         ).toEqual(expected);
+    });
+
+    it('method should replace sqlFilter with user attribute with multiple values', async () => {
+        expect(
+            replaceUserAttributes("'1' IN (${lightdash.attribute.test})", {
+                test: ['1', '2'],
+            }),
+        ).toEqual("'1' IN ('1','2')");
     });
 
     it('method should replace sqlFilter with multiple user attributes', async () => {

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -325,7 +325,7 @@ describe('replaceUserAttributes', () => {
             replaceUserAttributes("'1' IN (${lightdash.attribute.test})", {
                 test: ['1', '2'],
             }),
-        ).toEqual("'1' IN ('1','2')");
+        ).toEqual("'1' IN ('1', '2')");
     });
 
     it('method should replace sqlFilter with multiple user attributes', async () => {

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -128,7 +128,7 @@ export const replaceUserAttributes = (
                     (attributeValue) =>
                         `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
                 )
-                .join(','),
+                .join(', '),
         );
     }, sqlFilter);
 };

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -108,15 +108,14 @@ export const replaceUserAttributes = (
 
     return sqlAttributes.reduce<string>((acc, sqlAttribute) => {
         const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
-        const userValue: string | null | undefined =
-            userAttributes[attribute]?.[0]; // Pick first value, where user value takes precedence over group values
+        const attributeValues: string[] | undefined = userAttributes[attribute];
 
-        if (userValue === undefined) {
+        if (attributeValues === undefined) {
             throw new ForbiddenError(
                 `Missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
             );
         }
-        if (userValue === null) {
+        if (attributeValues.length === 0) {
             throw new ForbiddenError(
                 `Invalid or missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
             );
@@ -124,7 +123,12 @@ export const replaceUserAttributes = (
 
         return acc.replace(
             sqlAttribute,
-            `${stringQuoteChar}${userValue}${stringQuoteChar}`,
+            attributeValues
+                .map(
+                    (attributeValue) =>
+                        `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
+                )
+                .join(','),
         );
     }, sqlFilter);
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8536 <!-- reference the related issue e.g. #150 -->

### Description:

Developers should have access to all attribute values, independently if they are set at the user level, group level, or default value. This matches the behaviour we have for Table and Column filtering. 

- [x] backwards compatible ( if not using group attributes )
- [x] access all values in SQL template
- [x] compatible with all warehouses: [bigquery](https://cloud.google.com/bigquery/docs/reference/standard-sql/operators#in_operators) [postgres](https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-in/) [snowflake](https://docs.snowflake.com/en/sql-reference/functions/in) [databricks](https://docs.databricks.com/en/sql/language-manual/functions/in.html) [trino](https://trino.io/docs/current/functions/comparison.html#row-comparison-in)

- [x] update documentation
  - https://deploy-preview-8769--peaceful-bassi-cbf284.netlify.app/references/user-attributes#row-filtering-with-sql_filter
  - https://deploy-preview-8769--peaceful-bassi-cbf284.netlify.app/references/user-attributes#row-filtering

<img width="994" alt="Screenshot 2024-01-30 at 15 06 54" src="https://github.com/lightdash/lightdash/assets/9117144/9a0066ba-a061-496c-b797-9557cb481d57">

---

### Example 1: User has an attribute  with 1 value

**Current behaviour**

```sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}```

That would convert to

```sales.sales_region = 'USA'```

**New behaviour**

```sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}```
That would convert to
```sales.sales_region = 'USA'```

Note that is it backwards compatible.

--- 

### Example 2: User has an attribute with 2 values 

**Current behaviour**

```sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}```

That would convert to

```sales.sales_region = 'USA'```

Note that the user can only access 1 value. This is the problem we are solving in this PR.

**New behaviour** 

```sql_filter: ${TABLE}.sales_region = ${lightdash.attributes.sales_region}```

That would convert to

```sales.sales_region = 'USA', 'EU'```

Note that this would throw an error since it is not valid SQL. This is good because users won't have access to something they shouldn't have while admins can fix the SQL/YML. 

Our docs will now recommend using `IN` operator when handling user attributes to make sure it can handle multiple values.

So they would have the following SQL

```sql_filter: ${TABLE}.sales_region IN (${lightdash.attributes.sales_region})```

That would convert to

```sales.sales_region IN ('USA','EU')```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
