### PR TITLE
fix: TableHeader empty tooltip on results

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -86,7 +86,7 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                                                         label={tooltipLabel}
                                                         position="top"
                                                         disabled={
-                                                            tooltipLabel ==
+                                                            !tooltipLabel ||
                                                                 null ||
                                                             minimal ||
                                                             snapshot.isDropAnimating ||

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -35,6 +35,11 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                     <HeaderDroppable headerGroup={headerGroup}>
                         {headerGroup.headers.map((header) => {
                             const meta = header.column.columnDef.meta;
+                            const tooltipLabel =
+                                meta?.item && isField(meta?.item)
+                                    ? meta.item.description
+                                    : undefined;
+
                             return (
                                 <Th
                                     key={header.id}
@@ -78,15 +83,11 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                                                         withinPortal
                                                         maw={400}
                                                         multiline
-                                                        label={
-                                                            meta?.item &&
-                                                            isField(meta?.item)
-                                                                ? meta.item
-                                                                      .description
-                                                                : undefined
-                                                        }
+                                                        label={tooltipLabel}
                                                         position="top"
                                                         disabled={
+                                                            tooltipLabel ==
+                                                                null ||
                                                             minimal ||
                                                             snapshot.isDropAnimating ||
                                                             snapshot.isDragging

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -87,7 +87,6 @@ const TableHeader: FC<TableHeaderProps> = ({ minimal = false }) => {
                                                         position="top"
                                                         disabled={
                                                             !tooltipLabel ||
-                                                                null ||
                                                             minimal ||
                                                             snapshot.isDropAnimating ||
                                                             snapshot.isDragging


### PR DESCRIPTION
### Description:

Fixes the occasional empty tooltip, particularly if using table calculations as part of a result, when looking at result table header fields. This behavior applies to anything that isn't a field.

Before:

![image](https://github.com/lightdash/lightdash/assets/382538/074b2354-3cef-4b4c-b4af-342de8997b9e)

Now: 
![image](https://github.com/lightdash/lightdash/assets/382538/34f44350-28db-44a4-b29c-5c4749bdc590)

(No tooltip is displayed)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
